### PR TITLE
fix: enum backport UP042, test auth headers, GET board-kpis

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -14,3 +14,31 @@ class AIGovernanceKpiSummary(BaseModel):
     audit_events_last_30_days: int
     has_documented_ai_policy: bool = False
     has_ai_risk_register: bool = False
+
+
+class AIBoardKpiSummary(BaseModel):
+    tenant_id: str
+    ai_systems_total: int
+    active_ai_systems: int
+    high_risk_systems: int
+    open_policy_violations: int
+
+    # Aggregierter Board-Score (0..1)
+    board_maturity_score: float
+
+    # Cluster-Scores (0..1)
+    compliance_coverage_score: float
+    risk_governance_score: float
+    operational_resilience_score: float
+    responsible_ai_score: float
+
+    # Kerntreiber für das Board
+    high_risk_systems_without_dpia: int
+    critical_systems_without_owner: int
+    nis2_control_gaps: int  # Summe offener NIS2-Kontrollen (Runbook, Backup, Supplier-Risiko)
+
+    # Trends optional (im ersten Schritt statisch 0)
+    score_change_vs_last_quarter: float
+    incidents_last_quarter: int
+    complaints_last_quarter: int
+

--- a/app/datetime_compat.py
+++ b/app/datetime_compat.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+try:
+    from datetime import UTC
+except ImportError:  # pragma: no cover - Python < 3.11 fallback
+    from datetime import timezone as _timezone
+
+    UTC = _timezone.utc  # noqa: UP017
+
+
+__all__ = ["UTC"]
+

--- a/app/enum_compat.py
+++ b/app/enum_compat.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+try:
+    from enum import StrEnum  # type: ignore[assignment]
+except ImportError:  # pragma: no cover - Python < 3.11 fallback
+    from enum import Enum
+
+    class StrEnum(str, Enum):  # noqa: UP042
+        """Backport von enum.StrEnum für Python 3.10-Testumgebungen."""
+        pass
+
+
+__all__ = ["StrEnum"]
+

--- a/app/main.py
+++ b/app/main.py
@@ -11,7 +11,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
-from app.ai_governance_models import AIGovernanceKpiSummary
+from app.ai_governance_models import AIBoardKpiSummary, AIGovernanceKpiSummary
 from app.ai_system_models import (
     AISystem,
     AISystemComplianceReport,
@@ -54,7 +54,7 @@ from app.repositories.compliance_gap import ComplianceGapRepository
 from app.repositories.policies import PolicyRepository
 from app.repositories.violations import ViolationRepository
 from app.security import AuthContext, get_api_key_and_tenant, get_auth_context
-from app.services.ai_governance_kpis import compute_ai_governance_kpis
+from app.services.ai_governance_kpis import compute_ai_board_kpis, compute_ai_governance_kpis
 from app.services.classification_engine import classify_ai_system
 from app.services.compliance_engine import build_audit_hash, derive_actions
 from app.services.tenant_compliance_overview import (
@@ -83,7 +83,6 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
-
 
 class DocumentIntakeRequest(BaseModel):
     tenant_id: str = Field(..., examples=["tenant-001"])
@@ -450,6 +449,19 @@ def get_aisystem_compliance_report(
     summary = repository.compliance_summary_for_tenant(tenant_id)
     return AISystemComplianceReport(**summary)
 
+
+
+@app.get("/api/v1/ai-governance/board-kpis", response_model=AIBoardKpiSummary)
+def get_ai_governance_board_kpis(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repository: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    violation_repository: Annotated[ViolationRepository, Depends(get_violation_repository)],
+) -> AIBoardKpiSummary:
+    return compute_ai_board_kpis(
+        tenant_id=auth_context.tenant_id,
+        ai_system_repository=ai_repository,
+        violation_repository=violation_repository,
+    )
 
 
 @app.get(

--- a/app/services/ai_governance_kpis.py
+++ b/app/services/ai_governance_kpis.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
-from app.ai_governance_models import AIGovernanceKpiSummary
+from app.ai_governance_models import AIBoardKpiSummary, AIGovernanceKpiSummary
+from app.datetime_compat import UTC
 from app.repositories.ai_systems import AISystemRepository
 from app.repositories.audit import AuditRepository
 from app.repositories.policies import PolicyRepository
@@ -82,5 +83,91 @@ def compute_ai_governance_kpis(
         audit_events_last_30_days=audit_events_last_30_days,
         has_documented_ai_policy=has_documented_ai_policy,
         has_ai_risk_register=has_ai_risk_register,
+    )
+
+def compute_ai_board_kpis(
+    tenant_id: str,
+    ai_system_repository: AISystemRepository,
+    violation_repository: ViolationRepository,
+) -> AIBoardKpiSummary:
+    ai_systems = ai_system_repository.list_for_tenant(tenant_id)
+    violations = violation_repository.list_violations_for_tenant(tenant_id)
+
+    total_systems = len(ai_systems)
+    active_systems = sum(1 for s in ai_systems if s.status == "active")
+    high_risk_systems = sum(1 for s in ai_systems if s.risk_level == "high")
+    open_violations = len(violations)
+
+    high_risk_systems_without_dpia = sum(
+        1 for s in ai_systems if s.risk_level == "high" and not s.gdpr_dpia_required
+    )
+    critical_systems_without_owner = sum(
+        1
+        for s in ai_systems
+        if s.criticality in ("high", "very_high")
+        and not (s.owner_email and s.owner_email.strip())
+    )
+    nis2_control_gaps = sum(
+        (1 if not s.has_incident_runbook else 0)
+        + (1 if not s.has_backup_runbook else 0)
+        + (1 if not s.has_supplier_risk_register else 0)
+        for s in ai_systems
+    )
+
+    owner_ratio = (
+        sum(1 for s in ai_systems if s.owner_email and s.owner_email.strip())
+        / total_systems
+        if total_systems
+        else 1.0
+    )
+    dpia_ratio = (
+        sum(1 for s in ai_systems if s.risk_level == "high" and s.gdpr_dpia_required)
+        / high_risk_systems
+        if high_risk_systems
+        else 1.0
+    )
+    runbook_ratio = (
+        sum(
+            1
+            for s in ai_systems
+            if s.has_incident_runbook and s.has_backup_runbook and s.has_supplier_risk_register
+        )
+        / total_systems
+        if total_systems
+        else 1.0
+    )
+    violation_penalty = min(1.0, open_violations / max(total_systems, 1))
+    board_maturity_score = max(
+        0.0,
+        min(
+            1.0,
+            0.35 * owner_ratio
+            + 0.35 * dpia_ratio
+            + 0.2 * runbook_ratio
+            + 0.1 * (1 - violation_penalty),
+        ),
+    )
+    compliance_coverage_score = dpia_ratio
+    risk_governance_score = owner_ratio
+    operational_resilience_score = runbook_ratio
+    responsible_ai_score = 1.0 - violation_penalty
+
+    return AIBoardKpiSummary(
+        tenant_id=tenant_id,
+        ai_systems_total=total_systems,
+        active_ai_systems=active_systems,
+        high_risk_systems=high_risk_systems,
+        open_policy_violations=open_violations,
+        board_maturity_score=round(board_maturity_score, 3),
+        compliance_coverage_score=round(compliance_coverage_score, 3),
+        risk_governance_score=round(risk_governance_score, 3),
+        operational_resilience_score=round(operational_resilience_score, 3),
+        responsible_ai_score=round(responsible_ai_score, 3),
+        high_risk_systems_without_dpia=high_risk_systems_without_dpia,
+        critical_systems_without_owner=critical_systems_without_owner,
+        nis2_control_gaps=nis2_control_gaps,
+        score_change_vs_last_quarter=0.0,
+        incidents_last_quarter=0,
+        complaints_last_quarter=0,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Iterator
 
 import pytest
@@ -7,12 +8,29 @@ import pytest
 from app.db import engine, get_session
 from app.main import app
 from app.models_db import Base
+from app.security import get_settings
+
+
+# Alle API-Keys, die Tests in _headers() verwenden – get_settings().api_keys wird
+# einmal pro Session gecacht; damit alle Tests grün bleiben, hier Superset setzen.
+_TEST_API_KEYS = "board-kpi-key,test-key,test-api-key,tenant-overview-key,test-key-1,test-key-2"
 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_db() -> None:
+    os.environ["COMPLIANCEHUB_API_KEYS"] = _TEST_API_KEYS
+    get_settings.cache_clear()
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
+
+
+def _headers() -> dict[str, str]:
+    """Standard-Test-Header (x-api-key, x-tenant-id) für geschützte Endpoints.
+    Key muss in get_settings().api_keys liegen (kompatibel mit COMPLIANCEHUB_API_KEYS)."""
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": "board-kpi-tenant",
+    }
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_ai_board_kpis.py
+++ b/tests/test_ai_board_kpis.py
@@ -1,0 +1,45 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def test_ai_board_kpis_endpoint_returns_summary():
+    system_payload = {
+        "id": "board-kpi-system-1",
+        "name": "Board KPI System",
+        "description": "System for board KPI smoke test",
+        "business_unit": "Ops",
+        "risk_level": "high",
+        "ai_act_category": "high_risk",
+        "gdpr_dpia_required": False,
+        "owner_email": "",
+        "criticality": "high",
+        "data_sensitivity": "internal",
+        "has_incident_runbook": False,
+        "has_supplier_risk_register": False,
+        "has_backup_runbook": False,
+    }
+
+    create_response = client.post(
+        "/api/v1/ai-systems",
+        json=system_payload,
+        headers=_headers(),
+    )
+    assert create_response.status_code == 200
+
+    response = client.get(
+        "/api/v1/ai-governance/board-kpis",
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+
+    data = response.json()
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert 0.0 <= data["board_maturity_score"] <= 1.0
+    assert data["high_risk_systems_without_dpia"] >= 1
+    assert data["critical_systems_without_owner"] >= 1
+    assert data["nis2_control_gaps"] >= 1
+


### PR DESCRIPTION
- app/enum_compat.py: noqa UP042 for StrEnum backport (Python <3.11)
- tests/conftest.py: force COMPLIANCEHUB_API_KEYS, _headers() for auth
- app/main.py: GET /api/v1/ai-governance/board-kpis
- app/services/ai_governance_kpis.py: full AIBoardKpiSummary
- tests/test_ai_board_kpis.py: board-kpis endpoint test

Made-with: Cursor