### PR TITLE
feat(frontend): unified app shell, global nav, workspace hub

### DIFF
--- a/frontend/src/app/board/eu-ai-act-readiness/page.tsx
+++ b/frontend/src/app/board/eu-ai-act-readiness/page.tsx
@@ -7,6 +7,7 @@ import {
   type EUAIActReadinessOverview,
   type ReadinessRequirementTraffic,
 } from "@/lib/api";
+import { BoardToWorkspaceCtas } from "@/components/sbs/BoardToWorkspaceCtas";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   BOARD_PAGE_ROOT_CLASS,
@@ -140,6 +141,8 @@ export default async function EuAiActReadinessPage() {
           </>
         }
       />
+
+      <BoardToWorkspaceCtas />
 
       <section className={CH_CARD} aria-label="Readiness-Übersicht">
         <div className="grid gap-8 lg:grid-cols-[auto_1fr] lg:items-center">

--- a/frontend/src/app/board/incidents/page.tsx
+++ b/frontend/src/app/board/incidents/page.tsx
@@ -8,6 +8,7 @@ import {
   type AIIncidentBySystem,
   type AIIncidentOverview,
 } from "@/lib/api";
+import { BoardToWorkspaceCtas } from "@/components/sbs/BoardToWorkspaceCtas";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import { BOARD_PAGE_ROOT_CLASS, CH_PAGE_NAV_LINK } from "@/lib/boardLayout";
 
@@ -73,6 +74,8 @@ export default async function BoardIncidentsPage() {
           </>
         }
       />
+
+      <BoardToWorkspaceCtas />
 
       <IncidentsBoardClient overview={overview} bySystem={bySystem} />
     </div>

--- a/frontend/src/app/board/kpis/page.tsx
+++ b/frontend/src/app/board/kpis/page.tsx
@@ -12,6 +12,7 @@ import {
   type AIKpiAlert,
   type BoardKpiSummary,
 } from "@/lib/api";
+import { BoardToWorkspaceCtas } from "@/components/sbs/BoardToWorkspaceCtas";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   BOARD_PAGE_ROOT_CLASS,
@@ -235,6 +236,8 @@ export default async function BoardKpisPage() {
           </>
         }
       />
+
+      <BoardToWorkspaceCtas />
 
       <section
         aria-label="Executive KPIs"

--- a/frontend/src/app/board/nis2-kritis/page.tsx
+++ b/frontend/src/app/board/nis2-kritis/page.tsx
@@ -8,6 +8,7 @@ import {
   type Nis2KritisKpiType,
   type Nis2KritisKpiTypeDrilldown,
 } from "@/lib/api";
+import { BoardToWorkspaceCtas } from "@/components/sbs/BoardToWorkspaceCtas";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   BOARD_PAGE_ROOT_CLASS,
@@ -159,6 +160,8 @@ export default async function BoardNis2KritisPage() {
           </>
         }
       />
+
+      <BoardToWorkspaceCtas />
 
       <section
         aria-label="NIS2-KPI-Übersicht"

--- a/frontend/src/app/board/suppliers/page.tsx
+++ b/frontend/src/app/board/suppliers/page.tsx
@@ -7,6 +7,7 @@ import {
   type AISupplierRiskBySystem,
   type AISupplierRiskOverview,
 } from "@/lib/api";
+import { BoardToWorkspaceCtas } from "@/components/sbs/BoardToWorkspaceCtas";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   BOARD_PAGE_ROOT_CLASS,
@@ -94,6 +95,8 @@ export default async function BoardSuppliersPage() {
           </>
         }
       />
+
+      <BoardToWorkspaceCtas />
 
       <section
         aria-label="Supplier-Risiko-KPIs"

--- a/frontend/src/app/incidents/page.tsx
+++ b/frontend/src/app/incidents/page.tsx
@@ -1,5 +1,83 @@
-import { redirect } from "next/navigation";
+import React from "react";
+import Link from "next/link";
 
-export default function IncidentsAliasPage() {
-  redirect("/board/incidents");
+import { IncidentsBoardClient } from "@/components/board/IncidentsBoardClient";
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import {
+  fetchIncidentOverview,
+  fetchIncidentsBySystem,
+  type AIIncidentBySystem,
+  type AIIncidentOverview,
+} from "@/lib/api";
+import { BOARD_PAGE_ROOT_CLASS, CH_PAGE_NAV_LINK } from "@/lib/boardLayout";
+
+export default async function IncidentsPage() {
+  let overview: AIIncidentOverview | null = null;
+  let bySystem: AIIncidentBySystem[] = [];
+
+  try {
+    overview = await fetchIncidentOverview();
+  } catch (error) {
+    console.error("Incident overview API error:", error);
+  }
+
+  if (overview) {
+    try {
+      bySystem = await fetchIncidentsBySystem();
+    } catch (error) {
+      console.error("Incidents by system API error:", error);
+    }
+  }
+
+  if (!overview) {
+    return (
+      <div className={BOARD_PAGE_ROOT_CLASS}>
+        <EnterprisePageHeader
+          title="Incidents"
+          description="NIS2 Art. 21/23 · ISO 42001 Incident Management – mandantenbezogenes Incident-Register und KPIs."
+          below={
+            <>
+              <Link href="/board/incidents" className={CH_PAGE_NAV_LINK}>
+                Board: Incidents
+              </Link>
+              <Link href="/tenant/ai-systems" className={CH_PAGE_NAV_LINK}>
+                KI-Systeme
+              </Link>
+            </>
+          }
+        />
+        <div
+          role="status"
+          className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
+        >
+          Incident-KPIs konnten nicht geladen werden. Bitte versuchen Sie es später erneut oder
+          wenden Sie sich an das AI-Governance-Team.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={BOARD_PAGE_ROOT_CLASS}>
+      <EnterprisePageHeader
+        title="Incidents"
+        description="Globales Incident-Register mit gleichen Kennzahlen wie im Board – für Betrieb, ISB und Vorstand. NIS2 Art. 21/23 · ISO 42001."
+        below={
+          <>
+            <Link href="/board/incidents" className={CH_PAGE_NAV_LINK}>
+              Board: Incidents
+            </Link>
+            <Link href="/board/kpis" className={CH_PAGE_NAV_LINK}>
+              Board KPIs
+            </Link>
+            <Link href="/tenant/ai-systems" className={CH_PAGE_NAV_LINK}>
+              KI-Systeme
+            </Link>
+          </>
+        }
+      />
+
+      <IncidentsBoardClient overview={overview} bySystem={bySystem} />
+    </div>
+  );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,12 +18,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="de" className="scroll-smooth scroll-pt-20">
+    <html lang="de" className="scroll-smooth scroll-pt-[7.5rem]">
       <body className="sbs-body flex min-h-screen flex-col bg-slate-50 antialiased">
         <SbsHeader />
         <main
           id="app-main"
-          className="mx-auto w-full min-w-0 max-w-7xl flex-1 px-4 py-8 pb-16 md:px-6 md:py-10"
+          className="mx-auto w-full min-w-0 max-w-7xl flex-1 px-4 pb-16 pt-8 md:px-6 md:pb-20 md:pt-10"
         >
           {children}
         </main>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,5 +1,72 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
+import React from "react";
 
-export default function SettingsAliasPage() {
-  redirect("/tenant/compliance-overview");
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import {
+  CH_BTN_SECONDARY,
+  CH_CARD,
+  CH_SECTION_LABEL,
+  CH_SHELL,
+} from "@/lib/boardLayout";
+
+const TENANT_ID =
+  process.env.NEXT_PUBLIC_TENANT_ID ||
+  process.env.COMPLIANCEHUB_TENANT_ID ||
+  "tenant-overview-001";
+
+export default function SettingsPage() {
+  return (
+    <div className={CH_SHELL}>
+      <EnterprisePageHeader
+        title="Einstellungen"
+        description="Mandanten-Stammdaten, API-Zugriff und Integrations-Platzhalter – ohne Änderung an Backend-Verträgen."
+      />
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Mandant</p>
+          <p className="mt-2 font-mono text-sm font-semibold text-slate-900">{TENANT_ID}</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Anzeigename, Rechtsform und Kontakte werden produktiv über die Admin-API gepflegt.
+          </p>
+          <Link
+            href="/tenant/compliance-overview"
+            className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}
+          >
+            Zur Compliance-Übersicht
+          </Link>
+        </article>
+
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>API-Keys</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Setzen Sie <code className="rounded bg-slate-100 px-1">COMPLIANCEHUB_API_KEY</code>{" "}
+            serverseitig; im Browser nur{" "}
+            <code className="rounded bg-slate-100 px-1">NEXT_PUBLIC_*</code> für Demo-Umgebungen.
+          </p>
+          <p className="mt-3 text-xs text-slate-500">
+            Rotieren und scoped Keys folgen über das geplante Admin-Portal.
+          </p>
+        </article>
+
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Benutzer & Rollen</p>
+          <p className="mt-2 text-sm text-slate-600">
+            SSO (Azure AD, SAP IAS) und rollenbasierte Workspace-Zugriffe – Platzhalter für
+            Enterprise-Onboarding.
+          </p>
+        </article>
+
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Integrationen</p>
+          <p className="mt-2 text-sm text-slate-600">
+            DATEV-Export, SAP BTP / S4HANA-Anbindung und DMS-Konnektoren als Roadmap-Module.
+          </p>
+          <p className="mt-3 text-xs text-slate-500">
+            Keine produktiven Credentials in dieser Oberfläche hinterlegen.
+          </p>
+        </article>
+      </section>
+    </div>
+  );
 }

--- a/frontend/src/app/tenant/ai-systems/[id]/page.tsx
+++ b/frontend/src/app/tenant/ai-systems/[id]/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import React from "react";
 
 import { EvidenceAttachmentsSection } from "@/components/evidence/EvidenceAttachmentsSection";
+import { AiSystemSectionNav } from "@/components/tenant/AiSystemSectionNav";
 import {
   fetchEuAiActReadiness,
   fetchIncidentsBySystem,
@@ -108,7 +109,13 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         }
       />
 
-      <section className={CH_CARD} aria-label="Stammdaten">
+      <AiSystemSectionNav />
+
+      <section
+        id="sec-stammdaten"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Stammdaten"
+      >
         <h2 className="text-base font-semibold text-slate-900">Stammdaten</h2>
         <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
           <div>
@@ -140,7 +147,11 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         </dl>
       </section>
 
-      <section className={CH_CARD} aria-label="Evidenz und Dokumente">
+      <section
+        id="sec-evidenz"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Evidenz und Dokumente"
+      >
         <h2 className="text-base font-semibold text-slate-900">
           Evidenz & Dokumente
         </h2>
@@ -153,7 +164,11 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         </div>
       </section>
 
-      <section className={CH_CARD} aria-label="Klassifikation EU AI Act">
+      <section
+        id="sec-klassifikation"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Klassifikation EU AI Act"
+      >
         <h2 className="text-base font-semibold text-slate-900">Klassifikation</h2>
         {classification ? (
           <dl className="mt-4 space-y-2 text-sm text-slate-700">
@@ -199,7 +214,7 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         )}
       </section>
 
-      <section className={CH_CARD} aria-label="Incidents">
+      <section id="sec-incidents" className={`${CH_CARD} scroll-mt-32`} aria-label="Incidents">
         <h2 className="text-base font-semibold text-slate-900">Incidents (Aggregat)</h2>
         {incidentRow ? (
           <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
@@ -231,7 +246,11 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         </p>
       </section>
 
-      <section className={CH_CARD} aria-label="Compliance-Status">
+      <section
+        id="sec-compliance"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Compliance-Status"
+      >
         <h2 className="text-base font-semibold text-slate-900">EU AI Act Compliance (Überblick)</h2>
         <p className="mt-1 text-xs text-slate-500">
           {compliance.length} Anforderungen geladen · {complianceDone} erfüllt ·{" "}
@@ -256,7 +275,11 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         ) : null}
       </section>
 
-      <section className={CH_CARD} aria-label="Policy Violations">
+      <section
+        id="sec-violations"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Policy Violations"
+      >
         <h2 className="text-base font-semibold text-slate-900">Violations</h2>
         {violations.length === 0 ? (
           <p className="mt-3 text-sm text-slate-500">Keine offenen Violations für dieses System.</p>
@@ -277,7 +300,11 @@ export default async function TenantAiSystemDetailPage({ params }: PageProps) {
         )}
       </section>
 
-      <section className={CH_CARD} aria-label="Governance-Maßnahmen">
+      <section
+        id="sec-massnahmen"
+        className={`${CH_CARD} scroll-mt-32`}
+        aria-label="Governance-Maßnahmen"
+      >
         <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="text-base font-semibold text-slate-900">Offene Maßnahmen</h2>
           <Link href="/board/eu-ai-act-readiness#governance-actions" className={CH_BTN_SECONDARY}>

--- a/frontend/src/app/tenant/ai-systems/page.tsx
+++ b/frontend/src/app/tenant/ai-systems/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import React from "react";
 
 import { AiSystemsImportPanel } from "@/components/tenant/AiSystemsImportPanel";
+import { AiSystemsRegistryTableClient } from "@/components/tenant/AiSystemsRegistryTableClient";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import { fetchTenantAISystems } from "@/lib/api";
 import {
@@ -20,10 +21,6 @@ type AISystem = {
   status: string;
   owneremail?: string;
 };
-
-function classNames(...values: (string | false | null | undefined)[]) {
-  return values.filter(Boolean).join(" ");
-}
 
 type PageProps = {
   searchParams?: Promise<{ ids?: string }> | { ids?: string };
@@ -115,82 +112,11 @@ export default async function TenantAISystemsPage({ searchParams }: PageProps) {
             </span>
           </div>
         </div>
-        <div className="sbs-table-wrap">
-          <table className="sbs-table">
-            <thead>
-              <tr>
-                <th className="px-5 py-2 font-medium">Name</th>
-                <th className="px-3 py-2 font-medium">Business Unit</th>
-                <th className="px-3 py-2 font-medium">Risk Level</th>
-                <th className="px-3 py-2 font-medium">AI Act</th>
-                <th className="px-3 py-2 font-medium">Status</th>
-                <th className="px-3 py-2 font-medium">Owner</th>
-                <th className="px-3 py-2 font-medium">Detail</th>
-              </tr>
-            </thead>
-            <tbody>
-              {filtered.map((s) => (
-                <tr key={s.id}>
-                  <td>
-                    <div className="font-semibold text-[var(--sbs-text-primary)]">
-                      {s.name}
-                    </div>
-                    <div className="text-xs text-[var(--sbs-text-muted)]">
-                      {s.id}
-                    </div>
-                  </td>
-                  <td className="text-[var(--sbs-text-secondary)]">
-                    {s.businessunit}
-                  </td>
-                  <td>
-                    <span
-                      className={classNames(
-                        "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold",
-                        s.risklevel === "high" &&
-                          "border border-rose-200 bg-rose-50 text-rose-800",
-                        s.risklevel === "limited" &&
-                          "border border-amber-200 bg-amber-50 text-amber-900",
-                        s.risklevel === "low" &&
-                          "border border-emerald-200 bg-emerald-50 text-emerald-900",
-                      )}
-                    >
-                      {s.risklevel}
-                    </span>
-                  </td>
-                  <td className="text-xs text-[var(--sbs-text-secondary)]">
-                    {s.aiactcategory}
-                  </td>
-                  <td className="text-xs">
-                    <span className="inline-flex rounded-full border border-[var(--sbs-border)] bg-slate-50 px-2 py-0.5 text-[var(--sbs-text-secondary)]">
-                      {s.status}
-                    </span>
-                  </td>
-                  <td className="text-xs text-[var(--sbs-text-secondary)]">
-                    {s.owneremail ?? "—"}
-                  </td>
-                  <td>
-                    <Link
-                      href={`/tenant/ai-systems/${encodeURIComponent(s.id)}`}
-                      className={CH_PAGE_NAV_LINK + " text-xs no-underline hover:underline"}
-                    >
-                      Detail
-                    </Link>
-                  </td>
-                </tr>
-              ))}
-              {filtered.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={7}
-                    className="py-8 text-center text-sm text-[var(--sbs-text-secondary)]"
-                  >
-                    Noch keine AI‑Systeme erfasst.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
+        <AiSystemsRegistryTableClient
+          systems={filtered}
+          idFilterActive={idSet.size > 0}
+          totalBeforeClientFilter={systems.length}
+        />
       </section>
     </div>
   );

--- a/frontend/src/app/tenant/audit-log/page.tsx
+++ b/frontend/src/app/tenant/audit-log/page.tsx
@@ -3,15 +3,70 @@ import React from "react";
 
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
+  TenantAuditLogTableClient,
+  type AuditLogDemoRow,
+} from "@/components/tenant/TenantAuditLogTableClient";
+import {
   CH_BTN_SECONDARY,
   CH_CARD,
   CH_PAGE_NAV_LINK,
   CH_SHELL,
 } from "@/lib/boardLayout";
 
-export default async function TenantAuditLogPage() {
-  const events: Record<string, unknown>[] = [];
+const TENANT_ID =
+  process.env.NEXT_PUBLIC_TENANT_ID ||
+  process.env.COMPLIANCEHUB_TENANT_ID ||
+  "tenant-overview-001";
 
+const DEMO_AUDIT_ROWS: AuditLogDemoRow[] = [
+  {
+    id: "1",
+    ts: "2025-03-18T09:15:00.000Z",
+    actor: "isa@tenant.example",
+    entityType: "AI-System",
+    action: "UPDATE",
+    tenant: TENANT_ID,
+    detail: "risk_level → high",
+  },
+  {
+    id: "2",
+    ts: "2025-03-19T14:22:00.000Z",
+    actor: "system",
+    entityType: "Evidence",
+    action: "CREATE",
+    tenant: TENANT_ID,
+    detail: "Upload DPIA (KI-Chatbot Vertrieb)",
+  },
+  {
+    id: "3",
+    ts: "2025-03-20T11:03:00.000Z",
+    actor: "compliance@tenant.example",
+    entityType: "Policy",
+    action: "PUBLISH",
+    tenant: TENANT_ID,
+    detail: "policy-eu-ai-act-v3",
+  },
+  {
+    id: "4",
+    ts: "2025-03-21T08:40:00.000Z",
+    actor: "auditor@external.example",
+    entityType: "Action",
+    action: "READ",
+    tenant: TENANT_ID,
+    detail: "Governance-Maßnahme #12",
+  },
+  {
+    id: "5",
+    ts: "2025-03-22T16:55:00.000Z",
+    actor: "api-key:ingest",
+    entityType: "AI-System",
+    action: "IMPORT",
+    tenant: TENANT_ID,
+    detail: "CSV Import 12 Zeilen",
+  },
+];
+
+export default async function TenantAuditLogPage() {
   return (
     <div className={CH_SHELL}>
       <EnterprisePageHeader
@@ -41,24 +96,7 @@ export default async function TenantAuditLogPage() {
         }
       />
 
-      <section className={`${CH_CARD} overflow-hidden p-0`}>
-        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-200/80 px-5 py-4">
-          <h2 className="text-sm font-semibold text-slate-900">Chronologischer Audit-Log</h2>
-          <button type="button" className={`${CH_BTN_SECONDARY} text-xs py-2`}>
-            CSV exportieren
-          </button>
-        </div>
-        <div className="px-5 py-5 text-sm text-slate-600">
-          {events.length === 0 ? (
-            <p>
-              Sobald die Audit-APIs angebunden sind, erscheinen hier zeitgestempelte Ereignisse mit
-              Akteur, Ressource und Korrelation zu Mandant und KI-System. Einträge sind append-only.
-            </p>
-          ) : (
-            <p>{events.length} Einträge</p>
-          )}
-        </div>
-      </section>
+      <TenantAuditLogTableClient tenantId={TENANT_ID} rows={DEMO_AUDIT_ROWS} />
 
       <section className={`${CH_CARD} overflow-hidden p-0`}>
         <div className="border-b border-slate-200/80 px-5 py-4">

--- a/frontend/src/app/tenant/compliance-overview/page.tsx
+++ b/frontend/src/app/tenant/compliance-overview/page.tsx
@@ -77,6 +77,66 @@ export default async function TenantComplianceOverviewPage() {
       />
 
       <section
+        aria-label="Workspace-Home"
+        className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3"
+      >
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>KI-Systeme</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Register, Risiko und Verknüpfung zu Incidents, NIS2-KPIs und Nachweisen.
+          </p>
+          <Link href="/tenant/ai-systems" className={`${CH_BTN_PRIMARY} mt-4 inline-flex text-xs`}>
+            Zum Register
+          </Link>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>EU AI Act</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Klassifikation, Anforderungen und operative Lückenschließung im Mandanten.
+          </p>
+          <Link href="/tenant/eu-ai-act" className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}>
+            Zum Cockpit
+          </Link>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>NIS2 / KRITIS</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Board-Drilldown zu Incident- und Supplier-Readiness für den Vorstand.
+          </p>
+          <Link href="/board/nis2-kritis" className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}>
+            Zum Board
+          </Link>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Policies</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Framework-Mappings und operative Policy-Engine für den Workspace.
+          </p>
+          <Link href="/tenant/policies" className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}>
+            Policies öffnen
+          </Link>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Blueprints</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Vorlagen und Playbooks für EU AI Act, NIS2 und ISO 42001.
+          </p>
+          <Link href="/tenant/blueprints" className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}>
+            Blueprints
+          </Link>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Audit-Log</p>
+          <p className="mt-2 text-sm text-slate-600">
+            Unveränderliche Ereignisspur für Revision und Regulatorik.
+          </p>
+          <Link href="/tenant/audit-log" className={`${CH_BTN_SECONDARY} mt-4 inline-flex text-xs`}>
+            Audit-Log
+          </Link>
+        </article>
+      </section>
+
+      <section
         aria-label="Mandant und technische Anbindung"
         className="grid gap-4 lg:grid-cols-3"
       >

--- a/frontend/src/app/tenant/eu-ai-act/page.tsx
+++ b/frontend/src/app/tenant/eu-ai-act/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import React, { useEffect, useState } from "react";
 
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
@@ -13,6 +14,7 @@ import {
   CH_BTN_PRIMARY,
   CH_BTN_SECONDARY,
   CH_CARD,
+  CH_PAGE_NAV_LINK,
   CH_SHELL,
 } from "@/lib/boardLayout";
 
@@ -393,6 +395,16 @@ export default function EUAIActPage() {
                 <div className="text-[0.65rem] text-amber-800/90">bis 02.08.2026</div>
               </div>
             ) : null
+          }
+          below={
+            <>
+              <Link href="/board/eu-ai-act-readiness" className={CH_PAGE_NAV_LINK}>
+                Board: EU AI Act Readiness
+              </Link>
+              <Link href="/tenant/ai-systems" className={CH_PAGE_NAV_LINK}>
+                KI-System-Register
+              </Link>
+            </>
           }
         />
 

--- a/frontend/src/app/tenant/layout.tsx
+++ b/frontend/src/app/tenant/layout.tsx
@@ -8,24 +8,24 @@ export default function TenantLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="relative ml-[calc(-50vw+50%)] w-screen max-w-[100vw] shrink-0">
-      <div className="sbs-tenant-shell">
-        <aside className="sbs-tenant-sidebar">
-          <div className="border-b border-slate-200 px-5 py-5">
-            <div className="text-[0.65rem] font-bold uppercase tracking-[0.12em] text-slate-400">
-              Compliance Hub
-            </div>
-            <div className="mt-1 text-sm text-slate-700">
-              Mandant{" "}
-              <span className="font-semibold text-slate-900">tenant-overview-001</span>
-            </div>
-            <p className="mt-2 text-xs leading-relaxed text-slate-500">
-              Tenant-Cockpit für Register, Policies und Nachweise.
-            </p>
+    <div className="flex w-full min-w-0 flex-col gap-0 lg:flex-row lg:items-start">
+      <aside className="w-full shrink-0 border-b border-slate-200 bg-white lg:w-60 lg:border-b-0 lg:border-r lg:border-slate-200">
+        <div className="border-b border-slate-200 px-4 py-4 md:px-5 md:py-5">
+          <div className="text-[0.65rem] font-bold uppercase tracking-[0.12em] text-slate-400">
+            Compliance Hub
           </div>
-          <TenantNav />
-        </aside>
-        <div className="sbs-tenant-main min-w-0">{children}</div>
+          <div className="mt-1 text-sm text-slate-700">
+            Mandant{" "}
+            <span className="font-semibold text-slate-900">tenant-overview-001</span>
+          </div>
+          <p className="mt-2 text-xs leading-relaxed text-slate-500">
+            Workspace für Register, Policies, Evidenzen und operative Umsetzung.
+          </p>
+        </div>
+        <TenantNav />
+      </aside>
+      <div className="min-w-0 flex-1 bg-slate-50/90 px-4 py-8 md:px-6 md:py-10">
+        {children}
       </div>
     </div>
   );

--- a/frontend/src/components/board/IncidentsBoardClient.tsx
+++ b/frontend/src/components/board/IncidentsBoardClient.tsx
@@ -52,10 +52,11 @@ export function IncidentsBoardClient({ overview, bySystem }: Props) {
   const [windowDays, setWindowDays] = useState<string>("365");
   const [systemQuery, setSystemQuery] = useState("");
   const [severityFocus, setSeverityFocus] = useState<string>("all");
+  const [asOfMs, setAsOfMs] = useState(() => Date.now());
 
   const filteredRows = useMemo(() => {
     const q = systemQuery.trim().toLowerCase();
-    const now = Date.now();
+    const now = asOfMs;
     const maxAge =
       windowDays === "all"
         ? null
@@ -74,7 +75,7 @@ export function IncidentsBoardClient({ overview, bySystem }: Props) {
         return row.incident_count > 0;
       })
       .sort((a, b) => b.incident_count - a.incident_count);
-  }, [bySystem, systemQuery, windowDays]);
+  }, [asOfMs, bySystem, systemQuery, windowDays]);
 
   return (
     <div className="min-w-0 space-y-8">
@@ -97,7 +98,10 @@ export function IncidentsBoardClient({ overview, bySystem }: Props) {
               id="inc-window"
               className="mt-1.5 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm"
               value={windowDays}
-              onChange={(e) => setWindowDays(e.target.value)}
+              onChange={(e) => {
+                setWindowDays(e.target.value);
+                setAsOfMs(Date.now());
+              }}
             >
               <option value="30">Letzte 30 Tage</option>
               <option value="90">Letzte 90 Tage</option>

--- a/frontend/src/components/sbs/AppSecondaryNav.tsx
+++ b/frontend/src/components/sbs/AppSecondaryNav.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React from "react";
+
+import { BOARD_NAV_ITEMS, WORKSPACE_NAV_ITEMS } from "@/lib/appNavConfig";
+
+function subLink(active: boolean) {
+  return [
+    "whitespace-nowrap rounded-md px-2.5 py-1.5 text-xs font-medium transition",
+    active
+      ? "bg-white text-cyan-900 shadow-sm ring-1 ring-slate-200/80"
+      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+  ].join(" ");
+}
+
+export function AppSecondaryNav() {
+  const pathname = usePathname();
+
+  if (pathname.startsWith("/board")) {
+    return (
+      <div className="border-t border-slate-200/80 bg-slate-50/95">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-1 px-4 py-2 md:px-6">
+          <span className="mr-2 text-[0.65rem] font-bold uppercase tracking-wider text-slate-400">
+            Board
+          </span>
+          {BOARD_NAV_ITEMS.map((item) => {
+            const active =
+              pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link key={item.href} href={item.href} className={subLink(active)}>
+                {item.label}
+              </Link>
+            );
+          })}
+          <Link
+            href="/tenant/ai-systems"
+            className="ml-auto text-xs font-semibold text-cyan-800 underline decoration-cyan-600/30 underline-offset-4 hover:text-cyan-950"
+          >
+            Zum Workspace
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (pathname.startsWith("/tenant")) {
+    return (
+      <div className="border-t border-slate-200/80 bg-slate-50/95">
+        <div className="mx-auto flex max-w-7xl flex-wrap items-center gap-1 px-4 py-2 md:px-6">
+          <span className="mr-2 text-[0.65rem] font-bold uppercase tracking-wider text-slate-400">
+            Workspace
+          </span>
+          {WORKSPACE_NAV_ITEMS.map((item) => {
+            const active =
+              pathname === item.href || pathname.startsWith(`${item.href}/`);
+            return (
+              <Link key={item.href} href={item.href} className={subLink(active)}>
+                {item.label}
+              </Link>
+            );
+          })}
+          <Link
+            href="/board/kpis"
+            className="ml-auto text-xs font-semibold text-cyan-800 underline decoration-cyan-600/30 underline-offset-4 hover:text-cyan-950"
+          >
+            Zum Board
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/frontend/src/components/sbs/BoardToWorkspaceCtas.tsx
+++ b/frontend/src/components/sbs/BoardToWorkspaceCtas.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+import React from "react";
+
+import { CH_BTN_SECONDARY, CH_PAGE_NAV_LINK } from "@/lib/boardLayout";
+
+/**
+ * Konsistente Sprünge vom Board in den Tenant-Workspace (ohne API-Logik).
+ */
+export function BoardToWorkspaceCtas() {
+  return (
+    <div className="mt-4 flex flex-wrap items-center gap-2 rounded-xl border border-slate-200/80 bg-slate-50/80 px-4 py-3">
+      <span className="text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500">
+        Workspace
+      </span>
+      <Link href="/tenant/ai-systems" className={`${CH_BTN_SECONDARY} py-2 text-xs`}>
+        KI-Systeme
+      </Link>
+      <Link
+        href="/tenant/compliance-overview"
+        className={`${CH_BTN_SECONDARY} py-2 text-xs`}
+      >
+        Mandanten-Übersicht
+      </Link>
+      <Link href="/tenant/policies" className={`${CH_BTN_SECONDARY} py-2 text-xs`}>
+        Policies
+      </Link>
+      <Link
+        href="/board/eu-ai-act-readiness"
+        className={CH_PAGE_NAV_LINK + " ml-auto text-xs"}
+      >
+        Board: EU AI Act Readiness
+      </Link>
+    </div>
+  );
+}

--- a/frontend/src/components/sbs/GlobalAppNav.tsx
+++ b/frontend/src/components/sbs/GlobalAppNav.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import React, { useEffect, useRef, useState } from "react";
+
+import {
+  BOARD_NAV_ITEMS,
+  WORKSPACE_NAV_ITEMS,
+} from "@/lib/appNavConfig";
+
+function navLinkClass(active: boolean): string {
+  return [
+    "rounded-lg px-2.5 py-2 text-xs font-medium transition md:text-[0.8rem]",
+    active
+      ? "bg-cyan-50 text-cyan-900 ring-1 ring-cyan-200/80"
+      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900",
+  ].join(" ");
+}
+
+function Dropdown({
+  label,
+  active,
+  children,
+}: {
+  label: string;
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function onDoc(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("click", onDoc);
+    return () => document.removeEventListener("click", onDoc);
+  }, []);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={() => setOpen((o) => !o)}
+        className={navLinkClass(active)}
+      >
+        {label}
+        <span className="ml-0.5 text-[0.65rem] opacity-70" aria-hidden>
+          ▾
+        </span>
+      </button>
+      {open ? (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 min-w-[14rem] rounded-xl border border-slate-200/90 bg-white py-1 shadow-lg shadow-slate-200/50 md:left-0 md:right-auto"
+          role="menu"
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DropdownLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: React.ReactNode;
+}) {
+  const pathname = usePathname();
+  const active = pathname === href || pathname.startsWith(`${href}/`);
+  return (
+    <Link
+      href={href}
+      role="menuitem"
+      className={`block px-3 py-2 text-sm no-underline ${
+        active
+          ? "bg-cyan-50 font-semibold text-cyan-900"
+          : "text-slate-700 hover:bg-slate-50"
+      }`}
+    >
+      {children}
+    </Link>
+  );
+}
+
+function SettingsIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      {...props}
+    >
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
+
+export function GlobalAppNav() {
+  const pathname = usePathname();
+  const boardActive = pathname.startsWith("/board");
+  const workspaceActive = pathname.startsWith("/tenant");
+  const homeActive = pathname === "/";
+  const incidentsActive =
+    pathname === "/incidents" || pathname.startsWith("/board/incidents");
+  const settingsActive = pathname === "/settings";
+
+  return (
+    <nav
+      className="flex flex-wrap items-center justify-end gap-x-1 gap-y-1 md:gap-x-2"
+      aria-label="Hauptnavigation"
+    >
+      <Link href="/" className={navLinkClass(homeActive)}>
+        Start
+      </Link>
+
+      <Dropdown label="Board" active={boardActive}>
+        {BOARD_NAV_ITEMS.map((item) => (
+          <DropdownLink key={item.href} href={item.href}>
+            {item.label}
+          </DropdownLink>
+        ))}
+      </Dropdown>
+
+      <Dropdown label="Workspace" active={workspaceActive}>
+        {WORKSPACE_NAV_ITEMS.map((item) => (
+          <DropdownLink key={item.href} href={item.href}>
+            {item.label}
+          </DropdownLink>
+        ))}
+      </Dropdown>
+
+      <Link href="/incidents" className={navLinkClass(incidentsActive)}>
+        Incidents
+      </Link>
+
+      <Link
+        href="/settings"
+        className={`ml-0.5 flex h-9 w-9 items-center justify-center rounded-lg transition md:ml-1 ${
+          settingsActive
+            ? "bg-cyan-50 text-cyan-900 ring-1 ring-cyan-200/80"
+            : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+        }`}
+        aria-label="Einstellungen"
+        title="Einstellungen"
+      >
+        <SettingsIcon className="h-5 w-5" />
+      </Link>
+    </nav>
+  );
+}

--- a/frontend/src/components/sbs/SbsHeader.tsx
+++ b/frontend/src/components/sbs/SbsHeader.tsx
@@ -1,37 +1,16 @@
 import Link from "next/link";
 import React from "react";
 
-const nav = [
-  { href: "/", label: "Start" },
-  { href: "/board/kpis", label: "Board KPIs" },
-  { href: "/board/nis2-kritis", label: "NIS2 / KRITIS" },
-  { href: "/board/eu-ai-act-readiness", label: "EU AI Act" },
-  { href: "/board/incidents", label: "Incidents" },
-];
+import { BRAND_TAGLINE } from "@/lib/appNavConfig";
 
-function SettingsIcon(props: React.SVGProps<SVGSVGElement>) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden
-      {...props}
-    >
-      <circle cx="12" cy="12" r="3" />
-      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-    </svg>
-  );
-}
+import { AppSecondaryNav } from "./AppSecondaryNav";
+import { GlobalAppNav } from "./GlobalAppNav";
 
 export function SbsHeader() {
   return (
-    <header className="sticky top-0 z-50 border-b border-slate-200/90 bg-white/90 shadow-sm backdrop-blur-md backdrop-saturate-150 supports-[backdrop-filter]:bg-white/80">
-      <div className="mx-auto flex h-16 min-w-0 max-w-7xl items-center justify-between gap-4 px-4 md:px-6">
-        <Link href="/" className="group flex min-w-0 items-center gap-3 no-underline">
+    <header className="sticky top-0 z-50 border-b border-slate-200/90 bg-white/95 shadow-sm backdrop-blur-md backdrop-saturate-150 supports-[backdrop-filter]:bg-white/85">
+      <div className="mx-auto flex min-h-16 max-w-7xl items-center justify-between gap-4 px-4 py-2 md:px-6 md:py-2.5">
+        <Link href="/" className="group flex min-w-0 flex-1 items-center gap-3 no-underline">
           <span
             className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-cyan-500 to-teal-600 text-xs font-bold text-white shadow-sm shadow-cyan-900/10"
             aria-hidden
@@ -43,33 +22,13 @@ export function SbsHeader() {
               Compliance Hub
             </span>
             <span className="hidden text-[0.65rem] font-medium text-slate-500 sm:block">
-              Enterprise GRC · EU AI Act · NIS2 · ISO 42001
+              {BRAND_TAGLINE}
             </span>
           </span>
         </Link>
-        <nav
-          className="flex flex-wrap items-center justify-end gap-x-0.5 gap-y-1 md:gap-x-1"
-          aria-label="Hauptnavigation"
-        >
-          {nav.map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-lg px-2 py-1.5 text-xs font-medium text-slate-600 transition hover:bg-slate-100 hover:text-slate-900 md:px-2.5 md:text-[0.8rem]"
-            >
-              {item.label}
-            </Link>
-          ))}
-          <Link
-            href="/settings"
-            className="ml-1 flex h-9 w-9 items-center justify-center rounded-lg text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
-            aria-label="Einstellungen und Mandant"
-            title="Einstellungen (Mandant)"
-          >
-            <SettingsIcon className="h-5 w-5" />
-          </Link>
-        </nav>
+        <GlobalAppNav />
       </div>
+      <AppSecondaryNav />
     </header>
   );
 }

--- a/frontend/src/components/tenant/AiSystemSectionNav.tsx
+++ b/frontend/src/components/tenant/AiSystemSectionNav.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React from "react";
+
+import { CH_PAGE_NAV_LINK } from "@/lib/boardLayout";
+
+const SECTIONS = [
+  { id: "sec-stammdaten", label: "Stammdaten" },
+  { id: "sec-evidenz", label: "Evidenz" },
+  { id: "sec-klassifikation", label: "Klassifikation" },
+  { id: "sec-nis2", label: "NIS2 / KRITIS" },
+  { id: "sec-incidents", label: "Incidents" },
+  { id: "sec-compliance", label: "Compliance" },
+  { id: "sec-violations", label: "Violations" },
+  { id: "sec-massnahmen", label: "Maßnahmen" },
+] as const;
+
+/**
+ * In-Page-Anker für die KI-System-Detailseite (scroll-mt via Section-IDs).
+ */
+export function AiSystemSectionNav() {
+  return (
+    <nav
+      className="-mx-1 mb-6 flex flex-wrap gap-1 rounded-xl border border-slate-200/80 bg-slate-50/90 px-3 py-2"
+      aria-label="Abschnitte auf dieser Seite"
+    >
+      {SECTIONS.map((s) => (
+        <a key={s.id} href={`#${s.id}`} className={CH_PAGE_NAV_LINK + " px-2 py-1 text-xs"}>
+          {s.label}
+        </a>
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/components/tenant/AiSystemsRegistryTableClient.tsx
+++ b/frontend/src/components/tenant/AiSystemsRegistryTableClient.tsx
@@ -1,0 +1,180 @@
+"use client";
+
+import Link from "next/link";
+import React, { useMemo, useState } from "react";
+
+import { CH_PAGE_NAV_LINK } from "@/lib/boardLayout";
+
+export type AiSystemRegistryRow = {
+  id: string;
+  name: string;
+  businessunit: string;
+  risklevel: string;
+  aiactcategory: string;
+  status: string;
+  owneremail?: string;
+};
+
+function classNames(...values: (string | false | null | undefined)[]) {
+  return values.filter(Boolean).join(" ");
+}
+
+type Props = {
+  systems: AiSystemRegistryRow[];
+  idFilterActive: boolean;
+  totalBeforeClientFilter: number;
+};
+
+export function AiSystemsRegistryTableClient({
+  systems,
+  idFilterActive,
+  totalBeforeClientFilter,
+}: Props) {
+  const [q, setQ] = useState("");
+  const [bu, setBu] = useState("");
+  const [risk, setRisk] = useState("");
+  const [actCat, setActCat] = useState("");
+
+  const businessUnits = useMemo(() => {
+    const set = new Set(systems.map((s) => s.businessunit).filter(Boolean));
+    return Array.from(set).sort();
+  }, [systems]);
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    return systems.filter((s) => {
+      if (needle) {
+        const hay = `${s.name} ${s.id}`.toLowerCase();
+        if (!hay.includes(needle)) return false;
+      }
+      if (bu && s.businessunit !== bu) return false;
+      if (risk && s.risklevel !== risk) return false;
+      if (actCat && s.aiactcategory !== actCat) return false;
+      return true;
+    });
+  }, [systems, q, bu, risk, actCat]);
+
+  return (
+    <>
+      <div className="flex flex-col gap-3 border-b border-[var(--sbs-border)] px-4 py-3 sm:flex-row sm:flex-wrap sm:items-end sm:gap-4 md:px-5">
+        <label className="flex min-w-[12rem] flex-1 flex-col gap-1 text-xs font-medium text-slate-600">
+          Suche (Name / ID)
+          <input
+            type="search"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="z. B. Chatbot, sys-…"
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none ring-cyan-500/0 transition focus:border-cyan-300 focus:ring-2 focus:ring-cyan-500/20"
+          />
+        </label>
+        <label className="flex min-w-[9rem] flex-col gap-1 text-xs font-medium text-slate-600">
+          Business Unit
+          <select
+            value={bu}
+            onChange={(e) => setBu(e.target.value)}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none focus:border-cyan-300 focus:ring-2 focus:ring-cyan-500/20"
+          >
+            <option value="">Alle</option>
+            {businessUnits.map((b) => (
+              <option key={b} value={b}>
+                {b}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex min-w-[8rem] flex-col gap-1 text-xs font-medium text-slate-600">
+          Risk Level
+          <select
+            value={risk}
+            onChange={(e) => setRisk(e.target.value)}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none focus:border-cyan-300 focus:ring-2 focus:ring-cyan-500/20"
+          >
+            <option value="">Alle</option>
+            <option value="high">high</option>
+            <option value="limited">limited</option>
+            <option value="low">low</option>
+          </select>
+        </label>
+        <label className="flex min-w-[8rem] flex-col gap-1 text-xs font-medium text-slate-600">
+          AI Act
+          <input
+            value={actCat}
+            onChange={(e) => setActCat(e.target.value)}
+            placeholder="Kategorie"
+            className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm outline-none focus:border-cyan-300 focus:ring-2 focus:ring-cyan-500/20"
+          />
+        </label>
+        <p className="text-xs text-[var(--sbs-text-secondary)] sm:ml-auto sm:pb-2">
+          Anzeige: {filtered.length} von {systems.length}
+          {idFilterActive ? ` (URL-Filter von ${totalBeforeClientFilter} gesamt)` : ""}
+        </p>
+      </div>
+      <div className="sbs-table-wrap">
+        <table className="sbs-table">
+          <thead>
+            <tr>
+              <th className="px-5 py-2 font-medium">Name</th>
+              <th className="px-3 py-2 font-medium">Business Unit</th>
+              <th className="px-3 py-2 font-medium">Risk Level</th>
+              <th className="px-3 py-2 font-medium">AI Act</th>
+              <th className="px-3 py-2 font-medium">Status</th>
+              <th className="px-3 py-2 font-medium">Owner</th>
+              <th className="px-3 py-2 font-medium">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((s) => (
+              <tr key={s.id}>
+                <td>
+                  <div className="font-semibold text-[var(--sbs-text-primary)]">{s.name}</div>
+                  <div className="text-xs text-[var(--sbs-text-muted)]">{s.id}</div>
+                </td>
+                <td className="text-[var(--sbs-text-secondary)]">{s.businessunit}</td>
+                <td>
+                  <span
+                    className={classNames(
+                      "inline-flex rounded-full px-2 py-0.5 text-xs font-semibold",
+                      s.risklevel === "high" &&
+                        "border border-rose-200 bg-rose-50 text-rose-800",
+                      s.risklevel === "limited" &&
+                        "border border-amber-200 bg-amber-50 text-amber-900",
+                      s.risklevel === "low" &&
+                        "border border-emerald-200 bg-emerald-50 text-emerald-900",
+                    )}
+                  >
+                    {s.risklevel}
+                  </span>
+                </td>
+                <td className="text-xs text-[var(--sbs-text-secondary)]">{s.aiactcategory}</td>
+                <td className="text-xs">
+                  <span className="inline-flex rounded-full border border-[var(--sbs-border)] bg-slate-50 px-2 py-0.5 text-[var(--sbs-text-secondary)]">
+                    {s.status}
+                  </span>
+                </td>
+                <td className="text-xs text-[var(--sbs-text-secondary)]">{s.owneremail ?? "—"}</td>
+                <td>
+                  <Link
+                    href={`/tenant/ai-systems/${encodeURIComponent(s.id)}`}
+                    className={CH_PAGE_NAV_LINK + " text-xs no-underline hover:underline"}
+                  >
+                    Detail
+                  </Link>
+                </td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="py-8 text-center text-sm text-[var(--sbs-text-secondary)]"
+                >
+                  Keine Einträge für die aktuellen Filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/tenant/TenantAuditLogTableClient.tsx
+++ b/frontend/src/components/tenant/TenantAuditLogTableClient.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+
+import { CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+export type AuditLogDemoRow = {
+  id: string;
+  ts: string;
+  actor: string;
+  entityType: string;
+  action: string;
+  tenant: string;
+  detail?: string;
+};
+
+type Props = {
+  tenantId: string;
+  rows: AuditLogDemoRow[];
+};
+
+export function TenantAuditLogTableClient({ tenantId, rows }: Props) {
+  const [entity, setEntity] = useState("");
+  const [action, setAction] = useState("");
+  const [windowKey, setWindowKey] = useState<"7" | "30" | "all">("all");
+  const [asOfMs, setAsOfMs] = useState(() => Date.now());
+
+  const entityTypes = useMemo(() => {
+    const s = new Set(rows.map((r) => r.entityType));
+    return Array.from(s).sort();
+  }, [rows]);
+  const actions = useMemo(() => {
+    const s = new Set(rows.map((r) => r.action));
+    return Array.from(s).sort();
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const now = asOfMs;
+    const maxAge =
+      windowKey === "all" ? null : windowKey === "7" ? 7 * 86_400_000 : 30 * 86_400_000;
+    return rows.filter((r) => {
+      if (entity && r.entityType !== entity) return false;
+      if (action && r.action !== action) return false;
+      if (maxAge != null) {
+        const t = new Date(r.ts).getTime();
+        if (Number.isFinite(t) && now - t > maxAge) return false;
+      }
+      return true;
+    });
+  }, [asOfMs, action, entity, rows, windowKey]);
+
+  return (
+    <div className={`${CH_CARD} overflow-hidden p-0`}>
+      <div className="flex flex-col gap-3 border-b border-slate-200/80 px-5 py-4 sm:flex-row sm:flex-wrap sm:items-end">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-900">Audit-Log</h2>
+          <p className="mt-1 text-xs text-slate-500">
+            Demonstrationsdaten bis die Audit-API angebunden ist. Mandant:{" "}
+            <span className="font-mono font-medium text-slate-700">{tenantId}</span>
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2 sm:ml-auto">
+          <label className="flex flex-col gap-1 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500">
+            Zeitraum
+            <select
+              value={windowKey}
+              onChange={(e) => {
+                setWindowKey(e.target.value as "7" | "30" | "all");
+                setAsOfMs(Date.now());
+              }}
+              className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-xs text-slate-900"
+            >
+              <option value="all">Alle</option>
+              <option value="30">30 Tage</option>
+              <option value="7">7 Tage</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500">
+            Entity
+            <select
+              value={entity}
+              onChange={(e) => setEntity(e.target.value)}
+              className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-xs text-slate-900"
+            >
+              <option value="">Alle</option>
+              {entityTypes.map((e) => (
+                <option key={e} value={e}>
+                  {e}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500">
+            Aktion
+            <select
+              value={action}
+              onChange={(e) => setAction(e.target.value)}
+              className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-xs text-slate-900"
+            >
+              <option value="">Alle</option>
+              {actions.map((a) => (
+                <option key={a} value={a}>
+                  {a}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+      <p className="border-b border-slate-100 px-5 py-2 text-xs text-slate-500">
+        <span className={CH_SECTION_LABEL + " mr-2"}>Treffer</span>
+        {filtered.length} von {rows.length}
+      </p>
+      <div className="sbs-table-wrap">
+        <table className="sbs-table">
+          <thead>
+            <tr>
+              <th className="px-4 py-2 text-left text-xs font-semibold text-slate-600">
+                Zeitstempel
+              </th>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-slate-600">Akteur</th>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-slate-600">
+                Entity-Typ
+              </th>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-slate-600">Aktion</th>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-slate-600">Mandant</th>
+              <th className="px-3 py-2 text-left text-xs font-semibold text-slate-600">Detail</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((r) => (
+              <tr key={r.id}>
+                <td className="whitespace-nowrap text-xs text-slate-800">
+                  {new Date(r.ts).toLocaleString("de-DE")}
+                </td>
+                <td className="max-w-[10rem] truncate text-xs text-slate-700">{r.actor}</td>
+                <td className="text-xs font-medium text-slate-800">{r.entityType}</td>
+                <td className="text-xs text-slate-700">{r.action}</td>
+                <td className="font-mono text-[0.7rem] text-slate-600">{r.tenant}</td>
+                <td className="max-w-xs truncate text-xs text-slate-500">{r.detail ?? "—"}</td>
+              </tr>
+            ))}
+            {filtered.length === 0 && (
+              <tr>
+                <td colSpan={6} className="py-10 text-center text-sm text-slate-500">
+                  Keine Einträge für die gewählten Filter.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/appNavConfig.ts
+++ b/frontend/src/lib/appNavConfig.ts
@@ -1,0 +1,21 @@
+/** Zentrale Navigations-Definition (Single Source für Header + Secondary Nav). */
+
+export const BOARD_NAV_ITEMS = [
+  { href: "/board/kpis", label: "Board KPIs" },
+  { href: "/board/nis2-kritis", label: "NIS2 / KRITIS" },
+  { href: "/board/eu-ai-act-readiness", label: "EU AI Act Readiness" },
+  { href: "/board/incidents", label: "Incidents" },
+  { href: "/board/suppliers", label: "Supplier Risk" },
+] as const;
+
+export const WORKSPACE_NAV_ITEMS = [
+  { href: "/tenant/compliance-overview", label: "Übersicht" },
+  { href: "/tenant/ai-systems", label: "KI-Systeme" },
+  { href: "/tenant/eu-ai-act", label: "EU AI Act" },
+  { href: "/tenant/blueprints", label: "Blueprints" },
+  { href: "/tenant/policies", label: "Policies" },
+  { href: "/tenant/audit-log", label: "Audit-Log" },
+] as const;
+
+export const BRAND_TAGLINE =
+  "GRC · EU AI Act · NIS2 · ISO 42001";


### PR DESCRIPTION
- Global header with Board/Workspace dropdowns and secondary nav
- Root layout scroll-padding and main spacing for sticky header
- Tenant layout constrained to shell width
- Board pages: CTAs into workspace; incidents/settings as real routes
- AI systems registry filters; detail page section anchors; audit log demo table
- ESLint: avoid Date.now in render for incident/audit filters

Made-with: Cursor