### PR TITLE
feat: supplier risk drilldowns for board (NIS2 Art. 21/24)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -61,11 +61,19 @@ from app.services.ai_governance_incidents import (
     compute_ai_incidents_by_system,
 )
 from app.services.ai_governance_kpis import compute_ai_board_kpis, compute_ai_governance_kpis
+from app.services.ai_governance_suppliers import (
+    compute_ai_supplier_risk_by_system,
+    compute_ai_supplier_risk_overview,
+)
 from app.services.classification_engine import classify_ai_system
 from app.services.compliance_engine import build_audit_hash, derive_actions
 from app.services.tenant_compliance_overview import (
     TenantComplianceOverview,
     compute_tenant_compliance_overview,
+)
+from app.supplier_risk_models import (
+    AISupplierRiskBySystemEntry,
+    AISupplierRiskOverview,
 )
 
 APP_VERSION = os.getenv("COMPLIANCEHUB_VERSION", "0.1.0")
@@ -507,6 +515,36 @@ def get_ai_governance_incidents_by_system(
     return compute_ai_incidents_by_system(
         tenant_id=auth_context.tenant_id,
         incident_repository=incident_repository,
+        ai_system_repository=ai_repository,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/suppliers/overview",
+    response_model=AISupplierRiskOverview,
+)
+def get_ai_governance_suppliers_overview(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repository: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+) -> AISupplierRiskOverview:
+    """NIS2 Art. 21/24 Supply-Chain-Risiko – Board-Drilldown."""
+    return compute_ai_supplier_risk_overview(
+        tenant_id=auth_context.tenant_id,
+        ai_system_repository=ai_repository,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/suppliers/by-system",
+    response_model=list[AISupplierRiskBySystemEntry],
+)
+def get_ai_governance_suppliers_by_system(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repository: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+) -> list[AISupplierRiskBySystemEntry]:
+    """Supplier-Risiko pro KI-System für Board-Drilldown."""
+    return compute_ai_supplier_risk_by_system(
+        tenant_id=auth_context.tenant_id,
         ai_system_repository=ai_repository,
     )
 

--- a/app/services/ai_governance_suppliers.py
+++ b/app/services/ai_governance_suppliers.py
@@ -1,0 +1,92 @@
+"""AI-Governance Supplier-Risk-Übersicht für Board-Drilldown (NIS2 Art. 21/24)."""
+
+from __future__ import annotations
+
+from app.repositories.ai_systems import AISystemRepository
+from app.supplier_risk_models import (
+    AISupplierRiskBySystemEntry,
+    AISupplierRiskOverview,
+    BySupplierRiskLevelEntry,
+    SupplierRiskLevel,
+)
+
+
+def _criticality_to_supplier_risk_level(criticality: str) -> SupplierRiskLevel:
+    if criticality in ("high", "very_high"):
+        return SupplierRiskLevel.high
+    if criticality == "medium":
+        return SupplierRiskLevel.medium
+    return SupplierRiskLevel.low
+
+
+def _supplier_risk_score(has_register: bool, criticality: str) -> float:
+    """0..1: höher = mehr Risiko (ohne Register) bzw. besser abgesichert (mit Register)."""
+    if criticality in ("high", "very_high"):
+        return 1.0 if not has_register else 0.0
+    if criticality == "medium":
+        return 0.5 if not has_register else 0.0
+    return 0.25 if not has_register else 0.0
+
+
+def compute_ai_supplier_risk_overview(
+    tenant_id: str,
+    ai_system_repository: AISystemRepository,
+) -> AISupplierRiskOverview:
+    """Aggregierte Supplier-Risiko-Übersicht für GET .../suppliers/overview."""
+    ai_systems = ai_system_repository.list_for_tenant(tenant_id)
+    total = len(ai_systems)
+    with_register = sum(1 for s in ai_systems if s.has_supplier_risk_register)
+    without_register = total - with_register
+    critical = [s for s in ai_systems if s.criticality in ("high", "very_high")]
+    critical_total = len(critical)
+    critical_without_controls = sum(1 for s in critical if not s.has_supplier_risk_register)
+
+    by_level: dict[SupplierRiskLevel, tuple[int, int]] = {
+        SupplierRiskLevel.high: (0, 0),
+        SupplierRiskLevel.medium: (0, 0),
+        SupplierRiskLevel.low: (0, 0),
+    }
+    for s in ai_systems:
+        level = _criticality_to_supplier_risk_level(s.criticality)
+        with_r, without_r = by_level[level]
+        if s.has_supplier_risk_register:
+            by_level[level] = (with_r + 1, without_r)
+        else:
+            by_level[level] = (with_r, without_r + 1)
+
+    by_risk_level = [
+        BySupplierRiskLevelEntry(
+            risk_level=level,
+            systems_with_register=by_level[level][0],
+            systems_without_register=by_level[level][1],
+        )
+        for level in (SupplierRiskLevel.high, SupplierRiskLevel.medium, SupplierRiskLevel.low)
+    ]
+    return AISupplierRiskOverview(
+        tenant_id=tenant_id,
+        total_systems_with_suppliers=with_register,
+        systems_without_supplier_risk_register=without_register,
+        critical_suppliers_total=critical_total,
+        critical_suppliers_without_controls=critical_without_controls,
+        by_risk_level=by_risk_level,
+    )
+
+
+def compute_ai_supplier_risk_by_system(
+    tenant_id: str,
+    ai_system_repository: AISystemRepository,
+) -> list[AISupplierRiskBySystemEntry]:
+    """Pro-System-Liste für GET .../suppliers/by-system (höchstes Risiko zuerst)."""
+    ai_systems = ai_system_repository.list_for_tenant(tenant_id)
+    entries = [
+        AISupplierRiskBySystemEntry(
+            ai_system_id=s.id,
+            ai_system_name=s.name,
+            has_supplier_risk_register=s.has_supplier_risk_register,
+            supplier_risk_score=round(
+                _supplier_risk_score(s.has_supplier_risk_register, s.criticality), 2
+            ),
+        )
+        for s in ai_systems
+    ]
+    return sorted(entries, key=lambda e: (-e.supplier_risk_score, e.ai_system_name))

--- a/app/supplier_risk_models.py
+++ b/app/supplier_risk_models.py
@@ -1,0 +1,43 @@
+"""NIS2 Art. 21/24 Supply-Chain-Risiko – Board-Drilldown-Modelle."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class SupplierRiskLevel(StrEnum):
+    """Risikostufe für Lieferanten-/KI-System-Kontext (NIS2 Supply Chain)."""
+
+    high = "high"
+    medium = "medium"
+    low = "low"
+
+
+class BySupplierRiskLevelEntry(BaseModel):
+    """Anzahl KI-Systeme mit/ohne Supplier-Risikoregister pro Risikostufe."""
+
+    risk_level: SupplierRiskLevel
+    systems_with_register: int
+    systems_without_register: int
+
+
+class AISupplierRiskOverview(BaseModel):
+    """Übersicht Supplier-Risiko für Board-Drilldown (NIS2 Art. 21/24, KRITIS-Bezug)."""
+
+    tenant_id: str
+    total_systems_with_suppliers: int
+    systems_without_supplier_risk_register: int
+    critical_suppliers_total: int
+    critical_suppliers_without_controls: int
+    by_risk_level: list[BySupplierRiskLevelEntry]
+
+
+class AISupplierRiskBySystemEntry(BaseModel):
+    """Pro KI-System: Supplier-Risikoregister und abgeleiteter Score."""
+
+    ai_system_id: str
+    ai_system_name: str
+    has_supplier_risk_register: bool
+    supplier_risk_score: float

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -187,6 +187,15 @@ export default async function BoardKpisPage() {
             {formatPercent(kpis.nis2_supplier_risk_coverage_ratio)} der Systeme
             mit Supplier-Risikoregister.
           </p>
+          <p className="mt-3">
+            <Link
+              href="/board/suppliers"
+              className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
+              aria-label="Supplier-Risiko-Drilldown öffnen"
+            >
+              Details anzeigen
+            </Link>
+          </p>
         </div>
 
         {/* High-Risk KI-Systeme gesamt */}

--- a/frontend/src/app/board/suppliers/page.tsx
+++ b/frontend/src/app/board/suppliers/page.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import Link from "next/link";
+
+import {
+  fetchSupplierRiskOverview,
+  fetchSupplierRiskBySystem,
+  type AISupplierRiskBySystem,
+  type AISupplierRiskOverview,
+} from "@/lib/api";
+
+function riskLevelLabel(level: string): string {
+  const labels: Record<string, string> = {
+    high: "Hoch",
+    medium: "Mittel",
+    low: "Niedrig",
+  };
+  return labels[level] ?? level;
+}
+
+export default async function BoardSuppliersPage() {
+  let overview: AISupplierRiskOverview | null = null;
+  let bySystem: AISupplierRiskBySystem[] = [];
+
+  try {
+    overview = await fetchSupplierRiskOverview();
+  } catch (error) {
+    console.error("Supplier risk overview API error:", error);
+  }
+
+  if (overview) {
+    try {
+      bySystem = await fetchSupplierRiskBySystem();
+    } catch (error) {
+      console.error("Supplier risk by system API error:", error);
+    }
+  }
+
+  if (!overview) {
+    return (
+      <main className="mx-auto max-w-6xl px-4 py-8">
+        <header className="mb-6">
+          <h1 className="text-2xl font-bold text-slate-900">
+            AI Governance – Supplier-Risiko
+          </h1>
+          <p className="mt-1 text-sm text-slate-500">
+            NIS2 Art. 21/24 Supply-Chain-Security · KRITIS-Bezug
+          </p>
+        </header>
+        <div
+          role="status"
+          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+        >
+          Supplier-Risiko-KPIs konnten nicht geladen werden. Bitte versuchen Sie
+          es später erneut oder wenden Sie sich an das AI-Governance-Team.
+        </div>
+        <p className="mt-4">
+          <Link
+            href="/board/kpis"
+            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+          >
+            ← Zurück zu Board-KPIs
+          </Link>
+        </p>
+      </main>
+    );
+  }
+
+  const topSystems = bySystem.filter((e) => e.supplier_risk_score > 0).slice(0, 3);
+  const totalSystems =
+    overview.total_systems_with_suppliers + overview.systems_without_supplier_risk_register;
+  const coveragePercent =
+    totalSystems > 0
+      ? Math.round((overview.total_systems_with_suppliers / totalSystems) * 100)
+      : 0;
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <header className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">
+          AI Governance – Supplier-Risiko
+        </h1>
+        <p className="mt-1 text-sm text-slate-500">
+          NIS2 Art. 21/24 Supply-Chain-Security · Lieferanten-Risikoregister ·
+          KRITIS-Bezug · Standort Deutschland
+        </p>
+        <p className="mt-2">
+          <Link
+            href="/board/kpis"
+            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            aria-label="Zurück zu Board-KPIs"
+          >
+            ← Zurück zu Board-KPIs
+          </Link>
+        </p>
+      </header>
+
+      <section
+        aria-label="Supplier-Risiko-KPIs"
+        className="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4"
+      >
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Systeme mit Lieferanten-Register
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.total_systems_with_suppliers}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            {coveragePercent} % der KI-Systeme mit dokumentiertem
+            Lieferanten-Risikoregister
+          </p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Systeme ohne Supplier-Risikoregister
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.systems_without_supplier_risk_register}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            NIS2 Supply-Chain-Anforderung aktuell nicht erfüllt
+          </p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Kritische KI-Systeme gesamt
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.critical_suppliers_total}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            Hohe/Sehr hohe Kritikalität (KRITIS-relevant)
+          </p>
+        </div>
+        <div className="flex flex-col rounded-xl border border-slate-100 bg-white p-4 shadow-sm">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Kritische ohne Lieferanten-Controls
+          </h2>
+          <p className="mt-2 text-3xl font-semibold text-slate-900">
+            {overview.critical_suppliers_without_controls}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            Handlungsbedarf für Supply-Chain-Sicherheit
+          </p>
+        </div>
+      </section>
+
+      <section
+        aria-label="Supplier-Risiko nach Risikostufe"
+        className="mb-8 rounded-xl border border-slate-100 bg-white p-4 shadow-sm"
+      >
+        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+          KI-Systeme nach Supplier-Risikostufe
+        </h2>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                <th className="pb-2 font-semibold">Risikostufe</th>
+                <th className="pb-2 font-semibold">Mit Register</th>
+                <th className="pb-2 font-semibold">Ohne Register</th>
+              </tr>
+            </thead>
+            <tbody>
+              {overview.by_risk_level.map((entry) => (
+                <tr key={entry.risk_level} className="border-b border-slate-100">
+                  <td className="py-2 font-medium text-slate-900">
+                    {riskLevelLabel(entry.risk_level)}
+                  </td>
+                  <td className="py-2 text-slate-700">
+                    {entry.systems_with_register}
+                  </td>
+                  <td className="py-2 text-slate-700">
+                    {entry.systems_without_register}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {topSystems.length > 0 && (
+        <section
+          aria-label="Top-KI-Systeme mit höchstem Supplier-Risiko"
+          className="rounded-xl border border-slate-100 bg-white p-4 shadow-sm"
+        >
+          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+            Top 3 KI-Systeme mit höchstem Supplier-Risiko
+          </h2>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
+                  <th className="pb-2 font-semibold">KI-System</th>
+                  <th className="pb-2 font-semibold">Lieferanten-Register</th>
+                  <th className="pb-2 font-semibold">Risiko-Score</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topSystems.map((row) => (
+                  <tr key={row.ai_system_id} className="border-b border-slate-100">
+                    <td className="py-2 font-medium text-slate-900">
+                      {row.ai_system_name}
+                    </td>
+                    <td className="py-2 text-slate-700">
+                      {row.has_supplier_risk_register ? "Ja" : "Nein"}
+                    </td>
+                    <td className="py-2 text-slate-700">
+                      {row.supplier_risk_score.toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </main>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -261,4 +261,38 @@ export async function fetchIncidentsBySystem(): Promise<AIIncidentBySystem[]> {
   return apiFetch("/api/v1/ai-governance/incidents/by-system");
 }
 
+// ─── AI Governance Supplier Risk Drilldown (NIS2 Art. 21/24, Supply-Chain) ─────
+
+export type SupplierRiskLevel = "high" | "medium" | "low";
+
+export interface BySupplierRiskLevelEntry {
+  risk_level: SupplierRiskLevel;
+  systems_with_register: number;
+  systems_without_register: number;
+}
+
+export interface AISupplierRiskOverview {
+  tenant_id: string;
+  total_systems_with_suppliers: number;
+  systems_without_supplier_risk_register: number;
+  critical_suppliers_total: number;
+  critical_suppliers_without_controls: number;
+  by_risk_level: BySupplierRiskLevelEntry[];
+}
+
+export interface AISupplierRiskBySystem {
+  ai_system_id: string;
+  ai_system_name: string;
+  has_supplier_risk_register: boolean;
+  supplier_risk_score: number;
+}
+
+export async function fetchSupplierRiskOverview(): Promise<AISupplierRiskOverview> {
+  return apiFetch("/api/v1/ai-governance/suppliers/overview");
+}
+
+export async function fetchSupplierRiskBySystem(): Promise<AISupplierRiskBySystem[]> {
+  return apiFetch("/api/v1/ai-governance/suppliers/by-system");
+}
+
 

--- a/tests/test_ai_suppliers_overview.py
+++ b/tests/test_ai_suppliers_overview.py
@@ -1,0 +1,141 @@
+"""Tests für GET /api/v1/ai-governance/suppliers/overview und /by-system (NIS2 Art. 21/24)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+_SUPPLIER_TENANT = "tenant-supplier-overview"
+
+
+def test_suppliers_overview_happy_path():
+    """Happy Path: KI-Systeme mit/ohne Supplier-Register, Overview und by-system."""
+    headers = {"x-api-key": "board-kpi-key", "x-tenant-id": _SUPPLIER_TENANT}
+    # System mit Register
+    r1 = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "sup-sys-1",
+            "name": "KI-System mit Lieferanten-Register",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": True,
+            "owner_email": "a@b.de",
+            "criticality": "high",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": True,
+            "has_supplier_risk_register": True,
+            "has_backup_runbook": True,
+        },
+        headers=headers,
+    )
+    assert r1.status_code == 200
+    # System ohne Register (kritisch)
+    r2 = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "sup-sys-2",
+            "name": "Kritisches System ohne Register",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "b@b.de",
+            "criticality": "very_high",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=headers,
+    )
+    assert r2.status_code == 200
+
+    response = client.get(
+        "/api/v1/ai-governance/suppliers/overview",
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == _SUPPLIER_TENANT
+    assert data["total_systems_with_suppliers"] == 1
+    assert data["systems_without_supplier_risk_register"] == 1
+    assert data["critical_suppliers_total"] == 2
+    assert data["critical_suppliers_without_controls"] == 1
+    assert "by_risk_level" in data
+    assert len(data["by_risk_level"]) == 3
+
+    by_sys = client.get(
+        "/api/v1/ai-governance/suppliers/by-system",
+        headers=headers,
+    )
+    assert by_sys.status_code == 200
+    list_by_sys = by_sys.json()
+    assert len(list_by_sys) == 2
+    ids = {e["ai_system_id"] for e in list_by_sys}
+    assert "sup-sys-1" in ids and "sup-sys-2" in ids
+    entry_no_register = next(e for e in list_by_sys if e["ai_system_id"] == "sup-sys-2")
+    assert entry_no_register["has_supplier_risk_register"] is False
+    assert entry_no_register["supplier_risk_score"] == 1.0
+
+
+def test_suppliers_overview_tenant_isolation():
+    """Tenant-Isolation: Systeme von Tenant B erscheinen nicht für Tenant A."""
+    other_headers = {"x-api-key": "board-kpi-key", "x-tenant-id": "tenant-other-supplier"}
+    client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "other-sup-1",
+            "name": "Fremd-System",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "high",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=other_headers,
+    )
+
+    response = client.get(
+        "/api/v1/ai-governance/suppliers/overview",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _SUPPLIER_TENANT},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == _SUPPLIER_TENANT
+    assert data["total_systems_with_suppliers"] == 1
+
+    by_sys = client.get(
+        "/api/v1/ai-governance/suppliers/by-system",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": _SUPPLIER_TENANT},
+    )
+    assert by_sys.status_code == 200
+    system_ids = [e["ai_system_id"] for e in by_sys.json()]
+    assert "other-sup-1" not in system_ids
+
+
+def test_suppliers_overview_401_without_api_key():
+    """Ohne gültigen API-Key liefert der Endpoint 401."""
+    response = client.get(
+        "/api/v1/ai-governance/suppliers/overview",
+        headers={"x-tenant-id": _SUPPLIER_TENANT},
+    )
+    assert response.status_code == 401
+
+    response2 = client.get(
+        "/api/v1/ai-governance/suppliers/overview",
+        headers={"x-api-key": "invalid-key", "x-tenant-id": _SUPPLIER_TENANT},
+    )
+    assert response2.status_code == 401


### PR DESCRIPTION
- Backend: AISupplierRiskOverview, AISupplierRiskBySystemEntry, service
- GET /api/v1/ai-governance/suppliers/overview and /by-system
- tests/test_ai_suppliers_overview.py (happy path, tenant isolation, 401)
- Frontend: AISupplierRiskOverview/BySystem, fetchSupplierRiskOverview/BySystem
- New page /board/suppliers with KPIs, by_risk_level, top 3 systems
- Link Details anzeigen from NIS2 Supplier Risk Coverage card

Made-with: Cursor