### PR TITLE
fix(frontend): unify board layout shell and align header/footer width

### DIFF
--- a/frontend/public/static/css/components.css
+++ b/frontend/public/static/css/components.css
@@ -1,12 +1,21 @@
 /* Wiederverwendbare Bausteine für App-Seiten (Compliance Hub + SBS-Stil) */
 
 .sbs-page-main {
-  max-width: 72rem;
+  max-width: 80rem;
   margin: 0 auto;
   padding: 2rem 1rem 3rem;
   min-height: calc(100vh - var(--sbs-header-h) - 120px);
+  min-width: 0;
+  width: 100%;
   color: var(--sbs-text-primary);
   font-family: var(--sbs-font);
+}
+
+@media (min-width: 768px) {
+  .sbs-page-main {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+  }
 }
 
 .sbs-panel {

--- a/frontend/public/static/css/sbs-2026.css
+++ b/frontend/public/static/css/sbs-2026.css
@@ -10,6 +10,7 @@ body.has-fixed-header {
   background: var(--sbs-bg-page);
   color: var(--sbs-text-primary);
   -webkit-font-smoothing: antialiased;
+  overflow-x: clip;
 }
 
 .sbs-header-2026 {
@@ -29,14 +30,21 @@ body.has-fixed-header {
 }
 
 .sbs-header-inner {
-  max-width: 1200px;
+  max-width: 80rem;
   margin: 0 auto;
-  padding: 0 1.25rem;
+  padding: 0 1rem;
   width: 100%;
+  min-width: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .sbs-header-inner {
+    padding: 0 1.5rem;
+  }
 }
 
 .sbs-brand {
@@ -105,14 +113,22 @@ body.has-fixed-header {
 }
 
 .sbs-footer-inner {
-  max-width: 1200px;
+  max-width: 80rem;
   margin: 0 auto;
+  padding: 0 1rem;
+  min-width: 0;
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   gap: 1rem;
   font-size: 0.75rem;
   color: var(--sbs-text-secondary);
+}
+
+@media (min-width: 768px) {
+  .sbs-footer-inner {
+    padding: 0 1.5rem;
+  }
 }
 
 .sbs-footer-inner a {

--- a/frontend/src/app/board/eu-ai-act-readiness/page.tsx
+++ b/frontend/src/app/board/eu-ai-act-readiness/page.tsx
@@ -6,6 +6,7 @@ import {
   type EUAIActReadinessOverview,
   type ReadinessRequirementTraffic,
 } from "@/lib/api";
+import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
 
 function aiSystemsFilterHref(systemIds: string[]): string {
   const q = systemIds.length
@@ -35,7 +36,7 @@ export default async function EuAiActReadinessPage() {
 
   if (!data) {
     return (
-      <main className="sbs-page-main">
+      <main className={BOARD_PAGE_MAIN_CLASS}>
         <header className="mb-6">
           <h1 className="sbs-h1">
             EU AI Act Readiness
@@ -64,12 +65,12 @@ export default async function EuAiActReadinessPage() {
   const q3done = data.days_remaining > 0 && data.overall_readiness >= 0.85;
 
   return (
-    <main className="sbs-page-main">
+    <main className={BOARD_PAGE_MAIN_CLASS}>
       <header className="mb-6">
         <h1 className="sbs-h1">
           EU AI Act Readiness (High-Risk)
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="sbs-subtitle">
           Stichtag {data.deadline} · noch {data.days_remaining} Tage ·
           Gesamt-Readiness {readinessPct} %
         </p>
@@ -85,9 +86,9 @@ export default async function EuAiActReadinessPage() {
 
       <section
         aria-label="Kernkennzahlen"
-        className="mb-8 grid gap-4 md:grid-cols-3"
+        className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-3"
       >
-        <div className="sbs-panel p-4">
+        <div className="sbs-panel min-w-0 p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Overall Readiness
           </h2>
@@ -95,7 +96,7 @@ export default async function EuAiActReadinessPage() {
             {readinessPct} %
           </p>
         </div>
-        <div className="sbs-panel p-4">
+        <div className="sbs-panel min-w-0 p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             High-Risk mit essenziellen Controls
           </h2>
@@ -103,7 +104,7 @@ export default async function EuAiActReadinessPage() {
             {data.high_risk_systems_essential_complete}
           </p>
         </div>
-        <div className="sbs-panel p-4">
+        <div className="sbs-panel min-w-0 p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             High-Risk mit Lücken
           </h2>
@@ -149,7 +150,7 @@ export default async function EuAiActReadinessPage() {
             {data.critical_requirements.map((r) => (
               <li
                 key={r.requirement_id ?? `${r.code}-${r.name}`}
-                className="sbs-panel flex items-start gap-3 px-3 py-2 text-sm"
+                className="sbs-panel flex min-w-0 items-start gap-3 px-3 py-2 text-sm"
               >
                 <span
                   className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${trafficDot(r.traffic)}`}

--- a/frontend/src/app/board/incidents/page.tsx
+++ b/frontend/src/app/board/incidents/page.tsx
@@ -7,6 +7,7 @@ import {
   type AIIncidentBySystem,
   type AIIncidentOverview,
 } from "@/lib/api";
+import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
 
 function severityBadgeClass(severity: string): string {
   switch (severity) {
@@ -50,12 +51,12 @@ export default async function BoardIncidentsPage() {
 
   if (!overview) {
     return (
-      <main className="sbs-page-main">
+      <main className={BOARD_PAGE_MAIN_CLASS}>
         <header className="mb-6">
           <h1 className="sbs-h1">
             AI Governance – Incident-Übersicht
           </h1>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="sbs-subtitle">
             NIS2 Art. 21/23 · ISO 42001 Incident Management
           </p>
         </header>
@@ -81,12 +82,12 @@ export default async function BoardIncidentsPage() {
   const topSystems = bySystem.slice(0, 3);
 
   return (
-    <main className="sbs-page-main">
+    <main className={BOARD_PAGE_MAIN_CLASS}>
       <header className="mb-6">
         <h1 className="sbs-h1">
           AI Governance – Incident-Übersicht
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="sbs-subtitle">
           NIS2 Art. 21/23 (Incident & Business Continuity) · ISO 42001 Incident
           Management · Standort Deutschland
         </p>
@@ -103,9 +104,9 @@ export default async function BoardIncidentsPage() {
 
       <section
         aria-label="Incident-KPIs"
-        className="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4"
+        className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
       >
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Incidents letzte 12 Monate
           </h2>
@@ -114,7 +115,7 @@ export default async function BoardIncidentsPage() {
           </p>
           <p className="mt-1 text-xs text-slate-500">Gesamt (Rolling 12 Monate)</p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Aktuell offene Incidents
           </h2>
@@ -123,7 +124,7 @@ export default async function BoardIncidentsPage() {
           </p>
           <p className="mt-1 text-xs text-slate-500">Status: offen</p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Major Incidents (NIS2-relevant)
           </h2>
@@ -132,7 +133,7 @@ export default async function BoardIncidentsPage() {
           </p>
           <p className="mt-1 text-xs text-slate-500">Schweregrad Hoch, 12 Monate</p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             MTTA / MTTR
           </h2>

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -12,6 +12,7 @@ import {
   type AIKpiAlert,
   type BoardKpiSummary,
 } from "@/lib/api";
+import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
 
 import { BoardKpiAdvisorExport } from "./BoardKpiAdvisorExport";
 import { BoardReportAuditSection } from "./BoardReportAuditSection";
@@ -115,7 +116,7 @@ export default async function BoardKpisPage() {
 
   if (!kpis) {
     return (
-      <main className="sbs-page-main">
+      <main className={BOARD_PAGE_MAIN_CLASS}>
         <header className="mb-6">
           <h1 className="sbs-h1">
             AI Governance – Board KPIs
@@ -135,7 +136,7 @@ export default async function BoardKpisPage() {
   const isoScore = kpis.iso42001_governance_score;
 
   return (
-    <main className="sbs-page-main">
+    <main className={BOARD_PAGE_MAIN_CLASS}>
       <header className="mb-6">
         <h1 className="sbs-h1">
           AI Governance – Board KPIs
@@ -234,7 +235,7 @@ export default async function BoardKpisPage() {
         return (
           <section
             aria-label="AI-Governance-Reife nach ISO 42001"
-            className={`sbs-panel relative mb-8 flex flex-col justify-between gap-4 p-6 ${scoreColor(
+            className={`sbs-panel relative mb-8 flex min-w-0 flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between ${scoreColor(
               isoScore,
             )} ${hasCriticalForIso ? "ring-2 ring-red-300" : ""}`}
           >
@@ -244,31 +245,31 @@ export default async function BoardKpisPage() {
                 aria-hidden
               />
             )}
-            <div>
+            <div className="min-w-0 flex-1">
               <h2 className="text-sm font-semibold uppercase tracking-wide">
                 AI-Governance-Reife (ISO 42001)
               </h2>
-          <p className="mt-1 text-xs text-slate-700">
-            Aggregierter Reifegrad des AI-Managementsystems (Kontext, Führung,
-            Risikobewertung, Betrieb, Verbesserung).
-          </p>
-        </div>
-        <div className="flex items-baseline gap-3">
-          <span className="text-5xl font-semibold leading-none">
-            {formatPercent(isoScore)}
-          </span>
-          <span className="text-sm font-medium text-slate-700">
-            von 100&nbsp;% Zielreife
-          </span>
-        </div>
-      </section>
+              <p className="mt-1 text-xs text-slate-700">
+                Aggregierter Reifegrad des AI-Managementsystems (Kontext, Führung,
+                Risikobewertung, Betrieb, Verbesserung).
+              </p>
+            </div>
+            <div className="flex shrink-0 items-baseline gap-3">
+              <span className="text-5xl font-semibold leading-none">
+                {formatPercent(isoScore)}
+              </span>
+              <span className="text-sm font-medium text-slate-700">
+                von 100&nbsp;% Zielreife
+              </span>
+            </div>
+          </section>
         );
       })()}
 
       {/* KPI Grid */}
       <section
         aria-label="NIS2- und High-Risk-KPIs"
-        className="mb-4 grid gap-4 md:grid-cols-2 lg:grid-cols-4"
+        className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
       >
         {/* NIS2 Incident Readiness */}
         {(() => {
@@ -279,7 +280,7 @@ export default async function BoardKpisPage() {
           );
           return (
             <div
-              className={`sbs-panel relative flex flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
+              className={`sbs-panel relative flex min-w-0 flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
             >
               {hasCritical && (
                 <span
@@ -290,25 +291,25 @@ export default async function BoardKpisPage() {
               <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 NIS2 Incident Readiness
               </h3>
-          <p className="mt-1 text-xs text-slate-500">
-            Anteil KI-Systeme mit Incident- und Backup-Runbook.
-          </p>
-          <div className="mt-4 text-3xl font-semibold text-slate-900">
-            {formatPercent(kpis.nis2_incident_readiness_ratio)}
-          </div>
-          <p className="mt-1 text-xs text-slate-500">
-            {formatPercent(kpis.nis2_incident_readiness_ratio)} der
-            KI-Systeme mit Incident- &amp; Backup-Runbook.
-          </p>
-          <p className="mt-3">
-            <Link
-              href="/board/incidents"
-              className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
-              aria-label="Incident-Drilldown öffnen"
-            >
-              Incident-Details anzeigen
-            </Link>
-          </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Anteil KI-Systeme mit Incident- und Backup-Runbook.
+              </p>
+              <div className="mt-4 text-3xl font-semibold text-slate-900">
+                {formatPercent(kpis.nis2_incident_readiness_ratio)}
+              </div>
+              <p className="mt-1 text-xs text-slate-500">
+                {formatPercent(kpis.nis2_incident_readiness_ratio)} der
+                KI-Systeme mit Incident- &amp; Backup-Runbook.
+              </p>
+              <p className="mt-3">
+                <Link
+                  href="/board/incidents"
+                  className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
+                  aria-label="Incident-Drilldown öffnen"
+                >
+                  Incident-Details anzeigen
+                </Link>
+              </p>
             </div>
           );
         })()}
@@ -322,7 +323,7 @@ export default async function BoardKpisPage() {
           );
           return (
             <div
-              className={`sbs-panel relative flex flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
+              className={`sbs-panel relative flex min-w-0 flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
             >
               {hasCritical && (
                 <span
@@ -333,31 +334,31 @@ export default async function BoardKpisPage() {
               <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 NIS2 Supplier Risk Coverage
               </h3>
-          <p className="mt-1 text-xs text-slate-500">
-            Anteil KI-Systeme mit dokumentiertem Lieferanten-Risikoregister.
-          </p>
-          <div className="mt-4 text-3xl font-semibold text-slate-900">
-            {formatPercent(kpis.nis2_supplier_risk_coverage_ratio)}
-          </div>
-          <p className="mt-1 text-xs text-slate-500">
-            {formatPercent(kpis.nis2_supplier_risk_coverage_ratio)} der Systeme
-            mit Supplier-Risikoregister.
-          </p>
-          <p className="mt-3">
-            <Link
-              href="/board/suppliers"
-              className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
-              aria-label="Supplier-Risiko-Drilldown öffnen"
-            >
-              Details anzeigen
-            </Link>
-          </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Anteil KI-Systeme mit dokumentiertem Lieferanten-Risikoregister.
+              </p>
+              <div className="mt-4 text-3xl font-semibold text-slate-900">
+                {formatPercent(kpis.nis2_supplier_risk_coverage_ratio)}
+              </div>
+              <p className="mt-1 text-xs text-slate-500">
+                {formatPercent(kpis.nis2_supplier_risk_coverage_ratio)} der Systeme
+                mit Supplier-Risikoregister.
+              </p>
+              <p className="mt-3">
+                <Link
+                  href="/board/suppliers"
+                  className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
+                  aria-label="Supplier-Risiko-Drilldown öffnen"
+                >
+                  Details anzeigen
+                </Link>
+              </p>
             </div>
           );
         })()}
 
         {/* High-Risk KI-Systeme gesamt */}
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             High-Risk KI-Systeme gesamt
           </h3>
@@ -373,7 +374,7 @@ export default async function BoardKpisPage() {
         </div>
 
         {/* High-Risk ohne DPIA */}
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             High-Risk ohne DPIA
           </h3>
@@ -402,9 +403,9 @@ export default async function BoardKpisPage() {
             Readiness für High-Risk-Anforderungen bis Anwendungsbeginn EU AI Act
             (2. August 2026) und ISO 42001 AI-Managementsystem.
           </p>
-          <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+          <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
             <div
-              className={`flex flex-col rounded-xl border p-4 ${scoreColor(
+              className={`flex min-w-0 flex-col rounded-xl border p-4 ${scoreColor(
                 complianceOverview.overall_readiness,
               )}`}
             >
@@ -418,7 +419,7 @@ export default async function BoardKpisPage() {
                 EU AI Act &amp; ISO 42001 Anforderungen gewichtet.
               </p>
             </div>
-            <div className="flex flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
+            <div className="flex min-w-0 flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 Frist High-Risk
               </h3>
@@ -429,7 +430,7 @@ export default async function BoardKpisPage() {
                 Bis 2. August 2026 (Vollanwendung High-Risk).
               </p>
             </div>
-            <div className="flex flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
+            <div className="flex min-w-0 flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 High-Risk voll kontrolliert
               </h3>
@@ -440,7 +441,7 @@ export default async function BoardKpisPage() {
                 Systeme mit vollständig erfüllten Anforderungen.
               </p>
             </div>
-            <div className="flex flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
+            <div className="flex min-w-0 flex-col rounded-xl border border-slate-100 bg-slate-50 p-4">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
                 High-Risk mit kritischen Lücken
               </h3>
@@ -452,8 +453,8 @@ export default async function BoardKpisPage() {
               </p>
             </div>
           </div>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <div className="flex flex-col rounded-xl border border-indigo-100 bg-indigo-50/80 p-4">
+          <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div className="flex min-w-0 flex-col rounded-xl border border-indigo-100 bg-indigo-50/80 p-4">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-indigo-800">
                 NIS2 / KRITIS KPI (Mittelwert)
               </h3>
@@ -466,7 +467,7 @@ export default async function BoardKpisPage() {
                 Durchschnitt aller gepflegten Incident-/Supplier-/OT-IT-KPIs (0–100).
               </p>
             </div>
-            <div className="flex flex-col rounded-xl border border-indigo-100 bg-indigo-50/80 p-4">
+            <div className="flex min-w-0 flex-col rounded-xl border border-indigo-100 bg-indigo-50/80 p-4">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-indigo-800">
                 NIS2 / KRITIS KPI-Abdeckung
               </h3>
@@ -487,8 +488,8 @@ export default async function BoardKpisPage() {
               </h3>
               <ul className="mt-2 space-y-1.5 text-sm text-slate-600">
                 {complianceOverview.top_critical_requirements.map((req, i) => (
-                  <li key={i} className="flex justify-between gap-4">
-                    <span>
+                  <li key={i} className="flex min-w-0 justify-between gap-4">
+                    <span className="min-w-0">
                       <strong className="text-slate-800">{req.article}</strong>{" "}
                       {req.name}
                     </span>

--- a/frontend/src/app/board/nis2-kritis/page.tsx
+++ b/frontend/src/app/board/nis2-kritis/page.tsx
@@ -6,6 +6,7 @@ import {
   type Nis2KritisKpiDrilldown,
   type Nis2KritisKpiType,
 } from "@/lib/api";
+import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
 
 const KPI_LABEL: Record<Nis2KritisKpiType, string> = {
   INCIDENT_RESPONSE_MATURITY: "Incident-Response-Reife",
@@ -56,12 +57,12 @@ export default async function BoardNis2KritisPage() {
 
   if (!drilldown) {
     return (
-      <main className="sbs-page-main">
+      <main className={BOARD_PAGE_MAIN_CLASS}>
         <header className="mb-6">
           <h1 className="sbs-h1">
             NIS2 / KRITIS – KPI-Drilldown
           </h1>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="sbs-subtitle">
             Incident-, Supplier- und OT/IT-KPIs je KI-System
           </p>
         </header>
@@ -84,12 +85,12 @@ export default async function BoardNis2KritisPage() {
   }
 
   return (
-    <main className="sbs-page-main">
+    <main className={BOARD_PAGE_MAIN_CLASS}>
       <header className="mb-6">
         <h1 className="sbs-h1">
           NIS2 / KRITIS – KPI-Drilldown
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="sbs-subtitle">
           Verteilung der KPI-Prozentwerte und schwächste KI-Systeme je Typ
           (Top {drilldown.top_n}). Stand:{" "}
           {new Date(drilldown.generated_at).toLocaleString("de-DE")}
@@ -104,7 +105,7 @@ export default async function BoardNis2KritisPage() {
         </p>
       </header>
 
-      <div className="space-y-8">
+      <div className="min-w-0 space-y-8">
         {drilldown.by_kpi_type.map((block) => {
           const maxCount = Math.max(
             ...block.histogram.map((h) => h.count),
@@ -114,7 +115,7 @@ export default async function BoardNis2KritisPage() {
             <section
               key={block.kpi_type}
               aria-label={KPI_LABEL[block.kpi_type]}
-              className="sbs-panel p-5"
+              className="sbs-panel min-w-0 p-5"
             >
               <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
                 {KPI_LABEL[block.kpi_type]}
@@ -136,9 +137,9 @@ export default async function BoardNis2KritisPage() {
                   {block.critical_systems.map((s) => (
                     <li
                       key={`${s.ai_system_id}-${block.kpi_type}`}
-                      className="flex flex-wrap items-baseline justify-between gap-2 py-2 text-sm"
+                      className="flex min-w-0 flex-wrap items-baseline justify-between gap-2 py-2 text-sm"
                     >
-                      <div>
+                      <div className="min-w-0">
                         <span className="font-medium text-slate-900">
                           {s.name}
                         </span>

--- a/frontend/src/app/board/suppliers/page.tsx
+++ b/frontend/src/app/board/suppliers/page.tsx
@@ -7,6 +7,7 @@ import {
   type AISupplierRiskBySystem,
   type AISupplierRiskOverview,
 } from "@/lib/api";
+import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
 
 function riskLevelLabel(level: string): string {
   const labels: Record<string, string> = {
@@ -37,12 +38,12 @@ export default async function BoardSuppliersPage() {
 
   if (!overview) {
     return (
-      <main className="sbs-page-main">
+      <main className={BOARD_PAGE_MAIN_CLASS}>
         <header className="mb-6">
           <h1 className="sbs-h1">
             AI Governance – Supplier-Risiko
           </h1>
-          <p className="mt-1 text-sm text-slate-500">
+          <p className="sbs-subtitle">
             NIS2 Art. 21/24 Supply-Chain-Security · KRITIS-Bezug
           </p>
         </header>
@@ -74,12 +75,12 @@ export default async function BoardSuppliersPage() {
       : 0;
 
   return (
-    <main className="sbs-page-main">
+    <main className={BOARD_PAGE_MAIN_CLASS}>
       <header className="mb-6">
         <h1 className="sbs-h1">
           AI Governance – Supplier-Risiko
         </h1>
-        <p className="mt-1 text-sm text-slate-500">
+        <p className="sbs-subtitle">
           NIS2 Art. 21/24 Supply-Chain-Security · Lieferanten-Risikoregister ·
           KRITIS-Bezug · Standort Deutschland
         </p>
@@ -96,9 +97,9 @@ export default async function BoardSuppliersPage() {
 
       <section
         aria-label="Supplier-Risiko-KPIs"
-        className="mb-8 grid gap-4 md:grid-cols-2 lg:grid-cols-4"
+        className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
       >
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Systeme mit Lieferanten-Register
           </h2>
@@ -110,7 +111,7 @@ export default async function BoardSuppliersPage() {
             Lieferanten-Risikoregister
           </p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Systeme ohne Supplier-Risikoregister
           </h2>
@@ -121,7 +122,7 @@ export default async function BoardSuppliersPage() {
             NIS2 Supply-Chain-Anforderung aktuell nicht erfüllt
           </p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Kritische KI-Systeme gesamt
           </h2>
@@ -132,7 +133,7 @@ export default async function BoardSuppliersPage() {
             Hohe/Sehr hohe Kritikalität (KRITIS-relevant)
           </p>
         </div>
-        <div className="sbs-panel flex flex-col p-4">
+        <div className="sbs-panel flex min-w-0 flex-col p-4">
           <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
             Kritische ohne Lieferanten-Controls
           </h2>

--- a/frontend/src/lib/boardLayout.ts
+++ b/frontend/src/lib/boardLayout.ts
@@ -1,0 +1,5 @@
+/**
+ * Gemeinsamer Wrapper für Board-Routen: zentriert, max. Breite, kein horizontales Overflow.
+ */
+export const BOARD_PAGE_MAIN_CLASS =
+  "mx-auto w-full min-w-0 max-w-7xl px-4 pb-12 pt-8 md:px-6 min-h-[calc(100vh-var(--sbs-header-h)-120px)]";


### PR DESCRIPTION
- Add BOARD_PAGE_MAIN_CLASS (max-w-7xl, centered, min-w-0) for board routes
- Match sbs-header-inner / sbs-footer-inner to 80rem with responsive px
- Clip horizontal overflow on body; tighten sbs-page-main for legacy use
- Harmonize grids (grid-cols-1, min-w-0), ISO hero flex, sbs-subtitles

Made-with: Cursor