### PR TITLE
feat(ai-governance): Board-Report Markdown-Export (template-fähig)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -73,6 +73,7 @@ from app.services.ai_governance_suppliers import (
     compute_ai_supplier_risk_by_system,
     compute_ai_supplier_risk_overview,
 )
+from app.services.board_report_markdown import render_board_report_markdown
 from app.services.classification_engine import classify_ai_system
 from app.services.compliance_dashboard import (
     compute_ai_compliance_overview,
@@ -686,6 +687,68 @@ def get_board_governance_report(
         incidents_overview=incidents_overview,
         supplier_risk_overview=supplier_risk_overview,
         alerts=alerts,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/report/board/markdown",
+    response_class=Response,
+)
+def get_board_governance_report_markdown(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
+    violation_repo: Annotated[ViolationRepository, Depends(get_violation_repository)],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+) -> Response:
+    """Board-Report als Markdown (template-fähig, für PDF/Word-Weiterverarbeitung)."""
+    from app.datetime_compat import UTC
+
+    tenant_id = auth_context.tenant_id
+    generated_at = datetime.now(UTC)
+    kpis = compute_ai_board_kpis(
+        tenant_id=tenant_id,
+        ai_system_repository=ai_repo,
+        violation_repository=violation_repo,
+    )
+    compliance_overview = compute_ai_compliance_overview(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+    )
+    incidents_overview = compute_ai_incident_overview(
+        tenant_id=tenant_id,
+        incident_repository=incident_repo,
+    )
+    supplier_risk_overview = compute_ai_supplier_risk_overview(
+        tenant_id=tenant_id,
+        ai_system_repository=ai_repo,
+    )
+    alerts = compute_board_alerts(
+        tenant_id=tenant_id,
+        board_kpis=kpis,
+        compliance_overview=compliance_overview,
+    )
+    report = AIBoardGovernanceReport(
+        tenant_id=tenant_id,
+        generated_at=generated_at,
+        period="last_12_months",
+        kpis=kpis,
+        compliance_overview=compliance_overview,
+        incidents_overview=incidents_overview,
+        supplier_risk_overview=supplier_risk_overview,
+        alerts=alerts,
+    )
+    markdown_content = render_board_report_markdown(report)
+    filename = f"ai-board-report-{tenant_id}-{generated_at.strftime('%Y%m%d')}.md"
+    return Response(
+        content=markdown_content.encode("utf-8"),
+        media_type="text/markdown; charset=utf-8",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
     )
 
 

--- a/app/services/board_report_markdown.py
+++ b/app/services/board_report_markdown.py
@@ -1,0 +1,159 @@
+"""Markdown-Export für AI Board Governance Report (template-fähig, deterministisch)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from app.ai_governance_models import AIBoardGovernanceReport
+
+
+def _fmt_pct(value: float) -> str:
+    return f"{round(value * 100)} %"
+
+
+def _fmt_date(dt: datetime) -> str:
+    return dt.strftime("%d.%m.%Y")
+
+
+def render_board_report_markdown(report: AIBoardGovernanceReport) -> str:
+    """
+    Erzeugt ein strukturiertes Markdown-Dokument aus dem Board-Report.
+    Deterministisch aus Zahlen, keine LLM-Aufrufe. Keine personenbezogenen Daten.
+    """
+    k = report.kpis
+    c = report.compliance_overview
+    i = report.incidents_overview
+    s = report.supplier_risk_overview
+    date_str = _fmt_date(report.generated_at)
+
+    lines: list[str] = [
+        f"# AI Governance Board Report – {report.tenant_id} ({date_str})",
+        "",
+        f"*Berichtszeitraum: {report.period}*",
+        "",
+        "---",
+        "",
+        "## 1. Executive Summary",
+        "",
+    ]
+
+    # Kurze, deterministische Sätze aus KPIs/Alerts
+    lines.append(f"- AI-Systeme gesamt: {k.ai_systems_total} (aktiv: {k.active_ai_systems}).")
+    lines.append(
+        f"- High-Risk-Systeme: {k.high_risk_systems}; "
+        f"davon ohne DPIA: {k.high_risk_systems_without_dpia}."
+    )
+    lines.append(
+        f"- ISO 42001 Governance-Score: {_fmt_pct(k.iso42001_governance_score)}; "
+        f"NIS2 Incident Readiness: {_fmt_pct(k.nis2_incident_readiness_ratio)}; "
+        f"Supplier Risk Coverage: {_fmt_pct(k.nis2_supplier_risk_coverage_ratio)}."
+    )
+    lines.append(
+        f"- EU AI Act / ISO 42001 Gesamt-Readiness: {_fmt_pct(c.overall_readiness)}; "
+        f"Frist High-Risk: {c.days_remaining} Tage (bis {c.deadline})."
+    )
+    lines.append(
+        f"- Offene Incidents (12 Monate): {i.total_incidents_last_12_months}; "
+        f"offen: {i.open_incidents}."
+    )
+    lines.append(
+        f"- Lieferanten-Risiko: {s.systems_without_supplier_risk_register} Systeme ohne "
+        f"Supplier-Risikoregister (von {s.total_systems_with_suppliers} mit Lieferantenbezug)."
+    )
+    if report.alerts:
+        critical = sum(1 for a in report.alerts if a.severity == "critical")
+        lines.append(f"- **{len(report.alerts)} Alert(s)** (davon {critical} kritisch).")
+    else:
+        lines.append("- Keine aktuellen Alerts.")
+    lines.extend(["", "---", "", "## 2. KPIs", ""])
+
+    # KPIs als Tabelle
+    lines.extend(
+        [
+            "| Kennzahl | Wert |",
+            "|----------|------|",
+            f"| Board Maturity Score | {_fmt_pct(k.board_maturity_score)} |",
+            f"| ISO 42001 Governance Score | {_fmt_pct(k.iso42001_governance_score)} |",
+            f"| NIS2 Incident Readiness Ratio | {_fmt_pct(k.nis2_incident_readiness_ratio)} |",
+            f"| NIS2 Supplier Risk Coverage | {_fmt_pct(k.nis2_supplier_risk_coverage_ratio)} |",
+            f"| High-Risk-Systeme ohne DPIA | {k.high_risk_systems_without_dpia} |",
+            f"| Kritische Systeme ohne Owner | {k.critical_systems_without_owner} |",
+            f"| NIS2-Kontrolllücken (gesamt) | {k.nis2_control_gaps} |",
+            "",
+        ]
+    )
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "## 3. Compliance-Readiness EU AI Act / ISO 42001",
+            "",
+            f"- **Gesamt-Readiness:** {_fmt_pct(c.overall_readiness)}",
+            f"- High-Risk-Systeme voll kontrolliert: {c.high_risk_systems_with_full_controls}",
+            f"- High-Risk-Systeme mit kritischen Lücken: {c.high_risk_systems_with_critical_gaps}",
+            f"- Frist (High-Risk): {c.deadline} ({c.days_remaining} Tage verbleibend)",
+            "",
+        ]
+    )
+    if c.top_critical_requirements:
+        lines.append("**Top kritische Anforderungen:**")
+        for req in c.top_critical_requirements[:5]:
+            lines.append(f"- {req.article}: {req.name} – {req.affected_systems_count} System(e)")
+        lines.append("")
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "## 4. Incidents",
+            "",
+            f"- Incidents (letzte 12 Monate): {i.total_incidents_last_12_months}",
+            f"- Offene Incidents: {i.open_incidents}",
+            f"- Schwerwiegende Incidents (12 Monate): {i.major_incidents_last_12_months}",
+            "",
+        ]
+    )
+    if i.mean_time_to_ack_hours is not None:
+        lines.append(f"- Mittlere Zeit bis Bestätigung: {i.mean_time_to_ack_hours:.1f} h")
+    if i.mean_time_to_recover_hours is not None:
+        lines.append(f"- Mittlere Zeit bis Wiederherstellung: {i.mean_time_to_recover_hours:.1f} h")
+    if i.by_severity:
+        lines.append("Nach Schweregrad:")
+        for e in i.by_severity:
+            lines.append(f"- {e.severity}: {e.count}")
+        lines.append("")
+    else:
+        lines.append("")
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "## 5. Supplier-Risiken",
+            "",
+            f"- Systeme mit Lieferantenbezug: {s.total_systems_with_suppliers}",
+            f"- Davon ohne Supplier-Risikoregister: {s.systems_without_supplier_risk_register}",
+            f"- Kritische Lieferanten gesamt: {s.critical_suppliers_total}",
+            f"- Kritische Lieferanten ohne Kontrollen: {s.critical_suppliers_without_controls}",
+            "",
+        ]
+    )
+    if s.by_risk_level:
+        lines.append("| Risikostufe | Mit Register | Ohne Register |")
+        lines.append("|-------------|--------------|---------------|")
+        for e in s.by_risk_level:
+            row = f"| {e.risk_level} | {e.systems_with_register} | {e.systems_without_register} |"
+            lines.append(row)
+        lines.append("")
+    lines.extend(["---", "", "## 6. Alerts & Maßnahmenempfehlungen", ""])
+
+    if report.alerts:
+        for a in report.alerts:
+            lines.append(f"- **[{a.severity.upper()}]** {a.message}")
+        lines.append("")
+    else:
+        lines.append("Keine offenen Alerts.")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/frontend/src/app/api/board/report/markdown/route.ts
+++ b/frontend/src/app/api/board/report/markdown/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.COMPLIANCEHUB_API_BASE_URL || "http://localhost:8000";
+const API_KEY =
+  process.env.COMPLIANCEHUB_API_KEY || "tenant-overview-key";
+const TENANT_ID =
+  process.env.COMPLIANCEHUB_TENANT_ID || "tenant-overview-001";
+
+export async function GET() {
+  const url = `${API_BASE}/api/v1/ai-governance/report/board/markdown`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-tenant-id": TENANT_ID,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: "Markdown-Report konnte nicht geladen werden" },
+      { status: res.status },
+    );
+  }
+  const body = await res.text();
+  const contentDisposition = res.headers.get("content-disposition");
+  const headers = new Headers();
+  headers.set("Content-Type", "text/markdown; charset=utf-8");
+  if (contentDisposition) headers.set("Content-Disposition", contentDisposition);
+  return new NextResponse(body, { status: 200, headers });
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -7,6 +7,7 @@ import {
   fetchBoardKpis,
   fetchBoardAlertsExport,
   getBoardReportDownloadUrl,
+  getBoardReportMarkdownDownloadUrl,
   type AIComplianceOverview,
   type AIKpiAlert,
   type BoardKpiSummary,
@@ -194,6 +195,14 @@ export default async function BoardKpisPage() {
             className="font-medium text-slate-800 underline hover:text-slate-600"
           >
             Board-Report JSON
+          </a>
+          {" · "}
+          <a
+            href={getBoardReportMarkdownDownloadUrl()}
+            download
+            className="font-medium text-slate-800 underline hover:text-slate-600"
+          >
+            Board-Report als Markdown
           </a>
         </p>
       </section>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -291,6 +291,11 @@ export function getBoardReportDownloadUrl(): string {
   return "/api/board/report";
 }
 
+/** Download-URL für Board-Report als Markdown (Vorstand/Aufsicht, template-fähig). */
+export function getBoardReportMarkdownDownloadUrl(): string {
+  return "/api/board/report/markdown";
+}
+
 // ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
 
 export type IncidentSeverityLevel = "low" | "medium" | "high";

--- a/tests/test_ai_board_governance_report_markdown.py
+++ b/tests/test_ai_board_governance_report_markdown.py
@@ -1,0 +1,98 @@
+"""Tests für GET /api/v1/ai-governance/report/board/markdown."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def test_board_report_markdown_happy_path():
+    """Markdown enthält Kapitelüberschriften und eingebettete Werte."""
+    create = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": "md-report-sys",
+            "name": "Markdown Report System",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=_headers(),
+    )
+    assert create.status_code == 200
+
+    response = client.get(
+        "/api/v1/ai-governance/report/board/markdown",
+        headers=_headers(),
+    )
+    assert response.status_code == 200
+    assert "text/markdown" in response.headers.get("content-type", "")
+    assert "attachment" in response.headers.get("content-disposition", "").lower()
+    text = response.text
+    assert "# AI Governance Board Report" in text
+    assert "## 1. Executive Summary" in text
+    assert "## 2. KPIs" in text
+    assert "## 3. Compliance-Readiness" in text
+    assert "## 4. Incidents" in text
+    assert "## 5. Supplier-Risiken" in text
+    assert "## 6. Alerts" in text
+    assert "board-kpi-tenant" in text
+
+
+def test_board_report_markdown_tenant_isolation():
+    """Anderer Tenant erhält eigenes Markdown (tenant_id im Inhalt)."""
+    tenant_a = "md-tenant-a"
+    tenant_b = "md-tenant-b"
+    key = "board-kpi-key"
+    for tid, sys_id in [(tenant_a, "mda-1"), (tenant_b, "mdb-1")]:
+        client.post(
+            "/api/v1/ai-systems",
+            json={
+                "id": sys_id,
+                "name": sys_id,
+                "description": "Test",
+                "business_unit": "Ops",
+                "risk_level": "high",
+                "ai_act_category": "high_risk",
+                "gdpr_dpia_required": False,
+                "owner_email": "",
+                "criticality": "medium",
+                "data_sensitivity": "internal",
+                "has_incident_runbook": False,
+                "has_supplier_risk_register": False,
+                "has_backup_runbook": False,
+            },
+            headers={"x-api-key": key, "x-tenant-id": tid},
+        )
+    r_a = client.get(
+        "/api/v1/ai-governance/report/board/markdown",
+        headers={"x-api-key": key, "x-tenant-id": tenant_a},
+    )
+    r_b = client.get(
+        "/api/v1/ai-governance/report/board/markdown",
+        headers={"x-api-key": key, "x-tenant-id": tenant_b},
+    )
+    assert r_a.status_code == 200 and r_b.status_code == 200
+    assert tenant_a in r_a.text
+    assert tenant_b in r_b.text
+
+
+def test_board_report_markdown_401():
+    """Ohne API-Key wird 401 zurückgegeben."""
+    response = client.get(
+        "/api/v1/ai-governance/report/board/markdown",
+        headers={"x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
- render_board_report_markdown() mit Kapiteln Executive Summary, KPIs, Compliance, Incidents, Supplier, Alerts
- GET /api/v1/ai-governance/report/board/markdown (text/markdown, Content-Disposition)
- Frontend: getBoardReportMarkdownDownloadUrl, API-Route /api/board/report/markdown, Link Board-Report als Markdown
- Tests: test_ai_board_governance_report_markdown.py (Happy Path, Tenant-Isolation, 401)

Made-with: Cursor