### PR TITLE
feat(ai-governance): Audit-Ready-Schicht für Board-Reports (WP-/Prüfu…

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -136,3 +136,35 @@ class BoardReportExportJob(BaseModel):
     metadata: dict[str, str] | None = None
     error_message: str | None = None
     completed_at: datetime | None = None
+
+
+# Audit-Ready: Versionierung, Freigaben, Referenzen auf Export-Jobs (WP-/Prüfungsdokumentation)
+AuditRecordStatus = Literal["draft", "final"]
+
+
+class BoardReportAuditRecordCreate(BaseModel):
+    """Request-Body für Anlage eines Board-Report-Audit-Records."""
+
+    purpose: str = Field(..., min_length=1, max_length=200)
+    status: AuditRecordStatus = "draft"
+    linked_export_job_ids: list[str] = Field(default_factory=list, max_length=50)
+
+
+class BoardReportAuditRecord(BaseModel):
+    """Audit-Trail-Eintrag für Board-Report (Versionierung, verknüpfte Export-Jobs)."""
+
+    id: str
+    tenant_id: str
+    report_generated_at: datetime
+    report_version: str
+    created_at: datetime
+    created_by: str
+    purpose: str
+    linked_export_job_ids: list[str]
+    status: AuditRecordStatus
+
+
+class BoardReportAuditRecordWithJobs(BoardReportAuditRecord):
+    """Audit-Record inkl. aufgelöster verknüpfter Export-Jobs (für GET by id)."""
+
+    linked_export_jobs: list[BoardReportExportJob] = Field(default_factory=list)

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,9 @@ from app.ai_governance_models import (
     AIGovernanceKpiSummary,
     AIKpiAlert,
     AIKpiAlertExport,
+    BoardReportAuditRecord,
+    BoardReportAuditRecordCreate,
+    BoardReportAuditRecordWithJobs,
     BoardReportExportJob,
     BoardReportExportJobCreate,
 )
@@ -74,6 +77,11 @@ from app.services.ai_governance_kpis import compute_ai_board_kpis, compute_ai_go
 from app.services.ai_governance_suppliers import (
     compute_ai_supplier_risk_by_system,
     compute_ai_supplier_risk_overview,
+)
+from app.services.board_report_audit_records import (
+    create_audit_record,
+    get_record,
+    list_records,
 )
 from app.services.board_report_export_jobs import get_job, run_export_job
 from app.services.board_report_markdown import render_board_report_markdown
@@ -800,6 +808,90 @@ def get_board_report_export_job(
             detail="Export job not found",
         )
     return job
+
+
+# --- Board-Report Audit-Records (WP-/Prüfungsdokumentation, Audit-Ready) ---
+
+
+@app.post(
+    "/api/v1/ai-governance/report/board/audit-records",
+    response_model=BoardReportAuditRecord,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_board_report_audit_record(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
+    violation_repo: Annotated[ViolationRepository, Depends(get_violation_repository)],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+    body: BoardReportAuditRecordCreate,
+) -> BoardReportAuditRecord:
+    """Legt einen Audit-Record für den aktuellen Board-Report an (Version = Hash)."""
+    tenant_id = auth_context.tenant_id
+    created_by = (auth_context.api_key[:8] + "…") if auth_context.api_key else "api"
+    report = _build_board_report(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+        violation_repo=violation_repo,
+        incident_repo=incident_repo,
+    )
+    record = create_audit_record(
+        tenant_id=tenant_id,
+        report=report,
+        body=body,
+        created_by=created_by,
+    )
+    return record
+
+
+@app.get(
+    "/api/v1/ai-governance/report/board/audit-records",
+    response_model=list[BoardReportAuditRecord],
+)
+def list_board_report_audit_records(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    status_filter: Annotated[
+        str | None, Query(alias="status", description="Filter nach status")
+    ] = None,
+    limit: Annotated[int, Query(ge=1, le=100)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> list[BoardReportAuditRecord]:
+    """Listet Audit-Records des Tenants (paginiert, optional nach status)."""
+    return list_records(
+        auth_context.tenant_id,
+        status=status_filter,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@app.get(
+    "/api/v1/ai-governance/report/board/audit-records/{audit_id}",
+    response_model=BoardReportAuditRecordWithJobs,
+)
+def get_board_report_audit_record(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    audit_id: str,
+) -> BoardReportAuditRecordWithJobs:
+    """Details eines Audit-Records inkl. referenzierter Export-Jobs."""
+    record = get_record(audit_id, auth_context.tenant_id)
+    if record is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Audit record not found",
+        )
+    linked_jobs: list[BoardReportExportJob] = []
+    for jid in record.linked_export_job_ids:
+        job = get_job(jid, auth_context.tenant_id)
+        if job is not None:
+            linked_jobs.append(job)
+    return BoardReportAuditRecordWithJobs(
+        **record.model_dump(),
+        linked_export_jobs=linked_jobs,
+    )
 
 
 # --- Beispiel-Payload-Endpoint (NUR DEV/DOCS – nicht für Produktion) ---

--- a/app/services/board_report_audit_records.py
+++ b/app/services/board_report_audit_records.py
@@ -1,0 +1,76 @@
+"""Audit-Ready: Board-Report-Audit-Records (Versionierung, verknüpfte Export-Jobs)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from datetime import datetime
+
+from app.ai_governance_models import (
+    AIBoardGovernanceReport,
+    BoardReportAuditRecord,
+    BoardReportAuditRecordCreate,
+)
+
+_records: dict[str, BoardReportAuditRecord] = {}
+
+
+def _report_version(report: AIBoardGovernanceReport) -> str:
+    """Deterministischer Version-String aus Report-Inhalt (Hash)."""
+    raw = json.dumps(report.model_dump(mode="json"), sort_keys=True)
+    return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+
+def store_record(record: BoardReportAuditRecord) -> None:
+    _records[record.id] = record
+
+
+def create_audit_record(
+    tenant_id: str,
+    report: AIBoardGovernanceReport,
+    body: BoardReportAuditRecordCreate,
+    created_by: str,
+) -> BoardReportAuditRecord:
+    """Legt einen neuen Audit-Record an (Report-Version = Hash des JSON)."""
+    from app.datetime_compat import UTC
+
+    now = datetime.now(UTC)
+    record_id = str(uuid.uuid4())
+    report_version = _report_version(report)
+    gen_at = report.generated_at
+    record = BoardReportAuditRecord(
+        id=record_id,
+        tenant_id=tenant_id,
+        report_generated_at=gen_at,
+        report_version=report_version,
+        created_at=now,
+        created_by=created_by,
+        purpose=body.purpose,
+        linked_export_job_ids=body.linked_export_job_ids or [],
+        status=body.status,
+    )
+    store_record(record)
+    return record
+
+
+def get_record(record_id: str, tenant_id: str) -> BoardReportAuditRecord | None:
+    r = _records.get(record_id)
+    if r is None or r.tenant_id != tenant_id:
+        return None
+    return r
+
+
+def list_records(
+    tenant_id: str,
+    *,
+    status: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[BoardReportAuditRecord]:
+    """Listet Audit-Records des Tenants (gefiltert nach status, paginiert)."""
+    out = [r for r in _records.values() if r.tenant_id == tenant_id]
+    if status is not None:
+        out = [r for r in out if r.status == status]
+    out.sort(key=lambda r: r.created_at, reverse=True)
+    return out[offset : offset + limit]

--- a/docs/integration/wp-pruefungsdokumentation.md
+++ b/docs/integration/wp-pruefungsdokumentation.md
@@ -1,0 +1,73 @@
+# WP-Prüfungsdokumentation – Board-Report Audit-Ready
+
+**Blueprint-Dokumentation.** Beschreibung, wie **BoardReportAuditRecord** und **Export-Jobs** zusammen ein prüfungstaugliches Set an Nachweisen für EU AI Act, NIS2 und ISO 42001 bilden (Audit-Ready-Schicht ohne vollständiges DMS).
+
+---
+
+## 1. Ziel
+
+- **Versionierung:** Jeder „Schnappschuss“ eines Board-Reports kann als Audit-Record abgelegt werden (inkl. Hash-Version des Report-Inhalts).
+- **Referenzen auf Exporte:** Verknüpfung mit Export-Jobs (z. B. SAP BTP, DATEV-DMS) – welcher Report wurde wohin exportiert?
+- **Prüfungsnachweis:** Für Wirtschaftsprüfer und Aufsicht: Nachvollziehbarer Ablauf „Report erzeugen → Audit-Record anlegen → Export in DMS/DATEV → Referenz im Prüfungsbericht“.
+
+---
+
+## 2. Bausteine
+
+| Baustein | Beschreibung |
+|----------|--------------|
+| **Board-Report (JSON/Markdown)** | Aktueller AI-Governance-Report (KPIs, Compliance, Incidents, Supplier-Risiko, Alerts). |
+| **BoardReportAuditRecord** | Eintrag mit report_generated_at, report_version (Hash), purpose, status (draft/final), linked_export_job_ids. |
+| **Export-Jobs** | generic_webhook, sap_btp_http, datev_dms_prepared, … – versendeter Report an externe Systeme. |
+
+Audit-Record + verknüpfte Export-Job-IDs = nachvollziehbarer Pfad „dieser Report, diese Version, exportiert in diese Systeme“.
+
+---
+
+## 3. Beispiel-Ablauf für WP / Prüfungsdokumentation
+
+1. **Report generieren**  
+   Nutzer oder System ruft den aktuellen Board-Report ab (GET Board-Report oder Markdown).
+
+2. **Audit-Record anlegen**  
+   `POST /api/v1/ai-governance/report/board/audit-records`  
+   - Body: `purpose` (z. B. „NIS2 Board-Bericht Q1 2026“), `status` (draft/final), optional `linked_export_job_ids`.  
+   - Response: Audit-Record mit `id`, `report_version`, `report_generated_at`, `created_at`, `created_by`.
+
+3. **Export in DMS/DATEV**  
+   `POST /api/v1/ai-governance/report/board/export-jobs`  
+   - z. B. `target_system: datev_dms_prepared`, `callback_url`, optional `metadata` (Mandant, Aktenzeichen).  
+   - Response: Export-Job mit `id`, `status` (sent/failed).
+
+4. **Verknüpfung nachziehen (optional)**  
+   Falls der Audit-Record vor den Export-Jobs angelegt wurde: Audit-Record kann bei Anlage die Liste `linked_export_job_ids` enthalten; bei späterer Anlage werden die erhaltenen Job-IDs in einem (ggf. aktualisierten) Ablauf in der Dokumentation referenziert.  
+   GET Audit-Record by id liefert `linked_export_jobs` (aufgelöste Job-Details).
+
+5. **Referenz im Prüfungsbericht**  
+   WP kann Audit-Record-ID und ggf. Export-Job-IDs sowie report_version in der Prüfungsdokumentation anführen (EU AI Act, NIS2, ISO 42001 – Nachweis „Board-Report Version X am Datum Y exportiert in System Z“).
+
+---
+
+## 4. API-Überblick
+
+| Methode | Endpoint | Kurzbeschreibung |
+|---------|----------|------------------|
+| POST | `/api/v1/ai-governance/report/board/audit-records` | Audit-Record für aktuellen Report anlegen (Version = Hash). |
+| GET | `/api/v1/ai-governance/report/board/audit-records` | Liste (paginiert, filterbar nach status). |
+| GET | `/api/v1/ai-governance/report/board/audit-records/{audit_id}` | Einzelrecord inkl. verknüpfter Export-Jobs. |
+
+Alle Endpunkte tenant-isoliert, Auth wie bei den übrigen Board-Endpunkten.
+
+---
+
+## 5. Normbezug (EU AI Act, NIS2, ISO 42001)
+
+- **EU AI Act:** High-Risk-Systeme, Governance-Reife – Board-Report und Audit-Record als Nachweis des Überblicks.  
+- **NIS2:** Incident-/Supplier-Risiko-KPIs – Report-Version und Export in DMS/Archiv für Nachweisführung.  
+- **ISO 42001:** AI-Managementsystem, Reifegrad – Audit-Record mit purpose und status für Prüfdokumentation.
+
+Die Kombination aus Audit-Record (Version, Zeitpunkt, Zweck) und Export-Jobs (Wohin wurde exportiert?) bildet die Grundlage für eine prüfungstaugliche Dokumentation ohne vollständiges DMS/Freigabe-Workflow-System.
+
+---
+
+*Dokumentation: ComplianceHub Integration Blueprint – WP-Prüfungsdokumentation.*

--- a/frontend/src/app/board/kpis/BoardReportAuditSection.tsx
+++ b/frontend/src/app/board/kpis/BoardReportAuditSection.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import React, { useCallback, useState } from "react";
+import {
+  createBoardReportAuditRecord,
+  fetchBoardReportAuditRecords,
+  type BoardReportAuditRecord,
+} from "@/lib/api";
+
+const LIST_LIMIT = 5;
+
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("de-DE", {
+      day: "2-digit",
+      month: "2-digit",
+      year: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function BoardReportAuditSection() {
+  const [records, setRecords] = useState<BoardReportAuditRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [createLoading, setCreateLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [createdId, setCreatedId] = useState<string | null>(null);
+
+  const loadRecords = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const list = await fetchBoardReportAuditRecords({
+        limit: LIST_LIMIT,
+        offset: 0,
+      });
+      setRecords(list);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Audit-Records konnten nicht geladen werden."
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  async function handleCreate() {
+    setCreateLoading(true);
+    setError(null);
+    setCreatedId(null);
+    try {
+      const record = await createBoardReportAuditRecord({
+        purpose: "Board-Report Audit (EU AI Act / NIS2 / ISO 42001)",
+        status: "draft",
+        linked_export_job_ids: [],
+      });
+      setCreatedId(record.id);
+      await loadRecords();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Audit-Record konnte nicht angelegt werden."
+      );
+    } finally {
+      setCreateLoading(false);
+    }
+  }
+
+  return (
+    <section
+      aria-label="Audit-Ready"
+      className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm"
+    >
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+        Audit-Ready (Prüfungsdokumentation)
+      </h2>
+      <p className="mt-1 text-xs text-slate-500">
+        Versionierte Audit-Records für den Board-Report und Verknüpfung mit
+        Export-Jobs (DMS/DATEV) – für WP- und Prüfungsnachweise.
+      </p>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={handleCreate}
+          disabled={createLoading}
+          className="rounded-lg bg-slate-800 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+        >
+          {createLoading
+            ? "Wird angelegt…"
+            : "Audit-Record für aktuellen Board-Report anlegen"}
+        </button>
+        <button
+          type="button"
+          onClick={loadRecords}
+          disabled={loading}
+          className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          {loading ? "Laden…" : "Letzte Audit-Records laden"}
+        </button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"
+        >
+          {error}
+        </div>
+      )}
+
+      {createdId && (
+        <p className="mt-3 text-sm text-emerald-700">
+          Audit-Record angelegt (ID: {createdId.slice(0, 8)}…).
+        </p>
+      )}
+
+      {records.length > 0 && (
+        <div className="mt-4">
+          <h3 className="text-xs font-semibold uppercase text-slate-500">
+            Letzte {LIST_LIMIT} Audit-Records
+          </h3>
+          <ul className="mt-2 space-y-2">
+            {records.map((r) => (
+              <li
+                key={r.id}
+                className="rounded-lg border border-slate-100 bg-slate-50/50 px-3 py-2 text-sm"
+              >
+                <span className="font-medium text-slate-800">{r.purpose}</span>
+                <span className="mx-2 text-slate-400">·</span>
+                <span className="text-slate-600">
+                  {formatDate(r.created_at)} · Version {r.report_version}
+                </span>
+                {r.linked_export_job_ids.length > 0 && (
+                  <span className="ml-2 text-slate-500">
+                    · {r.linked_export_job_ids.length} Export
+                    {r.linked_export_job_ids.length !== 1 ? "e" : ""} verknüpft
+                  </span>
+                )}
+                <span
+                  className={`ml-2 rounded px-1.5 py-0.5 text-xs ${
+                    r.status === "final"
+                      ? "bg-emerald-100 text-emerald-800"
+                      : "bg-slate-200 text-slate-700"
+                  }`}
+                >
+                  {r.status}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -13,6 +13,7 @@ import {
   type BoardKpiSummary,
 } from "@/lib/api";
 
+import { BoardReportAuditSection } from "./BoardReportAuditSection";
 import { BoardReportExportForm } from "./BoardReportExportForm";
 
 function scoreColor(score: number): string {
@@ -471,6 +472,11 @@ export default async function BoardKpisPage() {
       {/* Externer Export (Webhook / DMS / SAP BTP) */}
       <section className="mb-8">
         <BoardReportExportForm />
+      </section>
+
+      {/* Audit-Ready (Prüfungsdokumentation) */}
+      <section className="mb-8">
+        <BoardReportAuditSection />
       </section>
 
       <ManagementSummary kpis={kpis} />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -347,6 +347,64 @@ export async function fetchBoardReportExportJobStatus(
   );
 }
 
+// ─── Board-Report Audit-Records (WP-/Prüfungsdokumentation, Audit-Ready) ────────
+
+export type AuditRecordStatus = "draft" | "final";
+
+export interface BoardReportAuditRecord {
+  id: string;
+  tenant_id: string;
+  report_generated_at: string;
+  report_version: string;
+  created_at: string;
+  created_by: string;
+  purpose: string;
+  linked_export_job_ids: string[];
+  status: AuditRecordStatus;
+}
+
+export interface BoardReportAuditRecordWithJobs extends BoardReportAuditRecord {
+  linked_export_jobs: BoardReportExportJob[];
+}
+
+export interface BoardReportAuditRecordCreate {
+  purpose: string;
+  status?: AuditRecordStatus;
+  linked_export_job_ids?: string[];
+}
+
+export async function createBoardReportAuditRecord(
+  payload: BoardReportAuditRecordCreate
+): Promise<BoardReportAuditRecord> {
+  return apiFetch("/api/v1/ai-governance/report/board/audit-records", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function fetchBoardReportAuditRecords(params?: {
+  status?: string;
+  limit?: number;
+  offset?: number;
+}): Promise<BoardReportAuditRecord[]> {
+  const search = new URLSearchParams();
+  if (params?.status) search.set("status", params.status);
+  if (params?.limit != null) search.set("limit", String(params.limit));
+  if (params?.offset != null) search.set("offset", String(params.offset));
+  const q = search.toString();
+  return apiFetch(
+    `/api/v1/ai-governance/report/board/audit-records${q ? `?${q}` : ""}`
+  );
+}
+
+export async function fetchBoardReportAuditRecordById(
+  auditId: string
+): Promise<BoardReportAuditRecordWithJobs> {
+  return apiFetch(
+    `/api/v1/ai-governance/report/board/audit-records/${auditId}`
+  );
+}
+
 // ─── AI Governance Incident Drilldown (NIS2 Art. 21/23, ISO 42001) ─────────────
 
 export type IncidentSeverityLevel = "low" | "medium" | "high";

--- a/tests/test_ai_board_report_audit_records.py
+++ b/tests/test_ai_board_report_audit_records.py
@@ -1,0 +1,211 @@
+"""Tests für Board-Report-Audit-Records (Audit-Ready, Versionierung, Export-Verknüpfung)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services.board_report_audit_records import _records
+from app.services.board_report_export_jobs import _jobs
+from tests.conftest import _headers
+
+client = TestClient(app)
+
+
+def _tenant_headers(tenant_id: str = "board-kpi-tenant") -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": tenant_id,
+    }
+
+
+def setup_ai_system(
+    tenant_id: str = "board-kpi-tenant",
+    system_id: str | None = None,
+) -> None:
+    sid = system_id or "audit-test-sys"
+    client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": sid,
+            "name": "Audit Test",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers=_tenant_headers(tenant_id),
+    )
+
+
+def test_create_audit_record():
+    """Erzeugen eines Audit-Records: 201, id, report_version, purpose."""
+    _records.clear()
+    setup_ai_system(system_id="audit-create-1")
+
+    response = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={
+            "purpose": "NIS2 Board-Bericht",
+            "status": "draft",
+            "linked_export_job_ids": [],
+        },
+        headers=_headers(),
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert "id" in data
+    assert data["tenant_id"] == "board-kpi-tenant"
+    assert data["purpose"] == "NIS2 Board-Bericht"
+    assert data["status"] == "draft"
+    assert data["report_version"] != ""
+    assert data["linked_export_job_ids"] == []
+    assert "report_generated_at" in data
+    assert "created_by" in data
+
+
+def test_audit_record_versioning():
+    """Jeder Audit-Record erhält eine deterministische report_version (Hash über Report)."""
+    _records.clear()
+    setup_ai_system(system_id="audit-version-1")
+
+    r1 = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "EU AI Act High-Risk Audit", "status": "draft"},
+        headers=_headers(),
+    )
+    r2 = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Zweiter Eintrag", "status": "final"},
+        headers=_headers(),
+    )
+    assert r1.status_code == 201 and r2.status_code == 201
+    v1, v2 = r1.json()["report_version"], r2.json()["report_version"]
+    assert len(v1) == 16 and len(v2) == 16
+    assert all(c in "0123456789abcdef" for c in v1 + v2)
+
+
+def test_audit_record_tenant_isolation():
+    """Audit-Record von Tenant A ist für Tenant B nicht sichtbar."""
+    _records.clear()
+    setup_ai_system("tenant-audit-a", system_id="audit-tenant-a")
+    create = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Mandant A", "status": "draft"},
+        headers=_tenant_headers("tenant-audit-a"),
+    )
+    assert create.status_code == 201
+    audit_id = create.json()["id"]
+
+    get_b = client.get(
+        f"/api/v1/ai-governance/report/board/audit-records/{audit_id}",
+        headers=_tenant_headers("tenant-audit-b"),
+    )
+    assert get_b.status_code == 404
+
+
+def test_audit_record_linked_export_jobs():
+    """Verknüpfung mit Export-Jobs: GET liefert linked_export_jobs."""
+    _records.clear()
+    _jobs.clear()
+    setup_ai_system(system_id="audit-link-1")
+
+    with patch(
+        "app.services.board_report_export_jobs._post_with_headers",
+        return_value=(True, ""),
+    ):
+        job_resp = client.post(
+            "/api/v1/ai-governance/report/board/export-jobs",
+            json={
+                "target_system": "datev_dms_prepared",
+                "callback_url": "https://x.com",
+            },
+            headers=_headers(),
+        )
+    assert job_resp.status_code == 201
+    job_id = job_resp.json()["id"]
+
+    create = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={
+            "purpose": "WP-Prüfungsdokumentation",
+            "status": "final",
+            "linked_export_job_ids": [job_id],
+        },
+        headers=_headers(),
+    )
+    assert create.status_code == 201
+    audit_id = create.json()["id"]
+
+    get_resp = client.get(
+        f"/api/v1/ai-governance/report/board/audit-records/{audit_id}",
+        headers=_headers(),
+    )
+    assert get_resp.status_code == 200
+    data = get_resp.json()
+    assert data["linked_export_job_ids"] == [job_id]
+    assert "linked_export_jobs" in data
+    assert len(data["linked_export_jobs"]) == 1
+    assert data["linked_export_jobs"][0]["id"] == job_id
+    assert data["linked_export_jobs"][0]["target_system"] == "datev_dms_prepared"
+
+
+def test_list_audit_records_paginated():
+    """GET audit-records: Liste paginiert, Filter status."""
+    _records.clear()
+    setup_ai_system(system_id="audit-list-1")
+    client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Eins", "status": "draft"},
+        headers=_headers(),
+    )
+    client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Zwei", "status": "final"},
+        headers=_headers(),
+    )
+
+    list_all = client.get(
+        "/api/v1/ai-governance/report/board/audit-records?limit=10&offset=0",
+        headers=_headers(),
+    )
+    assert list_all.status_code == 200
+    items = list_all.json()
+    assert len(items) >= 2
+
+    list_draft = client.get(
+        "/api/v1/ai-governance/report/board/audit-records?status=draft",
+        headers=_headers(),
+    )
+    assert list_draft.status_code == 200
+    drafts = list_draft.json()
+    assert all(r["status"] == "draft" for r in drafts)
+
+
+def test_audit_record_401_no_api_key():
+    """POST ohne API-Key → 401."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Test", "status": "draft"},
+        headers={"x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401
+
+
+def test_audit_record_401_invalid_api_key():
+    """POST mit ungültigem API-Key → 401."""
+    response = client.post(
+        "/api/v1/ai-governance/report/board/audit-records",
+        json={"purpose": "Test", "status": "draft"},
+        headers={"x-api-key": "invalid", "x-tenant-id": "board-kpi-tenant"},
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
…ngsdokumentation)

- BoardReportAuditRecord: Versionierung (Hash), purpose, status, linked_export_job_ids
- POST/GET audit-records, GET by id mit linked_export_jobs
- docs/integration/wp-pruefungsdokumentation.md (Ablauf WP, Normbezug)
- Frontend: Audit-Ready-Bereich, Button Audit-Record anlegen, Liste letzter Records
- Tests: Anlegen, Versionierung, Tenant-Isolation, Verknüpfung Export-Jobs, 401

Made-with: Cursor