### PR TITLE
feat(governance): erklärbare NIS2-Alerts, Readiness-Deep-Links, Expor…

### DIFF
--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -94,6 +94,40 @@ class AIBoardKpiSummary(BaseModel):
     )
 
 
+class AIKpiAlertMetadata(BaseModel):
+    """Optionale Kennzahlen-Kontext für Board-Alerts (v. a. NIS2-/KRITIS-KPI-Alerts)."""
+
+    current_percent: float | None = Field(
+        default=None,
+        description="Ist-Wert in Prozent (0–100) oder Readiness-Anteil, je nach Alert.",
+    )
+    threshold_percent: float | None = Field(
+        default=None,
+        description="Verglichene Schwellwert-Angabe in Prozent (0–100), sofern anwendbar.",
+    )
+    kpi_type: str | None = Field(
+        default=None,
+        description="NIS2-/KRITIS-KPI-Typ, z. B. INCIDENT_RESPONSE_MATURITY.",
+    )
+    affected_system_ids: list[str] = Field(
+        default_factory=list,
+        description="Bis zu drei KI-System-IDs mit niedrigsten Werten / Fokus.",
+        max_length=10,
+    )
+    coverage_ratio_current: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional: aktueller KPI-Vollständigkeits-Anteil (0–1) je System.",
+    )
+    coverage_ratio_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional: Schwellwert für coverage_ratio_current.",
+    )
+
+
 class AIKpiAlert(BaseModel):
     """Einzelalert für Board-KPIs (NIS2 / EU AI Act / ISO 42001)."""
 
@@ -104,6 +138,7 @@ class AIKpiAlert(BaseModel):
     message: str
     created_at: datetime
     resolved_at: datetime | None = None
+    alert_metadata: AIKpiAlertMetadata | None = None
 
 
 class AIKpiAlertExport(BaseModel):
@@ -249,6 +284,14 @@ class BoardKpiExportEnvelope(BaseModel):
     tenant_id: str
     generated_at: datetime
     systems: list[BoardKpiExportSystemRow]
+    regulatory_scope: list[str] = Field(
+        default_factory=lambda: ["EU_AI_ACT", "NIS2", "ISO_42001"],
+        description="Normative Einordnung für DMS/DATEV-/SAP-BTP-Routing.",
+    )
+    generated_by: str = Field(
+        default="board_kpi_export_v1",
+        description="Export-Pipeline-Label für Downstream-Integrationen.",
+    )
 
 
 KpiExportTargetLabel = Literal["datev", "dms", "sap_btp_placeholder"]

--- a/app/config/nis2_kritis_board_alert_thresholds.py
+++ b/app/config/nis2_kritis_board_alert_thresholds.py
@@ -1,14 +1,88 @@
-"""Nachvollziehbare Schwellen für NIS2-/KRITIS-KPI-basierte Board-Alerts."""
+"""Zentrale Schwellenkonfiguration für NIS2-/KRITIS-KPI-Board-Alerts.
+
+Diese Werte steuern Alerts, die aus den tabellarisch gepflegten NIS2-/KRITIS-KPIs
+(INCIDENT_RESPONSE_MATURITY, SUPPLIER_RISK_COVERAGE, OT_IT_SEGREGATION) abgeleitet werden.
+Sie ergänzen die runbook-/register-basierten Board-Ratios (z. B. Anteil Systeme mit
+Incident-Runbook), die direkt aus dem KI-System-Register kommen.
+
+Normativer Kontext (Auszug):
+- **NIS2 Art. 21** – Incident Handling, Krisenreaktion und betriebliche Widerstandsfähigkeit;
+  die Incident-Response-Maturity-KPI adressiert die Reife dokumentierter Incident-Prozesse
+  auf KI-Systemebene (KRITIS-/OT-Bezug über Fokus-Systeme).
+- **NIS2 Art. 23** – Melde- und Benachrichtigungspflichten; niedrige Incident-Reife ist ein
+  Hinweis auf Nachholbedarf vor meldepflichtigen Ereignissen.
+- **NIS2 Art. 24** – Lieferketten-/Dienstleister-Risiken; Supplier-Risk-Coverage und
+  „volle“ KPI-Erfassung je System unterstützen die Nachweisbarkeit gegenüber Aufsicht und WP.
+
+Die konkreten Prozent-Schwellen sind betrieblich kalibrierbar; fachliche Begründungen stehen
+an den jeweiligen Dataclass-Feldern.
+"""
 
 from __future__ import annotations
 
-# Mittelwert je KPI-Typ (0–100) über alle gespeicherten Werte des Tenants
-NIS2_KRITIS_INCIDENT_MATURITY_MEAN_ALERT_PCT = 50
-NIS2_KRITIS_SUPPLIER_COVERAGE_MEAN_ALERT_PCT = 50
+from dataclasses import dataclass
 
-# Voller KPI-Datensatz je System (alle drei Typen) – Ratio 0–1 aus Board-KPIs
-NIS2_KRITIS_FULL_COVERAGE_RATIO_ALERT = 0.5
 
-# OT/IT-Segmentierung: High-Risk-/Fokus-Systeme unter diesem Wert zählen für „viele“-Alert
-NIS2_KRITIS_OT_IT_ALERT_THRESHOLD_PCT = 60
-NIS2_KRITIS_OT_IT_ALERT_MIN_AFFECTED_SYSTEMS = 2
+@dataclass(frozen=True)
+class IncidentKpiAlertThresholds:
+    """INCIDENT_RESPONSE_MATURITY – Mittelwert je Tenant (0–100)."""
+
+    mean_percent_warning: int = 50
+    mean_warning_rationale: str = (
+        "Liegt der Mittelwert unter diesem Wert, besteht Nachholbedarf bei dokumentierter "
+        "Incident-Response-Reife (NIS2 Art. 21 / operative Resilienz)."
+    )
+
+
+@dataclass(frozen=True)
+class SupplierKpiAlertThresholds:
+    """SUPPLIER_RISK_COVERAGE + KPI-Vollständigkeit (alle drei Typen je System)."""
+
+    mean_percent_warning: int = 50
+    mean_warning_rationale: str = (
+        "Mittelwert Supplier-Risk-KPI unter diesem Wert deutet auf Lücken in der "
+        "Supply-Chain-Absicherung hin (NIS2 Art. 24)."
+    )
+    full_coverage_ratio_warning: float = 0.5
+    full_coverage_rationale: str = (
+        "Anteil der KI-Systeme mit allen drei NIS2-/KRITIS-KPI-Typen; unter diesem Wert "
+        "fehlen häufig Nachweise für Board- und Aufsichtsreporting."
+    )
+
+
+@dataclass(frozen=True)
+class OtItKpiAlertThresholds:
+    """OT_IT_SEGREGATION für Fokus-Systeme (High-Risk / hohe Criticality)."""
+
+    focus_system_value_below_percent: int = 60
+    value_rationale: str = (
+        "OT/IT-Segmentierung unter diesem Wert bei Fokus-Systemen erhöht "
+        "KRITIS-/Schnittstellenrisiken."
+    )
+    min_affected_systems_for_critical_alert: int = 2
+    count_rationale: str = (
+        "Erst ab dieser Anzahl betroffener Fokus-Systeme wird ein kritischer Alert ausgelöst "
+        "(Häufung statt Einzelfall)."
+    )
+
+
+@dataclass(frozen=True)
+class Nis2KritisThresholdConfig:
+    """Alle NIS2-/KRITIS-KPI-Alertschwellen an einer Stelle (typsicher)."""
+
+    incident_maturity: IncidentKpiAlertThresholds = IncidentKpiAlertThresholds()
+    supplier_coverage: SupplierKpiAlertThresholds = SupplierKpiAlertThresholds()
+    ot_it_segmentation: OtItKpiAlertThresholds = OtItKpiAlertThresholds()
+
+
+DEFAULT_NIS2_KRITIS_THRESHOLD_CONFIG = Nis2KritisThresholdConfig()
+
+# Rückwärtskompatible Modul-Konstanten (bestehende Imports)
+_cfg = DEFAULT_NIS2_KRITIS_THRESHOLD_CONFIG
+NIS2_KRITIS_INCIDENT_MATURITY_MEAN_ALERT_PCT = _cfg.incident_maturity.mean_percent_warning
+NIS2_KRITIS_SUPPLIER_COVERAGE_MEAN_ALERT_PCT = _cfg.supplier_coverage.mean_percent_warning
+NIS2_KRITIS_FULL_COVERAGE_RATIO_ALERT = _cfg.supplier_coverage.full_coverage_ratio_warning
+NIS2_KRITIS_OT_IT_ALERT_THRESHOLD_PCT = _cfg.ot_it_segmentation.focus_system_value_below_percent
+NIS2_KRITIS_OT_IT_ALERT_MIN_AFFECTED_SYSTEMS = (
+    _cfg.ot_it_segmentation.min_affected_systems_for_critical_alert
+)

--- a/app/eu_ai_act_readiness_models.py
+++ b/app/eu_ai_act_readiness_models.py
@@ -21,6 +21,25 @@ class ReadinessCriticalRequirement(BaseModel):
     affected_systems_count: int = Field(ge=0)
     traffic: ReadinessRequirementTraffic
     priority: int = Field(ge=1, le=5, description="1 = höchste Priorität")
+    requirement_id: str | None = Field(
+        default=None,
+        description="Interne Requirement-ID (Compliance-Gap), z. B. art9_risk_management.",
+    )
+    related_ai_system_ids: list[str] = Field(
+        default_factory=list,
+        description="KI-Systeme mit Lücke zu dieser Anforderung (Deep-Link zur Registry).",
+        max_length=100,
+    )
+    linked_governance_action_ids: list[str] = Field(
+        default_factory=list,
+        description="Offene/in Bearbeitung befindliche Maßnahmen mit Bezug zu dieser Anforderung.",
+        max_length=50,
+    )
+    open_actions_count_for_requirement: int = Field(
+        default=0,
+        ge=0,
+        description="Anzahl verknüpfter offener Maßnahmen (Badge).",
+    )
 
 
 class SuggestedGovernanceAction(BaseModel):

--- a/app/repositories/compliance_gap.py
+++ b/app/repositories/compliance_gap.py
@@ -6,7 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from app.compliance_gap_models import (
-    REQUIREMENTS,
+    GAP_REQUIREMENTS,
     ComplianceStatus,
     ComplianceStatusEntry,
     ComplianceStatusUpdate,
@@ -50,7 +50,7 @@ class ComplianceGapRepository:
         )
         existing_ids = set(self._session.execute(existing_stmt).scalars().all())
 
-        for req in REQUIREMENTS:
+        for req in GAP_REQUIREMENTS:
             if risk_level in req.applies_to and req.id not in existing_ids:
                 row = ComplianceStatusTable(
                     tenant_id=tenant_id,

--- a/app/repositories/nis2_kritis_kpis.py
+++ b/app/repositories/nis2_kritis_kpis.py
@@ -163,3 +163,50 @@ class Nis2KritisKpiRepository:
         )
         rows = self._session.execute(stmt).all()
         return [(self._to_domain(r[0]), str(r[1]), str(r[2])) for r in rows]
+
+    def list_system_ids_lowest_kpi(
+        self,
+        tenant_id: str,
+        kpi_type: Nis2KritisKpiType,
+        *,
+        limit: int = 3,
+    ) -> list[str]:
+        """KI-System-IDs mit niedrigstem KPI-Wert (für Alert-Kontext, Top-N)."""
+        stmt = (
+            select(Nis2KritisKpiDB.ai_system_id)
+            .where(
+                Nis2KritisKpiDB.tenant_id == tenant_id,
+                Nis2KritisKpiDB.kpi_type == kpi_type.value,
+            )
+            .order_by(Nis2KritisKpiDB.value_percent.asc(), Nis2KritisKpiDB.ai_system_id.asc())
+            .limit(limit)
+        )
+        return [str(x) for x in self._session.execute(stmt).scalars().all()]
+
+    def list_focus_system_ids_ot_it_below(
+        self,
+        tenant_id: str,
+        *,
+        threshold_percent: int,
+        limit: int = 3,
+    ) -> list[str]:
+        """Fokus-Systeme mit OT/IT-KPI unter Schwellwert, niedrigste zuerst."""
+        stmt = (
+            select(Nis2KritisKpiDB.ai_system_id)
+            .select_from(Nis2KritisKpiDB)
+            .join(AISystemTable, AISystemTable.id == Nis2KritisKpiDB.ai_system_id)
+            .where(
+                Nis2KritisKpiDB.tenant_id == tenant_id,
+                AISystemTable.tenant_id == tenant_id,
+                Nis2KritisKpiDB.kpi_type == Nis2KritisKpiType.OT_IT_SEGREGATION.value,
+                Nis2KritisKpiDB.value_percent < threshold_percent,
+                or_(
+                    AISystemTable.risk_level == "high",
+                    AISystemTable.ai_act_category == "high_risk",
+                    AISystemTable.criticality.in_(("high", "very_high")),
+                ),
+            )
+            .order_by(Nis2KritisKpiDB.value_percent.asc(), Nis2KritisKpiDB.ai_system_id.asc())
+            .limit(limit)
+        )
+        return [str(x) for x in self._session.execute(stmt).scalars().all()]

--- a/app/services/ai_board_alerts.py
+++ b/app/services/ai_board_alerts.py
@@ -6,17 +6,13 @@ import uuid
 from datetime import datetime
 from typing import Literal
 
-from app.ai_governance_models import AIBoardKpiSummary, AIKpiAlert
+from app.ai_governance_models import AIBoardKpiSummary, AIKpiAlert, AIKpiAlertMetadata
 from app.compliance_gap_models import AIComplianceOverview
-from app.config.nis2_kritis_board_alert_thresholds import (
-    NIS2_KRITIS_FULL_COVERAGE_RATIO_ALERT,
-    NIS2_KRITIS_INCIDENT_MATURITY_MEAN_ALERT_PCT,
-    NIS2_KRITIS_OT_IT_ALERT_MIN_AFFECTED_SYSTEMS,
-    NIS2_KRITIS_OT_IT_ALERT_THRESHOLD_PCT,
-    NIS2_KRITIS_SUPPLIER_COVERAGE_MEAN_ALERT_PCT,
-)
+from app.config.nis2_kritis_board_alert_thresholds import DEFAULT_NIS2_KRITIS_THRESHOLD_CONFIG
 from app.datetime_compat import UTC
 from app.services.nis2_kritis_alert_signals import Nis2KritisAlertSignals
+
+_cfg = DEFAULT_NIS2_KRITIS_THRESHOLD_CONFIG
 
 
 def compute_board_alerts(
@@ -35,6 +31,7 @@ def compute_board_alerts(
         kpi_key: str,
         severity: Literal["info", "warning", "critical"],
         msg: str,
+        alert_metadata: AIKpiAlertMetadata | None = None,
     ) -> None:
         alerts.append(
             AIKpiAlert(
@@ -45,6 +42,7 @@ def compute_board_alerts(
                 message=msg,
                 created_at=now,
                 resolved_at=None,
+                alert_metadata=alert_metadata,
             )
         )
 
@@ -105,19 +103,27 @@ def compute_board_alerts(
     # NIS2-/KRITIS-KPI-Tabellenwerte (Incident, Supplier, OT/IT)
     if nis2_kritis_signals is not None:
         inc = nis2_kritis_signals.incident_mean_percent
-        if inc is not None and inc < NIS2_KRITIS_INCIDENT_MATURITY_MEAN_ALERT_PCT:
+        inc_thr = float(_cfg.incident_maturity.mean_percent_warning)
+        if inc is not None and inc < inc_thr:
             add(
                 "nis2_kritis_incident_maturity_low",
                 "warning",
                 f"NIS2/KRITIS Incident-Response-Reife (KPI-Mittel) {round(inc, 1)} % "
-                f"unter {NIS2_KRITIS_INCIDENT_MATURITY_MEAN_ALERT_PCT} %.",
+                f"unter {int(inc_thr)} %.",
+                AIKpiAlertMetadata(
+                    current_percent=round(inc, 2),
+                    threshold_percent=inc_thr,
+                    kpi_type="INCIDENT_RESPONSE_MATURITY",
+                    affected_system_ids=list(nis2_kritis_signals.incident_worst_system_ids),
+                ),
             )
 
         sup_mean = nis2_kritis_signals.supplier_mean_percent
         cov_ratio = board_kpis.nis2_kritis_systems_full_coverage_ratio
-        thr_sup = NIS2_KRITIS_SUPPLIER_COVERAGE_MEAN_ALERT_PCT
+        thr_sup = float(_cfg.supplier_coverage.mean_percent_warning)
+        cov_thr = _cfg.supplier_coverage.full_coverage_ratio_warning
         supplier_gap = sup_mean is not None and sup_mean < thr_sup
-        coverage_gap = cov_ratio < NIS2_KRITIS_FULL_COVERAGE_RATIO_ALERT
+        coverage_gap = cov_ratio < cov_thr
         if supplier_gap or coverage_gap:
             parts: list[str] = []
             if supplier_gap and sup_mean is not None:
@@ -125,22 +131,37 @@ def compute_board_alerts(
             if coverage_gap:
                 parts.append(
                     f"KPI-Vollständigkeit je System {int(cov_ratio * 100)} % "
-                    f"(Ziel mindestens {int(NIS2_KRITIS_FULL_COVERAGE_RATIO_ALERT * 100)} %)",
+                    f"(Ziel mindestens {int(cov_thr * 100)} %)",
                 )
             add(
                 "nis2_kritis_supplier_coverage_gap",
                 "warning",
                 "NIS2/KRITIS Supplier-Risiko: " + "; ".join(parts) + ".",
+                AIKpiAlertMetadata(
+                    current_percent=round(sup_mean, 2) if sup_mean is not None else None,
+                    threshold_percent=thr_sup if supplier_gap else None,
+                    kpi_type="SUPPLIER_RISK_COVERAGE",
+                    affected_system_ids=list(nis2_kritis_signals.supplier_worst_system_ids),
+                    coverage_ratio_current=cov_ratio if coverage_gap else None,
+                    coverage_ratio_threshold=cov_thr if coverage_gap else None,
+                ),
             )
 
+        ot_thr = float(_cfg.ot_it_segmentation.focus_system_value_below_percent)
+        ot_min = _cfg.ot_it_segmentation.min_affected_systems_for_critical_alert
         ot_n = nis2_kritis_signals.high_risk_focus_low_ot_it_count
-        if ot_n >= NIS2_KRITIS_OT_IT_ALERT_MIN_AFFECTED_SYSTEMS:
+        if ot_n >= ot_min:
             add(
                 "nis2_kritis_ot_it_segmentation_risk",
                 "critical",
                 f"{ot_n} High-Risk-/Fokus-KI-Systeme mit OT/IT-Segmentierung "
-                f"unter {NIS2_KRITIS_OT_IT_ALERT_THRESHOLD_PCT} % – "
+                f"unter {int(ot_thr)} % – "
                 "Handlungsbedarf KRITIS/OT-Schnittstellen.",
+                AIKpiAlertMetadata(
+                    threshold_percent=ot_thr,
+                    kpi_type="OT_IT_SEGREGATION",
+                    affected_system_ids=list(nis2_kritis_signals.ot_it_worst_focus_system_ids),
+                ),
             )
 
     return alerts

--- a/app/services/board_kpi_export.py
+++ b/app/services/board_kpi_export.py
@@ -51,6 +51,8 @@ def build_board_kpi_export_envelope(
         tenant_id=tenant_id,
         generated_at=datetime.now(UTC),
         systems=rows,
+        regulatory_scope=["EU_AI_ACT", "NIS2", "ISO_42001"],
+        generated_by="board_kpi_export_v1",
     )
 
 
@@ -71,9 +73,12 @@ def board_kpi_export_csv(envelope: BoardKpiExportEnvelope) -> str:
             "nis2_kritis_ot_it_segregation_percent",
             "export_generated_at",
             "format_version",
+            "regulatory_scope",
+            "generated_by",
         ]
     )
     gen = envelope.generated_at.isoformat() if envelope.generated_at else ""
+    scope = "|".join(envelope.regulatory_scope)
     for r in envelope.systems:
         writer.writerow(
             [
@@ -95,6 +100,8 @@ def board_kpi_export_csv(envelope: BoardKpiExportEnvelope) -> str:
                 else "",
                 gen,
                 envelope.format_version,
+                scope,
+                envelope.generated_by,
             ]
         )
     return out.getvalue()

--- a/app/services/eu_ai_act_readiness.py
+++ b/app/services/eu_ai_act_readiness.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 from app.ai_governance_action_models import GovernanceActionStatus
-from app.compliance_gap_models import ComplianceStatus, ComplianceStatusEntry
+from app.compliance_gap_models import (
+    REQUIREMENTS,
+    REQUIREMENTS_BY_ID,
+    ComplianceStatus,
+    ComplianceStatusEntry,
+)
 from app.eu_ai_act_readiness_models import (
     EUAIActReadinessOverview,
     ReadinessCriticalRequirement,
@@ -15,9 +20,32 @@ from app.repositories.ai_systems import AISystemRepository
 from app.repositories.classifications import ClassificationRepository
 from app.repositories.compliance_gap import ComplianceGapRepository
 from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
-from app.services.compliance_dashboard import compute_ai_compliance_overview
+from app.services.compliance_dashboard import (
+    compute_ai_compliance_overview,
+    compute_compliance_dashboard,
+)
 
 ART12_ID = "art12_logging"
+
+
+def _action_matches_requirement(
+    action_related_requirement: str,
+    *,
+    article: str,
+    requirement_id: str,
+) -> bool:
+    """Heuristik: Maßnahmen-Freitext vs. Artikel-Kürzel / Requirement-ID."""
+    r = action_related_requirement.lower().strip()
+    rid = requirement_id.lower().strip()
+    if rid and rid in r:
+        return True
+    art = article.lower().strip()
+    if art and art in action_related_requirement.lower():
+        return True
+    compact_art = art.replace(" ", "")
+    if compact_art and compact_art in r.replace(" ", ""):
+        return True
+    return False
 
 
 def _statuses_map(
@@ -135,6 +163,12 @@ def compute_eu_ai_act_readiness_overview(
         gap_repo=gap_repo,
         nis2_kritis_kpi_repository=nis2_repo,
     )
+    dashboard = compute_compliance_dashboard(
+        tenant_id=tenant_id,
+        ai_repo=ai_repo,
+        cls_repo=cls_repo,
+        gap_repo=gap_repo,
+    )
     smap = _statuses_map(tenant_id, gap_repo)
     complete = 0
     incomplete = 0
@@ -155,31 +189,59 @@ def compute_eu_ai_act_readiness_overview(
         else:
             incomplete += 1
 
+    req_affected: dict[str, set[str]] = {}
+    for sys in dashboard.systems:
+        if sys.risk_level != "high_risk":
+            continue
+        for s in smap.get(sys.ai_system_id, []):
+            if s.status != ComplianceStatus.not_started:
+                continue
+            req = REQUIREMENTS_BY_ID.get(s.requirement_id)
+            if req:
+                req_affected.setdefault(req.id, set()).add(sys.ai_system_id)
+
+    open_actions_all = action_repo.list_for_tenant(tenant_id, limit=200)
+    open_for_match = [
+        a
+        for a in open_actions_all
+        if a.status in (GovernanceActionStatus.open, GovernanceActionStatus.in_progress)
+    ]
+
     critical: list[ReadinessCriticalRequirement] = []
-    sorted_top = sorted(
-        base.top_critical_requirements,
-        key=lambda r: -r.affected_systems_count,
-    )
-    for i, tr in enumerate(sorted_top[:8]):
+    _req_order = {r.id: i for i, r in enumerate(REQUIREMENTS)}
+    sorted_req = sorted(
+        req_affected.items(),
+        key=lambda x: (-len(x[1]), _req_order.get(x[0], 999)),
+    )[:8]
+    for i, (req_id, system_ids) in enumerate(sorted_req):
+        req = REQUIREMENTS_BY_ID.get(req_id)
+        if not req:
+            continue
+        linked = [
+            a.id
+            for a in open_for_match
+            if _action_matches_requirement(
+                a.related_requirement,
+                article=req.article,
+                requirement_id=req.id,
+            )
+        ]
+        n = len(system_ids)
         critical.append(
             ReadinessCriticalRequirement(
-                code=tr.article,
-                name=tr.name,
-                affected_systems_count=tr.affected_systems_count,
-                traffic=_traffic_for_count(tr.affected_systems_count),
+                requirement_id=req.id,
+                code=req.article,
+                name=req.name,
+                affected_systems_count=n,
+                traffic=_traffic_for_count(n),
                 priority=min(5, i + 1),
+                related_ai_system_ids=sorted(system_ids)[:100],
+                linked_governance_action_ids=linked,
+                open_actions_count_for_requirement=len(linked),
             )
         )
 
-    open_actions = action_repo.list_for_tenant(
-        tenant_id,
-        limit=50,
-    )
-    open_only = [
-        a
-        for a in open_actions
-        if a.status in (GovernanceActionStatus.open, GovernanceActionStatus.in_progress)
-    ][:20]
+    open_only = open_for_match[:20]
 
     suggested = _build_suggested(tenant_id, ai_repo, cls_repo, smap)
 

--- a/app/services/nis2_kritis_alert_signals.py
+++ b/app/services/nis2_kritis_alert_signals.py
@@ -14,6 +14,9 @@ class Nis2KritisAlertSignals:
     supplier_mean_percent: float | None
     ot_it_mean_percent: float | None
     high_risk_focus_low_ot_it_count: int
+    incident_worst_system_ids: tuple[str, ...]
+    supplier_worst_system_ids: tuple[str, ...]
+    ot_it_worst_focus_system_ids: tuple[str, ...]
 
 
 def build_nis2_kritis_alert_signals(
@@ -27,9 +30,27 @@ def build_nis2_kritis_alert_signals(
         tenant_id,
         threshold_percent=ot_it_threshold_percent,
     )
+    inc_ids = nis2_repo.list_system_ids_lowest_kpi(
+        tenant_id,
+        Nis2KritisKpiType.INCIDENT_RESPONSE_MATURITY,
+        limit=3,
+    )
+    sup_ids = nis2_repo.list_system_ids_lowest_kpi(
+        tenant_id,
+        Nis2KritisKpiType.SUPPLIER_RISK_COVERAGE,
+        limit=3,
+    )
+    ot_ids = nis2_repo.list_focus_system_ids_ot_it_below(
+        tenant_id,
+        threshold_percent=ot_it_threshold_percent,
+        limit=3,
+    )
     return Nis2KritisAlertSignals(
         incident_mean_percent=means.get(Nis2KritisKpiType.INCIDENT_RESPONSE_MATURITY),
         supplier_mean_percent=means.get(Nis2KritisKpiType.SUPPLIER_RISK_COVERAGE),
         ot_it_mean_percent=means.get(Nis2KritisKpiType.OT_IT_SEGREGATION),
         high_risk_focus_low_ot_it_count=low_ot,
+        incident_worst_system_ids=tuple(inc_ids),
+        supplier_worst_system_ids=tuple(sup_ids),
+        ot_it_worst_focus_system_ids=tuple(ot_ids),
     )

--- a/frontend/src/app/board/eu-ai-act-readiness/page.tsx
+++ b/frontend/src/app/board/eu-ai-act-readiness/page.tsx
@@ -7,6 +7,13 @@ import {
   type ReadinessRequirementTraffic,
 } from "@/lib/api";
 
+function aiSystemsFilterHref(systemIds: string[]): string {
+  const q = systemIds.length
+    ? `?ids=${encodeURIComponent(systemIds.slice(0, 100).join(","))}`
+    : "";
+  return `/tenant/ai-systems${q}`;
+}
+
 function trafficDot(traffic: ReadinessRequirementTraffic): string {
   switch (traffic) {
     case "red":
@@ -141,20 +148,54 @@ export default async function EuAiActReadinessPage() {
           <ul className="mt-3 space-y-2">
             {data.critical_requirements.map((r) => (
               <li
-                key={`${r.code}-${r.name}`}
+                key={r.requirement_id ?? `${r.code}-${r.name}`}
                 className="flex items-start gap-3 rounded-lg border border-slate-100 bg-white px-3 py-2 text-sm shadow-sm"
               >
                 <span
                   className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${trafficDot(r.traffic)}`}
                   title={r.traffic}
                 />
-                <div>
-                  <span className="font-medium text-slate-900">
-                    {r.code}: {r.name}
-                  </span>
-                  <span className="ml-2 text-slate-500">
-                    {r.affected_systems_count} Systeme · Prio {r.priority}
-                  </span>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="font-medium text-slate-900">
+                      {r.code}: {r.name}
+                    </span>
+                    <span className="text-slate-500">
+                      {r.affected_systems_count} Systeme · Prio {r.priority}
+                    </span>
+                    {(r.open_actions_count_for_requirement ?? 0) > 0 ? (
+                      <span
+                        className="inline-flex rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-900"
+                        title="Offene oder laufende Maßnahmen mit Bezug zu dieser Anforderung"
+                      >
+                        {r.open_actions_count_for_requirement} Maßnahme
+                        {(r.open_actions_count_for_requirement ?? 0) === 1 ? "" : "n"}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+                    {(r.related_ai_system_ids?.length ?? 0) > 0 ? (
+                      <Link
+                        href={aiSystemsFilterHref(r.related_ai_system_ids ?? [])}
+                        className="font-medium text-slate-600 underline hover:text-slate-900"
+                      >
+                        Zu den betroffenen Systemen
+                      </Link>
+                    ) : null}
+                    <Link
+                      href="/board/eu-ai-act-readiness#governance-actions"
+                      className="font-medium text-slate-600 underline hover:text-slate-900"
+                    >
+                      Maßnahmen ansehen
+                    </Link>
+                    <Link
+                      href="/board/eu-ai-act-readiness#governance-actions"
+                      className="font-medium text-slate-600 underline hover:text-slate-900"
+                      title="Neue Einträge z. B. über POST /api/v1/ai-governance/actions oder Ihr ITSM"
+                    >
+                      Maßnahme erfassen
+                    </Link>
+                  </div>
                 </div>
               </li>
             ))}
@@ -188,7 +229,7 @@ export default async function EuAiActReadinessPage() {
         )}
       </section>
 
-      <section aria-label="Offene Maßnahmen">
+      <section id="governance-actions" aria-label="Offene Maßnahmen">
         <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
           Offene Maßnahmen
         </h2>

--- a/frontend/src/app/board/kpis/BoardKpiAdvisorExport.tsx
+++ b/frontend/src/app/board/kpis/BoardKpiAdvisorExport.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import React, { useState } from "react";
+
+import { getBoardKpiExportUrl } from "@/lib/api";
+
+const TIP_JSON =
+  "Strukturierter Export: alle KI-Systeme des Tenants mit NIS2-/KRITIS-KPI-Werten " +
+  "(Incident-Reife, Supplier-Risk, OT/IT-Segmentierung), Szenario-Profil-ID, " +
+  "Risk-Level, AI-Act-Kategorie sowie Envelope-Felder (regulatory_scope, generated_by) " +
+  "für DMS- und Integrationspfade.";
+
+const TIP_CSV =
+  "Tabellarischer Export derselben Systemzeilen wie JSON – ideal für Excel, " +
+  "WP-Arbeitsmappen, DATEV-/DMS-Importe und manuelle Prüfung durch Kanzleien.";
+
+export function BoardKpiAdvisorExport() {
+  const [format, setFormat] = useState<"json" | "csv">("json");
+
+  return (
+    <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+        <label className="text-xs font-semibold text-slate-700">
+          Export für WP / DMS / DATEV
+          <select
+            className="ml-2 mt-1 block rounded-md border border-slate-300 bg-white px-2 py-1 text-xs font-normal text-slate-800 sm:mt-0 sm:inline-block"
+            value={format}
+            onChange={(e) => setFormat(e.target.value as "json" | "csv")}
+            aria-label="Exportformat für Berater und Archivierung"
+          >
+            <option value="json" title={TIP_JSON}>
+              JSON (API / DMS-Pipeline)
+            </option>
+            <option value="csv" title={TIP_CSV}>
+              CSV (Excel / WP / DATEV-Import)
+            </option>
+          </select>
+        </label>
+        <span className="text-xs text-slate-600" title={format === "json" ? TIP_JSON : TIP_CSV}>
+          {format === "json" ? TIP_JSON : TIP_CSV}
+        </span>
+        <a
+          href={getBoardKpiExportUrl(format)}
+          download
+          className="inline-flex shrink-0 items-center justify-center rounded-md border border-slate-300 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 underline-offset-2 hover:bg-slate-100 hover:underline"
+        >
+          Datei herunterladen
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -6,7 +6,6 @@ import {
   fetchBoardAlerts,
   fetchBoardKpis,
   fetchBoardAlertsExport,
-  getBoardKpiExportUrl,
   getBoardReportDownloadUrl,
   getBoardReportMarkdownDownloadUrl,
   type AIComplianceOverview,
@@ -14,6 +13,7 @@ import {
   type BoardKpiSummary,
 } from "@/lib/api";
 
+import { BoardKpiAdvisorExport } from "./BoardKpiAdvisorExport";
 import { BoardReportAuditSection } from "./BoardReportAuditSection";
 import { BoardReportExportForm } from "./BoardReportExportForm";
 
@@ -226,24 +226,7 @@ export default async function BoardKpisPage() {
             Board-Report als Markdown
           </a>
         </p>
-        <p className="mt-2 text-xs text-slate-600">
-          Export Board-KPIs (DMS / DATEV / SAP-BTP-Vorbereitung):{" "}
-          <a
-            href={getBoardKpiExportUrl("json")}
-            download
-            className="font-medium text-slate-800 underline hover:text-slate-600"
-          >
-            JSON
-          </a>
-          {" · "}
-          <a
-            href={getBoardKpiExportUrl("csv")}
-            download
-            className="font-medium text-slate-800 underline hover:text-slate-600"
-          >
-            CSV
-          </a>
-        </p>
+        <BoardKpiAdvisorExport />
       </section>
 
       {/* Hero: ISO 42001 Governance Score */}

--- a/frontend/src/app/tenant/ai-systems/page.tsx
+++ b/frontend/src/app/tenant/ai-systems/page.tsx
@@ -15,12 +15,28 @@ function classNames(...values: (string | false | null | undefined)[]) {
   return values.filter(Boolean).join(" ");
 }
 
-export default async function TenantAISystemsPage() {
+type PageProps = {
+  searchParams?: Promise<{ ids?: string }> | { ids?: string };
+};
+
+export default async function TenantAISystemsPage({ searchParams }: PageProps) {
   const systems = (await fetchTenantAISystems()) as AISystem[];
 
-  const total = systems.length;
-  const active = systems.filter((s) => s.status === "active").length;
-  const highRisk = systems.filter((s) => s.risklevel === "high").length;
+  const sp =
+    searchParams !== undefined ? await Promise.resolve(searchParams) : {};
+  const idFilterRaw = typeof sp.ids === "string" ? sp.ids : "";
+  const idSet = new Set(
+    idFilterRaw
+      .split(",")
+      .map((x) => x.trim())
+      .filter(Boolean),
+  );
+  const filtered =
+    idSet.size > 0 ? systems.filter((s) => idSet.has(s.id)) : systems;
+
+  const total = filtered.length;
+  const active = filtered.filter((s) => s.status === "active").length;
+  const highRisk = filtered.filter((s) => s.risklevel === "high").length;
 
   return (
     <>
@@ -37,6 +53,16 @@ export default async function TenantAISystemsPage() {
           Neues AI‑System anlegen
         </button>
       </header>
+
+      {idSet.size > 0 ? (
+        <div
+          role="status"
+          className="mb-4 rounded-lg border border-amber-500/40 bg-amber-500/10 px-4 py-2 text-xs text-amber-100"
+        >
+          Gefilterte Ansicht: {filtered.length} von {systems.length} Systemen
+          (Deep-Link aus EU-AI-Act-Readiness).
+        </div>
+      ) : null}
 
       <section className="mb-6 grid gap-4 md:grid-cols-3">
         <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
@@ -66,7 +92,10 @@ export default async function TenantAISystemsPage() {
       <section className="rounded-xl border border-slate-800 bg-slate-900/60">
         <div className="flex items-center justify-between border-b border-slate-800 px-5 py-3">
           <h2 className="text-sm font-semibold">AI‑Systeme</h2>
-          <span className="text-xs text-slate-500">{total} Einträge</span>
+          <span className="text-xs text-slate-500">
+            {total} Einträge
+            {idSet.size > 0 ? " (gefiltert)" : ""}
+          </span>
         </div>
         <div className="overflow-x-auto">
           <table className="min-w-full text-left text-sm">
@@ -81,7 +110,7 @@ export default async function TenantAISystemsPage() {
               </tr>
             </thead>
             <tbody>
-              {systems.map((s) => (
+              {filtered.map((s) => (
                 <tr
                   key={s.id}
                   className="border-t border-slate-800/80 hover:bg-slate-900"
@@ -121,7 +150,7 @@ export default async function TenantAISystemsPage() {
                   </td>
                 </tr>
               ))}
-              {systems.length === 0 && (
+              {filtered.length === 0 && (
                 <tr>
                   <td
                     colSpan={6}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -261,6 +261,16 @@ export async function fetchBoardKpis(): Promise<BoardKpiSummary> {
 /** Board-KPI-Alert (NIS2 / EU AI Act / ISO 42001 Schwellenwerte) */
 export type AIKpiAlertSeverity = "info" | "warning" | "critical";
 
+/** Optionale Kennzahlen zu NIS2-/KRITIS-KPI-Alerts (Ist/Soll, KPI-Typ, Top-Systeme). */
+export interface AIKpiAlertMetadata {
+  current_percent?: number | null;
+  threshold_percent?: number | null;
+  kpi_type?: string | null;
+  affected_system_ids?: string[];
+  coverage_ratio_current?: number | null;
+  coverage_ratio_threshold?: number | null;
+}
+
 export interface AIKpiAlert {
   id: string;
   tenant_id: string;
@@ -269,6 +279,7 @@ export interface AIKpiAlert {
   message: string;
   created_at: string;
   resolved_at: string | null;
+  alert_metadata?: AIKpiAlertMetadata | null;
 }
 
 export async function fetchBoardAlerts(): Promise<AIKpiAlert[]> {
@@ -675,6 +686,10 @@ export interface ReadinessCriticalRequirement {
   affected_systems_count: number;
   traffic: ReadinessRequirementTraffic;
   priority: number;
+  requirement_id?: string | null;
+  related_ai_system_ids?: string[];
+  linked_governance_action_ids?: string[];
+  open_actions_count_for_requirement?: number;
 }
 
 export interface SuggestedGovernanceAction {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 pythonpath = [
+  ".",
   "app",
 ]
 addopts = "-q"

--- a/tests/test_board_kpi_export.py
+++ b/tests/test_board_kpi_export.py
@@ -47,6 +47,8 @@ def test_board_kpi_export_json():
     data = json.loads(r.text)
     assert data["format_version"] == "1.0"
     assert data["tenant_id"] == "board-kpi-tenant"
+    assert data["generated_by"] == "board_kpi_export_v1"
+    assert data["regulatory_scope"] == ["EU_AI_ACT", "NIS2", "ISO_42001"]
     row = next(s for s in data["systems"] if s["ai_system_id"] == "kpi-exp-1")
     assert row["nis2_kritis_supplier_risk_coverage_percent"] == 62
     assert row["high_risk_scenario_profile_id"] == "manufacturing_quality_control"
@@ -61,6 +63,8 @@ def test_board_kpi_export_csv():
     assert r.status_code == 200
     assert "tenant_id" in r.text
     assert "format_version" in r.text
+    assert "regulatory_scope" in r.text
+    assert "generated_by" in r.text
 
 
 def test_board_kpi_export_tenant_isolation():

--- a/tests/test_eu_ai_act_readiness.py
+++ b/tests/test_eu_ai_act_readiness.py
@@ -36,3 +36,64 @@ def test_eu_ai_act_readiness_tenant_isolation():
     r = client.get("/api/v1/ai-governance/readiness/eu-ai-act", headers=_h(tid))
     assert r.status_code == 200
     assert r.json()["tenant_id"] == tid
+
+
+def test_eu_ai_act_readiness_critical_requirement_deep_links():
+    """Kritische Anforderungen: System-IDs und verknüpfte Governance-Actions."""
+    tid = "readiness-dl-tenant"
+    h = _h(tid)
+    sid = "readiness-dl-sys-1"
+    client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": sid,
+            "name": "DL High-Risk",
+            "description": "Test",
+            "business_unit": "Ops",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": True,
+            "owner_email": "a@b.de",
+            "criticality": "high",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": True,
+            "has_supplier_risk_register": True,
+            "has_backup_runbook": True,
+        },
+        headers=h,
+    )
+    cl = client.post(
+        f"/api/v1/ai-systems/{sid}/classify",
+        headers=h,
+        json={"use_case_domain": "biometrics"},
+    )
+    assert cl.status_code == 200
+    assert cl.json()["risk_level"] == "high_risk"
+    action_r = client.post(
+        "/api/v1/ai-governance/actions",
+        headers=h,
+        json={
+            "related_ai_system_id": sid,
+            "related_requirement": "EU AI Act Art. 9 – Risikomanagement",
+            "title": "Risiko-Maßnahme testen",
+            "status": "open",
+        },
+    )
+    assert action_r.status_code == 201
+    action_id = action_r.json()["id"]
+
+    r = client.get("/api/v1/ai-governance/readiness/eu-ai-act", headers=h)
+    assert r.status_code == 200
+    data = r.json()
+    art9 = next(
+        (
+            c
+            for c in data["critical_requirements"]
+            if c.get("requirement_id") == "art9_risk_management"
+        ),
+        None,
+    )
+    assert art9 is not None
+    assert sid in (art9.get("related_ai_system_ids") or [])
+    assert action_id in (art9.get("linked_governance_action_ids") or [])
+    assert art9.get("open_actions_count_for_requirement", 0) >= 1

--- a/tests/test_nis2_kritis_board_kpi_alerts.py
+++ b/tests/test_nis2_kritis_board_kpi_alerts.py
@@ -40,8 +40,15 @@ def test_board_alert_nis2_incident_maturity_low_from_kpi_mean():
     )
     r = client.get("/api/v1/ai-governance/alerts/board", headers=h)
     assert r.status_code == 200
-    keys = {a["kpi_key"] for a in r.json()}
+    alerts = r.json()
+    keys = {a["kpi_key"] for a in alerts}
     assert "nis2_kritis_incident_maturity_low" in keys
+    inc_alert = next(a for a in alerts if a["kpi_key"] == "nis2_kritis_incident_maturity_low")
+    meta = inc_alert.get("alert_metadata") or {}
+    assert meta.get("kpi_type") == "INCIDENT_RESPONSE_MATURITY"
+    assert meta.get("current_percent") == 30.0
+    assert meta.get("threshold_percent") == 50.0
+    assert meta.get("affected_system_ids") == [sid]
 
 
 def test_board_alert_nis2_ot_it_segmentation_risk():
@@ -76,8 +83,17 @@ def test_board_alert_nis2_ot_it_segmentation_risk():
         )
     r = client.get("/api/v1/ai-governance/alerts/board", headers=h)
     assert r.status_code == 200
-    keys = {a["kpi_key"] for a in r.json()}
+    alerts = r.json()
+    keys = {a["kpi_key"] for a in alerts}
     assert "nis2_kritis_ot_it_segmentation_risk" in keys
+    ot_alert = next(a for a in alerts if a["kpi_key"] == "nis2_kritis_ot_it_segmentation_risk")
+    ot_meta = ot_alert.get("alert_metadata") or {}
+    assert ot_meta.get("kpi_type") == "OT_IT_SEGREGATION"
+    assert ot_meta.get("threshold_percent") == 60.0
+    assert set(ot_meta.get("affected_system_ids") or []) <= {
+        f"alert-ot-{tid}-0",
+        f"alert-ot-{tid}-1",
+    }
 
 
 def test_board_alert_nis2_kpi_tenant_isolation():


### PR DESCRIPTION
…t-Metadaten

- NIS2-/KRITIS-Schwellen zentral typisiert; Board-Alerts mit optionalem alert_metadata (Ist-/Soll-Prozent, KPI-Typ, bis zu drei betroffene System-IDs).
- EU-AI-Act-Readiness: related_ai_system_ids, verknüpfte Actions, stabile Priorisierung bei gleicher Betroffenheit; Compliance-Gaps nutzen GAP_REQUIREMENTS (applies_to).
- KPI-Export-Envelope: regulatory_scope, generated_by; CSV-Spalten ergänzt.
- Frontend: WP/DMS/DATEV-Export-Dropdown mit Kurzinfos; Readiness-Links zur Registry (?ids=) und Anker #governance-actions; Badge für Maßnahmenzahl.
- pytest: pythonpath um Projektroot ergänzt (tests.*-Imports).

Made-with: Cursor