### PR TITLE
feat: incident drilldowns for board KPIs (NIS2 Art. 21/23, ISO 42001)

### DIFF
--- a/app/incident_models.py
+++ b/app/incident_models.py
@@ -41,3 +41,34 @@ class Incident(BaseModel):
         None,
         description="Zusätzliche Key-Value-Daten",
     )
+
+
+# ─── Board / AI Governance Incident Overview (NIS2 Art. 21/23, ISO 42001) ─────
+
+
+class BySeverityEntry(BaseModel):
+    """Anzahl Incidents pro Schweregrad für Board-Drilldown."""
+
+    severity: IncidentSeverity
+    count: int
+
+
+class AIIncidentOverview(BaseModel):
+    """Übersicht Incidents für Board-KPI-Drilldown (NIS2, ISO 42001 Incident Management)."""
+
+    tenant_id: str
+    total_incidents_last_12_months: int
+    open_incidents: int
+    major_incidents_last_12_months: int
+    mean_time_to_ack_hours: float | None = None
+    mean_time_to_recover_hours: float | None = None
+    by_severity: list[BySeverityEntry]
+
+
+class AIIncidentBySystemEntry(BaseModel):
+    """Pro KI-System: Incident-Anzahl und letztes Incident für Board-Drilldown."""
+
+    ai_system_id: str
+    ai_system_name: str
+    incident_count: int
+    last_incident_at: datetime | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.compliance_gap_models import (
     SystemReadiness,
 )
 from app.db import engine, get_session
+from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
 from app.models import (
     ComplianceAction,
     DocumentIngestRequest,
@@ -51,9 +52,14 @@ from app.repositories.audit import AuditRepository
 from app.repositories.audit_logs import AuditLogRepository
 from app.repositories.classifications import ClassificationRepository
 from app.repositories.compliance_gap import ComplianceGapRepository
+from app.repositories.incidents import IncidentRepository
 from app.repositories.policies import PolicyRepository
 from app.repositories.violations import ViolationRepository
 from app.security import AuthContext, get_api_key_and_tenant, get_auth_context
+from app.services.ai_governance_incidents import (
+    compute_ai_incident_overview,
+    compute_ai_incidents_by_system,
+)
 from app.services.ai_governance_kpis import compute_ai_board_kpis, compute_ai_governance_kpis
 from app.services.classification_engine import classify_ai_system
 from app.services.compliance_engine import build_audit_hash, derive_actions
@@ -155,6 +161,12 @@ def get_violation_repository(
     session: Annotated[Session, Depends(get_session)],
 ) -> ViolationRepository:
     return ViolationRepository(session)
+
+
+def get_incident_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> IncidentRepository:
+    return IncidentRepository(session)
 
 
 def get_classification_repository(
@@ -464,6 +476,38 @@ def get_ai_governance_board_kpis(
         tenant_id=auth_context.tenant_id,
         ai_system_repository=ai_repository,
         violation_repository=violation_repository,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/incidents/overview",
+    response_model=AIIncidentOverview,
+)
+def get_ai_governance_incidents_overview(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    incident_repository: Annotated[IncidentRepository, Depends(get_incident_repository)],
+) -> AIIncidentOverview:
+    """NIS2 Art. 21/23, ISO 42001 Incident Management – Board-Drilldown."""
+    return compute_ai_incident_overview(
+        tenant_id=auth_context.tenant_id,
+        incident_repository=incident_repository,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/incidents/by-system",
+    response_model=list[AIIncidentBySystemEntry],
+)
+def get_ai_governance_incidents_by_system(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    incident_repository: Annotated[IncidentRepository, Depends(get_incident_repository)],
+    ai_repository: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+) -> list[AIIncidentBySystemEntry]:
+    """Incidents pro KI-System für Board-Drilldown (Top-Systeme)."""
+    return compute_ai_incidents_by_system(
+        tenant_id=auth_context.tenant_id,
+        incident_repository=incident_repository,
+        ai_system_repository=ai_repository,
     )
 
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -129,6 +129,35 @@ class ComplianceStatusTable(Base):
     )
 
 
+class IncidentTable(Base):
+    """NIS2 Art. 21/23, ISO 42001 Incident Management – mandantenfähig, RLS-konform."""
+
+    __tablename__ = "incidents"
+
+    id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    ai_system_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    severity: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        nullable=False,
+    )
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        nullable=False,
+    )
+    acknowledged_at_utc: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    resolved_at_utc: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    actor: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    source: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class AuditLogTable(Base):
     __tablename__ = "audit_logs"
 

--- a/app/repositories/incidents.py
+++ b/app/repositories/incidents.py
@@ -1,0 +1,108 @@
+"""Incident-Repository für NIS2 Art. 21/23 und ISO 42001 Incident Management.
+
+Mandantenfähig: Alle Queries filtern strikt nach tenant_id (RLS-konform).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.incident_models import IncidentSeverity, IncidentStatus
+from app.models_db import IncidentTable
+
+
+class IncidentRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def list_for_tenant_last_12_months(self, tenant_id: str) -> list[IncidentTable]:
+        """Alle Incidents des Tenants der letzten 12 Monate (für Aggregationen)."""
+        since = datetime.now(UTC) - timedelta(days=365)
+        stmt = (
+            select(IncidentTable)
+            .where(
+                IncidentTable.tenant_id == tenant_id,
+                IncidentTable.created_at_utc >= since,
+            )
+            .order_by(IncidentTable.created_at_utc.desc())
+        )
+        rows = self._session.execute(stmt).scalars().all()
+        return list(rows)
+
+    def count_open_for_tenant(self, tenant_id: str) -> int:
+        """Anzahl offene Incidents (status open) des Tenants."""
+        stmt = select(func.count(IncidentTable.id)).where(
+            IncidentTable.tenant_id == tenant_id,
+            IncidentTable.status == IncidentStatus.open.value,
+        )
+        return self._session.execute(stmt).scalar_one() or 0
+
+    def aggregate_overview(
+        self,
+        tenant_id: str,
+    ) -> tuple[int, int, int, float | None, float | None, list[tuple[str, int]]]:
+        """Liefert (total_12m, open, major_12m, mtta_h, mttr_h, by_severity_list)."""
+        since = datetime.now(UTC) - timedelta(days=365)
+        # Total last 12 months
+        stmt_total = select(func.count(IncidentTable.id)).where(
+            IncidentTable.tenant_id == tenant_id,
+            IncidentTable.created_at_utc >= since,
+        )
+        total = self._session.execute(stmt_total).scalar_one() or 0
+        open_count = self.count_open_for_tenant(tenant_id)
+        # Major (high severity) last 12 months
+        stmt_major = select(func.count(IncidentTable.id)).where(
+            IncidentTable.tenant_id == tenant_id,
+            IncidentTable.created_at_utc >= since,
+            IncidentTable.severity == IncidentSeverity.high.value,
+        )
+        major = self._session.execute(stmt_major).scalar_one() or 0
+        # By severity (last 12 months)
+        stmt_sev = (
+            select(IncidentTable.severity, func.count(IncidentTable.id))
+            .where(
+                IncidentTable.tenant_id == tenant_id,
+                IncidentTable.created_at_utc >= since,
+            )
+            .group_by(IncidentTable.severity)
+        )
+        by_severity_rows = self._session.execute(stmt_sev).all()
+        by_severity = [(sev, cnt) for sev, cnt in by_severity_rows]
+        # MTTA / MTTR: aus acknowledged_at_utc - created_at_utc bzw. resolved - created
+        rows = self.list_for_tenant_last_12_months(tenant_id)
+        mtta_hours: list[float] = []
+        mttr_hours: list[float] = []
+        for row in rows:
+            if row.acknowledged_at_utc and row.created_at_utc:
+                delta = row.acknowledged_at_utc - row.created_at_utc
+                mtta_hours.append(delta.total_seconds() / 3600.0)
+            if row.resolved_at_utc and row.created_at_utc:
+                delta = row.resolved_at_utc - row.created_at_utc
+                mttr_hours.append(delta.total_seconds() / 3600.0)
+        mtta = sum(mtta_hours) / len(mtta_hours) if mtta_hours else None
+        mttr = sum(mttr_hours) / len(mttr_hours) if mttr_hours else None
+        return (total, open_count, major, mtta, mttr, by_severity)
+
+    def aggregate_by_system(
+        self,
+        tenant_id: str,
+    ) -> list[tuple[str, int, datetime | None]]:
+        """(ai_system_id, incident_count, last_incident_at) pro System, letzte 12 Monate."""
+        since = datetime.now(UTC) - timedelta(days=365)
+        stmt = (
+            select(
+                IncidentTable.ai_system_id,
+                func.count(IncidentTable.id).label("cnt"),
+                func.max(IncidentTable.created_at_utc).label("last_at"),
+            )
+            .where(
+                IncidentTable.tenant_id == tenant_id,
+                IncidentTable.created_at_utc >= since,
+            )
+            .group_by(IncidentTable.ai_system_id)
+        )
+        rows = self._session.execute(stmt).all()
+        return [(r[0], r[1], r[2]) for r in rows]

--- a/app/services/ai_governance_incidents.py
+++ b/app/services/ai_governance_incidents.py
@@ -1,0 +1,61 @@
+"""AI-Governance Incident-Übersicht für Board-Drilldown (NIS2 Art. 21/23, ISO 42001)."""
+
+from __future__ import annotations
+
+from app.incident_models import (
+    AIIncidentBySystemEntry,
+    AIIncidentOverview,
+    BySeverityEntry,
+    IncidentSeverity,
+)
+from app.repositories.ai_systems import AISystemRepository
+from app.repositories.incidents import IncidentRepository
+
+
+def compute_ai_incident_overview(
+    tenant_id: str,
+    incident_repository: IncidentRepository,
+) -> AIIncidentOverview:
+    """Aggregierte Incident-Übersicht für GET /api/v1/ai-governance/incidents/overview."""
+    total, open_count, major, mtta, mttr, by_severity = incident_repository.aggregate_overview(
+        tenant_id
+    )
+    by_severity_entries = [
+        BySeverityEntry(severity=IncidentSeverity(s), count=c) for s, c in by_severity
+    ]
+    return AIIncidentOverview(
+        tenant_id=tenant_id,
+        total_incidents_last_12_months=total,
+        open_incidents=open_count,
+        major_incidents_last_12_months=major,
+        mean_time_to_ack_hours=round(mtta, 2) if mtta is not None else None,
+        mean_time_to_recover_hours=round(mttr, 2) if mttr is not None else None,
+        by_severity=by_severity_entries,
+    )
+
+
+def compute_ai_incidents_by_system(
+    tenant_id: str,
+    incident_repository: IncidentRepository,
+    ai_system_repository: AISystemRepository,
+) -> list[AIIncidentBySystemEntry]:
+    """Pro-System-Incident-Liste für GET /api/v1/ai-governance/incidents/by-system."""
+    rows = incident_repository.aggregate_by_system(tenant_id)
+    entries: list[AIIncidentBySystemEntry] = []
+    for ai_system_id, incident_count, last_incident_at in rows:
+        ai_system = ai_system_repository.get_by_id(tenant_id, ai_system_id)
+        name = ai_system.name if ai_system else ai_system_id
+        entries.append(
+            AIIncidentBySystemEntry(
+                ai_system_id=ai_system_id,
+                ai_system_name=name,
+                incident_count=incident_count,
+                last_incident_at=last_incident_at,
+            )
+        )
+
+    def _sort_key(e: AIIncidentBySystemEntry) -> tuple[int, float]:
+        ts = e.last_incident_at.timestamp() if e.last_incident_at else 0.0
+        return (-e.incident_count, ts)
+
+    return sorted(entries, key=_sort_key)

--- a/frontend/src/app/board/incidents/page.tsx
+++ b/frontend/src/app/board/incidents/page.tsx
@@ -1,0 +1,220 @@
+import React from "react";
+import Link from "next/link";
+
+import {
+  fetchIncidentOverview,
+  fetchIncidentsBySystem,
+  type AIIncidentBySystem,
+  type AIIncidentOverview,
+} from "@/lib/api";
+
+function severityBadgeClass(severity: string): string {
+  switch (severity) {
+    case "high":
+      return "bg-red-100 text-red-800";
+    case "medium":
+      return "bg-amber-100 text-amber-800";
+    case "low":
+      return "bg-emerald-100 text-emerald-800";
+    default:
+      return "bg-slate-100 text-slate-700";
+  }
+}
+
+function severityLabel(severity: string): string {
+  const labels: Record<string, string> = {
+    low: "Niedrig",
+    medium: "Mittel",
+    high: "Hoch",
+  };
+  return labels[severity] ?? severity;
+}
+
+export default async function BoardIncidentsPage() {
+  let overview: AIIncidentOverview | null = null;
+  let bySystem: AIIncidentBySystem[] = [];
+
+  try {
+    overview = await fetchIncidentOverview();
+  } catch (error) {
+    console.error("Incident overview API error:", error);
+  }
+
+  if (overview) {
+    try {
+      bySystem = await fetchIncidentsBySystem();
+    } catch (error) {
+      console.error("Incidents by system API error:", error);
+    }
+  }
+
+  if (!overview) {
+    return (
+      <main className="mx-auto max-w-6xl px-4 py-8">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-slate-900">
+            AI Governance – Incident-Übersicht
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            NIS2 Art. 21/23 · ISO 42001 Incident Management
+          </p>
+        </header>
+        <div
+          role="status"
+          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          Incident-KPIs konnten nicht geladen werden. Bitte versuchen Sie es
+          später erneut oder wenden Sie sich an das AI-Governance-Team.
+        </div>
+        <p className="mt-4">
+          <Link
+            href="/board/kpis"
+            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+          >
+            ← Zurück zu Board-KPIs
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  const topSystems = bySystem.slice(0, 3);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">
+          AI Governance – Incident-Übersicht
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          NIS2 Art. 21/23 (Incident & Business Continuity) · ISO 42001 Incident
+          Management · Standort Deutschland
+        </p>
+        <p className="mt-2">
+          <Link
+            href="/board/kpis"
+            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            aria-label="Zurück zu Board-KPIs"
+          >
+            ← Zurück zu Board-KPIs
+          </Link>
+        </p>
+      </header>
+
+      <section
+        aria-label="Incident-KPIs"
+        className="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4"
+      >
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Incidents letzte 12 Monate
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.total_incidents_last_12_months}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Gesamt (Rolling 12 Monate)</p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Aktuell offene Incidents
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.open_incidents}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Status: offen</p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Major Incidents (NIS2-relevant)
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.major_incidents_last_12_months}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Schweregrad Hoch, 12 Monate</p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            MTTA / MTTR
+          </h2>
+          <p className="mt-2 text-lg font-semibold text-slate-900">
+            {overview.mean_time_to_ack_hours != null
+              ? `~${overview.mean_time_to_ack_hours} h`
+              : "–"}{" "}
+            /{" "}
+            {overview.mean_time_to_recover_hours != null
+              ? `~${overview.mean_time_to_recover_hours} h`
+              : "–"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            Ø Zeit bis Bestätigung / Wiederherstellung
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-label="Incidents nach Schweregrad"
+        className="mb-8 rounded-xl border border-slate-100 bg-white p-4 shadow-sm"
+      >
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+          Incidents nach Schweregrad
+        </h2>
+        {overview.by_severity.length === 0 ? (
+          <p className="text-sm text-slate-500">
+            In den letzten 12 Monaten keine Incidents erfasst.
+          </p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {overview.by_severity.map((entry) => (
+              <span
+                key={entry.severity}
+                className={`rounded-full px-3 py-1 text-sm font-medium ${severityBadgeClass(entry.severity)}`}
+              >
+                {severityLabel(entry.severity)}: {entry.count}
+              </span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {topSystems.length > 0 && (
+        <section
+          aria-label="Top-KI-Systeme nach Incident-Anzahl"
+          className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm"
+        >
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+            Top 3 KI-Systeme mit den meisten Incidents (12 Monate)
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                  <th className="pb-2 font-semibold">KI-System</th>
+                  <th className="pb-2 font-semibold">Anzahl Incidents</th>
+                  <th className="pb-2 font-semibold">Letztes Incident</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topSystems.map((row) => (
+                  <tr key={row.ai_system_id} className="border-b border-slate-100">
+                    <td className="py-2 font-medium text-slate-900">
+                      {row.ai_system_name}
+                    </td>
+                    <td className="py-2 text-slate-700">{row.incident_count}</td>
+                    <td className="py-2 text-slate-600">
+                      {row.last_incident_at
+                        ? new Date(row.last_incident_at).toLocaleString("de-DE", {
+                            dateStyle: "short",
+                            timeStyle: "short",
+                          })
+                        : "–"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 
 import { fetchBoardKpis, type BoardKpiSummary } from "@/lib/api";
 
@@ -159,6 +160,15 @@ export default async function BoardKpisPage() {
           <p className="mt-1 text-xs text-slate-500">
             {formatPercent(kpis.nis2_incident_readiness_ratio)} der
             KI-Systeme mit Incident- &amp; Backup-Runbook.
+          </p>
+          <p className="mt-3">
+            <Link
+              href="/board/incidents"
+              className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
+              aria-label="Incident-Drilldown öffnen"
+            >
+              Incident-Details anzeigen
+            </Link>
           </p>
         </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -227,4 +227,38 @@ export async function fetchBoardKpis(): Promise<BoardKpiSummary> {
   return apiFetch("/api/v1/ai-governance/board-kpis");
 }
 
+// ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
+
+export type IncidentSeverityLevel = "low" | "medium" | "high";
+
+export interface BySeverityEntry {
+  severity: IncidentSeverityLevel;
+  count: number;
+}
+
+export interface AIIncidentOverview {
+  tenant_id: string;
+  total_incidents_last_12_months: number;
+  open_incidents: number;
+  major_incidents_last_12_months: number;
+  mean_time_to_ack_hours: number | null;
+  mean_time_to_recover_hours: number | null;
+  by_severity: BySeverityEntry[];
+}
+
+export interface AIIncidentBySystem {
+  ai_system_id: string;
+  ai_system_name: string;
+  incident_count: number;
+  last_incident_at: string | null;
+}
+
+export async function fetchIncidentOverview(): Promise<AIIncidentOverview> {
+  return apiFetch("/api/v1/ai-governance/incidents/overview");
+}
+
+export async function fetchIncidentsBySystem(): Promise<AIIncidentBySystem[]> {
+  return apiFetch("/api/v1/ai-governance/incidents/by-system");
+}
+
 

--- a/tests/test_ai_incidents_overview.py
+++ b/tests/test_ai_incidents_overview.py
@@ -1,0 +1,142 @@
+"""Tests für GET /api/v1/ai-governance/incidents/overview und /by-system (NIS2, ISO 42001)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.main import app
+from app.models_db import IncidentTable
+
+client = TestClient(app)
+
+_INCIDENT_TENANT = "tenant-incident-overview"
+
+
+def _create_incident(
+    session: Session,
+    tenant_id: str,
+    ai_system_id: str,
+    severity: str = "medium",
+    status: str = "open",
+) -> None:
+    now = datetime.now(UTC)
+    row = IncidentTable(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        ai_system_id=ai_system_id,
+        severity=severity,
+        status=status,
+        created_at_utc=now - timedelta(days=1),
+        updated_at_utc=now,
+        acknowledged_at_utc=now if status != "open" else None,
+        resolved_at_utc=now if status == "resolved" else None,
+        actor="test",
+        source="pytest",
+        summary="Test incident",
+    )
+    session.add(row)
+    session.commit()
+
+
+def test_incidents_overview_happy_path():
+    """Happy Path: Incidents für Tenant anlegen, Overview liefert Zählwerte und by_severity."""
+    session = SessionLocal()
+    try:
+        # AI-System für by-system Namen
+        create = client.post(
+            "/api/v1/ai-systems",
+            json={
+                "id": "inc-sys-1",
+                "name": "KI-System für Incidents",
+                "description": "Test",
+                "business_unit": "Ops",
+                "risk_level": "high",
+                "ai_act_category": "high_risk",
+                "gdpr_dpia_required": False,
+                "owner_email": "a@b.de",
+                "criticality": "medium",
+                "data_sensitivity": "internal",
+                "has_incident_runbook": True,
+                "has_supplier_risk_register": False,
+                "has_backup_runbook": True,
+            },
+            headers={"x-api-key": "board-kpi-key", "x-tenant-id": _INCIDENT_TENANT},
+        )
+        assert create.status_code == 200
+
+        _create_incident(session, _INCIDENT_TENANT, "inc-sys-1", "low", "open")
+        _create_incident(session, _INCIDENT_TENANT, "inc-sys-1", "medium", "resolved")
+        _create_incident(session, _INCIDENT_TENANT, "inc-sys-1", "high", "open")
+    finally:
+        session.close()
+
+    response = client.get(
+        "/api/v1/ai-governance/incidents/overview",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == _INCIDENT_TENANT
+    assert data["total_incidents_last_12_months"] == 3
+    assert data["open_incidents"] == 2
+    assert data["major_incidents_last_12_months"] == 1
+    assert isinstance(data["by_severity"], list)
+    assert len(data["by_severity"]) >= 1
+
+    by_sys = client.get(
+        "/api/v1/ai-governance/incidents/by-system",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert by_sys.status_code == 200
+    list_by_sys = by_sys.json()
+    assert isinstance(list_by_sys, list)
+    assert len(list_by_sys) == 1
+    assert list_by_sys[0]["ai_system_id"] == "inc-sys-1"
+    assert list_by_sys[0]["ai_system_name"] == "KI-System für Incidents"
+    assert list_by_sys[0]["incident_count"] == 3
+
+
+def test_incidents_overview_tenant_isolation():
+    """Tenant-Isolation: Incidents von Tenant B erscheinen nicht für Tenant A."""
+    session = SessionLocal()
+    try:
+        _create_incident(session, "tenant-other-inc", "sys-other", "high", "open")
+    finally:
+        session.close()
+
+    response = client.get(
+        "/api/v1/ai-governance/incidents/overview",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == _INCIDENT_TENANT
+
+    by_sys = client.get(
+        "/api/v1/ai-governance/incidents/by-system",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert by_sys.status_code == 200
+    list_by_sys = by_sys.json()
+    system_ids = [e["ai_system_id"] for e in list_by_sys]
+    assert "sys-other" not in system_ids
+
+
+def test_incidents_overview_401_without_api_key():
+    """Ohne gültigen API-Key liefert der Endpoint 401."""
+    response = client.get(
+        "/api/v1/ai-governance/incidents/overview",
+        headers={"x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert response.status_code == 401
+
+    response2 = client.get(
+        "/api/v1/ai-governance/incidents/overview",
+        headers={"x-api-key": "invalid-key", "x-tenant-id": _INCIDENT_TENANT},
+    )
+    assert response2.status_code == 401


### PR DESCRIPTION
- Backend: IncidentTable, IncidentRepository, AIIncidentOverview/BySystem
- GET /api/v1/ai-governance/incidents/overview and /by-system
- tests/test_ai_incidents_overview.py (happy path, tenant isolation, 401)
- Frontend: AIIncidentOverview/BySystem types, fetchIncidentOverview/BySystem
- New page /board/incidents with KPI tiles, by_severity, top 3 systems
- Link from Board-KPIs NIS2 card to Incident-Details

Made-with: Cursor