### PR TITLE
feat(frontend): Apple/Sintra-inspired shell, home hero, board redesign

### DIFF
--- a/frontend/public/static/css/design-tokens.css
+++ b/frontend/public/static/css/design-tokens.css
@@ -9,7 +9,7 @@
   --sbs-text-secondary: #64748b;
   --sbs-text-muted: #94a3b8;
   --sbs-text-accent: #0066b3;
-  --sbs-bg-page: #f1f5f9;
+  --sbs-bg-page: #f8fafc;
   --sbs-bg-elevated: #ffffff;
   --sbs-bg-alt: #e2e8f0;
   --sbs-border: #e2e8f0;

--- a/frontend/src/app/board/eu-ai-act-readiness/page.tsx
+++ b/frontend/src/app/board/eu-ai-act-readiness/page.tsx
@@ -6,7 +6,13 @@ import {
   type EUAIActReadinessOverview,
   type ReadinessRequirementTraffic,
 } from "@/lib/api";
-import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
+import {
+  BOARD_PAGE_ROOT_CLASS,
+  CH_CARD,
+  CH_PAGE_SUB,
+  CH_PAGE_TITLE,
+  CH_SECTION_LABEL,
+} from "@/lib/boardLayout";
 
 function aiSystemsFilterHref(systemIds: string[]): string {
   const q = systemIds.length
@@ -26,6 +32,40 @@ function trafficDot(traffic: ReadinessRequirementTraffic): string {
   }
 }
 
+function trafficLabel(traffic: ReadinessRequirementTraffic): string {
+  switch (traffic) {
+    case "red":
+      return "Rot";
+    case "amber":
+      return "Gelb";
+    default:
+      return "Grün";
+  }
+}
+
+function ReadinessRing({ percent }: { percent: number }) {
+  const p = Math.min(100, Math.max(0, percent));
+  return (
+    <div
+      className="relative mx-auto h-36 w-36 shrink-0"
+      aria-hidden
+    >
+      <div
+        className="absolute inset-0 rounded-full"
+        style={{
+          background: `conic-gradient(rgb(8 145 178) 0% ${p}%, rgb(226 232 240) ${p}% 100%)`,
+        }}
+      />
+      <div className="absolute inset-[12px] flex flex-col items-center justify-center rounded-full bg-white shadow-inner">
+        <span className="text-3xl font-semibold tabular-nums text-slate-900">{p}%</span>
+        <span className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+          Readiness
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export default async function EuAiActReadinessPage() {
   let data: EUAIActReadinessOverview | null = null;
   try {
@@ -36,27 +76,26 @@ export default async function EuAiActReadinessPage() {
 
   if (!data) {
     return (
-      <main className={BOARD_PAGE_MAIN_CLASS}>
-        <header className="mb-6">
-          <h1 className="sbs-h1">
-            EU AI Act Readiness
-          </h1>
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <header className="mb-8">
+          <h1 className={CH_PAGE_TITLE}>EU AI Act Readiness</h1>
+          <p className={CH_PAGE_SUB}>High-Risk-Systeme bis 02.08.2026</p>
         </header>
         <div
           role="status"
-          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
         >
           Readiness-Daten konnten nicht geladen werden.
         </div>
         <p className="mt-4">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
-      </main>
+      </div>
     );
   }
 
@@ -65,136 +104,132 @@ export default async function EuAiActReadinessPage() {
   const q3done = data.days_remaining > 0 && data.overall_readiness >= 0.85;
 
   return (
-    <main className={BOARD_PAGE_MAIN_CLASS}>
-      <header className="mb-6">
-        <h1 className="sbs-h1">
-          EU AI Act Readiness (High-Risk)
-        </h1>
-        <p className="sbs-subtitle">
-          Stichtag {data.deadline} · noch {data.days_remaining} Tage ·
-          Gesamt-Readiness {readinessPct} %
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <header className="mb-8">
+        <h1 className={CH_PAGE_TITLE}>EU AI Act Readiness</h1>
+        <p className={CH_PAGE_SUB}>
+          High-Risk-Systeme bis{" "}
+          <time dateTime="2026-08-02">02.08.2026</time>
+          {" · "}
+          noch {data.days_remaining} Tage · Gesamt {readinessPct}%
         </p>
-        <p className="mt-2">
+        <p className="mt-3">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
       </header>
 
-      <section
-        aria-label="Kernkennzahlen"
-        className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-3"
-      >
-        <div className="sbs-panel min-w-0 p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Overall Readiness
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
-            {readinessPct} %
-          </p>
-        </div>
-        <div className="sbs-panel min-w-0 p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            High-Risk mit essenziellen Controls
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
-            {data.high_risk_systems_essential_complete}
-          </p>
-        </div>
-        <div className="sbs-panel min-w-0 p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            High-Risk mit Lücken
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
-            {data.high_risk_systems_essential_incomplete}
-          </p>
+      <section className={`${CH_CARD} mb-8`} aria-label="Readiness-Übersicht">
+        <div className="grid gap-8 lg:grid-cols-[auto_1fr] lg:items-center">
+          <ReadinessRing percent={readinessPct} />
+          <div className="min-w-0 space-y-6">
+            <div>
+              <p className={CH_SECTION_LABEL}>Fortschritt</p>
+              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-100">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-cyan-600 to-teal-500 transition-all"
+                  style={{ width: `${readinessPct}%` }}
+                />
+              </div>
+              <p className="mt-2 text-sm text-slate-600">
+                Ziel empfohlen: ≥ 85&nbsp;% vor Stichtag.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-4">
+                <p className="text-xs font-medium text-slate-500">Tage verbleibend</p>
+                <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900">
+                  {data.days_remaining}
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-4">
+                <p className="text-xs font-medium text-slate-500">HR + Controls komplett</p>
+                <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900">
+                  {data.high_risk_systems_essential_complete}
+                </p>
+              </div>
+              <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-4">
+                <p className="text-xs font-medium text-slate-500">HR mit Lücken</p>
+                <p className="mt-1 text-2xl font-semibold tabular-nums text-slate-900">
+                  {data.high_risk_systems_essential_incomplete}
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
-      <section
-        aria-label="Roadmap"
-        className="sbs-panel-muted mb-8 p-4"
-      >
-        <h2 className="text-sm font-semibold text-slate-800">
-          Grobe Timeline bis Stichtag
-        </h2>
-        <ol className="mt-3 space-y-2 text-sm text-slate-700">
-          <li className="flex items-center gap-2">
+      <section aria-label="Roadmap" className={`${CH_CARD} mb-8`}>
+        <h2 className="text-base font-semibold text-slate-900">Roadmap bis Stichtag</h2>
+        <ol className="mt-4 space-y-3 text-sm text-slate-700">
+          <li className="flex items-start gap-3">
             <span
-              className={`h-2 w-2 rounded-full ${q2done ? "bg-emerald-500" : "bg-slate-300"}`}
+              className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${q2done ? "bg-emerald-500" : "bg-slate-300"}`}
             />
-            Q2 2026 – Fokus Lücken schließen (aktuell {readinessPct} % Readiness)
+            Q2 2026 – Lücken schließen (aktuell {readinessPct}% Readiness)
           </li>
-          <li className="flex items-center gap-2">
+          <li className="flex items-start gap-3">
             <span
-              className={`h-2 w-2 rounded-full ${q3done ? "bg-emerald-500" : "bg-slate-300"}`}
+              className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${q3done ? "bg-emerald-500" : "bg-slate-300"}`}
             />
-            Q3 2026 – Ziel ≥ 85 % Readiness vor Frist
+            Q3 2026 – Ziel ≥ 85&nbsp;% Readiness vor Frist
           </li>
         </ol>
       </section>
 
       <section className="mb-8" aria-label="Kritische Anforderungen">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
-          Top Critical Requirements
-        </h2>
+        <h2 className={`${CH_SECTION_LABEL} mb-4`}>Top Critical Requirements</h2>
         {data.critical_requirements.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Keine priorisierten Lücken aus dem Compliance-Register.
           </p>
         ) : (
-          <ul className="mt-3 space-y-2">
+          <ul className="space-y-3">
             {data.critical_requirements.map((r) => (
               <li
                 key={r.requirement_id ?? `${r.code}-${r.name}`}
-                className="sbs-panel flex min-w-0 items-start gap-3 px-3 py-2 text-sm"
+                className={`${CH_CARD} flex min-w-0 flex-col gap-4 sm:flex-row sm:items-start`}
               >
-                <span
-                  className={`mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full ${trafficDot(r.traffic)}`}
-                  title={r.traffic}
-                />
+                <div className="flex shrink-0 items-center gap-2">
+                  <span
+                    className={`h-3 w-3 rounded-full ${trafficDot(r.traffic)}`}
+                    title={r.traffic}
+                  />
+                  <span className="text-xs font-semibold text-slate-600">
+                    {trafficLabel(r.traffic)}
+                  </span>
+                </div>
                 <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="font-medium text-slate-900">
-                      {r.code}: {r.name}
-                    </span>
-                    <span className="text-slate-500">
-                      {r.affected_systems_count} Systeme · Prio {r.priority}
-                    </span>
-                    {(r.open_actions_count_for_requirement ?? 0) > 0 ? (
-                      <span
-                        className="inline-flex rounded-full bg-indigo-100 px-2 py-0.5 text-xs font-medium text-indigo-900"
-                        title="Offene oder laufende Maßnahmen mit Bezug zu dieser Anforderung"
-                      >
-                        {r.open_actions_count_for_requirement} Maßnahme
-                        {(r.open_actions_count_for_requirement ?? 0) === 1 ? "" : "n"}
-                      </span>
-                    ) : null}
+                  <div className="font-semibold text-slate-900">
+                    {r.code}: {r.name}
                   </div>
-                  <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+                  <p className="mt-1 text-sm text-slate-600">
+                    {r.affected_systems_count} Systeme · Priorität {r.priority}
+                  </p>
+                  {(r.open_actions_count_for_requirement ?? 0) > 0 ? (
+                    <span className="mt-2 inline-flex rounded-full bg-indigo-100 px-2.5 py-0.5 text-xs font-semibold text-indigo-900">
+                      {r.open_actions_count_for_requirement} offene Maßnahme
+                      {(r.open_actions_count_for_requirement ?? 0) === 1 ? "" : "n"}
+                    </span>
+                  ) : null}
+                  <div className="mt-3 flex flex-wrap gap-2">
                     {(r.related_ai_system_ids?.length ?? 0) > 0 ? (
                       <Link
                         href={aiSystemsFilterHref(r.related_ai_system_ids ?? [])}
-                        className="font-medium text-slate-600 underline hover:text-slate-900"
+                        className="inline-flex rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-800 shadow-sm hover:border-slate-300"
                       >
-                        Zu den betroffenen Systemen
+                        Betroffene Systeme
                       </Link>
                     ) : null}
                     <Link
                       href="/board/eu-ai-act-readiness#governance-actions"
-                      className="font-medium text-slate-600 underline hover:text-slate-900"
+                      className="inline-flex rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-slate-800"
                     >
-                      Maßnahmen ansehen
-                    </Link>
-                    <Link
-                      href="/board/eu-ai-act-readiness#governance-actions"
-                      className="font-medium text-slate-600 underline hover:text-slate-900"
-                      title="Neue Einträge z. B. über POST /api/v1/ai-governance/actions oder Ihr ITSM"
-                    >
-                      Maßnahme erfassen
+                      Maßnahmen
                     </Link>
                   </div>
                 </div>
@@ -205,25 +240,25 @@ export default async function EuAiActReadinessPage() {
       </section>
 
       <section className="mb-8" aria-label="Vorgeschlagene Maßnahmen">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
+        <h2 className={`${CH_SECTION_LABEL} mb-4`}>
           Vorgeschlagene Maßnahmen (nicht persistiert)
         </h2>
         {data.suggested_actions.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Keine automatischen Vorschläge – oder alle Fokus-Systeme vollständig.
           </p>
         ) : (
-          <ul className="mt-3 space-y-2 text-sm text-slate-700">
+          <ul className="space-y-3 text-sm text-slate-700">
             {data.suggested_actions.map((s, i) => (
               <li
                 key={`${s.title}-${i}`}
-                className="sbs-panel-muted border border-dashed border-[var(--sbs-border)] px-3 py-2"
+                className="rounded-2xl border border-dashed border-slate-200 bg-slate-50/60 px-4 py-3"
               >
-                <span className="font-medium">{s.title}</span>
+                <span className="font-semibold text-slate-900">{s.title}</span>
                 <span className="ml-2 text-xs text-slate-500">
                   {s.related_requirement} · Prio {s.suggested_priority}
                 </span>
-                <p className="mt-1 text-xs text-slate-600">{s.rationale}</p>
+                <p className="mt-1 text-xs leading-relaxed text-slate-600">{s.rationale}</p>
               </li>
             ))}
           </ul>
@@ -231,38 +266,48 @@ export default async function EuAiActReadinessPage() {
       </section>
 
       <section id="governance-actions" aria-label="Offene Maßnahmen">
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
-          Offene Maßnahmen
-        </h2>
+        <h2 className={`${CH_SECTION_LABEL} mb-4`}>Offene Maßnahmen</h2>
         {data.open_governance_actions.length === 0 ? (
-          <p className="mt-2 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Keine offenen Einträge in{" "}
-            <code className="rounded bg-slate-100 px-1">ai_governance_actions</code>.
+            <code className="rounded bg-slate-100 px-1 text-xs">ai_governance_actions</code>.
           </p>
         ) : (
-          <ul className="sbs-panel mt-3 divide-y divide-[var(--sbs-border)] overflow-hidden p-0">
-            {data.open_governance_actions.map((a) => (
-              <li key={a.id} className="px-4 py-3 text-sm">
-                <div className="font-medium text-slate-900">{a.title}</div>
-                <div className="mt-1 text-xs text-slate-500">
-                  {a.related_requirement} · {a.status}
-                  {a.due_date
-                    ? ` · Fällig ${new Date(a.due_date).toLocaleDateString("de-DE")}`
-                    : ""}
-                </div>
-                {a.related_ai_system_id ? (
-                  <Link
-                    href="/tenant/eu-ai-act"
-                    className="mt-1 inline-block text-xs font-medium text-slate-600 underline hover:text-slate-900"
-                  >
-                    KI-System {a.related_ai_system_id} (EU-AI-Act-Ansicht)
-                  </Link>
-                ) : null}
-              </li>
-            ))}
-          </ul>
+          <div className={`${CH_CARD} overflow-hidden p-0`}>
+            <ul className="divide-y divide-slate-100">
+              {data.open_governance_actions.map((a) => (
+                <li
+                  key={a.id}
+                  className="flex flex-col gap-2 px-5 py-4 transition hover:bg-slate-50/80 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div className="min-w-0">
+                    <div className="font-semibold text-slate-900">{a.title}</div>
+                    <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                      <span>{a.related_requirement}</span>
+                      <span
+                        className="rounded-full bg-slate-100 px-2 py-0.5 font-semibold text-slate-700"
+                      >
+                        {a.status}
+                      </span>
+                      {a.due_date
+                        ? ` · Fällig ${new Date(a.due_date).toLocaleDateString("de-DE")}`
+                        : null}
+                    </div>
+                    {a.related_ai_system_id ? (
+                      <Link
+                        href="/tenant/eu-ai-act"
+                        className="mt-2 inline-block text-xs font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
+                      >
+                        KI-System {a.related_ai_system_id}
+                      </Link>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
         )}
       </section>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/board/incidents/page.tsx
+++ b/frontend/src/app/board/incidents/page.tsx
@@ -7,18 +7,24 @@ import {
   type AIIncidentBySystem,
   type AIIncidentOverview,
 } from "@/lib/api";
-import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
+import {
+  BOARD_PAGE_ROOT_CLASS,
+  CH_CARD,
+  CH_PAGE_SUB,
+  CH_PAGE_TITLE,
+  CH_SECTION_LABEL,
+} from "@/lib/boardLayout";
 
 function severityBadgeClass(severity: string): string {
   switch (severity) {
     case "high":
-      return "bg-red-100 text-red-800";
+      return "bg-red-100 text-red-800 ring-red-200/60";
     case "medium":
-      return "bg-amber-100 text-amber-800";
+      return "bg-amber-100 text-amber-900 ring-amber-200/60";
     case "low":
-      return "bg-emerald-100 text-emerald-800";
+      return "bg-emerald-100 text-emerald-800 ring-emerald-200/60";
     default:
-      return "bg-slate-100 text-slate-700";
+      return "bg-slate-100 text-slate-700 ring-slate-200/60";
   }
 }
 
@@ -51,18 +57,16 @@ export default async function BoardIncidentsPage() {
 
   if (!overview) {
     return (
-      <main className={BOARD_PAGE_MAIN_CLASS}>
-        <header className="mb-6">
-          <h1 className="sbs-h1">
-            AI Governance – Incident-Übersicht
-          </h1>
-          <p className="sbs-subtitle">
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <header className="mb-8">
+          <h1 className={CH_PAGE_TITLE}>Incidents</h1>
+          <p className={CH_PAGE_SUB}>
             NIS2 Art. 21/23 · ISO 42001 Incident Management
           </p>
         </header>
         <div
           role="status"
-          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
         >
           Incident-KPIs konnten nicht geladen werden. Bitte versuchen Sie es
           später erneut oder wenden Sie sich an das AI-Governance-Team.
@@ -70,31 +74,29 @@ export default async function BoardIncidentsPage() {
         <p className="mt-4">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
-      </main>
+      </div>
     );
   }
 
   const topSystems = bySystem.slice(0, 3);
 
   return (
-    <main className={BOARD_PAGE_MAIN_CLASS}>
-      <header className="mb-6">
-        <h1 className="sbs-h1">
-          AI Governance – Incident-Übersicht
-        </h1>
-        <p className="sbs-subtitle">
-          NIS2 Art. 21/23 (Incident & Business Continuity) · ISO 42001 Incident
-          Management · Standort Deutschland
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <header className="mb-8">
+        <h1 className={CH_PAGE_TITLE}>Incidents</h1>
+        <p className={CH_PAGE_SUB}>
+          NIS2 Art. 21/23 (Incident &amp; Business Continuity) · ISO 42001 ·
+          Standort Deutschland
         </p>
-        <p className="mt-2">
+        <p className="mt-3">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
             aria-label="Zurück zu Board-KPIs"
           >
             ← Zurück zu Board-KPIs
@@ -102,73 +104,91 @@ export default async function BoardIncidentsPage() {
         </p>
       </header>
 
+      <div
+        className="mb-8 flex flex-wrap items-end gap-3 rounded-2xl border border-slate-200/90 bg-white/90 p-4 shadow-sm"
+        aria-label="Filter (Demonstration)"
+      >
+        <div className="min-w-[12rem] flex-1">
+          <label className="text-xs font-semibold text-slate-500" htmlFor="inc-search">
+            Suche
+          </label>
+          <input
+            id="inc-search"
+            type="search"
+            placeholder="KI-System, ID…"
+            disabled
+            title="Demonstrativ – keine Filterlogik"
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 opacity-80"
+          />
+        </div>
+        <div className="w-full min-w-[10rem] sm:w-48">
+          <span className="text-xs font-semibold text-slate-500">Schweregrad</span>
+          <select
+            disabled
+            title="Demonstrativ"
+            className="mt-1 w-full rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600 opacity-80"
+            defaultValue="all"
+          >
+            <option value="all">Alle</option>
+            <option value="high">Hoch</option>
+            <option value="medium">Mittel</option>
+            <option value="low">Niedrig</option>
+          </select>
+        </div>
+      </div>
+
       <section
         aria-label="Incident-KPIs"
         className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
       >
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Incidents letzte 12 Monate
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
-            {overview.total_incidents_last_12_months}
-          </p>
-          <p className="mt-1 text-xs text-slate-500">Gesamt (Rolling 12 Monate)</p>
-        </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Aktuell offene Incidents
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Offene Incidents</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
             {overview.open_incidents}
           </p>
-          <p className="mt-1 text-xs text-slate-500">Status: offen</p>
+          <p className="mt-1 text-xs text-slate-500">Aktueller Bestand</p>
         </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Major Incidents (NIS2-relevant)
-          </h2>
-          <p className="mt-2 text-3xl font-semibold text-slate-900">
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>12 Monate</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {overview.total_incidents_last_12_months}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Gesamt (Rolling)</p>
+        </div>
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Major (NIS2)</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
             {overview.major_incidents_last_12_months}
           </p>
-          <p className="mt-1 text-xs text-slate-500">Schweregrad Hoch, 12 Monate</p>
+          <p className="mt-1 text-xs text-slate-500">Schweregrad hoch</p>
         </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            MTTA / MTTR
-          </h2>
-          <p className="mt-2 text-lg font-semibold text-slate-900">
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>MTTA / MTTR</p>
+          <p className="mt-2 text-lg font-semibold tabular-nums text-slate-900">
             {overview.mean_time_to_ack_hours != null
               ? `~${overview.mean_time_to_ack_hours} h`
               : "–"}{" "}
-            /{" "}
+            <span className="text-slate-400">/</span>{" "}
             {overview.mean_time_to_recover_hours != null
               ? `~${overview.mean_time_to_recover_hours} h`
               : "–"}
           </p>
-          <p className="mt-1 text-xs text-slate-500">
-            Ø Zeit bis Bestätigung / Wiederherstellung
-          </p>
+          <p className="mt-1 text-xs text-slate-500">Ø Bestätigung / Recovery</p>
         </div>
       </section>
 
-      <section
-        aria-label="Incidents nach Schweregrad"
-        className="sbs-panel mb-8 p-4"
-      >
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
-          Incidents nach Schweregrad
-        </h2>
+      <section aria-label="Incidents nach Schweregrad" className={`${CH_CARD} mb-8`}>
+        <h2 className="text-base font-semibold text-slate-900">Nach Schweregrad</h2>
         {overview.by_severity.length === 0 ? (
-          <p className="text-sm text-slate-500">
+          <p className="mt-3 text-sm text-slate-500">
             In den letzten 12 Monaten keine Incidents erfasst.
           </p>
         ) : (
-          <div className="flex flex-wrap gap-2">
+          <div className="mt-4 flex flex-wrap gap-2">
             {overview.by_severity.map((entry) => (
               <span
                 key={entry.severity}
-                className={`rounded-full px-3 py-1 text-sm font-medium ${severityBadgeClass(entry.severity)}`}
+                className={`inline-flex rounded-full px-3 py-1 text-sm font-semibold ring-1 ring-inset ${severityBadgeClass(entry.severity)}`}
               >
                 {severityLabel(entry.severity)}: {entry.count}
               </span>
@@ -180,28 +200,33 @@ export default async function BoardIncidentsPage() {
       {topSystems.length > 0 && (
         <section
           aria-label="Top-KI-Systeme nach Incident-Anzahl"
-          className="sbs-panel p-4"
+          className={CH_CARD}
         >
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
-            Top 3 KI-Systeme mit den meisten Incidents (12 Monate)
+          <h2 className="text-base font-semibold text-slate-900">
+            Top 3 KI-Systeme (12 Monate)
           </h2>
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
+          <div className="mt-4 overflow-x-auto rounded-xl border border-slate-100">
+            <table className="w-full min-w-[320px] text-sm">
               <thead>
-                <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
-                  <th className="pb-2 font-semibold">KI-System</th>
-                  <th className="pb-2 font-semibold">Anzahl Incidents</th>
-                  <th className="pb-2 font-semibold">Letztes Incident</th>
+                <tr className="border-b border-slate-200 bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th className="px-4 py-3">KI-System</th>
+                  <th className="px-4 py-3">Anzahl</th>
+                  <th className="px-4 py-3">Letztes Incident</th>
                 </tr>
               </thead>
               <tbody>
                 {topSystems.map((row) => (
-                  <tr key={row.ai_system_id} className="border-b border-slate-100">
-                    <td className="py-2 font-medium text-slate-900">
+                  <tr
+                    key={row.ai_system_id}
+                    className="border-b border-slate-100 transition hover:bg-cyan-50/40"
+                  >
+                    <td className="px-4 py-3 font-semibold text-slate-900">
                       {row.ai_system_name}
                     </td>
-                    <td className="py-2 text-slate-700">{row.incident_count}</td>
-                    <td className="py-2 text-slate-600">
+                    <td className="px-4 py-3 tabular-nums text-slate-700">
+                      {row.incident_count}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
                       {row.last_incident_at
                         ? new Date(row.last_incident_at).toLocaleString("de-DE", {
                             dateStyle: "short",
@@ -216,6 +241,6 @@ export default async function BoardIncidentsPage() {
           </div>
         </section>
       )}
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -12,7 +12,14 @@ import {
   type AIKpiAlert,
   type BoardKpiSummary,
 } from "@/lib/api";
-import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
+import {
+  BOARD_PAGE_ROOT_CLASS,
+  CH_CARD,
+  CH_CARD_MUTED,
+  CH_PAGE_SUB,
+  CH_PAGE_TITLE,
+  CH_SECTION_LABEL,
+} from "@/lib/boardLayout";
 
 import { BoardKpiAdvisorExport } from "./BoardKpiAdvisorExport";
 import { BoardReportAuditSection } from "./BoardReportAuditSection";
@@ -26,6 +33,36 @@ function scoreColor(score: number): string {
 
 function formatPercent(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
+}
+
+function alertInsightLink(kpiKey: string): { href: string; label: string } {
+  if (
+    kpiKey === "nis2_incident_readiness_ratio" ||
+    kpiKey.includes("incident")
+  ) {
+    return { href: "/board/incidents", label: "Incident-Ansicht" };
+  }
+  if (
+    kpiKey === "nis2_supplier_risk_coverage_ratio" ||
+    kpiKey.includes("supplier")
+  ) {
+    return { href: "/board/suppliers", label: "Supplier-Risiko" };
+  }
+  if (
+    kpiKey.includes("nis2") ||
+    kpiKey.includes("kritis") ||
+    kpiKey.includes("ot_it")
+  ) {
+    return { href: "/board/nis2-kritis", label: "NIS2-Drilldown" };
+  }
+  if (
+    kpiKey.includes("readiness") ||
+    kpiKey.includes("eu_ai") ||
+    kpiKey.includes("iso42001")
+  ) {
+    return { href: "/board/eu-ai-act-readiness", label: "EU AI Act Readiness" };
+  }
+  return { href: "/board/kpis", label: "Board-KPIs" };
 }
 
 function ManagementSummary({ kpis }: { kpis: BoardKpiSummary }) {
@@ -76,7 +113,7 @@ function ManagementSummary({ kpis }: { kpis: BoardKpiSummary }) {
   return (
     <section
       aria-label="Management-Zusammenfassung AI Governance"
-      className="sbs-panel-muted mt-8 space-y-1 p-4 text-sm text-[var(--sbs-text-primary)]"
+      className={`${CH_CARD_MUTED} mt-8 space-y-2 text-sm text-slate-700`}
     >
       {lines.map((line) => (
         <p key={line}>{line}</p>
@@ -93,6 +130,17 @@ function alertSeverityStyles(severity: AIKpiAlert["severity"]): string {
       return "border-amber-200 bg-amber-50 text-amber-800";
     default:
       return "border-slate-200 bg-slate-50 text-slate-700";
+  }
+}
+
+function alertSeverityChipClass(severity: AIKpiAlert["severity"]): string {
+  switch (severity) {
+    case "critical":
+      return "bg-red-100 text-red-800 ring-red-200/60";
+    case "warning":
+      return "bg-amber-100 text-amber-900 ring-amber-200/60";
+    default:
+      return "bg-slate-100 text-slate-700 ring-slate-200/60";
   }
 }
 
@@ -116,48 +164,48 @@ export default async function BoardKpisPage() {
 
   if (!kpis) {
     return (
-      <main className={BOARD_PAGE_MAIN_CLASS}>
-        <header className="mb-6">
-          <h1 className="sbs-h1">
-            AI Governance – Board KPIs
-          </h1>
-          <p className="sbs-subtitle">
-            Überblick über Reifegrad, NIS2-Readiness und High-Risk-KI-Systeme.
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <header className="mb-8">
+          <h1 className={CH_PAGE_TITLE}>Board KPIs</h1>
+          <p className={CH_PAGE_SUB}>
+            Executive Overview Ihrer AI-Governance – Reifegrad, NIS2 und
+            High-Risk-Register.
           </p>
         </header>
-        <div role="status" className="sbs-alert-warn">
+        <div
+          role="status"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
           KPI-Daten konnten nicht geladen werden. Bitte versuchen Sie es später
           erneut oder wenden Sie sich an das AI-Governance-Team.
         </div>
-      </main>
+      </div>
     );
   }
 
   const isoScore = kpis.iso42001_governance_score;
 
   return (
-    <main className={BOARD_PAGE_MAIN_CLASS}>
-      <header className="mb-6">
-        <h1 className="sbs-h1">
-          AI Governance – Board KPIs
-        </h1>
-        <p className="sbs-subtitle">
-          ISO 42001 Reifegrad, NIS2-Incident-Readiness und Lieferanten-Risiko im
-          Überblick für den Standort Deutschland.
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <header className="mb-8">
+        <h1 className={CH_PAGE_TITLE}>Board KPIs</h1>
+        <p className={CH_PAGE_SUB}>
+          Executive Overview Ihrer AI-Governance – ISO 42001, NIS2-Readiness und
+          Lieferanten-Risiko (Standort Deutschland).
         </p>
         <nav
-          className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-sm font-medium text-slate-600"
+          className="mt-4 flex flex-wrap gap-x-4 gap-y-2 text-sm font-medium"
           aria-label="Board-Unterseiten"
         >
           <Link
             href="/board/nis2-kritis"
-            className="underline hover:text-slate-900"
+            className="rounded-lg text-cyan-700 underline decoration-cyan-700/30 underline-offset-4 hover:text-cyan-900"
           >
             NIS2 / KRITIS KPI-Drilldown
           </Link>
           <Link
             href="/board/eu-ai-act-readiness"
-            className="underline hover:text-slate-900"
+            className="rounded-lg text-cyan-700 underline decoration-cyan-700/30 underline-offset-4 hover:text-cyan-900"
           >
             EU AI Act Readiness
           </Link>
@@ -165,26 +213,46 @@ export default async function BoardKpisPage() {
       </header>
 
       {/* Alerts & Hinweise (max 5) + Export für CISO/ISB/Vorstand */}
-      <section
-        aria-label="Alerts und Hinweise"
-        className="sbs-panel mb-6 p-4"
-      >
-        <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-600">
-          Alerts &amp; Hinweise
-        </h2>
+      <section aria-label="Alerts und Hinweise" className={`${CH_CARD} mb-8`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <h2 className={CH_SECTION_LABEL}>Alerts &amp; Hinweise</h2>
+          <span className="text-xs text-slate-500">max. 5 Einträge</span>
+        </div>
         {alerts.length > 0 ? (
-          <ul className="mt-3 space-y-2">
-            {alerts.slice(0, 5).map((alert) => (
-              <li
-                key={alert.id}
-                className={`rounded-lg border px-3 py-2 text-sm ${alertSeverityStyles(alert.severity)}`}
-              >
-                {alert.message}
-              </li>
-            ))}
+          <ul className="mt-4 space-y-3">
+            {alerts.slice(0, 5).map((alert) => {
+              const cta = alertInsightLink(alert.kpi_key);
+              return (
+                <li
+                  key={alert.id}
+                  className={`flex flex-col gap-3 rounded-xl border p-4 sm:flex-row sm:items-center sm:justify-between ${alertSeverityStyles(alert.severity)}`}
+                >
+                  <p className="min-w-0 flex-1 text-sm leading-relaxed">
+                    {alert.message}
+                  </p>
+                  <div className="flex shrink-0 flex-wrap items-center gap-2">
+                    <span
+                      className={`inline-flex rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset ${alertSeverityChipClass(alert.severity)}`}
+                    >
+                      {alert.severity === "critical"
+                        ? "Kritisch"
+                        : alert.severity === "warning"
+                          ? "Warnung"
+                          : "Info"}
+                    </span>
+                    <Link
+                      href={cta.href}
+                      className="text-xs font-semibold text-slate-800 underline decoration-slate-400 underline-offset-2 hover:text-slate-950"
+                    >
+                      {cta.label} →
+                    </Link>
+                  </div>
+                </li>
+              );
+            })}
           </ul>
         ) : (
-          <p className="mt-3 text-sm text-slate-500">
+          <p className="mt-4 text-sm text-slate-500">
             Keine aktuellen Alerts.
           </p>
         )}
@@ -235,7 +303,7 @@ export default async function BoardKpisPage() {
         return (
           <section
             aria-label="AI-Governance-Reife nach ISO 42001"
-            className={`sbs-panel relative mb-8 flex min-w-0 flex-col gap-4 p-6 md:flex-row md:items-center md:justify-between ${scoreColor(
+            className={`relative mb-8 flex min-w-0 flex-col gap-4 rounded-2xl border p-6 shadow-md shadow-slate-200/40 md:flex-row md:items-center md:justify-between ${scoreColor(
               isoScore,
             )} ${hasCriticalForIso ? "ring-2 ring-red-300" : ""}`}
           >
@@ -246,7 +314,8 @@ export default async function BoardKpisPage() {
               />
             )}
             <div className="min-w-0 flex-1">
-              <h2 className="text-sm font-semibold uppercase tracking-wide">
+              <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide">
+                <span aria-hidden>📈</span>
                 AI-Governance-Reife (ISO 42001)
               </h2>
               <p className="mt-1 text-xs text-slate-700">
@@ -269,7 +338,7 @@ export default async function BoardKpisPage() {
       {/* KPI Grid */}
       <section
         aria-label="NIS2- und High-Risk-KPIs"
-        className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
+        className="mb-6 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
       >
         {/* NIS2 Incident Readiness */}
         {(() => {
@@ -280,7 +349,7 @@ export default async function BoardKpisPage() {
           );
           return (
             <div
-              className={`sbs-panel relative flex min-w-0 flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
+              className={`${CH_CARD} relative flex min-w-0 flex-col ${hasCritical ? "ring-2 ring-red-300" : ""}`}
             >
               {hasCritical && (
                 <span
@@ -288,7 +357,8 @@ export default async function BoardKpisPage() {
                   aria-hidden
                 />
               )}
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <span aria-hidden>🛡️</span>
                 NIS2 Incident Readiness
               </h3>
               <p className="mt-1 text-xs text-slate-500">
@@ -323,7 +393,7 @@ export default async function BoardKpisPage() {
           );
           return (
             <div
-              className={`sbs-panel relative flex min-w-0 flex-col p-4 ${hasCritical ? "ring-2 ring-red-300" : ""}`}
+              className={`${CH_CARD} relative flex min-w-0 flex-col ${hasCritical ? "ring-2 ring-red-300" : ""}`}
             >
               {hasCritical && (
                 <span
@@ -331,7 +401,8 @@ export default async function BoardKpisPage() {
                   aria-hidden
                 />
               )}
-              <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <span aria-hidden>📦</span>
                 NIS2 Supplier Risk Coverage
               </h3>
               <p className="mt-1 text-xs text-slate-500">
@@ -358,8 +429,9 @@ export default async function BoardKpisPage() {
         })()}
 
         {/* High-Risk KI-Systeme gesamt */}
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <span aria-hidden>⚠️</span>
             High-Risk KI-Systeme gesamt
           </h3>
           <p className="mt-1 text-xs text-slate-500">
@@ -374,8 +446,9 @@ export default async function BoardKpisPage() {
         </div>
 
         {/* High-Risk ohne DPIA */}
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <span aria-hidden>🔒</span>
             High-Risk ohne DPIA
           </h3>
           <p className="mt-1 text-xs text-slate-500">
@@ -392,11 +465,9 @@ export default async function BoardKpisPage() {
 
       {/* EU AI Act / ISO 42001 Readiness */}
       {complianceOverview && (
-        <section
-          aria-label="EU AI Act und ISO 42001 Readiness"
-          className="sbs-panel mb-8 p-6"
-        >
-          <h2 className="text-lg font-semibold text-slate-900">
+        <section aria-label="EU AI Act und ISO 42001 Readiness" className={`${CH_CARD} mb-8`}>
+          <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-900">
+            <span aria-hidden>🤖</span>
             EU AI Act / ISO 42001 Readiness
           </h2>
           <p className="mt-1 text-sm text-slate-600">
@@ -525,7 +596,7 @@ export default async function BoardKpisPage() {
       </section>
 
       <ManagementSummary kpis={kpis} />
-    </main>
+    </div>
   );
 }
 

--- a/frontend/src/app/board/nis2-kritis/page.tsx
+++ b/frontend/src/app/board/nis2-kritis/page.tsx
@@ -2,17 +2,39 @@ import React from "react";
 import Link from "next/link";
 
 import {
+  fetchBoardKpis,
   fetchNis2KritisKpiDrilldown,
   type Nis2KritisKpiDrilldown,
   type Nis2KritisKpiType,
+  type Nis2KritisKpiTypeDrilldown,
 } from "@/lib/api";
-import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
+import {
+  BOARD_PAGE_ROOT_CLASS,
+  CH_CARD,
+  CH_PAGE_SUB,
+  CH_PAGE_TITLE,
+  CH_SECTION_LABEL,
+} from "@/lib/boardLayout";
 
 const KPI_LABEL: Record<Nis2KritisKpiType, string> = {
-  INCIDENT_RESPONSE_MATURITY: "Incident-Response-Reife",
+  INCIDENT_RESPONSE_MATURITY: "Incident-Readiness",
   SUPPLIER_RISK_COVERAGE: "Supplier-Risk-Coverage",
   OT_IT_SEGREGATION: "OT/IT-Segmentierung",
 };
+
+function histogramApproxMean(block: Nis2KritisKpiTypeDrilldown): number | null {
+  const buckets = block.histogram;
+  let sum = 0;
+  let n = 0;
+  for (const b of buckets) {
+    const hi = b.range_max_exclusive === 101 ? 100 : b.range_max_exclusive - 1;
+    const mid = (b.range_min_inclusive + hi) / 2;
+    sum += mid * b.count;
+    n += b.count;
+  }
+  if (!n) return null;
+  return Math.round(sum / n);
+}
 
 function Histogram({
   buckets,
@@ -22,21 +44,22 @@ function Histogram({
   maxCount: number;
 }) {
   return (
-    <div className="mt-3 space-y-2">
+    <div className="mt-4 space-y-3">
       {buckets.map((b) => {
         const w = maxCount > 0 ? Math.round((b.count / maxCount) * 100) : 0;
         return (
           <div key={`${b.range_min_inclusive}-${b.range_max_exclusive}`}>
-            <div className="flex justify-between text-xs text-slate-600">
+            <div className="flex justify-between text-xs font-medium text-slate-600">
               <span>
-                {b.range_min_inclusive}–{b.range_max_exclusive === 101 ? 100 : b.range_max_exclusive - 1}{" "}
+                {b.range_min_inclusive}–
+                {b.range_max_exclusive === 101 ? 100 : b.range_max_exclusive - 1}{" "}
                 %
               </span>
-              <span>{b.count}</span>
+              <span className="tabular-nums text-slate-500">{b.count}</span>
             </div>
-            <div className="mt-0.5 h-2 w-full rounded bg-slate-100">
+            <div className="mt-1.5 h-2.5 w-full overflow-hidden rounded-full bg-slate-100">
               <div
-                className="h-2 rounded bg-slate-700"
+                className="h-full rounded-full bg-gradient-to-r from-cyan-600 to-teal-500 shadow-sm transition-all"
                 style={{ width: `${w}%` }}
               />
             </div>
@@ -49,111 +72,171 @@ function Histogram({
 
 export default async function BoardNis2KritisPage() {
   let drilldown: Nis2KritisKpiDrilldown | null = null;
-  try {
-    drilldown = await fetchNis2KritisKpiDrilldown(5);
-  } catch (error) {
-    console.error("NIS2 drilldown API error:", error);
-  }
+  let boardKpis: Awaited<ReturnType<typeof fetchBoardKpis>> | null = null;
+
+  const [ddRes, kpRes] = await Promise.allSettled([
+    fetchNis2KritisKpiDrilldown(5),
+    fetchBoardKpis(),
+  ]);
+  if (ddRes.status === "fulfilled") drilldown = ddRes.value;
+  else console.error("NIS2 drilldown API error:", ddRes.reason);
+  if (kpRes.status === "fulfilled") boardKpis = kpRes.value;
+  else console.error("Board KPIs API error:", kpRes.reason);
 
   if (!drilldown) {
     return (
-      <main className={BOARD_PAGE_MAIN_CLASS}>
-        <header className="mb-6">
-          <h1 className="sbs-h1">
-            NIS2 / KRITIS – KPI-Drilldown
-          </h1>
-          <p className="sbs-subtitle">
-            Incident-, Supplier- und OT/IT-KPIs je KI-System
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <header className="mb-8">
+          <h1 className={CH_PAGE_TITLE}>NIS2 / KRITIS</h1>
+          <p className={CH_PAGE_SUB}>
+            Incident &amp; Supplier Readiness – Drilldown je KI-System.
           </p>
         </header>
         <div
           role="status"
-          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
         >
           Drilldown-Daten konnten nicht geladen werden.
         </div>
         <p className="mt-4">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
-      </main>
+      </div>
     );
   }
 
+  const incidentBlock = drilldown.by_kpi_type.find(
+    (b) => b.kpi_type === "INCIDENT_RESPONSE_MATURITY",
+  );
+  const supplierBlock = drilldown.by_kpi_type.find(
+    (b) => b.kpi_type === "SUPPLIER_RISK_COVERAGE",
+  );
+  const otBlock = drilldown.by_kpi_type.find(
+    (b) => b.kpi_type === "OT_IT_SEGREGATION",
+  );
+
+  const incidentMean = incidentBlock ? histogramApproxMean(incidentBlock) : null;
+  const supplierMean = supplierBlock ? histogramApproxMean(supplierBlock) : null;
+  const otMean = otBlock ? histogramApproxMean(otBlock) : null;
+
+  const incidentPct =
+    boardKpis != null
+      ? Math.round(boardKpis.nis2_incident_readiness_ratio * 100)
+      : incidentMean;
+  const supplierPct =
+    boardKpis != null
+      ? Math.round(boardKpis.nis2_supplier_risk_coverage_ratio * 100)
+      : supplierMean;
+  const fullCoveragePct =
+    boardKpis?.nis2_kritis_systems_full_coverage_ratio != null
+      ? Math.round(boardKpis.nis2_kritis_systems_full_coverage_ratio * 100)
+      : null;
+
   return (
-    <main className={BOARD_PAGE_MAIN_CLASS}>
-      <header className="mb-6">
-        <h1 className="sbs-h1">
-          NIS2 / KRITIS – KPI-Drilldown
-        </h1>
-        <p className="sbs-subtitle">
-          Verteilung der KPI-Prozentwerte und schwächste KI-Systeme je Typ
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <header className="mb-8">
+        <h1 className={CH_PAGE_TITLE}>NIS2 / KRITIS</h1>
+        <p className={CH_PAGE_SUB}>
+          Incident &amp; Supplier Readiness – Verteilung und schwächste Systeme
           (Top {drilldown.top_n}). Stand:{" "}
           {new Date(drilldown.generated_at).toLocaleString("de-DE")}
         </p>
-        <p className="mt-2">
+        <p className="mt-3">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
       </header>
 
+      <section
+        aria-label="NIS2-KPI-Übersicht"
+        className="mb-10 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Incident-Readiness</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {incidentPct != null ? `${incidentPct} %` : "–"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            {boardKpis != null ? "Board-KPI (Runbooks)" : "Ø aus Histogramm"}
+          </p>
+        </div>
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Supplier-Risk-Coverage</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {supplierPct != null ? `${supplierPct} %` : "–"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">
+            {boardKpis != null ? "Board-KPI (Register)" : "Ø aus Histogramm"}
+          </p>
+        </div>
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>OT/IT (Ø aus Verteilung)</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {otMean != null ? `${otMean} %` : "–"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Histogramm-Mittel</p>
+        </div>
+        <div className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Volle NIS2-KPI-Abdeckung</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {fullCoveragePct != null ? `${fullCoveragePct} %` : "–"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">Alle drei KPI-Typen befüllt</p>
+        </div>
+      </section>
+
       <div className="min-w-0 space-y-8">
         {drilldown.by_kpi_type.map((block) => {
-          const maxCount = Math.max(
-            ...block.histogram.map((h) => h.count),
-            1,
-          );
+          const maxCount = Math.max(...block.histogram.map((h) => h.count), 1);
           return (
             <section
               key={block.kpi_type}
               aria-label={KPI_LABEL[block.kpi_type]}
-              className="sbs-panel min-w-0 p-5"
+              className={CH_CARD}
             >
-              <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+              <h2 className="flex items-center gap-2 text-base font-semibold text-slate-900">
+                <span aria-hidden>🛡️</span>
                 {KPI_LABEL[block.kpi_type]}
               </h2>
-              <p className="mt-1 text-xs text-slate-500">
-                Histogramm (Buckets 0–25, 25–50, 50–75, 75–100 %)
+              <p className="mt-1 text-sm text-slate-500">
+                Verteilung (Buckets 0–25, 25–50, 50–75, 75–100 %)
               </p>
               <Histogram buckets={block.histogram} maxCount={maxCount} />
 
-              <h3 className="mt-6 text-xs font-semibold uppercase tracking-wide text-slate-500">
-                Top {drilldown.top_n} niedrigste Werte
+              <h3 className={`${CH_SECTION_LABEL} mt-8`}>
+                Top {drilldown.top_n} Risiko-Systeme
               </h3>
               {block.critical_systems.length === 0 ? (
                 <p className="mt-2 text-sm text-slate-500">
                   Keine KPI-Werte für diesen Typ erfasst.
                 </p>
               ) : (
-                <ul className="mt-2 divide-y divide-slate-100">
+                <ul className="mt-3 divide-y divide-slate-100">
                   {block.critical_systems.map((s) => (
                     <li
                       key={`${s.ai_system_id}-${block.kpi_type}`}
-                      className="flex min-w-0 flex-wrap items-baseline justify-between gap-2 py-2 text-sm"
+                      className="flex min-w-0 flex-wrap items-center justify-between gap-3 py-4 text-sm first:pt-0"
                     >
                       <div className="min-w-0">
-                        <span className="font-medium text-slate-900">
-                          {s.name}
-                        </span>
-                        <span className="ml-2 text-slate-500">
-                          {s.business_unit}
-                        </span>
+                        <div className="font-semibold text-slate-900">{s.name}</div>
+                        <div className="text-xs text-slate-500">{s.business_unit}</div>
                       </div>
-                      <div className="flex items-center gap-3">
-                        <span className="tabular-nums text-slate-700">
+                      <div className="flex items-center gap-4">
+                        <span className="tabular-nums text-lg font-semibold text-slate-800">
                           {s.value_percent} %
                         </span>
                         <Link
                           href={s.detail_href}
-                          className="text-xs font-medium text-slate-600 underline hover:text-slate-900"
+                          className="shrink-0 rounded-lg bg-slate-900 px-3 py-1.5 text-xs font-semibold text-white shadow-sm hover:bg-slate-800"
                         >
                           EU-AI-Act-Ansicht
                         </Link>
@@ -166,6 +249,6 @@ export default async function BoardNis2KritisPage() {
           );
         })}
       </div>
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/board/suppliers/page.tsx
+++ b/frontend/src/app/board/suppliers/page.tsx
@@ -7,7 +7,13 @@ import {
   type AISupplierRiskBySystem,
   type AISupplierRiskOverview,
 } from "@/lib/api";
-import { BOARD_PAGE_MAIN_CLASS } from "@/lib/boardLayout";
+import {
+  BOARD_PAGE_ROOT_CLASS,
+  CH_CARD,
+  CH_PAGE_SUB,
+  CH_PAGE_TITLE,
+  CH_SECTION_LABEL,
+} from "@/lib/boardLayout";
 
 function riskLevelLabel(level: string): string {
   const labels: Record<string, string> = {
@@ -38,18 +44,16 @@ export default async function BoardSuppliersPage() {
 
   if (!overview) {
     return (
-      <main className={BOARD_PAGE_MAIN_CLASS}>
-        <header className="mb-6">
-          <h1 className="sbs-h1">
-            AI Governance – Supplier-Risiko
-          </h1>
-          <p className="sbs-subtitle">
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <header className="mb-8">
+          <h1 className={CH_PAGE_TITLE}>Supplier-Risiko</h1>
+          <p className={CH_PAGE_SUB}>
             NIS2 Art. 21/24 Supply-Chain-Security · KRITIS-Bezug
           </p>
         </header>
         <div
           role="status"
-          className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
         >
           Supplier-Risiko-KPIs konnten nicht geladen werden. Bitte versuchen Sie
           es später erneut oder wenden Sie sich an das AI-Governance-Team.
@@ -57,12 +61,12 @@ export default async function BoardSuppliersPage() {
         <p className="mt-4">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
           >
             ← Zurück zu Board-KPIs
           </Link>
         </p>
-      </main>
+      </div>
     );
   }
 
@@ -75,19 +79,17 @@ export default async function BoardSuppliersPage() {
       : 0;
 
   return (
-    <main className={BOARD_PAGE_MAIN_CLASS}>
-      <header className="mb-6">
-        <h1 className="sbs-h1">
-          AI Governance – Supplier-Risiko
-        </h1>
-        <p className="sbs-subtitle">
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <header className="mb-8">
+        <h1 className={CH_PAGE_TITLE}>Supplier-Risiko</h1>
+        <p className={CH_PAGE_SUB}>
           NIS2 Art. 21/24 Supply-Chain-Security · Lieferanten-Risikoregister ·
           KRITIS-Bezug · Standort Deutschland
         </p>
-        <p className="mt-2">
+        <p className="mt-3">
           <Link
             href="/board/kpis"
-            className="text-sm font-medium text-slate-600 underline hover:text-slate-900"
+            className="text-sm font-semibold text-cyan-700 underline decoration-cyan-700/30 hover:text-cyan-900"
             aria-label="Zurück zu Board-KPIs"
           >
             ← Zurück zu Board-KPIs
@@ -99,10 +101,8 @@ export default async function BoardSuppliersPage() {
         aria-label="Supplier-Risiko-KPIs"
         className="mb-8 grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4"
       >
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Systeme mit Lieferanten-Register
-          </h2>
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <p className={CH_SECTION_LABEL}>Mit Lieferanten-Register</p>
           <p className="mt-2 text-3xl font-semibold text-slate-900">
             {overview.total_systems_with_suppliers}
           </p>
@@ -111,10 +111,8 @@ export default async function BoardSuppliersPage() {
             Lieferanten-Risikoregister
           </p>
         </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Systeme ohne Supplier-Risikoregister
-          </h2>
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <p className={CH_SECTION_LABEL}>Ohne Supplier-Risikoregister</p>
           <p className="mt-2 text-3xl font-semibold text-slate-900">
             {overview.systems_without_supplier_risk_register}
           </p>
@@ -122,10 +120,8 @@ export default async function BoardSuppliersPage() {
             NIS2 Supply-Chain-Anforderung aktuell nicht erfüllt
           </p>
         </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Kritische KI-Systeme gesamt
-          </h2>
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <p className={CH_SECTION_LABEL}>Kritische KI-Systeme gesamt</p>
           <p className="mt-2 text-3xl font-semibold text-slate-900">
             {overview.critical_suppliers_total}
           </p>
@@ -133,10 +129,8 @@ export default async function BoardSuppliersPage() {
             Hohe/Sehr hohe Kritikalität (KRITIS-relevant)
           </p>
         </div>
-        <div className="sbs-panel flex min-w-0 flex-col p-4">
-          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-            Kritische ohne Lieferanten-Controls
-          </h2>
+        <div className={`${CH_CARD} flex min-w-0 flex-col`}>
+          <p className={CH_SECTION_LABEL}>Kritisch ohne Lieferanten-Controls</p>
           <p className="mt-2 text-3xl font-semibold text-slate-900">
             {overview.critical_suppliers_without_controls}
           </p>
@@ -146,32 +140,32 @@ export default async function BoardSuppliersPage() {
         </div>
       </section>
 
-      <section
-        aria-label="Supplier-Risiko nach Risikostufe"
-        className="sbs-panel mb-8 p-4"
-      >
-        <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+      <section aria-label="Supplier-Risiko nach Risikostufe" className={`${CH_CARD} mb-8`}>
+        <h2 className="text-base font-semibold text-slate-900">
           KI-Systeme nach Supplier-Risikostufe
         </h2>
-        <div className="overflow-x-auto">
+        <div className="mt-4 overflow-x-auto rounded-xl border border-slate-100">
           <table className="w-full text-sm">
             <thead>
-              <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
-                <th className="pb-2 font-semibold">Risikostufe</th>
-                <th className="pb-2 font-semibold">Mit Register</th>
-                <th className="pb-2 font-semibold">Ohne Register</th>
+              <tr className="border-b border-slate-200 bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <th className="px-4 py-3">Risikostufe</th>
+                <th className="px-4 py-3">Mit Register</th>
+                <th className="px-4 py-3">Ohne Register</th>
               </tr>
             </thead>
             <tbody>
               {overview.by_risk_level.map((entry) => (
-                <tr key={entry.risk_level} className="border-b border-slate-100">
-                  <td className="py-2 font-medium text-slate-900">
+                <tr
+                  key={entry.risk_level}
+                  className="border-b border-slate-100 transition hover:bg-cyan-50/40"
+                >
+                  <td className="px-4 py-3 font-semibold text-slate-900">
                     {riskLevelLabel(entry.risk_level)}
                   </td>
-                  <td className="py-2 text-slate-700">
+                  <td className="px-4 py-3 tabular-nums text-slate-700">
                     {entry.systems_with_register}
                   </td>
-                  <td className="py-2 text-slate-700">
+                  <td className="px-4 py-3 tabular-nums text-slate-700">
                     {entry.systems_without_register}
                   </td>
                 </tr>
@@ -184,30 +178,33 @@ export default async function BoardSuppliersPage() {
       {topSystems.length > 0 && (
         <section
           aria-label="Top-KI-Systeme mit höchstem Supplier-Risiko"
-          className="sbs-panel p-4"
+          className={CH_CARD}
         >
-          <h2 className="mb-4 text-sm font-semibold uppercase tracking-wide text-slate-700">
+          <h2 className="text-base font-semibold text-slate-900">
             Top 3 KI-Systeme mit höchstem Supplier-Risiko
           </h2>
-          <div className="overflow-x-auto">
+          <div className="mt-4 overflow-x-auto rounded-xl border border-slate-100">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b border-slate-200 text-left text-xs text-slate-500">
-                  <th className="pb-2 font-semibold">KI-System</th>
-                  <th className="pb-2 font-semibold">Lieferanten-Register</th>
-                  <th className="pb-2 font-semibold">Risiko-Score</th>
+                <tr className="border-b border-slate-200 bg-slate-50/80 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <th className="px-4 py-3">KI-System</th>
+                  <th className="px-4 py-3">Lieferanten-Register</th>
+                  <th className="px-4 py-3">Risiko-Score</th>
                 </tr>
               </thead>
               <tbody>
                 {topSystems.map((row) => (
-                  <tr key={row.ai_system_id} className="border-b border-slate-100">
-                    <td className="py-2 font-medium text-slate-900">
+                  <tr
+                    key={row.ai_system_id}
+                    className="border-b border-slate-100 transition hover:bg-cyan-50/40"
+                  >
+                    <td className="px-4 py-3 font-semibold text-slate-900">
                       {row.ai_system_name}
                     </td>
-                    <td className="py-2 text-slate-700">
+                    <td className="px-4 py-3 text-slate-700">
                       {row.has_supplier_risk_register ? "Ja" : "Nein"}
                     </td>
-                    <td className="py-2 text-slate-700">
+                    <td className="px-4 py-3 tabular-nums text-slate-700">
                       {row.supplier_risk_score.toFixed(2)}
                     </td>
                   </tr>
@@ -217,6 +214,6 @@ export default async function BoardSuppliersPage() {
           </div>
         </section>
       )}
-    </main>
+    </div>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -19,9 +19,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="de">
-      <body className="has-fixed-header sbs-body">
+      <body className="has-fixed-header sbs-body flex min-h-screen flex-col bg-slate-100/80">
         <SbsHeader />
-        {children}
+        <main
+          id="app-main"
+          className="mx-auto w-full min-w-0 max-w-7xl flex-1 px-4 py-8 pb-16 md:px-6 md:py-10"
+        >
+          {children}
+        </main>
         <SbsFooter />
       </body>
     </html>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,466 +1,167 @@
 import Link from "next/link";
 import React from "react";
 
+import { HomeHeroSlides } from "@/components/home/HomeHeroSlides";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD } from "@/lib/boardLayout";
+
 export default function HomePage() {
   return (
-    <>
-      <section className="hero-2026">
-        <div className="hero-content animate-in">
-          <div className="hero-badge">
-            <span className="pulse-dot" aria-hidden />
-            Compliance Hub · Live
-          </div>
-          <h1>
-            Enterprise-Governance für den
-            <br />
-            <span className="text-gradient">deutschen Mittelstand</span>
-          </h1>
-          <p className="hero-subtitle">
-            Von KI-System-Register und EU-AI-Act-Readiness bis zu NIS2-Board-KPIs
-            und exportfähigen Nachweisen – eine Plattform für Beratungen,
-            Konzerne und WP-Kanzleien. DSGVO-orientiert. Made for DACH.
+    <div className="min-w-0 space-y-16 md:space-y-20">
+      <section className="grid gap-10 lg:grid-cols-[1.05fr_0.95fr] lg:items-center lg:gap-12">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700">
+            Board-ready · DACH · Enterprise
           </p>
-          <div className="hero-cta-group">
-            <Link href="/tenant/compliance-overview" className="cta-primary">
-              Tenant öffnen →
+          <h1 className="mt-3 text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl sm:leading-[1.08]">
+            Board-ready AI Governance für EU AI Act &amp; NIS2
+          </h1>
+          <p className="mt-4 max-w-xl text-lg leading-relaxed text-slate-600">
+            Eine ruhige, auditierbare Sicht auf Reifegrad, regulatorische KPIs und
+            offene Maßnahmen – gebaut für Vorstand, ISB und externe Prüfer.
+          </p>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Link href="/board/kpis" className={CH_BTN_PRIMARY}>
+              Board öffnen
             </Link>
-            <Link href="/board/kpis" className="cta-secondary">
-              Board-KPIs ansehen
+            <Link href="/tenant/compliance-overview" className={CH_BTN_SECONDARY}>
+              Tenant-Cockpit
             </Link>
           </div>
-          <div className="hero-stats">
-            <div className="hero-stat">
-              <div className="stat-value">4+</div>
-              <div className="stat-label">Regulatory Pillars</div>
-            </div>
-            <div className="hero-stat">
-              <div className="stat-value">RLS</div>
-              <div className="stat-label">Tenant-Isolation</div>
-            </div>
-            <div className="hero-stat">
-              <div className="stat-value">JSON</div>
-              <div className="stat-label">DATEV-ready Export</div>
-            </div>
-            <div className="hero-stat">
-              <div className="stat-value">🇩🇪</div>
-              <div className="stat-label">DACH-Fokus</div>
-            </div>
-          </div>
         </div>
+        <HomeHeroSlides />
       </section>
 
-      <section className="section-2026" style={{ padding: "40px 24px" }}>
-        <div className="section-inner">
-          <div
-            className="trust-badges-2026"
-            style={{ justifyContent: "center" }}
-          >
-            <div className="trust-badge-2026">
-              <span className="badge-icon">🏢</span> Enterprise-Grade
+      <section aria-label="Kernmodule">
+        <h2 className="sr-only">Kernmodule</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          <article className={CH_CARD}>
+            <div className="flex items-start justify-between gap-3">
+              <span className="text-2xl" aria-hidden>
+                📊
+              </span>
+              <span className="rounded-full bg-cyan-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-cyan-800">
+                Board
+              </span>
             </div>
-            <div className="trust-badge-2026">
-              <span className="badge-icon">🔒</span> DSGVO-orientiert
-            </div>
-            <div className="trust-badge-2026">
-              <span className="badge-icon">📋</span> EU AI Act &amp; ISO 42001
-            </div>
-            <div className="trust-badge-2026">
-              <span className="badge-icon">⚡</span> NIS2 / KRITIS KPIs
-            </div>
-            <div className="trust-badge-2026">
-              <span className="badge-icon">🔗</span> DATEV &amp; SAP-ready
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="section-2026 alt-bg">
-        <div className="section-inner">
-          <div className="featured-product-2026">
-            <div className="fp-grid">
-              <div>
-                <div className="fp-badge">🚀 Board-ready</div>
-                <h2
-                  style={{
-                    fontSize: "clamp(1.6rem,3vw,2.4rem)",
-                    fontWeight: 800,
-                    letterSpacing: "-0.02em",
-                    marginBottom: "16px",
-                  }}
-                >
-                  AI Governance &amp; NIS2 in einer Ansicht
-                </h2>
-                <p
-                  style={{
-                    fontSize: "1.05rem",
-                    color: "var(--sbs-text-secondary)",
-                    lineHeight: 1.6,
-                    marginBottom: "24px",
-                  }}
-                >
-                  KPI-Drilldowns, Alerts mit Schwellen-Kontext, EU-AI-Act-Readiness
-                  mit Maßnahmen-Deep-Links und revisionssichere Exporte – gebaut für
-                  Aufsicht, ISB und externe Prüfer.
-                </p>
-                <div
-                  style={{
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "12px",
-                    marginBottom: "28px",
-                  }}
-                >
-                  {[
-                    "KI-System-Register mit Risiko & Technical-File-Spuren",
-                    "NIS2/KRITIS-Incident- und Supplier-Drilldowns",
-                    "Readiness-API mit Verknüpfung zu Governance-Actions",
-                    "KPI-Export JSON/CSV mit regulatory_scope für DMS/DATEV-Pipelines",
-                  ].map((t) => (
-                    <div
-                      key={t}
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "10px",
-                        fontSize: "0.92rem",
-                        color: "var(--sbs-text-secondary)",
-                      }}
-                    >
-                      <span style={{ color: "var(--sbs-text-accent)" }}>✓</span>
-                      {t}
-                    </div>
-                  ))}
-                </div>
-                <Link href="/board/kpis" className="sbs-btn-primary">
-                  Zum Board →
-                </Link>
-              </div>
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
-              >
-                <div
-                  style={{
-                    background: "#F1F5F9",
-                    border: "1px solid var(--sbs-border)",
-                    borderRadius: "16px",
-                    padding: "32px",
-                    textAlign: "center",
-                    width: "100%",
-                  }}
-                >
-                  <div style={{ fontSize: "4rem", marginBottom: "16px" }} aria-hidden>
-                    📊
-                  </div>
-                  <div
-                    style={{
-                      fontSize: "0.82rem",
-                      color: "#64748B",
-                      textTransform: "uppercase",
-                      letterSpacing: "0.08em",
-                      marginBottom: "8px",
-                    }}
-                  >
-                    Datenfluss
-                  </div>
-                  <div
-                    style={{
-                      display: "flex",
-                      justifyContent: "center",
-                      alignItems: "center",
-                      gap: "12px",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    {["Register", "Policies", "Engine", "Reports"].map((x, i) => (
-                      <React.Fragment key={x}>
-                        {i > 0 ? (
-                          <span style={{ color: "var(--sbs-text-muted)" }}>→</span>
-                        ) : null}
-                        <span
-                          style={{
-                            padding: "8px 14px",
-                            background: "rgba(0,102,179,0.08)",
-                            border: "1px solid rgba(0,102,179,0.2)",
-                            borderRadius: "8px",
-                            fontSize: "0.82rem",
-                            color: "var(--sbs-text-accent)",
-                          }}
-                        >
-                          {x}
-                        </span>
-                      </React.Fragment>
-                    ))}
-                  </div>
-                  <p
-                    style={{
-                      fontSize: "0.82rem",
-                      color: "#64748B",
-                      marginTop: "16px",
-                    }}
-                  >
-                    Ein konsistenter Pfad von Inventar bis Board-Export
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="section-2026">
-        <div className="section-inner">
-          <div className="section-header-center">
-            <div className="section-badge">Module</div>
-            <h2 className="section-title">
-              Board, Tenant &amp; Export.
-              <br />
-              Eine Oberfläche.
-            </h2>
-            <p className="section-subtitle">
-              Wählen Sie den Einstieg: operatives Tenant-Cockpit, Vorstands-KPIs
-              oder tiefe NIS2-/Readiness-Drilldowns.
+            <h3 className="mt-4 text-xl font-semibold text-slate-900">Board KPIs</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              ISO-42001-Reife, NIS2-Incident- und Supplier-Kennzahlen, Alerts und
+              Exporte für CISO und Aufsicht.
             </p>
-          </div>
-          <div className="card-grid-3" style={{ marginBottom: "20px" }}>
-            <Link href="/board/kpis" className="product-card-2026">
-              <span className="arrow">→</span>
-              <div className="product-icon">📈</div>
-              <h3>Board KPIs</h3>
-              <p>
-                ISO-42001-Reife, NIS2-Incident- und Supplier-Ratios, Alerts mit
-                Kennzahlen-Kontext und Exporte für CISO/Vorstand.
-              </p>
-              <div className="product-tags">
-                <span className="tag">ISO 42001</span>
-                <span className="tag">NIS2</span>
-                <span className="tag">Alerts</span>
+            <dl className="mt-5 grid grid-cols-3 gap-3 border-t border-slate-100 pt-5 text-center">
+              <div>
+                <dt className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+                  Reife
+                </dt>
+                <dd className="mt-1 text-lg font-semibold tabular-nums text-slate-900">
+                  Live
+                </dd>
               </div>
-            </Link>
-            <Link href="/board/nis2-kritis" className="product-card-2026">
-              <span className="arrow">→</span>
-              <div className="product-icon">🛡️</div>
-              <h3>NIS2 / KRITIS Drilldown</h3>
-              <p>
-                KPI-Typen Incident, Supplier, OT/IT – sortiert und für
-                Aufsichtsreporting aufbereitet.
-              </p>
-              <div className="product-tags">
-                <span className="tag">KRITIS</span>
-                <span className="tag">OT/IT</span>
-                <span className="tag">Top-N</span>
+              <div>
+                <dt className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+                  Alerts
+                </dt>
+                <dd className="mt-1 text-lg font-semibold tabular-nums text-slate-900">
+                  API
+                </dd>
               </div>
-            </Link>
-            <Link href="/board/eu-ai-act-readiness" className="product-card-2026">
-              <span className="arrow">→</span>
-              <div className="product-icon">⚖️</div>
-              <h3>EU AI Act Readiness</h3>
-              <p>
-                Stichtag High-Risk, kritische Anforderungen, Deep-Links zu
-                Systemen und Governance-Actions.
-              </p>
-              <div className="product-tags">
-                <span className="tag">Art. 9–15</span>
-                <span className="tag">Actions</span>
-                <span className="tag">Gaps</span>
+              <div>
+                <dt className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+                  Export
+                </dt>
+                <dd className="mt-1 text-lg font-semibold tabular-nums text-slate-900">
+                  JSON
+                </dd>
               </div>
-            </Link>
-          </div>
-          <div className="card-grid-2">
-            <Link href="/tenant/compliance-overview" className="product-card-2026">
-              <span className="arrow">→</span>
-              <div className="product-icon">🏢</div>
-              <h3>Tenant Compliance</h3>
-              <p>
-                AI-Systeme, Violations und Status in einem Cockpit für
-                Betriebsteams.
-              </p>
-              <div className="product-tags">
-                <span className="tag">Multi-Tenant</span>
-                <span className="tag">Violations</span>
-              </div>
-            </Link>
+            </dl>
             <Link
               href="/board/kpis"
-              className="product-card-2026"
-              style={{ borderColor: "var(--sbs-border-amber)" }}
+              className={`${CH_BTN_PRIMARY} mt-6 w-full sm:w-auto`}
             >
-              <span className="arrow">→</span>
-              <div
-                className="product-icon"
-                style={{ background: "var(--sbs-gradient-amber)" }}
-              >
-                📦
-              </div>
-              <h3>WP / DMS / DATEV Export</h3>
-              <p>
-                Strukturierte KPI-Exports mit Norm-Kontext im Envelope – bereit
-                für Kanzlei- und Archiv-Workflows.
-              </p>
-              <div className="product-tags">
-                <span className="tag">JSON</span>
-                <span className="tag">CSV</span>
-                <span className="tag">Audit</span>
-              </div>
+              Board öffnen
             </Link>
-          </div>
-        </div>
-      </section>
+          </article>
 
-      <section className="section-2026 alt-bg">
-        <div className="section-inner">
-          <div className="section-header-center">
-            <div className="section-badge">Vorteile</div>
-            <h2 className="section-title">Warum Compliance Hub</h2>
-            <p className="section-subtitle">
-              Normen übersetzen sich in messbare Controls – ohne Medienbrüche
-              zwischen Fachbereich, IT und Prüfern.
-            </p>
-          </div>
-          <div className="card-grid-3">
-            <div className="card-2026">
-              <div className="card-icon">🇩🇪</div>
-              <h3>DACH &amp; Regulatorik</h3>
-              <p>
-                EU AI Act, NIS2, ISO 42001, DSGVO/GoBD als Leitplanken – nicht
-                nur als Buzzwords, sondern im Datenmodell verankert.
-              </p>
-            </div>
-            <div className="card-2026">
-              <div className="card-icon">⚡</div>
-              <h3>Board-tauglich</h3>
-              <p>
-                Aggregierte KPIs, Ampeln und Exporte, die ISB und Aufsicht
-                direkt weiterverwenden können.
-              </p>
-            </div>
-            <div className="card-2026">
-              <div className="card-icon">🔗</div>
-              <h3>Integration</h3>
-              <p>
-                APIs, Webhooks und Export-Jobs – andockbar an SAP, DATEV, DMS
-                und n8n-Workflows.
-              </p>
-            </div>
-            <div className="card-2026">
-              <div className="card-icon">🔒</div>
-              <h3>Security by design</h3>
-              <p>
-                Mandanten-Isolation, nachvollziehbare Audit-Events und klare
-                Grenzen zwischen Demo und Produktion.
-              </p>
-            </div>
-            <div className="card-2026">
-              <div className="card-icon">📊</div>
-              <h3>Evidence</h3>
-              <p>
-                Lücken, Maßnahmen und Reports aus einer Quelle – weniger
-                Copy-Paste vor der Prüfung.
-              </p>
-            </div>
-            <div className="card-2026">
-              <div className="card-icon">🎯</div>
-              <h3>Berater-first</h3>
-              <p>
-                Wiederholbare Blueprints und mandantenfähige Sichten für
-                skalierbare GRC-Projekte.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="section-2026 alt-bg" style={{ padding: "60px 24px" }}>
-        <div className="section-inner">
-          <div className="section-header-center" style={{ marginBottom: "32px" }}>
-            <div className="section-badge">Technologie</div>
-            <h2 style={{ fontSize: "1.4rem", fontWeight: 700 }}>
-              Powered by moderner Stack
-            </h2>
-          </div>
-          <div className="tech-badges-2026">
-            {[
-              "FastAPI",
-              "Python 3.11+",
-              "Next.js",
-              "PostgreSQL / RLS",
-              "Pydantic v2",
-              "n8n",
-              "LangChain",
-              "DATEV",
-              "SAP S/4HANA",
-              "Multi-LLM",
-            ].map((t) => (
-              <span key={t} className="tech-badge-2026">
-                {t}
+          <article className={CH_CARD}>
+            <div className="flex items-start justify-between gap-3">
+              <span className="text-2xl" aria-hidden>
+                🛡️
               </span>
-            ))}
-          </div>
-        </div>
-      </section>
-
-      <section className="cta-section-2026">
-        <div className="cta-box">
-          <div className="section-badge" style={{ marginBottom: "20px" }}>
-            Jetzt starten
-          </div>
-          <h2
-            style={{
-              fontSize: "clamp(1.6rem,3vw,2.2rem)",
-              fontWeight: 800,
-              letterSpacing: "-0.02em",
-              marginBottom: "14px",
-            }}
-          >
-            Bereit für Enterprise-Governance?
-          </h2>
-          <p
-            style={{
-              fontSize: "1rem",
-              color: "var(--sbs-text-secondary)",
-              maxWidth: "480px",
-              margin: "0 auto 28px",
-              lineHeight: 1.6,
-            }}
-          >
-            Öffnen Sie das Tenant-Cockpit oder die Board-Ansicht – ohne
-            Kreditkarte, rein demonstrativ gegen die ComplianceHub-API.
-          </p>
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              justifyContent: "center",
-              gap: "14px",
-            }}
-          >
+              <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-700">
+                NIS2
+              </span>
+            </div>
+            <h3 className="mt-4 text-xl font-semibold text-slate-900">NIS2 / KRITIS</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              Verteilung und schwächste Systeme je KPI-Typ – für
+              Aufsichtsreporting und KRITIS-Bezug.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-slate-600">
+              <li className="flex gap-2">
+                <span className="text-cyan-600">·</span>
+                Incident-Response- und Backup-Runbook-Reife
+              </li>
+              <li className="flex gap-2">
+                <span className="text-cyan-600">·</span>
+                Supplier-Risk-Coverage und Supply-Chain-Sicht
+              </li>
+            </ul>
             <Link
-              href="/tenant/compliance-overview"
-              style={{
-                display: "inline-flex",
-                alignItems: "center",
-                gap: "8px",
-                padding: "14px 28px",
-                background: "var(--sbs-gradient-amber)",
-                color: "#003366",
-                fontWeight: 700,
-                fontSize: "0.95rem",
-                borderRadius: "10px",
-                textDecoration: "none",
-                boxShadow: "var(--sbs-shadow-amber)",
-              }}
+              href="/board/nis2-kritis"
+              className={`${CH_BTN_SECONDARY} mt-6 w-full sm:w-auto`}
             >
-              Tenant öffnen →
+              NIS2-Drilldown
             </Link>
-            <Link href="/board/kpis" className="sbs-btn-secondary">
-              Board-KPIs
+          </article>
+
+          <article className={CH_CARD}>
+            <div className="flex items-start justify-between gap-3">
+              <span className="text-2xl" aria-hidden>
+                🤖
+              </span>
+              <span className="rounded-full bg-amber-50 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-amber-900">
+                EU AI Act
+              </span>
+            </div>
+            <h3 className="mt-4 text-xl font-semibold text-slate-900">EU AI Act Readiness</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              High-Risk-Fokus, kritische Anforderungen und Verknüpfung zu
+              Maßnahmen und Systemen.
+            </p>
+            <p className="mt-4 rounded-xl bg-slate-50 px-3 py-2 text-sm font-medium text-slate-800">
+              Stichtag High-Risk:{" "}
+              <time dateTime="2026-08-02">02.08.2026</time>
+            </p>
+            <Link
+              href="/board/eu-ai-act-readiness"
+              className={`${CH_BTN_PRIMARY} mt-6 w-full sm:w-auto`}
+            >
+              Readiness-Dashboard
             </Link>
-          </div>
+          </article>
+
+          <article className={`${CH_CARD} border-dashed border-cyan-200/80 bg-gradient-to-br from-white to-cyan-50/30`}>
+            <div className="flex items-start justify-between gap-3">
+              <span className="text-2xl" aria-hidden>
+                📁
+              </span>
+              <span className="rounded-full bg-white/80 px-2 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-700">
+                Audit
+              </span>
+            </div>
+            <h3 className="mt-4 text-xl font-semibold text-slate-900">
+              Audit-Ready / Beratermodus
+            </h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">
+              Board-Reports, KPI-Exporte und Prüfspuren – strukturiert für DMS,
+              Kanzlei und DATEV-Pipelines.
+            </p>
+            <Link href="/board/kpis" className={`${CH_BTN_SECONDARY} mt-6 w-full sm:w-auto`}>
+              Zu Exporten &amp; Reports
+            </Link>
+          </article>
         </div>
       </section>
-    </>
+    </div>
   );
 }

--- a/frontend/src/app/tenant/layout.tsx
+++ b/frontend/src/app/tenant/layout.tsx
@@ -8,7 +8,8 @@ export default function TenantLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="sbs-tenant-shell">
+    <div className="relative ml-[calc(-50vw+50%)] w-screen max-w-[100vw] shrink-0">
+      <div className="sbs-tenant-shell">
       <aside className="sbs-tenant-sidebar">
         <div
           style={{
@@ -36,6 +37,7 @@ export default function TenantLayout({
         <TenantNav />
       </aside>
       <div className="sbs-tenant-main">{children}</div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/home/HomeHeroSlides.tsx
+++ b/frontend/src/components/home/HomeHeroSlides.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+
+const slides = [
+  {
+    id: "kpis",
+    label: "Board KPIs",
+    icon: "📊",
+    content: (
+      <div className="flex h-full flex-col justify-between p-6">
+        <div className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Executive KPIs
+        </div>
+        <div className="mt-4 grid grid-cols-3 gap-2">
+          {[
+            { v: "78%", l: "ISO 42001" },
+            { v: "64%", l: "NIS2 Inc." },
+            { v: "82%", l: "Supplier" },
+          ].map((k) => (
+            <div
+              key={k.l}
+              className="rounded-xl border border-slate-200/80 bg-white/90 p-3 shadow-sm"
+            >
+              <div className="text-lg font-semibold tabular-nums text-slate-900">{k.v}</div>
+              <div className="text-[0.65rem] font-medium text-slate-500">{k.l}</div>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 h-2 overflow-hidden rounded-full bg-slate-200">
+          <div className="h-full w-[72%] rounded-full bg-gradient-to-r from-cyan-500 to-teal-500" />
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "nis2",
+    label: "NIS2 / KRITIS",
+    icon: "🛡️",
+    content: (
+      <div className="flex h-full flex-col p-6">
+        <div className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Incident &amp; Supply Chain
+        </div>
+        <div className="mt-5 flex h-36 items-end gap-2 sm:gap-3">
+          {[45, 72, 58, 88, 64].map((h, i) => (
+            <div key={i} className="flex h-full min-w-0 flex-1 flex-col justify-end">
+              <div
+                className="w-full rounded-t-lg bg-gradient-to-t from-slate-800 to-slate-600 shadow-inner"
+                style={{ height: `${h}%` }}
+              />
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 flex justify-between text-[0.65rem] text-slate-500">
+          <span>Incident</span>
+          <span>Supplier</span>
+          <span>OT/IT</span>
+        </div>
+      </div>
+    ),
+  },
+  {
+    id: "euai",
+    label: "EU AI Act",
+    icon: "🤖",
+    content: (
+      <div className="flex h-full flex-col items-center justify-center p-6 text-center">
+        <div className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          High-Risk Readiness
+        </div>
+        <div className="relative mt-4 h-28 w-28">
+          <div
+            className="absolute inset-0 rounded-full"
+            style={{
+              background: `conic-gradient(rgb(8 145 178) 0% 68%, rgb(226 232 240) 68% 100%)`,
+            }}
+          />
+          <div className="absolute inset-[10px] flex items-center justify-center rounded-full bg-white shadow-inner">
+            <span className="text-2xl font-semibold tabular-nums text-slate-900">68%</span>
+          </div>
+        </div>
+        <p className="mt-3 text-xs text-slate-600">
+          Ziel: 85&nbsp;% vor dem Stichtag · 02.08.2026
+        </p>
+        <div className="mt-3 flex w-full gap-2">
+          <div className="h-1 flex-1 rounded-full bg-slate-200">
+            <div className="h-full w-1/3 rounded-full bg-cyan-500" />
+          </div>
+          <div className="h-1 flex-1 rounded-full bg-slate-200">
+            <div className="h-full w-2/3 rounded-full bg-teal-500" />
+          </div>
+        </div>
+      </div>
+    ),
+  },
+] as const;
+
+export function HomeHeroSlides() {
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    const t = window.setInterval(() => {
+      setActive((i) => (i + 1) % slides.length);
+    }, 7000);
+    return () => window.clearInterval(t);
+  }, []);
+
+  return (
+    <div className="min-w-0">
+      <div
+        className="relative min-h-[280px] overflow-hidden rounded-3xl border border-slate-200/80 bg-gradient-to-br from-white via-slate-50 to-cyan-50/40 shadow-lg shadow-slate-300/40 sm:min-h-[320px]"
+        role="region"
+        aria-roledescription="carousel"
+        aria-label="Produktüberblick"
+      >
+        {slides.map((s, i) => (
+          <div
+            key={s.id}
+            className={`absolute inset-0 transition-opacity duration-500 ease-out ${
+              i === active ? "z-10 opacity-100" : "z-0 opacity-0 pointer-events-none"
+            }`}
+            aria-hidden={i !== active}
+          >
+            {s.content}
+          </div>
+        ))}
+      </div>
+      <div
+        className="mt-4 flex flex-wrap justify-center gap-2"
+        role="tablist"
+        aria-label="Bereiche"
+      >
+        {slides.map((s, i) => (
+          <button
+            key={s.id}
+            type="button"
+            role="tab"
+            aria-selected={i === active}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition ${
+              i === active
+                ? "border-cyan-600/30 bg-cyan-600 text-white shadow-sm"
+                : "border-slate-200 bg-white text-slate-600 hover:border-slate-300 hover:bg-slate-50"
+            }`}
+            onClick={() => setActive(i)}
+          >
+            <span aria-hidden>{s.icon}</span>
+            {s.label}
+          </button>
+        ))}
+      </div>
+      <div className="mt-3 flex justify-center gap-1.5" aria-hidden>
+        {slides.map((_, i) => (
+          <span
+            key={i}
+            className={`h-1.5 rounded-full transition-all ${
+              i === active ? "w-6 bg-cyan-600" : "w-1.5 bg-slate-300"
+            }`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sbs/SbsFooter.tsx
+++ b/frontend/src/components/sbs/SbsFooter.tsx
@@ -4,25 +4,27 @@ import React from "react";
 export function SbsFooter() {
   const y = new Date().getFullYear();
   return (
-    <footer className="sbs-footer-2026">
-      <div className="sbs-footer-inner">
-        <div>
-          © {y} Compliance Hub · Enterprise GRC für den DACH-Markt ·{" "}
-          <span style={{ color: "var(--sbs-text-muted)" }}>
-            Design angelehnt an{" "}
-            <a
-              href="https://sbsdeutschland.com/sbshomepage/"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              SBS Deutschland
-            </a>
-          </span>
+    <footer className="mt-auto border-t border-slate-200/90 bg-white/90 py-8 backdrop-blur-sm">
+      <div className="mx-auto flex min-w-0 max-w-7xl flex-col gap-4 px-4 text-xs text-slate-500 md:flex-row md:items-center md:justify-between md:px-6">
+        <div className="leading-relaxed">
+          © {y} Compliance Hub · Enterprise GRC für den DACH-Markt
         </div>
-        <div style={{ display: "flex", gap: "1rem" }}>
-          <Link href="/">Start</Link>
-          <Link href="/board/kpis">Board</Link>
-          <Link href="/tenant/compliance-overview">Tenant</Link>
+        <div className="flex flex-wrap gap-x-4 gap-y-2">
+          <Link href="/" className="font-medium text-slate-600 hover:text-slate-900">
+            Start
+          </Link>
+          <Link href="/board/kpis" className="font-medium text-slate-600 hover:text-slate-900">
+            Board KPIs
+          </Link>
+          <Link
+            href="/tenant/compliance-overview"
+            className="font-medium text-slate-600 hover:text-slate-900"
+          >
+            Tenant
+          </Link>
+          <Link href="/board/suppliers" className="font-medium text-slate-600 hover:text-slate-900">
+            Supplier
+          </Link>
         </div>
       </div>
     </footer>

--- a/frontend/src/components/sbs/SbsHeader.tsx
+++ b/frontend/src/components/sbs/SbsHeader.tsx
@@ -7,31 +7,67 @@ const nav = [
   { href: "/board/nis2-kritis", label: "NIS2 / KRITIS" },
   { href: "/board/eu-ai-act-readiness", label: "EU AI Act" },
   { href: "/board/incidents", label: "Incidents" },
-  { href: "/board/suppliers", label: "Supplier" },
-  { href: "/tenant/compliance-overview", label: "Tenant" },
 ];
+
+function SettingsIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
 
 export function SbsHeader() {
   return (
-    <header className="sbs-header-2026">
-      <div className="sbs-header-inner">
-        <Link href="/" className="sbs-brand">
-          <span className="sbs-brand-mark" aria-hidden>
+    <header className="fixed top-0 left-0 right-0 z-[100] border-b border-white/10 bg-slate-950/85 shadow-sm shadow-black/20 backdrop-blur-xl backdrop-saturate-150">
+      <div className="mx-auto flex h-16 min-w-0 max-w-7xl items-center justify-between gap-4 px-4 md:px-6">
+        <Link href="/" className="group flex min-w-0 items-center gap-3 no-underline">
+          <span
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-400 to-teal-600 text-xs font-bold text-slate-950 shadow-md shadow-cyan-900/30"
+            aria-hidden
+          >
             CH
           </span>
-          <span className="sbs-brand-text">
-            <span className="sbs-brand-name">Compliance Hub</span>
-            <span className="sbs-brand-tag">
+          <span className="min-w-0 leading-tight">
+            <span className="block truncate text-sm font-semibold tracking-tight text-white md:text-base">
+              Compliance Hub
+            </span>
+            <span className="hidden text-[0.65rem] font-medium text-slate-400 sm:block">
               GRC · EU AI Act · NIS2 · ISO 42001
             </span>
           </span>
         </Link>
-        <nav className="sbs-header-nav" aria-label="Hauptnavigation">
+        <nav
+          className="flex flex-wrap items-center justify-end gap-x-1 gap-y-1 md:gap-x-2"
+          aria-label="Hauptnavigation"
+        >
           {nav.map((item) => (
-            <Link key={item.href} href={item.href}>
+            <Link
+              key={item.href}
+              href={item.href}
+              className="rounded-lg px-2 py-1.5 text-xs font-medium text-slate-300 transition hover:bg-white/10 hover:text-white md:px-2.5 md:text-[0.8rem]"
+            >
               {item.label}
             </Link>
           ))}
+          <Link
+            href="/tenant/compliance-overview"
+            className="ml-1 flex h-9 w-9 items-center justify-center rounded-lg text-slate-300 transition hover:bg-white/10 hover:text-white"
+            aria-label="Einstellungen und Tenant-Bereich"
+            title="Tenant / Einstellungen"
+          >
+            <SettingsIcon className="h-5 w-5" />
+          </Link>
         </nav>
       </div>
     </header>

--- a/frontend/src/lib/boardLayout.ts
+++ b/frontend/src/lib/boardLayout.ts
@@ -1,5 +1,24 @@
-/**
- * Gemeinsamer Wrapper für Board-Routen: zentriert, max. Breite, kein horizontales Overflow.
- */
-export const BOARD_PAGE_MAIN_CLASS =
-  "mx-auto w-full min-w-0 max-w-7xl px-4 pb-12 pt-8 md:px-6 min-h-[calc(100vh-var(--sbs-header-h)-120px)]";
+/** Seiten-Root innerhalb des globalen `<main>` (kein verschachteltes `<main>`). */
+export const BOARD_PAGE_ROOT_CLASS = "min-w-0";
+
+/** Einheitliche Karten (Apple-/AI-SaaS-inspiriert). */
+export const CH_CARD =
+  "rounded-2xl border border-slate-200/90 bg-white p-5 shadow-md shadow-slate-200/50";
+
+export const CH_CARD_MUTED =
+  "rounded-2xl border border-slate-200/60 bg-slate-50/80 p-5 shadow-sm";
+
+export const CH_PAGE_TITLE =
+  "text-3xl font-semibold tracking-tight text-slate-900 sm:text-[2rem] sm:leading-tight";
+
+export const CH_PAGE_SUB =
+  "mt-2 max-w-2xl text-base leading-relaxed text-slate-600";
+
+export const CH_SECTION_LABEL =
+  "text-xs font-semibold uppercase tracking-[0.12em] text-slate-500";
+
+export const CH_BTN_PRIMARY =
+  "inline-flex items-center justify-center rounded-xl bg-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-cyan-700";
+
+export const CH_BTN_SECONDARY =
+  "inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50";


### PR DESCRIPTION
- Dark glass header, settings icon; shared main max-w-7xl wrapper
- Home: hero slides carousel, module cards; CH_* design tokens
- Board pages: CH_CARD typography, KPI/NIS2/EU-AI/incidents/suppliers UI
- Tenant layout full-bleed under main; softer page bg token

Made-with: Cursor