### PR TITLE
feat(ai-governance): Board-Report Export-Jobs für PDF/DMS/Webhook-Int…

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -101,3 +101,30 @@ class AIBoardGovernanceReport(BaseModel):
     incidents_overview: AIIncidentOverview
     supplier_risk_overview: AISupplierRiskOverview
     alerts: list[AIKpiAlert]
+
+
+# Export-Job für PDF-/DMS-Integration (Webhook, SAP BTP, SharePoint)
+TargetSystem = Literal["generic_webhook", "sap_btp", "sharepoint"]
+ExportJobStatus = Literal["pending", "sent", "failed"]
+
+
+class BoardReportExportJobCreate(BaseModel):
+    """Request-Body für Anlage eines Board-Report-Export-Jobs."""
+
+    target_system: TargetSystem
+    callback_url: str | None = None
+    metadata: dict[str, str] | None = None
+
+
+class BoardReportExportJob(BaseModel):
+    """Export-Job für Board-Report (in-memory, Tenant-isoliert)."""
+
+    id: str
+    tenant_id: str
+    created_at: datetime
+    status: ExportJobStatus
+    target_system: TargetSystem
+    callback_url: str | None = None
+    metadata: dict[str, str] | None = None
+    error_message: str | None = None
+    completed_at: datetime | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,8 @@ from app.ai_governance_models import (
     AIGovernanceKpiSummary,
     AIKpiAlert,
     AIKpiAlertExport,
+    BoardReportExportJob,
+    BoardReportExportJobCreate,
 )
 from app.ai_system_models import (
     AISystem,
@@ -73,6 +75,7 @@ from app.services.ai_governance_suppliers import (
     compute_ai_supplier_risk_by_system,
     compute_ai_supplier_risk_overview,
 )
+from app.services.board_report_export_jobs import get_job, run_export_job
 from app.services.board_report_markdown import render_board_report_markdown
 from app.services.classification_engine import classify_ai_system
 from app.services.compliance_dashboard import (
@@ -648,45 +651,13 @@ def get_board_governance_report(
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
 ) -> AIBoardGovernanceReport:
     """Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt (nur JSON)."""
-    from app.datetime_compat import UTC
-
-    tenant_id = auth_context.tenant_id
-    generated_at = datetime.now(UTC)
-
-    kpis = compute_ai_board_kpis(
-        tenant_id=tenant_id,
-        ai_system_repository=ai_repo,
-        violation_repository=violation_repo,
-    )
-    compliance_overview = compute_ai_compliance_overview(
-        tenant_id=tenant_id,
+    return _build_board_report(
+        tenant_id=auth_context.tenant_id,
         ai_repo=ai_repo,
         cls_repo=cls_repo,
         gap_repo=gap_repo,
-    )
-    incidents_overview = compute_ai_incident_overview(
-        tenant_id=tenant_id,
-        incident_repository=incident_repo,
-    )
-    supplier_risk_overview = compute_ai_supplier_risk_overview(
-        tenant_id=tenant_id,
-        ai_system_repository=ai_repo,
-    )
-    alerts = compute_board_alerts(
-        tenant_id=tenant_id,
-        board_kpis=kpis,
-        compliance_overview=compliance_overview,
-    )
-
-    return AIBoardGovernanceReport(
-        tenant_id=tenant_id,
-        generated_at=generated_at,
-        period="last_12_months",
-        kpis=kpis,
-        compliance_overview=compliance_overview,
-        incidents_overview=incidents_overview,
-        supplier_risk_overview=supplier_risk_overview,
-        alerts=alerts,
+        violation_repo=violation_repo,
+        incident_repo=incident_repo,
     )
 
 
@@ -703,9 +674,36 @@ def get_board_governance_report_markdown(
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
 ) -> Response:
     """Board-Report als Markdown (template-fähig, für PDF/Word-Weiterverarbeitung)."""
+    report = _build_board_report(
+        tenant_id=auth_context.tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+        violation_repo=violation_repo,
+        incident_repo=incident_repo,
+    )
+    markdown_content = render_board_report_markdown(report)
+    filename = f"ai-board-report-{report.tenant_id}-{report.generated_at.strftime('%Y%m%d')}.md"
+    return Response(
+        content=markdown_content.encode("utf-8"),
+        media_type="text/markdown; charset=utf-8",
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )
+
+
+def _build_board_report(
+    tenant_id: str,
+    ai_repo: AISystemRepository,
+    cls_repo: ClassificationRepository,
+    gap_repo: ComplianceGapRepository,
+    violation_repo: ViolationRepository,
+    incident_repo: IncidentRepository,
+) -> AIBoardGovernanceReport:
+    """Orchestriert alle Services und liefert AIBoardGovernanceReport."""
     from app.datetime_compat import UTC
 
-    tenant_id = auth_context.tenant_id
     generated_at = datetime.now(UTC)
     kpis = compute_ai_board_kpis(
         tenant_id=tenant_id,
@@ -731,7 +729,7 @@ def get_board_governance_report_markdown(
         board_kpis=kpis,
         compliance_overview=compliance_overview,
     )
-    report = AIBoardGovernanceReport(
+    return AIBoardGovernanceReport(
         tenant_id=tenant_id,
         generated_at=generated_at,
         period="last_12_months",
@@ -741,15 +739,57 @@ def get_board_governance_report_markdown(
         supplier_risk_overview=supplier_risk_overview,
         alerts=alerts,
     )
-    markdown_content = render_board_report_markdown(report)
-    filename = f"ai-board-report-{tenant_id}-{generated_at.strftime('%Y%m%d')}.md"
-    return Response(
-        content=markdown_content.encode("utf-8"),
-        media_type="text/markdown; charset=utf-8",
-        headers={
-            "Content-Disposition": f'attachment; filename="{filename}"',
-        },
+
+
+@app.post(
+    "/api/v1/ai-governance/report/board/export-jobs",
+    response_model=BoardReportExportJob,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_board_report_export_job(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
+    violation_repo: Annotated[ViolationRepository, Depends(get_violation_repository)],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+    body: BoardReportExportJobCreate,
+) -> BoardReportExportJob:
+    """Erstellt Export-Job (Report + Markdown), optional Webhook-POST an callback_url."""
+    if body.target_system == "generic_webhook" and not body.callback_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="callback_url required for target_system generic_webhook",
+        )
+    tenant_id = auth_context.tenant_id
+    report = _build_board_report(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+        violation_repo=violation_repo,
+        incident_repo=incident_repo,
     )
+    job = run_export_job(tenant_id=tenant_id, report=report, body=body)
+    return job
+
+
+@app.get(
+    "/api/v1/ai-governance/report/board/export-jobs/{job_id}",
+    response_model=BoardReportExportJob,
+)
+def get_board_report_export_job(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    job_id: str,
+) -> BoardReportExportJob:
+    """Liefert Export-Job-Status (Tenant-isoliert)."""
+    job = get_job(job_id, auth_context.tenant_id)
+    if job is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Export job not found",
+        )
+    return job
 
 
 @app.get(

--- a/app/services/board_report_export_jobs.py
+++ b/app/services/board_report_export_jobs.py
@@ -1,0 +1,119 @@
+"""Export-Jobs für Board-Report (PDF-/DMS-Integration, generischer Webhook)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime
+
+import httpx
+
+from app.ai_governance_models import (
+    AIBoardGovernanceReport,
+    BoardReportExportJob,
+    BoardReportExportJobCreate,
+    ExportJobStatus,
+)
+from app.services.board_report_markdown import render_board_report_markdown
+
+logger = logging.getLogger(__name__)
+
+# In-memory Store (Tenant-isoliert, nur Job-Metadaten)
+_jobs: dict[str, BoardReportExportJob] = {}
+
+WEBHOOK_TIMEOUT_SEC = 10.0
+
+
+def store_job(job: BoardReportExportJob) -> None:
+    _jobs[job.id] = job
+
+
+def get_job(job_id: str, tenant_id: str) -> BoardReportExportJob | None:
+    job = _jobs.get(job_id)
+    if job is None or job.tenant_id != tenant_id:
+        return None
+    return job
+
+
+def _post_webhook(url: str, payload: dict) -> tuple[bool, str]:
+    """Sendet Payload per POST an url. Returns (success, error_message)."""
+    try:
+        with httpx.Client(timeout=WEBHOOK_TIMEOUT_SEC) as client:
+            r = client.post(url, json=payload)
+            if r.is_success:
+                return True, ""
+            return False, f"HTTP {r.status_code}"
+    except httpx.TimeoutException:
+        return False, "Timeout"
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)[:200]
+
+
+def run_export_job(
+    tenant_id: str,
+    report: AIBoardGovernanceReport,
+    body: BoardReportExportJobCreate,
+) -> BoardReportExportJob:
+    """
+    Erstellt Job, optional Webhook-POST, speichert Job. Keine personenbezogenen Daten.
+    """
+    from app.datetime_compat import UTC
+
+    now = datetime.now(UTC)
+    job_id = str(uuid.uuid4())
+    status: ExportJobStatus = "pending"
+    error_message: str | None = None
+    completed_at: datetime | None = None
+
+    if body.target_system == "generic_webhook" and body.callback_url:
+        markdown = render_board_report_markdown(report)
+        payload = {
+            "job": {
+                "id": job_id,
+                "tenant_id": tenant_id,
+                "created_at": now.isoformat(),
+                "target_system": body.target_system,
+            },
+            "report": report.model_dump(mode="json"),
+            "markdown": markdown,
+        }
+        ok, err = _post_webhook(body.callback_url, payload)
+        completed_at = datetime.now(UTC)
+        if ok:
+            status = "sent"
+            logger.info(
+                "Export job %s webhook sent target=%s",
+                job_id,
+                body.target_system,
+            )
+        else:
+            status = "failed"
+            error_message = err
+            logger.warning(
+                "Export job %s webhook failed target=%s error=%s",
+                job_id,
+                body.target_system,
+                err,
+            )
+    else:
+        status = "sent"
+        completed_at = now
+        logger.info(
+            "Export job %s created (no webhook) target=%s",
+            job_id,
+            body.target_system,
+        )
+
+    job = BoardReportExportJob(
+        id=job_id,
+        tenant_id=tenant_id,
+        created_at=now,
+        status=status,
+        target_system=body.target_system,
+        callback_url=body.callback_url,
+        metadata=body.metadata,
+        error_message=error_message,
+        completed_at=completed_at,
+    )
+    store_job(job)
+    return job

--- a/frontend/src/app/board/kpis/BoardReportExportForm.tsx
+++ b/frontend/src/app/board/kpis/BoardReportExportForm.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  createBoardReportExportJob,
+  type BoardReportExportJob,
+  type BoardReportTargetSystem,
+} from "@/lib/api";
+
+const TARGET_LABELS: Record<BoardReportTargetSystem, string> = {
+  generic_webhook: "Generischer Webhook",
+  sap_btp: "SAP BTP",
+  sharepoint: "SharePoint",
+};
+
+export function BoardReportExportForm() {
+  const [targetSystem, setTargetSystem] =
+    useState<BoardReportTargetSystem>("generic_webhook");
+  const [callbackUrl, setCallbackUrl] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [lastJob, setLastJob] = useState<BoardReportExportJob | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    setLastJob(null);
+
+    if (targetSystem === "generic_webhook" && !callbackUrl.trim()) {
+      setError("Bei „Generischer Webhook“ ist eine Callback-URL erforderlich.");
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const job = await createBoardReportExportJob({
+        target_system: targetSystem,
+        callback_url:
+          targetSystem === "generic_webhook" ? callbackUrl.trim() || null : null,
+      });
+      setLastJob(job);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Export fehlgeschlagen. Bitte erneut versuchen."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <section
+      aria-label="Externer Export"
+      className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+        Externer Export
+      </h2>
+      <p className="mt-1 text-xs text-slate-500">
+        Vorbereitung für PDF-/DMS-/SAP-BTP-Integration: Board-Report (JSON +
+        Markdown) an ein externes System senden (z. B. Webhook für
+        Weiterverarbeitung oder Archiv).
+      </p>
+
+      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+        <div>
+          <label
+            htmlFor="board-export-target"
+            className="block text-xs font-medium text-slate-700"
+          >
+            Zielsystem
+          </label>
+          <select
+            id="board-export-target"
+            value={targetSystem}
+            onChange={(e) =>
+              setTargetSystem(e.target.value as BoardReportTargetSystem)
+            }
+            className="mt-1 block w-full max-w-md rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+          >
+            <option value="generic_webhook">
+              {TARGET_LABELS.generic_webhook}
+            </option>
+          </select>
+        </div>
+
+        {targetSystem === "generic_webhook" && (
+          <div>
+            <label
+              htmlFor="board-export-callback-url"
+              className="block text-xs font-medium text-slate-700"
+            >
+              Callback-URL <span className="text-red-600">*</span>
+            </label>
+            <input
+              id="board-export-callback-url"
+              type="url"
+              value={callbackUrl}
+              onChange={(e) => setCallbackUrl(e.target.value)}
+              placeholder="https://..."
+              className="mt-1 block w-full max-w-md rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
+              required={targetSystem === "generic_webhook"}
+            />
+          </div>
+        )}
+
+        {error && (
+          <div
+            role="alert"
+            className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+          >
+            {error}
+          </div>
+        )}
+
+        {lastJob && (
+          <div
+            className={`rounded-lg border px-3 py-2 text-sm ${
+              lastJob.status === "failed"
+                ? "border-red-200 bg-red-50 text-red-800"
+                : "border-emerald-200 bg-emerald-50 text-emerald-800"
+            }`}
+          >
+            <p className="font-medium">
+              {lastJob.status === "sent"
+                ? "Export erfolgreich gesendet."
+                : "Export fehlgeschlagen."}
+            </p>
+            <p className="mt-1 text-xs">
+              Job-ID: {lastJob.id} · Status: {lastJob.status}
+              {lastJob.error_message && ` · ${lastJob.error_message}`}
+            </p>
+          </div>
+        )}
+
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+        >
+          {loading
+            ? "Wird gesendet…"
+            : "Board-Report an externes System senden"}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -13,6 +13,8 @@ import {
   type BoardKpiSummary,
 } from "@/lib/api";
 
+import { BoardReportExportForm } from "./BoardReportExportForm";
+
 function scoreColor(score: number): string {
   if (score < 0.4) return "bg-red-50 text-red-800 border-red-100";
   if (score <= 0.7) return "bg-amber-50 text-amber-800 border-amber-100";
@@ -465,6 +467,11 @@ export default async function BoardKpisPage() {
           </p>
         </section>
       )}
+
+      {/* Externer Export (Webhook / DMS / SAP BTP) */}
+      <section className="mb-8">
+        <BoardReportExportForm />
+      </section>
 
       <ManagementSummary kpis={kpis} />
     </main>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -296,6 +296,50 @@ export function getBoardReportMarkdownDownloadUrl(): string {
   return "/api/board/report/markdown";
 }
 
+// ─── Board-Report Export-Jobs (PDF-/DMS-/SAP-BTP-Integration) ─────────────────
+
+export type BoardReportTargetSystem =
+  | "generic_webhook"
+  | "sap_btp"
+  | "sharepoint";
+
+export type BoardReportExportJobStatus = "pending" | "sent" | "failed";
+
+export interface BoardReportExportJobCreate {
+  target_system: BoardReportTargetSystem;
+  callback_url?: string | null;
+  metadata?: Record<string, string> | null;
+}
+
+export interface BoardReportExportJob {
+  id: string;
+  tenant_id: string;
+  created_at: string;
+  status: BoardReportExportJobStatus;
+  target_system: BoardReportTargetSystem;
+  callback_url: string | null;
+  metadata: Record<string, string> | null;
+  error_message: string | null;
+  completed_at: string | null;
+}
+
+export async function createBoardReportExportJob(
+  payload: BoardReportExportJobCreate
+): Promise<BoardReportExportJob> {
+  return apiFetch("/api/v1/ai-governance/report/board/export-jobs", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchBoardReportExportJobStatus(
+  jobId: string
+): Promise<BoardReportExportJob> {
+  return apiFetch(
+    `/api/v1/ai-governance/report/board/export-jobs/${jobId}`
+  );
+}
+
 // ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
 
 export type IncidentSeverityLevel = "low" | "medium" | "high";

--- a/tests/test_ai_board_report_export_jobs.py
+++ b/tests/test_ai_board_report_export_jobs.py
@@ -1,0 +1,196 @@
+"""Tests für Board-Report-Export-Jobs (POST/GET, Webhook optional, Tenant-Isolation)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.board_report_export_jobs import _jobs
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def _tenant_headers(tenant_id: str = "board-kpi-tenant") -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": tenant_id,
+    }
+
+
+def setup_ai_system(
+    tenant_id: str = "board-kpi-tenant",
+    system_id: str | None = None,
+) -> None:
+    """Legt ein AI-System an (eindeutige system_id pro Test wegen gemeinsamer DB)."""
+    sid = system_id or "export-test-sys"
+    client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": sid,
+            "name": "Export Test",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=_tenant_headers(tenant_id),
+    )
+
+
+def test_create_export_job_no_webhook():
+    """Happy Path: Job ohne externen Call (z.B. target_system=sap_btp)."""
+    _jobs.clear()
+    setup_ai_system(system_id="export-job-no-webhook")
+
+    response = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "sap_btp"},
+        headers=_headers(),
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert data["status"] == "sent"
+    assert data["target_system"] == "sap_btp"
+    assert "id" in data
+    assert "created_at" in data
+    assert data.get("callback_url") is None
+
+
+def test_create_export_job_generic_webhook_missing_callback():
+    """generic_webhook ohne callback_url → 400."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "generic_webhook"},
+        headers=_headers(),
+    )
+    assert response.status_code == 400
+    assert "callback_url" in response.json().get("detail", "").lower()
+
+
+def test_create_export_job_generic_webhook_success():
+    """Happy Path mit generic_webhook: Mock HTTP POST, Job status sent."""
+    _jobs.clear()
+    setup_ai_system(system_id="export-job-webhook-ok")
+
+    with patch(
+        "app.services.board_report_export_jobs._post_webhook",
+        return_value=(True, ""),
+    ):
+        response = client.post(
+            "/api/v1/ai-governance/report/board/export-jobs",
+            json={
+                "target_system": "generic_webhook",
+                "callback_url": "https://example.com/webhook",
+            },
+            headers=_headers(),
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["status"] == "sent"
+    assert data["target_system"] == "generic_webhook"
+    assert data.get("callback_url") == "https://example.com/webhook"
+
+
+def test_create_export_job_webhook_failure():
+    """Webhook schlägt fehl → Job status failed, error_message gesetzt."""
+    _jobs.clear()
+    setup_ai_system(system_id="export-job-webhook-fail")
+
+    with patch(
+        "app.services.board_report_export_jobs._post_webhook",
+        return_value=(False, "Connection refused"),
+    ):
+        response = client.post(
+            "/api/v1/ai-governance/report/board/export-jobs",
+            json={
+                "target_system": "generic_webhook",
+                "callback_url": "https://example.com/webhook",
+            },
+            headers=_headers(),
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["status"] == "failed"
+    assert "Connection refused" in (data.get("error_message") or "")
+
+
+def test_get_export_job_status():
+    """GET liefert Job-Status nach Erstellung."""
+    _jobs.clear()
+    setup_ai_system(system_id="export-job-get-status")
+    create = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "sharepoint"},
+        headers=_headers(),
+    )
+    assert create.status_code == 201
+    job_id = create.json()["id"]
+
+    get_resp = client.get(
+        f"/api/v1/ai-governance/report/board/export-jobs/{job_id}",
+        headers=_headers(),
+    )
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["id"] == job_id
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert data["status"] == "sent"
+
+
+def test_get_export_job_404_unknown():
+    """GET mit unbekannter job_id → 404."""
+    response = client.get(
+        "/api/v1/ai-governance/report/board/export-jobs/00000000-0000-0000-0000-000000000000",
+        headers=_headers(),
+    )
+    assert response.status_code == 404
+
+
+def test_export_job_tenant_isolation():
+    """Job mit Tenant A erstellt, GET mit Tenant B → 404."""
+    _jobs.clear()
+    setup_ai_system("tenant-export-a", system_id="export-job-tenant-a")
+    create = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "sap_btp"},
+        headers=_tenant_headers("tenant-export-a"),
+    )
+    assert create.status_code == 201
+    job_id = create.json()["id"]
+
+    get_b = client.get(
+        f"/api/v1/ai-governance/report/board/export-jobs/{job_id}",
+        headers=_tenant_headers("tenant-export-b"),
+    )
+    assert get_b.status_code == 404
+
+
+def test_export_job_401_no_api_key():
+    """POST ohne gültigen API-Key → 401."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "sap_btp"},
+        headers={"x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401
+
+
+def test_export_job_401_invalid_api_key():
+    """POST mit ungültigem API-Key → 401."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "sap_btp"},
+        headers={"x-api-key": "invalid-key", "x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
…egration

- POST/GET /api/v1/ai-governance/report/board/export-jobs
- BoardReportExportJob-Modell, in-memory Store, optional generic_webhook HTTP POST
- Frontend: Externer Export (Generischer Webhook, Callback-URL), Status/Fehler
- Tests: Happy Path, Webhook-Mock, Validierung, 401, Tenant-Isolation

Made-with: Cursor