### PR TITLE
feat(ai-governance): Vorstands-/Aufsichtsreport API (Board AI Governa…

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -5,6 +5,10 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.compliance_gap_models import AIComplianceOverview
+from app.incident_models import AIIncidentOverview
+from app.supplier_risk_models import AISupplierRiskOverview
+
 
 class AIGovernanceKpiSummary(BaseModel):
     tenant_id: str
@@ -83,4 +87,17 @@ class AIKpiAlertExport(BaseModel):
     tenant_id: str
     generated_at: datetime
     format_version: str = "1.0"
+    alerts: list[AIKpiAlert]
+
+
+class AIBoardGovernanceReport(BaseModel):
+    """Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt (PDF/Word-Mapping)."""
+
+    tenant_id: str
+    generated_at: datetime
+    period: str = "last_12_months"
+    kpis: AIBoardKpiSummary
+    compliance_overview: AIComplianceOverview
+    incidents_overview: AIIncidentOverview
+    supplier_risk_overview: AISupplierRiskOverview
     alerts: list[AIKpiAlert]

--- a/app/main.py
+++ b/app/main.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.ai_governance_models import (
+    AIBoardGovernanceReport,
     AIBoardKpiSummary,
     AIGovernanceKpiSummary,
     AIKpiAlert,
@@ -630,6 +631,61 @@ def get_board_alerts_export(
         headers={
             "Content-Disposition": f'attachment; filename="{filename}"',
         },
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/report/board",
+    response_model=AIBoardGovernanceReport,
+)
+def get_board_governance_report(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
+    violation_repo: Annotated[ViolationRepository, Depends(get_violation_repository)],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+) -> AIBoardGovernanceReport:
+    """Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt (nur JSON)."""
+    from app.datetime_compat import UTC
+
+    tenant_id = auth_context.tenant_id
+    generated_at = datetime.now(UTC)
+
+    kpis = compute_ai_board_kpis(
+        tenant_id=tenant_id,
+        ai_system_repository=ai_repo,
+        violation_repository=violation_repo,
+    )
+    compliance_overview = compute_ai_compliance_overview(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+    )
+    incidents_overview = compute_ai_incident_overview(
+        tenant_id=tenant_id,
+        incident_repository=incident_repo,
+    )
+    supplier_risk_overview = compute_ai_supplier_risk_overview(
+        tenant_id=tenant_id,
+        ai_system_repository=ai_repo,
+    )
+    alerts = compute_board_alerts(
+        tenant_id=tenant_id,
+        board_kpis=kpis,
+        compliance_overview=compliance_overview,
+    )
+
+    return AIBoardGovernanceReport(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        period="last_12_months",
+        kpis=kpis,
+        compliance_overview=compliance_overview,
+        incidents_overview=incidents_overview,
+        supplier_risk_overview=supplier_risk_overview,
+        alerts=alerts,
     )
 
 

--- a/frontend/src/app/api/board/report/route.ts
+++ b/frontend/src/app/api/board/report/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.COMPLIANCEHUB_API_BASE_URL || "http://localhost:8000";
+const API_KEY =
+  process.env.COMPLIANCEHUB_API_KEY || "tenant-overview-key";
+const TENANT_ID =
+  process.env.COMPLIANCEHUB_TENANT_ID || "tenant-overview-001";
+
+export async function GET() {
+  const url = `${API_BASE}/api/v1/ai-governance/report/board`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-tenant-id": TENANT_ID,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: "Report konnte nicht geladen werden" },
+      { status: res.status },
+    );
+  }
+  const report = (await res.json()) as {
+    tenant_id: string;
+    generated_at: string;
+    [key: string]: unknown;
+  };
+  const dateStr =
+    report.generated_at?.slice(0, 10).replace(/-/g, "") ?? "report";
+  const filename = `ai-board-report-${report.tenant_id ?? "tenant"}-${dateStr}.json`;
+  const body = JSON.stringify(report);
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json; charset=utf-8");
+  headers.set(
+    "Content-Disposition",
+    `attachment; filename="${filename}"`,
+  );
+  return new NextResponse(body, { status: 200, headers });
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -6,6 +6,7 @@ import {
   fetchBoardAlerts,
   fetchBoardKpis,
   fetchBoardAlertsExport,
+  getBoardReportDownloadUrl,
   type AIComplianceOverview,
   type AIKpiAlert,
   type BoardKpiSummary,
@@ -183,6 +184,16 @@ export default async function BoardKpisPage() {
             className="font-medium text-slate-800 underline hover:text-slate-600"
           >
             Alerts als CSV exportieren
+          </a>
+        </p>
+        <p className="mt-2 text-xs text-slate-600">
+          Für Vorstand / SVV / ISB-Reportings:{" "}
+          <a
+            href={getBoardReportDownloadUrl()}
+            download
+            className="font-medium text-slate-800 underline hover:text-slate-600"
+          >
+            Board-Report JSON
           </a>
         </p>
       </section>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -270,6 +270,27 @@ export function fetchBoardAlertsExport(format?: "json" | "csv"): string {
   return `/api/board/alerts/export?format=${format ?? "json"}`;
 }
 
+/** Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt. */
+export interface AIBoardGovernanceReport {
+  tenant_id: string;
+  generated_at: string;
+  period: string;
+  kpis: BoardKpiSummary;
+  compliance_overview: AIComplianceOverview;
+  incidents_overview: AIIncidentOverview;
+  supplier_risk_overview: AISupplierRiskOverview;
+  alerts: AIKpiAlert[];
+}
+
+export async function fetchBoardGovernanceReport(): Promise<AIBoardGovernanceReport> {
+  return apiFetch("/api/v1/ai-governance/report/board");
+}
+
+/** Download-URL für Board-Report JSON (für Vorstand/SVV/ISB-Reportings). */
+export function getBoardReportDownloadUrl(): string {
+  return "/api/board/report";
+}
+
 // ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
 
 export type IncidentSeverityLevel = "low" | "medium" | "high";

--- a/tests/test_ai_board_governance_report.py
+++ b/tests/test_ai_board_governance_report.py
@@ -1,0 +1,105 @@
+"""Tests für GET /api/v1/ai-governance/report/board (Vorstands-/Aufsichtsreport)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def test_board_report_happy_path():
+    """Response-Struktur und Feldbelegung (kpis, compliance, incidents, supplier, alerts)."""
+    create = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "report-sys-1",
+            "name": "Report Test System",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=_headers(),
+    )
+    assert create.status_code == 200
+
+    response = client.get(
+        "/api/v1/ai-governance/report/board",
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert "generated_at" in data
+    assert data.get("period") == "last_12_months"
+    assert "kpis" in data
+    assert data["kpis"]["tenant_id"] == "board-kpi-tenant"
+    assert "board_maturity_score" in data["kpis"]
+    assert "compliance_overview" in data
+    assert "overall_readiness" in data["compliance_overview"]
+    assert "incidents_overview" in data
+    assert "total_incidents_last_12_months" in data["incidents_overview"]
+    assert "supplier_risk_overview" in data
+    assert "total_systems_with_suppliers" in data["supplier_risk_overview"]
+    assert "alerts" in data
+    assert isinstance(data["alerts"], list)
+
+
+def test_board_report_tenant_isolation():
+    """Anderer Tenant erhält eigenen Report (tenant_id in allen Teilstrukturen)."""
+    tenant_a = "report-tenant-a"
+    tenant_b = "report-tenant-b"
+    key = "board-kpi-key"
+    for tid, sys_id in [(tenant_a, "rpt-a-1"), (tenant_b, "rpt-b-1")]:
+        client.post(
+            "/api/v1/ai-systems",
+            json={
+                "id": sys_id,
+                "name": sys_id,
+                "description": "Test",
+                "business_unit": "Ops",
+                "risk_level": "high",
+                "ai_act_category": "high_risk",
+                "gdpr_dpia_required": False,
+                "owner_email": "",
+                "criticality": "medium",
+                "data_sensitivity": "internal",
+                "has_incident_runbook": False,
+                "has_supplier_risk_register": False,
+                "has_backup_runbook": False,
+            },
+            headers={"x-api-key": key, "x-tenant-id": tid},
+        )
+
+    r_a = client.get(
+        "/api/v1/ai-governance/report/board",
+        headers={"x-api-key": key, "x-tenant-id": tenant_a},
+    )
+    r_b = client.get(
+        "/api/v1/ai-governance/report/board",
+        headers={"x-api-key": key, "x-tenant-id": tenant_b},
+    )
+    assert r_a.status_code == 200 and r_b.status_code == 200
+    assert r_a.json()["tenant_id"] == tenant_a
+    assert r_b.json()["tenant_id"] == tenant_b
+    assert r_a.json()["kpis"]["tenant_id"] == tenant_a
+    assert r_b.json()["kpis"]["tenant_id"] == tenant_b
+
+
+def test_board_report_401():
+    """Ohne API-Key wird 401 zurückgegeben."""
+    response = client.get(
+        "/api/v1/ai-governance/report/board",
+        headers={"x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
…nce Report)

- AIBoardGovernanceReport (kpis, compliance, incidents, supplier, alerts)
- GET /api/v1/ai-governance/report/board orchestriert alle Board-Services
- Frontend: AIBoardGovernanceReport, fetchBoardGovernanceReport, Download-Link Board-Report JSON
- API-Route /api/board/report mit Content-Disposition für ai-board-report-<tenant>-<date>.json
- Tests: test_ai_board_governance_report.py (Happy Path, Tenant-Isolation, 401)

Made-with: Cursor