### PR TITLE
feat(ai-governance): DATEV/Steuerkanzlei-DMS-Export (datev_dms_prepared)

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -111,6 +111,7 @@ TargetSystem = Literal[
     "sharepoint",
     "sap_btp_http",  # SAP BTP HTTP-Inbound / Cloud Integration
     "dms_generic",  # DMS/Archiv (Platzhalter)
+    "datev_dms_prepared",  # Steuerberater/WP-Kanzlei, DATEV-/DMS-Ready
 ]
 ExportJobStatus = Literal["pending", "sent", "failed", "not_implemented"]
 

--- a/app/main.py
+++ b/app/main.py
@@ -766,6 +766,11 @@ def create_board_report_export_job(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="callback_url required for target_system sap_btp_http",
         )
+    if body.target_system == "datev_dms_prepared" and not body.callback_url:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="callback_url required for target_system datev_dms_prepared",
+        )
     tenant_id = auth_context.tenant_id
     report = _build_board_report(
         tenant_id=tenant_id,

--- a/app/services/board_report_export_jobs.py
+++ b/app/services/board_report_export_jobs.py
@@ -24,6 +24,19 @@ _jobs: dict[str, BoardReportExportJob] = {}
 WEBHOOK_TIMEOUT_SEC = 10.0
 SAP_BTP_HTTP_HEADER = "X-ComplianceHub-Integration"
 SAP_BTP_HTTP_HEADER_VALUE = "sap_btp_http"
+DATEV_DMS_PREPARED_HEADER_VALUE = "datev_dms_prepared"
+
+# Steuerkanzlei/DATEV-DMS: erwartete Metadata-Keys (optional, aus body.metadata)
+DATEV_META_MANDANT_NR = "mandant_nr"
+DATEV_META_MANDANT_NAME = "mandant_name"
+DATEV_META_AKTENZEICHEN = "aktenzeichen"
+DATEV_META_PRUEFUNGSAUFTRAG_ID = "pruefungsauftrag_id"
+DATEV_META_BERICHTSZEITRAUM_VON = "berichtszeitraum_von"
+DATEV_META_BERICHTSZEITRAUM_BIS = "berichtszeitraum_bis"
+DATEV_META_NORMBEZUG = "normbezug"
+DATEV_META_DOKUMENT_TYP = "dokument_typ"
+DEFAULT_NORMBEZUG = ["EU AI Act", "NIS2", "ISO 42001"]
+DEFAULT_DOKUMENT_TYP = "AI Governance Board Report"
 
 
 def store_job(job: BoardReportExportJob) -> None:
@@ -87,6 +100,86 @@ def _build_sap_btp_http_payload(
     }
 
 
+def _parse_normbezug(meta: dict[str, str] | None) -> list[str]:
+    """Normbezug aus metadata: kommagetrennt oder Default-Liste."""
+    if not meta or DATEV_META_NORMBEZUG not in meta:
+        return list(DEFAULT_NORMBEZUG)
+    raw = meta.get(DATEV_META_NORMBEZUG, "").strip()
+    if not raw:
+        return list(DEFAULT_NORMBEZUG)
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def _build_datev_dms_prepared_payload(
+    job_id: str,
+    tenant_id: str,
+    created_at: datetime,
+    report: AIBoardGovernanceReport,
+    markdown: str,
+    body: BoardReportExportJobCreate,
+) -> dict:
+    """
+    Deterministisches Payload-Schema für Steuerberater/WP-Kanzlei (DATEV-/DMS-Ready).
+    Nutzt body.metadata für Mandant, Aktenzeichen, Zeitraum, Normbezug, dokument_typ.
+    """
+    meta = body.metadata or {}
+    gen_at = report.generated_at
+    gen_at_str = gen_at.isoformat() if hasattr(gen_at, "isoformat") else str(gen_at)
+
+    mandant_nr = meta.get(DATEV_META_MANDANT_NR) or tenant_id
+    mandant_name = meta.get(DATEV_META_MANDANT_NAME) or ""
+    aktenzeichen = (
+        meta.get(DATEV_META_AKTENZEICHEN) or meta.get(DATEV_META_PRUEFUNGSAUFTRAG_ID) or ""
+    )
+    zeitraum_von = meta.get(DATEV_META_BERICHTSZEITRAUM_VON) or ""
+    zeitraum_bis = meta.get(DATEV_META_BERICHTSZEITRAUM_BIS) or ""
+    dokument_typ = meta.get(DATEV_META_DOKUMENT_TYP) or DEFAULT_DOKUMENT_TYP
+    normbezug = _parse_normbezug(meta)
+
+    k = report.kpis
+    # Risiko-Level vereinfacht aus Reifegrad (0–1): low/medium/high
+    if k.board_maturity_score >= 0.7:
+        risiko_level = "low"
+    elif k.board_maturity_score >= 0.4:
+        risiko_level = "medium"
+    else:
+        risiko_level = "high"
+
+    summary = {
+        "ai_systems_total": k.ai_systems_total,
+        "active_ai_systems": k.active_ai_systems,
+        "high_risk_systems": k.high_risk_systems,
+        "board_maturity_score": k.board_maturity_score,
+        "risiko_level": risiko_level,
+    }
+
+    return {
+        "mandant": {
+            "mandant_nr": mandant_nr,
+            "mandant_name": mandant_name,
+            "aktenzeichen": aktenzeichen,
+        },
+        "bericht": {
+            "typ": dokument_typ,
+            "zeitraum": {
+                "period": report.period,
+                "von": zeitraum_von,
+                "bis": zeitraum_bis,
+                "generated_at": gen_at_str,
+            },
+            "normbezug": normbezug,
+        },
+        "content": {
+            "markdown": markdown,
+            "summary": summary,
+        },
+        "technisch": {
+            "tenant_id": tenant_id,
+            "export_job_id": job_id,
+        },
+    }
+
+
 def dispatch_board_report_export_job(
     job_id: str,
     tenant_id: str,
@@ -98,8 +191,8 @@ def dispatch_board_report_export_job(
     Führt den Export je nach target_system aus.
     Returns (status, error_message).
     - generic_webhook: HTTP POST auf callback_url (Payload: job, report, markdown).
-    - sap_btp_http: HTTP POST mit Header X-ComplianceHub-Integration: sap_btp_http,
-      Payload tenant_id, report_period, markdown, report_metadata.
+    - sap_btp_http: HTTP POST mit Header, Payload tenant_id, report_period, markdown.
+    - datev_dms_prepared: HTTP POST mit Header, Payload mandant/bericht/content/technisch.
     - dms_generic: Platzhalter → not_implemented.
     - sap_btp / sharepoint: Kein Aufruf → sent (Backward-Kompatibilität).
     """
@@ -126,6 +219,17 @@ def dispatch_board_report_export_job(
         markdown = render_board_report_markdown(report)
         payload = _build_sap_btp_http_payload(job_id, tenant_id, created_at, report, markdown)
         headers = {SAP_BTP_HTTP_HEADER: SAP_BTP_HTTP_HEADER_VALUE}
+        ok, err = _post_with_headers(body.callback_url, payload, headers)
+        return ("sent", None) if ok else ("failed", err)
+
+    if body.target_system == "datev_dms_prepared":
+        if not body.callback_url:
+            return "failed", "callback_url required for target_system datev_dms_prepared"
+        markdown = render_board_report_markdown(report)
+        payload = _build_datev_dms_prepared_payload(
+            job_id, tenant_id, created_at, report, markdown, body
+        )
+        headers = {SAP_BTP_HTTP_HEADER: DATEV_DMS_PREPARED_HEADER_VALUE}
         ok, err = _post_with_headers(body.callback_url, payload, headers)
         return ("sent", None) if ok else ("failed", err)
 

--- a/docs/integration/steuerkanzlei-datev-dms-integration.md
+++ b/docs/integration/steuerkanzlei-datev-dms-integration.md
@@ -1,0 +1,79 @@
+# Steuerkanzlei / DATEV-DMS – Board-Report-Export
+
+**Blueprint-Dokumentation.** Beschreibung der auf Steuerberater und WP-Kanzleien ausgerichteten Export-Variante für den AI-Governance-Board-Report: Mandanten-Akte, Prüfungsdokumentation, Nachweise zu EU AI Act, NIS2 und ISO 42001. **DATEV-/DMS-Ready-Format** – keine offizielle DATEV-API-Integration, aber klar strukturiert für spätere Anbindung (z. B. DATEV-Connector, Kanzlei-DMS).
+
+---
+
+## 1. Anwendungsfall
+
+- **Mandanten-Akten:** Board-Report als Prüfungs-/Governance-Dokument einem Mandanten (Mandantennummer, -name, Aktenzeichen) zuordnen.
+- **Prüfungsdokumentation:** Nachweis für WP-Prüfungen und Compliance-Reporting (EU AI Act, NIS2, ISO 42001).
+- **DMS/Archiv:** Ablage in Kanzlei-DMS oder DATEV-nahen Systemen mit strukturierten Metadaten (Zeitraum, Normbezug, Dokumenttyp).
+
+ComplianceHub erzeugt einen deterministischen JSON-Payload und sendet ihn per HTTP POST an eine konfigurierbare Callback-URL (z. B. Middleware oder Connector zur DATEV-/DMS-Anbindung).
+
+---
+
+## 2. target_system: datev_dms_prepared
+
+Beim Anlegen eines Export-Jobs wird `target_system: "datev_dms_prepared"` gewählt. **callback_url** ist Pflicht. Optionale **metadata**-Felder steuern Mandant, Aktenzeichen, Zeitraum und Normbezug (siehe Abschnitt 3).
+
+---
+
+## 3. Metadaten-Schema (Job-metadata)
+
+Die folgenden Keys können im Request-Body unter `metadata` (dict) übergeben werden. Alle Werte sind optional; fehlende werden mit Defaults gefüllt.
+
+| Key | Typ | Beschreibung | Default |
+|-----|-----|--------------|---------|
+| `mandant_nr` | string | Mandantennummer / Kanzlei-Referenz | `tenant_id` |
+| `mandant_name` | string | Anzeigename Mandant | leer |
+| `aktenzeichen` | string | Aktenzeichen für die Ablage | leer |
+| `pruefungsauftrag_id` | string | Alternative zu Aktenzeichen (Prüfungsauftrag) | – |
+| `berichtszeitraum_von` | string | Beginn Berichtszeitraum (z. B. YYYY-MM-DD) | leer |
+| `berichtszeitraum_bis` | string | Ende Berichtszeitraum | leer |
+| `normbezug` | string | Kommagetrennte Normen | „EU AI Act,NIS2,ISO 42001“ |
+| `dokument_typ` | string | Dokumenttyp für DMS | „AI Governance Board Report“ |
+
+---
+
+## 4. Payload-Schema (HTTP POST)
+
+Der an die **callback_url** gesendete JSON-Body hat folgende Struktur. Keine personenbezogenen Daten, nur Aggregat- und Systemdaten.
+
+| Top-Level-Key | Inhalt |
+|---------------|--------|
+| **mandant** | `mandant_nr`, `mandant_name`, `aktenzeichen` |
+| **bericht** | `typ` (Dokumenttyp), `zeitraum` (period, von, bis, generated_at), `normbezug` (Array) |
+| **content** | `markdown` (vollständiger Report), `summary` (z. B. ai_systems_total, board_maturity_score, risiko_level) |
+| **technisch** | `tenant_id`, `export_job_id` |
+
+**Header:** `X-ComplianceHub-Integration: datev_dms_prepared`
+
+---
+
+## 5. Mapping-Vorschlag auf DATEV-/DMS-Felder
+
+| ComplianceHub-Payload | Typisches DATEV-/DMS-Feld / Verwendung |
+|-----------------------|----------------------------------------|
+| `mandant.mandant_nr` | Mandantennummer / Mandanten-ID |
+| `mandant.mandant_name` | Bezeichnung Mandant / Akte |
+| `mandant.aktenzeichen` | Aktenzeichen / Vorgangsnummer |
+| `bericht.typ` | Dokumentart / Belegtyp |
+| `bericht.zeitraum.von` / `.bis` | Zeitraum für Archiv/Prüfung |
+| `bericht.normbezug` | Schlagwörter / Normen (EU AI Act, NIS2, …) |
+| `content.markdown` | Dokumentinhalt (z. B. für PDF-Erzeugung) |
+| `content.summary` | Kurzinfos für Listen/Übersichten |
+| `technisch.export_job_id` | Referenz für Nachverfolgbarkeit |
+
+Konkrete Zuordnung hängt vom jeweiligen DMS bzw. DATEV-Connector ab.
+
+---
+
+## 6. Hinweis zur DATEV-Integration
+
+Dieses Format ist **„DATEV-/DMS-Ready“**: strukturiert und für die Weiterverarbeitung durch einen späteren **DATEV-Connector** oder Kanzlei-DMS vorbereitet. Es **ersetzt keine** offizielle DATEV-API-Integration. Für eine produktive Anbindung an DATEV sind die offiziellen DATEV-Schnittstellen und -Vereinbarungen zu beachten.
+
+---
+
+*Dokumentation: ComplianceHub Integration Blueprint – Steuerkanzlei / DATEV-DMS.*

--- a/frontend/src/app/board/kpis/BoardReportExportForm.tsx
+++ b/frontend/src/app/board/kpis/BoardReportExportForm.tsx
@@ -13,40 +13,58 @@ const TARGET_LABELS: Record<BoardReportTargetSystem, string> = {
   sharepoint: "SharePoint",
   sap_btp_http: "SAP BTP HTTP",
   dms_generic: "DMS (generisch – vorbereitet)",
+  datev_dms_prepared: "Steuerkanzlei / DATEV-DMS (vorbereitet)",
 };
 
 export function BoardReportExportForm() {
   const [targetSystem, setTargetSystem] =
     useState<BoardReportTargetSystem>("generic_webhook");
   const [callbackUrl, setCallbackUrl] = useState("");
+  const [metadata, setMetadata] = useState({
+    mandant_nr: "",
+    mandant_name: "",
+    aktenzeichen: "",
+    berichtszeitraum_von: "",
+    berichtszeitraum_bis: "",
+  });
   const [loading, setLoading] = useState(false);
   const [lastJob, setLastJob] = useState<BoardReportExportJob | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  const needsCallback =
+    targetSystem === "generic_webhook" ||
+    targetSystem === "sap_btp_http" ||
+    targetSystem === "datev_dms_prepared";
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
     setLastJob(null);
 
-    const needsCallback =
-      targetSystem === "generic_webhook" || targetSystem === "sap_btp_http";
     if (needsCallback && !callbackUrl.trim()) {
-      setError(
-        targetSystem === "sap_btp_http"
-          ? "Bei „SAP BTP HTTP“ ist eine Callback-URL erforderlich."
-          : "Bei „Generischer Webhook“ ist eine Callback-URL erforderlich."
-      );
+      const messages: Record<string, string> = {
+        generic_webhook: "Bei „Generischer Webhook“ ist eine Callback-URL erforderlich.",
+        sap_btp_http: "Bei „SAP BTP HTTP“ ist eine Callback-URL erforderlich.",
+        datev_dms_prepared:
+          "Bei „Steuerkanzlei / DATEV-DMS“ ist eine Callback-URL erforderlich.",
+      };
+      setError(messages[targetSystem] ?? "Callback-URL erforderlich.");
       return;
     }
+
+    const meta =
+      targetSystem === "datev_dms_prepared"
+        ? Object.fromEntries(
+            Object.entries(metadata).filter(([, v]) => v.trim() !== "")
+          )
+        : undefined;
 
     setLoading(true);
     try {
       const job = await createBoardReportExportJob({
         target_system: targetSystem,
-        callback_url:
-          targetSystem === "generic_webhook" || targetSystem === "sap_btp_http"
-            ? callbackUrl.trim() || null
-            : null,
+        callback_url: needsCallback ? callbackUrl.trim() || null : null,
+        metadata: meta && Object.keys(meta).length > 0 ? meta : undefined,
       });
       setLastJob(job);
     } catch (err) {
@@ -93,6 +111,9 @@ export function BoardReportExportForm() {
             </option>
             <option value="sap_btp_http">{TARGET_LABELS.sap_btp_http}</option>
             <option value="dms_generic">{TARGET_LABELS.dms_generic}</option>
+            <option value="datev_dms_prepared">
+              {TARGET_LABELS.datev_dms_prepared}
+            </option>
           </select>
           {targetSystem === "sap_btp_http" && (
             <p className="mt-1 text-xs text-slate-500">
@@ -104,9 +125,15 @@ export function BoardReportExportForm() {
               DMS-/Archiv-Anbindung vorbereitet; Integration folgt.
             </p>
           )}
+          {targetSystem === "datev_dms_prepared" && (
+            <p className="mt-1 text-xs text-slate-500">
+              Optimiert für Weiterleitung an DATEV-/Kanzlei-DMS (Mandanten-Akte,
+              Prüfungsdokumentation, EU-AI-Act-/NIS2-Nachweise).
+            </p>
+          )}
         </div>
 
-        {(targetSystem === "generic_webhook" || targetSystem === "sap_btp_http") && (
+        {needsCallback && (
           <div>
             <label
               htmlFor="board-export-callback-url"
@@ -121,11 +148,69 @@ export function BoardReportExportForm() {
               onChange={(e) => setCallbackUrl(e.target.value)}
               placeholder="https://..."
               className="mt-1 block w-full max-w-md rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-1 focus:ring-slate-500"
-              required={
-                targetSystem === "generic_webhook" ||
-                targetSystem === "sap_btp_http"
-              }
+              required={needsCallback}
             />
+          </div>
+        )}
+
+        {targetSystem === "datev_dms_prepared" && (
+          <div className="space-y-3 rounded-lg border border-slate-100 bg-slate-50/50 p-3">
+            <p className="text-xs font-medium text-slate-600">
+              Optionale Metadaten (Mandant, Aktenzeichen, Zeitraum)
+            </p>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <input
+                type="text"
+                value={metadata.mandant_nr}
+                onChange={(e) =>
+                  setMetadata((m) => ({ ...m, mandant_nr: e.target.value }))
+                }
+                placeholder="Mandantennummer"
+                className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              />
+              <input
+                type="text"
+                value={metadata.mandant_name}
+                onChange={(e) =>
+                  setMetadata((m) => ({ ...m, mandant_name: e.target.value }))
+                }
+                placeholder="Mandantenname"
+                className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              />
+              <input
+                type="text"
+                value={metadata.aktenzeichen}
+                onChange={(e) =>
+                  setMetadata((m) => ({ ...m, aktenzeichen: e.target.value }))
+                }
+                placeholder="Aktenzeichen"
+                className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              />
+              <input
+                type="text"
+                value={metadata.berichtszeitraum_von}
+                onChange={(e) =>
+                  setMetadata((m) => ({
+                    ...m,
+                    berichtszeitraum_von: e.target.value,
+                  }))
+                }
+                placeholder="Zeitraum von (z. B. 2025-01-01)"
+                className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              />
+              <input
+                type="text"
+                value={metadata.berichtszeitraum_bis}
+                onChange={(e) =>
+                  setMetadata((m) => ({
+                    ...m,
+                    berichtszeitraum_bis: e.target.value,
+                  }))
+                }
+                placeholder="Zeitraum bis (z. B. 2026-01-01)"
+                className="rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              />
+            </div>
           </div>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -303,7 +303,8 @@ export type BoardReportTargetSystem =
   | "sap_btp"
   | "sharepoint"
   | "sap_btp_http"
-  | "dms_generic";
+  | "dms_generic"
+  | "datev_dms_prepared";
 
 export type BoardReportExportJobStatus =
   | "pending"

--- a/tests/test_ai_board_report_export_jobs.py
+++ b/tests/test_ai_board_report_export_jobs.py
@@ -169,6 +169,81 @@ def test_create_export_job_dms_generic_not_implemented():
     assert "not yet implemented" in (data.get("error_message") or "")
 
 
+def test_create_export_job_datev_dms_prepared_missing_callback():
+    """datev_dms_prepared ohne callback_url → 400."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/export-jobs",
+        json={"target_system": "datev_dms_prepared"},
+        headers=_headers(),
+    )
+    assert response.status_code == 400
+    assert "callback_url" in response.json().get("detail", "").lower()
+
+
+def test_create_export_job_datev_dms_prepared_payload_structure():
+    """datev_dms_prepared: Payload hat mandant, bericht, content, technisch mit stabilen Keys."""
+    _jobs.clear()
+    setup_ai_system(system_id="export-job-datev")
+
+    captured_payload: dict = {}
+    captured_headers: dict = {}
+
+    def fake_post(url: str, payload: dict, headers: dict) -> tuple[bool, str]:
+        captured_payload.update(payload)
+        captured_headers.update(headers)
+        return (True, "")
+
+    with patch(
+        "app.services.board_report_export_jobs._post_with_headers",
+        side_effect=fake_post,
+    ):
+        response = client.post(
+            "/api/v1/ai-governance/report/board/export-jobs",
+            json={
+                "target_system": "datev_dms_prepared",
+                "callback_url": "https://datev-dms.example.com/inbound",
+                "metadata": {
+                    "mandant_nr": "M-001",
+                    "mandant_name": "Beispiel Kanzlei",
+                    "aktenzeichen": "AI-GOV-2026-001",
+                    "berichtszeitraum_von": "2025-01-01",
+                    "berichtszeitraum_bis": "2026-01-01",
+                    "normbezug": "EU AI Act,NIS2,ISO 42001",
+                    "dokument_typ": "AI Governance Board Report",
+                },
+            },
+            headers=_headers(),
+        )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["status"] == "sent"
+    assert data["target_system"] == "datev_dms_prepared"
+    assert captured_headers.get("X-ComplianceHub-Integration") == "datev_dms_prepared"
+
+    assert "mandant" in captured_payload
+    assert captured_payload["mandant"]["mandant_nr"] == "M-001"
+    assert captured_payload["mandant"]["mandant_name"] == "Beispiel Kanzlei"
+    assert captured_payload["mandant"]["aktenzeichen"] == "AI-GOV-2026-001"
+
+    assert "bericht" in captured_payload
+    assert captured_payload["bericht"]["typ"] == "AI Governance Board Report"
+    assert "zeitraum" in captured_payload["bericht"]
+    assert captured_payload["bericht"]["zeitraum"]["von"] == "2025-01-01"
+    assert captured_payload["bericht"]["zeitraum"]["bis"] == "2026-01-01"
+    assert "normbezug" in captured_payload["bericht"]
+    assert "EU AI Act" in captured_payload["bericht"]["normbezug"]
+
+    assert "content" in captured_payload
+    assert "markdown" in captured_payload["content"]
+    assert "summary" in captured_payload["content"]
+    assert "ai_systems_total" in captured_payload["content"]["summary"]
+    assert "risiko_level" in captured_payload["content"]["summary"]
+
+    assert "technisch" in captured_payload
+    assert captured_payload["technisch"]["tenant_id"] == "board-kpi-tenant"
+    assert "export_job_id" in captured_payload["technisch"]
+
+
 def test_create_export_job_webhook_failure():
     """Webhook schlägt fehl → Job status failed, error_message gesetzt."""
     _jobs.clear()


### PR DESCRIPTION
- target_system datev_dms_prepared, Payload mandant/bericht/content/technisch
- Job-metadata: mandant_nr, mandant_name, aktenzeichen, zeitraum, normbezug
- dispatch_board_report_export_job + HTTP POST mit X-ComplianceHub-Integration
- docs/integration/steuerkanzlei-datev-dms-integration.md (Blueprint, DATEV-Ready-Hinweis)
- Frontend: Option Steuerkanzlei/DATEV-DMS, optionale Metadatenfelder
- Tests: datev_dms_prepared callback-Pflicht + Payload-Struktur

Made-with: Cursor