### PR TITLE
feat(ai-governance): Board-Alerts Export (JSON/CSV) für CISO/ISB/Vors…

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -75,3 +75,12 @@ class AIKpiAlert(BaseModel):
     message: str
     created_at: datetime
     resolved_at: datetime | None = None
+
+
+class AIKpiAlertExport(BaseModel):
+    """Export-Objekt für Board-Alerts (Reporting / CISO / Vorstand)."""
+
+    tenant_id: str
+    generated_at: datetime
+    format_version: str = "1.0"
+    alerts: list[AIKpiAlert]

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import csv
+import io
 import json
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
-from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi import Depends, FastAPI, HTTPException, Query, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -15,6 +17,7 @@ from app.ai_governance_models import (
     AIBoardKpiSummary,
     AIGovernanceKpiSummary,
     AIKpiAlert,
+    AIKpiAlertExport,
 )
 from app.ai_system_models import (
     AISystem,
@@ -542,6 +545,91 @@ def get_board_alerts(
         tenant_id=tenant_id,
         board_kpis=board_kpis,
         compliance_overview=compliance_overview,
+    )
+
+
+def _alerts_export_csv(tenant_id: str, alerts: list[AIKpiAlert], generated_at: datetime) -> str:
+    """Eine Zeile pro Alert, CSV-konform (RFC 4180)."""
+    out = io.StringIO()
+    writer = csv.writer(out)
+    writer.writerow(
+        ["id", "tenant_id", "kpi_key", "severity", "message", "created_at", "resolved_at"]
+    )
+    for a in alerts:
+        writer.writerow(
+            [
+                a.id,
+                a.tenant_id,
+                a.kpi_key,
+                a.severity,
+                a.message,
+                a.created_at.isoformat() if a.created_at else "",
+                a.resolved_at.isoformat() if a.resolved_at else "",
+            ]
+        )
+    return out.getvalue()
+
+
+@app.get(
+    "/api/v1/ai-governance/alerts/board/export",
+    response_class=Response,
+)
+def get_board_alerts_export(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
+    violation_repo: Annotated[ViolationRepository, Depends(get_violation_repository)],
+    format: Annotated[
+        Literal["json", "csv"],
+        Query(description="Export-Format: json (Standard) oder csv"),
+    ] = "json",
+) -> Response:
+    """Board-Alerts als JSON oder CSV für Reporting / CISO / Vorstand (keine Personenbezogenen)."""
+    from app.datetime_compat import UTC
+
+    tenant_id = auth_context.tenant_id
+    board_kpis = compute_ai_board_kpis(
+        tenant_id=tenant_id,
+        ai_system_repository=ai_repo,
+        violation_repository=violation_repo,
+    )
+    compliance_overview = compute_ai_compliance_overview(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+    )
+    alerts = compute_board_alerts(
+        tenant_id=tenant_id,
+        board_kpis=board_kpis,
+        compliance_overview=compliance_overview,
+    )
+    generated_at = datetime.now(UTC)
+
+    if format == "csv":
+        csv_content = _alerts_export_csv(tenant_id, alerts, generated_at)
+        filename = f"ai-governance-alerts-{tenant_id}-{generated_at.strftime('%Y%m%d')}.csv"
+        return Response(
+            content=csv_content,
+            media_type="text/csv; charset=utf-8",
+            headers={
+                "Content-Disposition": f'attachment; filename="{filename}"',
+            },
+        )
+    export_data = AIKpiAlertExport(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        format_version="1.0",
+        alerts=alerts,
+    )
+    filename = f"ai-governance-alerts-{tenant_id}-{generated_at.strftime('%Y%m%d')}.json"
+    return Response(
+        content=export_data.model_dump_json(),
+        media_type="application/json",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
     )
 
 

--- a/frontend/src/app/api/board/alerts/export/route.ts
+++ b/frontend/src/app/api/board/alerts/export/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.COMPLIANCEHUB_API_BASE_URL || "http://localhost:8000";
+const API_KEY =
+  process.env.COMPLIANCEHUB_API_KEY || "tenant-overview-key";
+const TENANT_ID =
+  process.env.COMPLIANCEHUB_TENANT_ID || "tenant-overview-001";
+
+export async function GET(request: NextRequest) {
+  const format = request.nextUrl.searchParams.get("format") || "json";
+  const validFormat = format === "csv" ? "csv" : "json";
+  const url = `${API_BASE}/api/v1/ai-governance/alerts/board/export?format=${validFormat}`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-tenant-id": TENANT_ID,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: "Export fehlgeschlagen" },
+      { status: res.status },
+    );
+  }
+  const body = await res.arrayBuffer();
+  const contentType = res.headers.get("content-type") || "application/json";
+  const contentDisposition = res.headers.get("content-disposition");
+  const headers = new Headers();
+  headers.set("Content-Type", contentType);
+  if (contentDisposition) headers.set("Content-Disposition", contentDisposition);
+  return new NextResponse(body, { status: 200, headers });
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -5,6 +5,7 @@ import {
   fetchAIComplianceOverview,
   fetchBoardAlerts,
   fetchBoardKpis,
+  fetchBoardAlertsExport,
   type AIComplianceOverview,
   type AIKpiAlert,
   type BoardKpiSummary,
@@ -142,15 +143,15 @@ export default async function BoardKpisPage() {
         </p>
       </header>
 
-      {/* Alerts & Hinweise (max 5) */}
-      {alerts.length > 0 && (
-        <section
-          aria-label="Alerts und Hinweise"
-          className="mb-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
-        >
-          <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
-            Alerts &amp; Hinweise
-          </h2>
+      {/* Alerts & Hinweise (max 5) + Export für CISO/ISB/Vorstand */}
+      <section
+        aria-label="Alerts und Hinweise"
+        className="mb-6 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+      >
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+          Alerts &amp; Hinweise
+        </h2>
+        {alerts.length > 0 ? (
           <ul className="mt-3 space-y-2">
             {alerts.slice(0, 5).map((alert) => (
               <li
@@ -161,8 +162,30 @@ export default async function BoardKpisPage() {
               </li>
             ))}
           </ul>
-        </section>
-      )}
+        ) : (
+          <p className="mt-3 text-sm text-slate-500">
+            Keine aktuellen Alerts.
+          </p>
+        )}
+        <p className="mt-4 text-xs text-slate-600">
+          Für Weiterleitung an CISO / ISB / Vorstand:{" "}
+          <a
+            href={fetchBoardAlertsExport("json")}
+            download
+            className="font-medium text-slate-800 underline hover:text-slate-600"
+          >
+            Alerts als JSON exportieren
+          </a>
+          {" · "}
+          <a
+            href={fetchBoardAlertsExport("csv")}
+            download
+            className="font-medium text-slate-800 underline hover:text-slate-600"
+          >
+            Alerts als CSV exportieren
+          </a>
+        </p>
+      </section>
 
       {/* Hero: ISO 42001 Governance Score */}
       {(() => {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -265,6 +265,11 @@ export async function fetchBoardAlerts(): Promise<AIKpiAlert[]> {
   return apiFetch("/api/v1/ai-governance/alerts/board");
 }
 
+/** Export-URL für Board-Alerts (JSON/CSV) – für Weiterleitung an CISO/ISB/Vorstand. */
+export function fetchBoardAlertsExport(format?: "json" | "csv"): string {
+  return `/api/board/alerts/export?format=${format ?? "json"}`;
+}
+
 // ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
 
 export type IncidentSeverityLevel = "low" | "medium" | "high";

--- a/tests/test_ai_board_alerts_export.py
+++ b/tests/test_ai_board_alerts_export.py
@@ -1,0 +1,117 @@
+"""Tests für GET /api/v1/ai-governance/alerts/board/export (JSON/CSV)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def test_board_alerts_export_json_happy_path():
+    """Export als JSON liefert AIKpiAlertExport mit tenant_id, generated_at, alerts."""
+    create = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "export-json-sys",
+            "name": "Export Test",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=_headers(),
+    )
+    assert create.status_code == 200
+
+    response = client.get(
+        "/api/v1/ai-governance/alerts/board/export",
+        params={"format": "json"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/json")
+    assert "attachment" in response.headers.get("content-disposition", "").lower()
+    data = response.json()
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert "generated_at" in data
+    assert data.get("format_version") == "1.0"
+    assert isinstance(data["alerts"], list)
+    for a in data["alerts"]:
+        assert "id" in a and "kpi_key" in a and "severity" in a and "message" in a
+
+
+def test_board_alerts_export_csv():
+    """Export mit format=csv liefert text/csv, eine Zeile pro Alert."""
+    response = client.get(
+        "/api/v1/ai-governance/alerts/board/export",
+        params={"format": "csv"},
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert "text/csv" in response.headers.get("content-type", "")
+    assert "attachment" in response.headers.get("content-disposition", "").lower()
+    text = response.text
+    lines = text.strip().split("\n")
+    assert len(lines) >= 1
+    assert "id" in lines[0] and "kpi_key" in lines[0] and "severity" in lines[0]
+
+
+def test_board_alerts_export_tenant_isolation():
+    """Anderer Tenant erhält eigenen Export (tenant_id im Body/CSV)."""
+    tenant_a = "export-tenant-a"
+    tenant_b = "export-tenant-b"
+    key = "board-kpi-key"
+    for tid, sys_id in [(tenant_a, "ex-a-1"), (tenant_b, "ex-b-1")]:
+        client.post(
+            "/api/v1/ai-systems",
+            json={
+                "id": sys_id,
+                "name": sys_id,
+                "description": "Test",
+                "business_unit": "Ops",
+                "risk_level": "high",
+                "ai_act_category": "high_risk",
+                "gdpr_dpia_required": False,
+                "owner_email": "",
+                "criticality": "medium",
+                "data_sensitivity": "internal",
+                "has_incident_runbook": False,
+                "has_supplier_risk_register": False,
+                "has_backup_runbook": False,
+            },
+            headers={"x-api-key": key, "x-tenant-id": tid},
+        )
+
+    r_a = client.get(
+        "/api/v1/ai-governance/alerts/board/export",
+        params={"format": "json"},
+        headers={"x-api-key": key, "x-tenant-id": tenant_a},
+    )
+    r_b = client.get(
+        "/api/v1/ai-governance/alerts/board/export",
+        params={"format": "json"},
+        headers={"x-api-key": key, "x-tenant-id": tenant_b},
+    )
+    assert r_a.status_code == 200 and r_b.status_code == 200
+    assert r_a.json()["tenant_id"] == tenant_a
+    assert r_b.json()["tenant_id"] == tenant_b
+
+
+def test_board_alerts_export_401():
+    """Ohne API-Key wird 401 zurückgegeben."""
+    response = client.get(
+        "/api/v1/ai-governance/alerts/board/export",
+        params={"format": "json"},
+        headers={"x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
…tand

- AIKpiAlertExport, GET /api/v1/ai-governance/alerts/board/export?format=json|csv
- CSV: eine Zeile pro Alert, Content-Disposition für Dateinamen
- Frontend: fetchBoardAlertsExport, API-Route Proxy, Export-Links in Alerts-Sektion
- Tests: test_ai_board_alerts_export.py (JSON, CSV, Tenant-Isolation, 401)

Made-with: Cursor