### PR TITLE
feat(demo): Tenant-Templates, One-Click-Seed, UI und Tests

### DIFF
--- a/app/demo_models.py
+++ b/app/demo_models.py
@@ -1,0 +1,27 @@
+"""API- und Ergebnis-Modelle für Demo-Tenant-Seeding (nur Demo-/Pilot-Umgebungen)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DemoSeedRequest(BaseModel):
+    template_key: str = Field(..., min_length=1, max_length=64)
+    tenant_id: str = Field(..., min_length=1, max_length=255)
+    advisor_id: str | None = Field(
+        default=None,
+        max_length=320,
+        description="Optional: Eintrag in advisor_tenants nach erfolgreichem Seed.",
+    )
+
+
+class DemoSeedResponse(BaseModel):
+    template_key: str
+    tenant_id: str
+    ai_systems_count: int
+    governance_actions_count: int
+    evidence_files_count: int
+    nis2_kpi_rows_count: int
+    policy_rows_count: int
+    classifications_count: int
+    advisor_linked: bool

--- a/app/demo_templates.py
+++ b/app/demo_templates.py
@@ -1,0 +1,79 @@
+"""Statische Demo-Mandanten-Templates für Pilot- und Demo-Umgebungen (nicht produktiv)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class DemoTenantTemplate(BaseModel):
+    """Leichtgewichtige Template-Metadaten für UI und Doku."""
+
+    key: str = Field(..., description="Stabiler Schlüssel, z. B. kritis_energy")
+    name: str
+    description: str
+    industry: str
+    segment: str
+    country: str = "DE"
+    nis2_scope: bool = Field(
+        default=True,
+        description="Template enthält NIS2-/KRITIS-KPI-Szenario.",
+    )
+    ai_act_high_risk_focus: bool = Field(
+        default=True,
+        description="Mindestens ein Hochrisiko-/Anhang-III-Fokus im Register.",
+    )
+
+
+DEMO_TENANT_TEMPLATES: tuple[DemoTenantTemplate, ...] = (
+    DemoTenantTemplate(
+        key="kritis_energy",
+        name="KRITIS-Energieversorger",
+        description=(
+            "Netzlast-Prognose-KI, Ausfallvorhersage und Supplier-Risk-Fokus – "
+            "bewusst Lücken bei OT/IT und Lieferanten-KPIs für Board-Alerts."
+        ),
+        industry="Energie / Versorgung",
+        segment="KRITIS",
+        country="DE",
+        nis2_scope=True,
+        ai_act_high_risk_focus=True,
+    ),
+    DemoTenantTemplate(
+        key="industrial_sme",
+        name="Industrie-Mittelstand",
+        description=(
+            "Qualitätskontrolle (Vision), vorausschauende Instandhaltung und "
+            "interne Wissens-KI – Mix aus High-Risk-Produktion und begleitenden Systemen."
+        ),
+        industry="Manufacturing",
+        segment="Mittelstand",
+        country="DE",
+        nis2_scope=True,
+        ai_act_high_risk_focus=True,
+    ),
+    DemoTenantTemplate(
+        key="tax_advisor",
+        name="WP- / Steuerkanzlei",
+        description=(
+            "AI-gestützte Dokumentenprüfung, Umsatzsteuer-Assistenz und Mandanten-Chatbot – "
+            "Fokus DSGVO/GoBD und EU-AI-Act-Transparenz."
+        ),
+        industry="Professional Services",
+        segment="Steuerberatung",
+        country="DE",
+        nis2_scope=False,
+        ai_act_high_risk_focus=True,
+    ),
+)
+
+
+def list_demo_tenant_templates() -> list[DemoTenantTemplate]:
+    return list(DEMO_TENANT_TEMPLATES)
+
+
+def get_demo_template(key: str) -> DemoTenantTemplate | None:
+    k = key.strip()
+    for t in DEMO_TENANT_TEMPLATES:
+        if t.key == k:
+            return t
+    return None

--- a/app/main.py
+++ b/app/main.py
@@ -77,6 +77,8 @@ from app.compliance_gap_models import (
 )
 from app.config.nis2_kritis_board_alert_thresholds import NIS2_KRITIS_OT_IT_ALERT_THRESHOLD_PCT
 from app.db import engine, get_session
+from app.demo_models import DemoSeedRequest, DemoSeedResponse
+from app.demo_templates import DemoTenantTemplate, list_demo_tenant_templates
 from app.eu_ai_act_readiness_models import EUAIActReadinessOverview
 from app.evidence_models import EvidenceFile, EvidenceFileListResponse
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
@@ -110,9 +112,11 @@ from app.repositories.violations import ViolationRepository
 from app.security import (
     AuthContext,
     delete_evidence_allowed_for_api_key,
+    ensure_demo_tenant_seed_allowed,
     get_api_key_and_tenant,
     get_auth_context,
     require_advisor_api_access,
+    require_demo_seed_api_key,
 )
 from app.services.advisor_portfolio import (
     advisor_portfolio_to_csv,
@@ -153,6 +157,7 @@ from app.services.compliance_dashboard import (
     compute_compliance_dashboard,
 )
 from app.services.compliance_engine import build_audit_hash, derive_actions
+from app.services.demo_tenant_seeder import seed_demo_tenant
 from app.services.eu_ai_act_readiness import compute_eu_ai_act_readiness_overview
 from app.services.evidence_service import (
     delete_evidence as delete_evidence_file,
@@ -1870,6 +1875,68 @@ def get_advisor_tenant_report(
             headers={"Content-Disposition": _evidence_content_disposition(fname)},
         )
     return report
+
+
+@app.get(
+    "/api/v1/demo/tenant-templates",
+    response_model=list[DemoTenantTemplate],
+    tags=["demo"],
+)
+def list_demo_tenant_template_definitions(
+    _api_key: Annotated[str, Depends(require_demo_seed_api_key)],
+) -> list[DemoTenantTemplate]:
+    """Demo/Pilot: verfügbare Mandanten-Templates (geschützter API-Key)."""
+    return list_demo_tenant_templates()
+
+
+@app.post(
+    "/api/v1/demo/tenants/seed",
+    response_model=DemoSeedResponse,
+    tags=["demo"],
+)
+def post_demo_tenant_seed(
+    body: DemoSeedRequest,
+    session: Annotated[Session, Depends(get_session)],
+    _api_key: Annotated[str, Depends(require_demo_seed_api_key)],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
+    nis2_repo: Annotated[Nis2KritisKpiRepository, Depends(get_nis2_kritis_kpi_repository)],
+    policy_repo: Annotated[PolicyRepository, Depends(get_policy_repository)],
+    action_repo: Annotated[
+        AIGovernanceActionRepository,
+        Depends(get_ai_governance_action_repository),
+    ],
+    evidence_repo: Annotated[EvidenceFileRepository, Depends(get_evidence_file_repository)],
+) -> DemoSeedResponse:
+    """
+    Demo/Pilot: leeren Mandanten aus Template befüllen.
+    Nur für tenant_id in COMPLIANCEHUB_DEMO_SEED_TENANT_IDS und mit Demo-Seed-API-Key.
+    """
+    ensure_demo_tenant_seed_allowed(body.tenant_id)
+    try:
+        return seed_demo_tenant(
+            session,
+            body.template_key,
+            body.tenant_id,
+            advisor_id=body.advisor_id,
+            ai_repo=ai_repo,
+            cls_repo=cls_repo,
+            nis2_repo=nis2_repo,
+            policy_repo=policy_repo,
+            action_repo=action_repo,
+            evidence_repo=evidence_repo,
+        )
+    except ValueError as exc:
+        msg = str(exc)
+        if "already has AI systems" in msg:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=msg,
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=msg,
+        ) from exc
 
 
 @app.get("/api/v1/tenant/compliance-overview", response_model=TenantComplianceOverview)

--- a/app/security.py
+++ b/app/security.py
@@ -118,6 +118,63 @@ def get_auth_context(
     return AuthContext(tenant_id=tenant_id, api_key=x_api_key or "")
 
 
+def demo_seed_api_keys() -> frozenset[str]:
+    """API-Keys, die POST /api/v1/demo/tenants/seed und Template-Liste nutzen dürfen."""
+    raw = os.getenv("COMPLIANCEHUB_DEMO_SEED_API_KEYS", "").strip()
+    if not raw:
+        return frozenset()
+    return frozenset(part.strip() for part in raw.split(",") if part.strip())
+
+
+def demo_seed_tenant_allowlist() -> frozenset[str] | None:
+    """Wenn gesetzt, dürfen nur diese tenant_ids geseedet werden (Komma-getrennt)."""
+    raw = os.getenv("COMPLIANCEHUB_DEMO_SEED_TENANT_IDS", "").strip()
+    if not raw:
+        return None
+    ids = {part.strip() for part in raw.split(",") if part.strip()}
+    return frozenset(ids) if ids else None
+
+
+def require_demo_seed_api_key(
+    x_api_key: Annotated[str | None, Header(alias="x-api-key")] = None,
+) -> str:
+    """
+    Schützt Demo-Seeding: eigener Key-Pool, unabhängig vom normalen Mandanten-API-Key.
+    """
+    keys = demo_seed_api_keys()
+    if not keys:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Demo seeding is disabled (no COMPLIANCEHUB_DEMO_SEED_API_KEYS)",
+        )
+    if x_api_key is None or not str(x_api_key).strip():
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing API key",
+        )
+    key = str(x_api_key).strip()
+    if key not in keys:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid demo seed API key",
+        )
+    return key
+
+
+def ensure_demo_tenant_seed_allowed(tenant_id: str) -> None:
+    allowed = demo_seed_tenant_allowlist()
+    if allowed is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Demo tenant allowlist not configured (set COMPLIANCEHUB_DEMO_SEED_TENANT_IDS)",
+        )
+    if tenant_id not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Tenant is not in COMPLIANCEHUB_DEMO_SEED_TENANT_IDS",
+        )
+
+
 def delete_evidence_allowed_for_api_key(api_key: str) -> bool:
     """Nur API-Keys in COMPLIANCEHUB_EVIDENCE_DELETE_API_KEYS dürfen Evidence löschen."""
     raw = os.getenv("COMPLIANCEHUB_EVIDENCE_DELETE_API_KEYS", "")

--- a/app/services/demo_tenant_seeder.py
+++ b/app/services/demo_tenant_seeder.py
@@ -1,0 +1,536 @@
+"""Befüllt einen leeren Mandanten mit realistischen Demo-Daten (nur für Demo-/Pilot-Tenants)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.ai_governance_action_models import AIGovernanceActionCreate, GovernanceActionStatus
+from app.ai_system_models import (
+    AIActCategory,
+    AISystemCreate,
+    AISystemCriticality,
+    AISystemRiskLevel,
+    DataSensitivity,
+)
+from app.classification_models import ClassificationPath, RiskClassification, RiskLevel
+from app.demo_models import DemoSeedResponse
+from app.demo_templates import get_demo_template
+from app.models_db import (
+    AIGovernanceActionDB,
+    AISystemTable,
+    EvidenceFileTable,
+    PolicyTable,
+    RiskClassificationDB,
+)
+from app.nis2_kritis_models import Nis2KritisKpiType
+from app.repositories.advisor_tenants import AdvisorTenantRepository
+from app.repositories.ai_governance_actions import AIGovernanceActionRepository
+from app.repositories.ai_systems import AISystemRepository
+from app.repositories.classifications import ClassificationRepository
+from app.repositories.evidence_files import EvidenceFileRepository
+from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
+from app.repositories.policies import PolicyRepository
+from app.services.evidence_storage import EvidenceStorageBackend, get_evidence_storage
+
+
+def _annex_iii_high(ai_id: str, category: int, rationale: str) -> RiskClassification:
+    return RiskClassification(
+        ai_system_id=ai_id,
+        risk_level=RiskLevel.high_risk,
+        classification_path=ClassificationPath.annex_iii,
+        annex_iii_category=category,
+        profiles_natural_persons=False,
+        classification_rationale=rationale,
+        classified_by="demo-seed",
+    )
+
+
+def _limited(ai_id: str, rationale: str) -> RiskClassification:
+    return RiskClassification(
+        ai_system_id=ai_id,
+        risk_level=RiskLevel.limited_risk,
+        classification_path=ClassificationPath.transparency,
+        profiles_natural_persons=False,
+        classification_rationale=rationale,
+        classified_by="demo-seed",
+    )
+
+
+def _minimal(ai_id: str, rationale: str) -> RiskClassification:
+    return RiskClassification(
+        ai_system_id=ai_id,
+        risk_level=RiskLevel.minimal_risk,
+        classification_path=ClassificationPath.none,
+        profiles_natural_persons=False,
+        classification_rationale=rationale,
+        classified_by="demo-seed",
+    )
+
+
+def _bid(tenant_id: str, slug: str) -> str:
+    return f"{tenant_id}-demo-{slug}"
+
+
+def _build_plan(
+    template_key: str,
+    tenant_id: str,
+) -> list[tuple[AISystemCreate, RiskClassification, tuple[int, int, int] | None]]:
+    """
+    Liefert (AISystemCreate, Classification, kpi_triple | None).
+    kpi_triple = (incident %, supplier %, ot_it %) für High-Risk-Systeme, sonst None.
+    """
+    if template_key == "kritis_energy":
+        return [
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "netzlast"),
+                    name="Netzlast-Prognose (KRITIS)",
+                    description=(
+                        "Hochrisiko-KI für Lastprognose im Verteilnetz; Lieferanten-Register "
+                        "noch unvollständig (Demo-Lücke)."
+                    ),
+                    business_unit="Netzbetrieb",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="ciso@demo-kritis.example",
+                    criticality=AISystemCriticality.very_high,
+                    data_sensitivity=DataSensitivity.restricted,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=False,
+                    has_backup_runbook=True,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "netzlast"),
+                    2,
+                    "Demo: Anhang III, kritische Infrastruktur / Energie.",
+                ),
+                (72, 48, 38),
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "outage"),
+                    name="Ausfall-Warnmodell (SCADA-Anbindung)",
+                    description="Prognose von Schalthandlungen; begrenzte Transparenzpflichten.",
+                    business_unit="Leittechnik",
+                    risk_level=AISystemRiskLevel.limited,
+                    ai_act_category=AIActCategory.limited_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="ot@demo-kritis.example",
+                    criticality=AISystemCriticality.high,
+                    data_sensitivity=DataSensitivity.confidential,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=False,
+                ),
+                _limited(
+                    _bid(tenant_id, "outage"),
+                    "Demo: Transparenz / dokumentierte Einschränkungen.",
+                ),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "supplier_bot"),
+                    name="Supplier-Risk Scoring (Drittparteien)",
+                    description="Bewertung von IT-/OT-Lieferanten; Minimalrisiko im Register.",
+                    business_unit="Beschaffung",
+                    risk_level=AISystemRiskLevel.low,
+                    ai_act_category=AIActCategory.minimal_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="procurement@demo-kritis.example",
+                    criticality=AISystemCriticality.medium,
+                    data_sensitivity=DataSensitivity.internal,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _minimal(_bid(tenant_id, "supplier_bot"), "Demo: unterhalb Hochrisiko."),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "smart_meter"),
+                    name="Smart-Meter Anomalieerkennung",
+                    description="Batch-Auswertung ohne Echtzeit-Biometrie; KPI-Lücken OT/IT.",
+                    business_unit="Messstellenbetrieb",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="metering@demo-kritis.example",
+                    criticality=AISystemCriticality.high,
+                    data_sensitivity=DataSensitivity.confidential,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "smart_meter"),
+                    2,
+                    "Demo: Hochrisiko Use-Case mit vollständigeren Kontrollen.",
+                ),
+                (68, 62, 41),
+            ),
+        ]
+
+    if template_key == "industrial_sme":
+        return [
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "qc-vision"),
+                    name="Qualitätskontrolle Vision",
+                    description="Inline-Inspektion; DPIA relevant; Supplier-Register Lücke.",
+                    business_unit="Produktion",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="qm@demo-mfg.example",
+                    criticality=AISystemCriticality.high,
+                    data_sensitivity=DataSensitivity.confidential,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=False,
+                    has_backup_runbook=True,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "qc-vision"),
+                    5,
+                    "Demo: Anhang III / wesentliche private Dienste (Produktsicherheit).",
+                ),
+                (55, 52, 58),
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "pm"),
+                    name="Predictive Maintenance",
+                    description="Sensorfusion für Anlagen; begrenztes Risiko.",
+                    business_unit="Instandhaltung",
+                    risk_level=AISystemRiskLevel.limited,
+                    ai_act_category=AIActCategory.limited_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="maint@demo-mfg.example",
+                    criticality=AISystemCriticality.medium,
+                    data_sensitivity=DataSensitivity.internal,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _limited(_bid(tenant_id, "pm"), "Demo: Transparenzpflichten erfüllt."),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "doc-rag"),
+                    name="Internes Wissens-RAG",
+                    description="Suche in Handbüchern; Minimalrisiko.",
+                    business_unit="IT",
+                    risk_level=AISystemRiskLevel.low,
+                    ai_act_category=AIActCategory.minimal_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="it@demo-mfg.example",
+                    criticality=AISystemCriticality.low,
+                    data_sensitivity=DataSensitivity.internal,
+                    has_incident_runbook=False,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _minimal(_bid(tenant_id, "doc-rag"), "Demo: Minimalrisiko-Chatbot."),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "safety"),
+                    name="Arbeitssicherheit-Assistenz",
+                    description="Hochrisiko-Empfehlungen an Maschinen; vollständige Runbooks.",
+                    business_unit="EHS",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="ehs@demo-mfg.example",
+                    criticality=AISystemCriticality.very_high,
+                    data_sensitivity=DataSensitivity.restricted,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "safety"),
+                    5,
+                    "Demo: Sicherheitskomponente / Arbeitsumgebung.",
+                ),
+                (61, 70, 44),
+            ),
+        ]
+
+    if template_key == "tax_advisor":
+        return [
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "doc-review"),
+                    name="Dokumentenprüfung Belege",
+                    description=(
+                        "High-Risk Klassifikation für automatisierte Steuerberatung (Demo)."
+                    ),
+                    business_unit="Mandantenbetreuung",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="partner@demo-wp.example",
+                    criticality=AISystemCriticality.high,
+                    data_sensitivity=DataSensitivity.restricted,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=False,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "doc-review"),
+                    8,
+                    "Demo: Justiz / Rechtsauslegung (Assistenz).",
+                ),
+                (58, 66, 72),
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "vat"),
+                    name="Umsatzsteuer-Plausibilisierung",
+                    description="Regelbasiert mit ML; Transparenz.",
+                    business_unit="Steuern",
+                    risk_level=AISystemRiskLevel.limited,
+                    ai_act_category=AIActCategory.limited_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="vat@demo-wp.example",
+                    criticality=AISystemCriticality.medium,
+                    data_sensitivity=DataSensitivity.confidential,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _limited(_bid(tenant_id, "vat"), "Demo: Transparenz / Kennzeichnung."),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "client-chat"),
+                    name="Mandanten-Chatbot (FAQ)",
+                    description="Öffentliche FAQs; Minimalrisiko.",
+                    business_unit="Kanzlei-Marketing",
+                    risk_level=AISystemRiskLevel.low,
+                    ai_act_category=AIActCategory.minimal_risk,
+                    gdpr_dpia_required=False,
+                    owner_email="marketing@demo-wp.example",
+                    criticality=AISystemCriticality.low,
+                    data_sensitivity=DataSensitivity.public,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _minimal(_bid(tenant_id, "client-chat"), "Demo: Minimalrisiko."),
+                None,
+            ),
+            (
+                AISystemCreate(
+                    id=_bid(tenant_id, "anomaly"),
+                    name="Anomalie-Erkennung Buchungen",
+                    description="Auffällige Buchungsmuster; High-Risk für GoBD-Nachweis.",
+                    business_unit="Revision",
+                    risk_level=AISystemRiskLevel.high,
+                    ai_act_category=AIActCategory.high_risk,
+                    gdpr_dpia_required=True,
+                    owner_email="revision@demo-wp.example",
+                    criticality=AISystemCriticality.high,
+                    data_sensitivity=DataSensitivity.confidential,
+                    has_incident_runbook=True,
+                    has_supplier_risk_register=True,
+                    has_backup_runbook=True,
+                ),
+                _annex_iii_high(
+                    _bid(tenant_id, "anomaly"),
+                    8,
+                    "Demo: Hochrisiko-Assistenz im steuerlichen Kontext.",
+                ),
+                (64, 59, 68),
+            ),
+        ]
+
+    raise ValueError(f"Unknown template_key: {template_key}")
+
+
+def _action_specs(primary_system: str, secondary: str) -> list[AIGovernanceActionCreate]:
+    return [
+        AIGovernanceActionCreate(
+            related_ai_system_id=primary_system,
+            related_requirement="EU AI Act Art. 9 Risikomanagementsystem",
+            title="Risikomanagement-Dokumentation für Hochrisiko-KI finalisieren",
+            status=GovernanceActionStatus.in_progress,
+        ),
+        AIGovernanceActionCreate(
+            related_ai_system_id=primary_system,
+            related_requirement="EU AI Act Art. 12 Protokollierung",
+            title="Logging-Konzept und Aufbewahrung prüfen",
+            status=GovernanceActionStatus.open,
+        ),
+        AIGovernanceActionCreate(
+            related_ai_system_id=secondary,
+            related_requirement="NIS2 Art. 21 Incident Response",
+            title="Incident-Playbook mit KI-Betrieb abstimmen",
+            status=GovernanceActionStatus.open,
+        ),
+        AIGovernanceActionCreate(
+            related_ai_system_id=secondary,
+            related_requirement="NIS2 Art. 21 Lieferketten",
+            title="Supplier-Risk-Register für kritische KI-Lieferanten vervollständigen",
+            status=GovernanceActionStatus.open,
+        ),
+        AIGovernanceActionCreate(
+            related_ai_system_id=None,
+            related_requirement="ISO 42001 AI IMS",
+            title="AI-Governance-Rollen (CISO, DSB, Fachbereich) schriftlich festlegen",
+            status=GovernanceActionStatus.open,
+        ),
+    ]
+
+
+def seed_demo_tenant(
+    session: Session,
+    template_key: str,
+    tenant_id: str,
+    *,
+    advisor_id: str | None = None,
+    ai_repo: AISystemRepository,
+    cls_repo: ClassificationRepository,
+    nis2_repo: Nis2KritisKpiRepository,
+    policy_repo: PolicyRepository,
+    action_repo: AIGovernanceActionRepository,
+    evidence_repo: EvidenceFileRepository,
+    storage: EvidenceStorageBackend | None = None,
+) -> DemoSeedResponse:
+    if get_demo_template(template_key) is None:
+        raise ValueError(f"Unknown template_key: {template_key}")
+
+    if ai_repo.list_for_tenant(tenant_id):
+        raise ValueError(
+            "Tenant already has AI systems; demo seeding only supports empty tenants.",
+        )
+
+    plan = _build_plan(template_key, tenant_id)
+    now = datetime.now(UTC)
+    kpi_count = 0
+
+    for create_body, classification, kpi_triple in plan:
+        ai_repo.create(tenant_id, create_body)
+        cls_repo.save(tenant_id, classification)
+        if kpi_triple is not None:
+            inc, sup, ot = kpi_triple
+            nis2_repo.upsert(
+                tenant_id,
+                create_body.id,
+                Nis2KritisKpiType.INCIDENT_RESPONSE_MATURITY,
+                inc,
+                "demo-seed",
+                now,
+            )
+            nis2_repo.upsert(
+                tenant_id,
+                create_body.id,
+                Nis2KritisKpiType.SUPPLIER_RISK_COVERAGE,
+                sup,
+                "demo-seed",
+                now,
+            )
+            nis2_repo.upsert(
+                tenant_id,
+                create_body.id,
+                Nis2KritisKpiType.OT_IT_SEGREGATION,
+                ot,
+                "demo-seed",
+                now,
+            )
+            kpi_count += 3
+
+    policy_repo.ensure_default_policy_rules(tenant_id)
+
+    primary = plan[0][0].id
+    secondary = plan[1][0].id
+    for body in _action_specs(primary, secondary):
+        action_repo.create(tenant_id, body)
+
+    store = storage or get_evidence_storage()
+    demo_bytes = b"# Demo-Evidenz\nNur fuer Demos/Piloten. Keine produktiven Inhalte.\n"
+    for label, sys_id in (
+        ("readme", primary),
+        ("kpi-nachweis", primary),
+        ("prozessbeschreibung", secondary),
+    ):
+        key = store.store_file(tenant_id, demo_bytes, "text/markdown")
+        evidence_repo.create(
+            tenant_id=tenant_id,
+            storage_key=key,
+            filename_original=f"demo-{label}.md",
+            content_type="text/markdown",
+            size_bytes=len(demo_bytes),
+            uploaded_by="demo-seed",
+            ai_system_id=sys_id,
+            audit_record_id=None,
+            action_id=None,
+            norm_framework="DEMO",
+            norm_reference="internal-demo",
+        )
+
+    advisor_linked = False
+    if advisor_id and str(advisor_id).strip():
+        adv = AdvisorTenantRepository(session)
+        tmpl = get_demo_template(template_key)
+        adv.upsert_link(
+            advisor_id=str(advisor_id).strip(),
+            tenant_id=tenant_id,
+            tenant_display_name=tmpl.name if tmpl else None,
+            industry=tmpl.industry if tmpl else None,
+            country=tmpl.country if tmpl else None,
+        )
+        advisor_linked = True
+
+    n_policies = int(
+        session.scalar(
+            select(func.count()).select_from(PolicyTable).where(PolicyTable.tenant_id == tenant_id),
+        )
+        or 0,
+    )
+    n_actions_db = int(
+        session.scalar(
+            select(func.count())
+            .select_from(AIGovernanceActionDB)
+            .where(AIGovernanceActionDB.tenant_id == tenant_id),
+        )
+        or 0,
+    )
+    n_class = int(
+        session.scalar(
+            select(func.count(func.distinct(RiskClassificationDB.ai_system_id)))
+            .select_from(RiskClassificationDB)
+            .join(AISystemTable, AISystemTable.id == RiskClassificationDB.ai_system_id)
+            .where(AISystemTable.tenant_id == tenant_id),
+        )
+        or 0,
+    )
+    n_evidence_db = int(
+        session.scalar(
+            select(func.count())
+            .select_from(EvidenceFileTable)
+            .where(EvidenceFileTable.tenant_id == tenant_id),
+        )
+        or 0,
+    )
+
+    return DemoSeedResponse(
+        template_key=template_key,
+        tenant_id=tenant_id,
+        ai_systems_count=len(plan),
+        governance_actions_count=n_actions_db,
+        evidence_files_count=n_evidence_db,
+        nis2_kpi_rows_count=kpi_count,
+        policy_rows_count=n_policies,
+        classifications_count=n_class,
+        advisor_linked=advisor_linked,
+    )

--- a/docs/e2e-demo-flow.md
+++ b/docs/e2e-demo-flow.md
@@ -32,6 +32,16 @@ Für **Angebotsunterlagen, Kickoff-Workshops, Status-Reviews oder kurze Vorstand
 2. **API:** `GET /api/v1/advisors/{advisor_id}/tenants/{tenant_id}/report?format=json|markdown` mit denselben Headern wie das Portfolio (`x-advisor-id`, `x-api-key`). Nur wenn der Mandant in **`advisor_tenants`** dem Berater zugeordnet ist.
 3. **Markdown:** `Content-Type: text/markdown; charset=utf-8`, Dateiname z. B. `tenant-report-{tenant_id}.md` – als Basis für PDF, Slides oder Executive Summaries weiterverarbeiten.
 
+## Demo-Tenant-Templates & One-Click-Setup
+
+**Nur für interne Demos und Berater-Piloten** – nicht für produktive Mandanten. Das Seeding ist an **`COMPLIANCEHUB_DEMO_SEED_TENANT_IDS`** gebunden (Komma-getrennte erlaubte `tenant_id`-Werte) und erfordert einen separaten API-Key **`COMPLIANCEHUB_DEMO_SEED_API_KEYS`**.
+
+1. **Leeren Demo-Mandanten** anlegen bzw. eine noch leere `tenant_id` wählen, die in der Allowlist steht.
+2. **Backend:** `GET /api/v1/demo/tenant-templates` (mit `x-api-key` aus `COMPLIANCEHUB_DEMO_SEED_API_KEYS`) listet Szenarien: z. B. KRITIS-Energie, Industrie-Mittelstand, WP-Kanzlei.
+3. **Backend:** `POST /api/v1/demo/tenants/seed` mit JSON `{ "template_key": "…", "tenant_id": "…", "advisor_id": "…" optional }` – legt KI-Systeme, Klassifikationen, NIS2-KPIs, Policies, Actions und Demo-Evidenzen an (nur wenn der Mandant noch **kein** KI-Register hat).
+4. **Frontend:** Unter **`/settings`** und **`/advisor`** der Bereich **Demo-Tenants** – Button **Demo-Daten einspielen** ruft die Next.js-Routen **`/api/demo/tenant-templates`** und **`/api/demo/seed`** auf; serverseitig **`COMPLIANCEHUB_DEMO_SEED_API_KEY`** (ein Key aus der Backend-Allowlist) und **`COMPLIANCEHUB_API_BASE_URL`** setzen.
+5. **Nach dem Seed:** Meldung mit Kennzahlen; **Compliance-Übersicht öffnen** setzt **`ch_workspace_tenant`** und springt zu **`/tenant/compliance-overview`**. Von dort **Guided Setup**, **`/board/*`**, **`/tenant/*`** und ggf. **`/advisor`** mit Portfolio/Steckbrief.
+
 ## 1) KI-System anlegen
 
 1. Öffnen: **`/tenant/ai-systems`**.
@@ -63,4 +73,4 @@ Für **Angebotsunterlagen, Kickoff-Workshops, Status-Reviews oder kurze Vorstand
 
 ---
 
-**API-Referenz (kurz):** `GET /api/v1/tenants/{tenant_id}/setup-status` → `GET /api/v1/advisors/{advisor_id}/tenants/portfolio` (optional Export) → `POST /api/v1/ai-systems` oder `POST /api/v1/ai-systems/import` → `POST .../classify` → `POST .../nis2-kritis-kpis` → `POST /api/v1/ai-governance/actions` → `POST /api/v1/evidence/uploads` → `GET .../compliance/overview`, `GET .../readiness/eu-ai-act`, `GET .../board-kpis`, `GET .../alerts/board`, KPI-/Alert-Export.
+**API-Referenz (kurz):** `GET /api/v1/demo/tenant-templates` → `POST /api/v1/demo/tenants/seed` (nur Demo-Allowlist) → `GET /api/v1/tenants/{tenant_id}/setup-status` → `GET /api/v1/advisors/{advisor_id}/tenants/portfolio` (optional Export) → `POST /api/v1/ai-systems` oder `POST /api/v1/ai-systems/import` → `POST .../classify` → `POST .../nis2-kritis-kpis` → `POST /api/v1/ai-governance/actions` → `POST /api/v1/evidence/uploads` → `GET .../compliance/overview`, `GET .../readiness/eu-ai-act`, `GET .../board-kpis`, `GET .../alerts/board`, KPI-/Alert-Export.

--- a/frontend/src/app/advisor/page.tsx
+++ b/frontend/src/app/advisor/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 
 import { AdvisorPortfolioExportToolbar, AdvisorPortfolioTable } from "@/components/advisor/AdvisorPortfolioTable";
+import { DemoTenantSetupPanel } from "@/components/demo/DemoTenantSetupPanel";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   ADVISOR_ID_FROM_ENV,
@@ -157,6 +158,10 @@ export default function AdvisorPortfolioPage() {
           )}
         </div>
       </section>
+
+      {advisorId ? (
+        <DemoTenantSetupPanel advisorId={advisorId} defaultTenantId="" />
+      ) : null}
 
       <AdvisorPortfolioTable rows={processed} advisorId={advisorId} />
     </div>

--- a/frontend/src/app/api/demo/seed/route.ts
+++ b/frontend/src/app/api/demo/seed/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.COMPLIANCEHUB_API_BASE_URL || "http://localhost:8000";
+const DEMO_KEY = process.env.COMPLIANCEHUB_DEMO_SEED_API_KEY?.trim() || "";
+
+export async function POST(request: NextRequest) {
+  if (!DEMO_KEY) {
+    return NextResponse.json(
+      { error: "COMPLIANCEHUB_DEMO_SEED_API_KEY nicht gesetzt" },
+      { status: 503 },
+    );
+  }
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Ungültiger JSON-Body" }, { status: 400 });
+  }
+  const res = await fetch(`${API_BASE}/api/v1/demo/tenants/seed`, {
+    method: "POST",
+    headers: {
+      "x-api-key": DEMO_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    try {
+      const err = JSON.parse(text) as { detail?: string };
+      return NextResponse.json(
+        { error: err.detail || "Demo-Seed fehlgeschlagen" },
+        { status: res.status },
+      );
+    } catch {
+      return NextResponse.json(
+        { error: "Demo-Seed fehlgeschlagen" },
+        { status: res.status },
+      );
+    }
+  }
+  try {
+    return NextResponse.json(JSON.parse(text) as object);
+  } catch {
+    return NextResponse.json({ error: "Ungültige API-Antwort" }, { status: 502 });
+  }
+}

--- a/frontend/src/app/api/demo/tenant-templates/route.ts
+++ b/frontend/src/app/api/demo/tenant-templates/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+const API_BASE =
+  process.env.COMPLIANCEHUB_API_BASE_URL || "http://localhost:8000";
+const DEMO_KEY = process.env.COMPLIANCEHUB_DEMO_SEED_API_KEY?.trim() || "";
+
+export async function GET() {
+  if (!DEMO_KEY) {
+    return NextResponse.json(
+      { error: "COMPLIANCEHUB_DEMO_SEED_API_KEY nicht gesetzt" },
+      { status: 503 },
+    );
+  }
+  const res = await fetch(`${API_BASE}/api/v1/demo/tenant-templates`, {
+    headers: { "x-api-key": DEMO_KEY },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    return NextResponse.json(
+      { error: "Templates konnten nicht geladen werden" },
+      { status: res.status },
+    );
+  }
+  const data = await res.json();
+  return NextResponse.json(data);
+}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import React from "react";
 
+import { DemoTenantSetupPanel } from "@/components/demo/DemoTenantSetupPanel";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
   CH_BTN_SECONDARY,
@@ -55,6 +56,10 @@ export default function SettingsPage() {
             SSO (Azure AD, SAP IAS) und rollenbasierte Workspace-Zugriffe – Platzhalter für
             Enterprise-Onboarding.
           </p>
+        </article>
+
+        <article className={`${CH_CARD} md:col-span-2`}>
+          <DemoTenantSetupPanel defaultTenantId={TENANT_ID} />
         </article>
 
         <article className={CH_CARD}>

--- a/frontend/src/components/demo/DemoTenantSetupPanel.test.tsx
+++ b/frontend/src/components/demo/DemoTenantSetupPanel.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { postDemoTenantSeed, fetchDemoTenantTemplates } = vi.hoisted(() => ({
+  postDemoTenantSeed: vi.fn(),
+  fetchDemoTenantTemplates: vi.fn(),
+}));
+
+vi.mock("@/lib/api", () => ({
+  fetchDemoTenantTemplates,
+  postDemoTenantSeed,
+}));
+
+vi.mock("@/lib/workspaceTenantClient", () => ({
+  openWorkspaceTenantAndGoComplianceOverview: vi.fn(),
+}));
+
+import { DemoTenantSetupPanel } from "./DemoTenantSetupPanel";
+
+const oneTemplate = [
+  {
+    key: "kritis_energy",
+    name: "KRITIS-Energieversorger",
+    description: "Demo-Szenario.",
+    industry: "Energie",
+    segment: "KRITIS",
+    country: "DE",
+    nis2_scope: true,
+    ai_act_high_risk_focus: true,
+  },
+];
+
+describe("DemoTenantSetupPanel", () => {
+  it("loads templates and calls postDemoTenantSeed with tenant id", async () => {
+    fetchDemoTenantTemplates.mockResolvedValue(oneTemplate);
+    postDemoTenantSeed.mockResolvedValue({
+      template_key: "kritis_energy",
+      tenant_id: "demo-x",
+      ai_systems_count: 4,
+      governance_actions_count: 5,
+      evidence_files_count: 3,
+      nis2_kpi_rows_count: 6,
+      policy_rows_count: 4,
+      classifications_count: 4,
+      advisor_linked: false,
+    });
+
+    render(<DemoTenantSetupPanel defaultTenantId="demo-x" />);
+
+    await waitFor(() => {
+      expect(fetchDemoTenantTemplates).toHaveBeenCalled();
+    });
+
+    expect(screen.getByRole("button", { name: /Demo-Daten einspielen/i })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /Demo-Daten einspielen/i }));
+
+    await waitFor(() => {
+      expect(postDemoTenantSeed).toHaveBeenCalledWith({
+        template_key: "kritis_energy",
+        tenant_id: "demo-x",
+        advisor_id: undefined,
+      });
+    });
+
+    expect(await screen.findByText(/Demo-Setup abgeschlossen/i)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/demo/DemoTenantSetupPanel.tsx
+++ b/frontend/src/components/demo/DemoTenantSetupPanel.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  fetchDemoTenantTemplates,
+  postDemoTenantSeed,
+  type DemoSeedResponseDto,
+  type DemoTenantTemplateDto,
+} from "@/lib/api";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+import { openWorkspaceTenantAndGoComplianceOverview } from "@/lib/workspaceTenantClient";
+
+export interface DemoTenantSetupPanelProps {
+  /** Wenn gesetzt, wird nach erfolgreichem Seed advisor_tenants verknüpft. */
+  advisorId?: string;
+  /** Vorschlag für das Ziel-Mandantenfeld. */
+  defaultTenantId?: string;
+}
+
+export function DemoTenantSetupPanel({
+  advisorId,
+  defaultTenantId = "",
+}: DemoTenantSetupPanelProps) {
+  const [templates, setTemplates] = useState<DemoTenantTemplateDto[]>([]);
+  const [templateKey, setTemplateKey] = useState("");
+  const [tenantId, setTenantId] = useState(defaultTenantId);
+  const [linkAdvisor, setLinkAdvisor] = useState(!!advisorId?.trim());
+  const [loadingList, setLoadingList] = useState(true);
+  const [seeding, setSeeding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<DemoSeedResponseDto | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoadingList(true);
+      setError(null);
+      try {
+        const list = await fetchDemoTenantTemplates();
+        if (!cancelled) {
+          setTemplates(list);
+          if (list.length > 0) setTemplateKey(list[0].key);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(
+            "Templates nicht ladbar. Server-Env COMPLIANCEHUB_DEMO_SEED_API_KEY und Allowlist prüfen.",
+          );
+        }
+      } finally {
+        if (!cancelled) setLoadingList(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const runSeed = useCallback(async () => {
+    setError(null);
+    setResult(null);
+    const tid = tenantId.trim();
+    if (!tid || !templateKey) {
+      setError("Bitte Template und Mandanten-ID angeben.");
+      return;
+    }
+    setSeeding(true);
+    try {
+      const res = await postDemoTenantSeed({
+        template_key: templateKey,
+        tenant_id: tid,
+        advisor_id:
+          linkAdvisor && advisorId?.trim() ? advisorId.trim() : undefined,
+      });
+      setResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Demo-Seed fehlgeschlagen.");
+    } finally {
+      setSeeding(false);
+    }
+  }, [tenantId, templateKey, linkAdvisor, advisorId]);
+
+  return (
+    <section className={CH_CARD} aria-label="Demo-Mandanten">
+      <p className={CH_SECTION_LABEL}>Demo-Tenants (Pilot / intern)</p>
+      <p className="mt-1 text-sm text-slate-600">
+        Nur für Mandanten-IDs in{" "}
+        <code className="rounded bg-slate-100 px-1 text-xs">COMPLIANCEHUB_DEMO_SEED_TENANT_IDS</code>{" "}
+        und mit separatem Demo-Seed-Key. Anschließend Guided Setup, Boards und Advisor-Report
+        nutzen.
+      </p>
+
+      {error ? (
+        <p className="mt-3 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-900">
+          {error}
+        </p>
+      ) : null}
+
+      {result ? (
+        <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-3 text-sm text-emerald-950">
+          <p className="font-semibold">Demo-Setup abgeschlossen</p>
+          <ul className="mt-2 list-inside list-disc text-emerald-900">
+            <li>{result.ai_systems_count} KI-Systeme</li>
+            <li>{result.governance_actions_count} Governance-Actions</li>
+            <li>{result.evidence_files_count} Evidenzen</li>
+            <li>{result.nis2_kpi_rows_count} NIS2-KPI-Zeilen</li>
+            <li>{result.policy_rows_count} Policy-Zeilen</li>
+          </ul>
+          <p className="mt-2 text-xs text-emerald-800">
+            Alerts und Readiness sind aktiv. Öffnen Sie den Mandanten im Workspace für die
+            Compliance-Übersicht.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              className={`${CH_BTN_PRIMARY} text-xs`}
+              onClick={() => openWorkspaceTenantAndGoComplianceOverview(result.tenant_id)}
+            >
+              Compliance-Übersicht öffnen
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="mt-4 grid gap-4 md:grid-cols-2">
+        <div>
+          <label className="block text-xs font-semibold text-slate-600" htmlFor="demo-template">
+            Szenario-Template
+          </label>
+          <select
+            id="demo-template"
+            className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            disabled={loadingList || templates.length === 0}
+            value={templateKey}
+            onChange={(e) => setTemplateKey(e.target.value)}
+          >
+            {templates.map((t) => (
+              <option key={t.key} value={t.key}>
+                {t.name}
+              </option>
+            ))}
+          </select>
+          {templates.find((t) => t.key === templateKey) ? (
+            <p className="mt-2 text-xs text-slate-500">
+              {templates.find((t) => t.key === templateKey)?.description}
+            </p>
+          ) : null}
+        </div>
+        <div>
+          <label className="block text-xs font-semibold text-slate-600" htmlFor="demo-tenant-id">
+            Ziel-Mandanten-ID
+          </label>
+          <input
+            id="demo-tenant-id"
+            className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 font-mono text-sm"
+            placeholder="z. B. demo-pilot-001"
+            value={tenantId}
+            onChange={(e) => setTenantId(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {advisorId?.trim() ? (
+        <label className="mt-3 flex items-center gap-2 text-sm text-slate-700">
+          <input
+            type="checkbox"
+            checked={linkAdvisor}
+            onChange={(e) => setLinkAdvisor(e.target.checked)}
+          />
+          Mandant mit diesem Berater verknüpfen (advisor_tenants)
+        </label>
+      ) : null}
+
+      <div className="mt-4">
+        <button
+          type="button"
+          disabled={seeding || loadingList}
+          className={`${CH_BTN_SECONDARY} text-sm disabled:opacity-50`}
+          onClick={() => void runSeed()}
+        >
+          {seeding ? "Spiele Demo-Daten ein…" : "Demo-Daten einspielen"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1027,3 +1027,54 @@ export function getAdvisorTenantReportUrl(
   });
   return `/api/advisor/tenant-report?${params.toString()}`;
 }
+
+// ─── Demo-Tenant-Seeding (nur Pilot/Demo; Proxy nutzt COMPLIANCEHUB_DEMO_SEED_API_KEY) ─
+
+export interface DemoTenantTemplateDto {
+  key: string;
+  name: string;
+  description: string;
+  industry: string;
+  segment: string;
+  country: string;
+  nis2_scope: boolean;
+  ai_act_high_risk_focus: boolean;
+}
+
+export interface DemoSeedResponseDto {
+  template_key: string;
+  tenant_id: string;
+  ai_systems_count: number;
+  governance_actions_count: number;
+  evidence_files_count: number;
+  nis2_kpi_rows_count: number;
+  policy_rows_count: number;
+  classifications_count: number;
+  advisor_linked: boolean;
+}
+
+export async function fetchDemoTenantTemplates(): Promise<DemoTenantTemplateDto[]> {
+  const res = await fetch("/api/demo/tenant-templates", { cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Demo templates failed: ${res.status}`);
+  }
+  return res.json() as Promise<DemoTenantTemplateDto[]>;
+}
+
+export async function postDemoTenantSeed(payload: {
+  template_key: string;
+  tenant_id: string;
+  advisor_id?: string | null;
+}): Promise<DemoSeedResponseDto> {
+  const res = await fetch("/api/demo/seed", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error || `Demo seed failed: ${res.status}`);
+  }
+  return res.json() as Promise<DemoSeedResponseDto>;
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,13 +12,20 @@ from app.security import get_settings
 
 # Alle API-Keys, die Tests in _headers() verwenden – get_settings().api_keys wird
 # einmal pro Session gecacht; damit alle Tests grün bleiben, hier Superset setzen.
-_TEST_API_KEYS = "board-kpi-key,test-key,test-api-key,tenant-overview-key,test-key-1,test-key-2"
+_TEST_API_KEYS = (
+    "board-kpi-key,test-key,test-api-key,tenant-overview-key,test-key-1,test-key-2,demo-seed-key"
+)
+_DEMO_SEED_TENANTS = (
+    "demo-seed-tenant-1,demo-seed-tenant-2,demo-isolation-a,demo-isolation-b,demo-direct-only"
+)
 
 
 @pytest.fixture(scope="session", autouse=True)
 def setup_test_db() -> None:
     os.environ["COMPLIANCEHUB_API_KEYS"] = _TEST_API_KEYS
     os.environ["COMPLIANCEHUB_EVIDENCE_DELETE_API_KEYS"] = _TEST_API_KEYS
+    os.environ["COMPLIANCEHUB_DEMO_SEED_API_KEYS"] = "demo-seed-key"
+    os.environ["COMPLIANCEHUB_DEMO_SEED_TENANT_IDS"] = _DEMO_SEED_TENANTS
     get_settings.cache_clear()
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
@@ -29,6 +36,8 @@ def _restore_api_keys_superset() -> None:
     """Nach Tests, die COMPLIANCEHUB_API_KEYS verkleinern, wieder vollständige Key-Liste."""
     os.environ["COMPLIANCEHUB_API_KEYS"] = _TEST_API_KEYS
     os.environ["COMPLIANCEHUB_EVIDENCE_DELETE_API_KEYS"] = _TEST_API_KEYS
+    os.environ["COMPLIANCEHUB_DEMO_SEED_API_KEYS"] = "demo-seed-key"
+    os.environ["COMPLIANCEHUB_DEMO_SEED_TENANT_IDS"] = _DEMO_SEED_TENANTS
     get_settings.cache_clear()
 
 

--- a/tests/test_demo_tenant_seed.py
+++ b/tests/test_demo_tenant_seed.py
@@ -1,0 +1,152 @@
+"""Demo-Tenant-Seeding: API-Schutz, Counts, Tenant-Isolation, Advisor-Link."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import SessionLocal
+from app.main import app
+from app.repositories.advisor_tenants import AdvisorTenantRepository
+from app.repositories.ai_governance_actions import AIGovernanceActionRepository
+from app.repositories.ai_systems import AISystemRepository
+from app.repositories.classifications import ClassificationRepository
+from app.repositories.evidence_files import EvidenceFileRepository
+from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
+from app.repositories.policies import PolicyRepository
+from app.services.demo_tenant_seeder import seed_demo_tenant
+
+client = TestClient(app)
+
+DEMO_KEY = "demo-seed-key"
+T1 = "demo-seed-tenant-1"
+T2 = "demo-seed-tenant-2"
+TA = "demo-isolation-a"
+TB = "demo-isolation-b"
+TD = "demo-direct-only"
+
+
+def _demo_headers() -> dict[str, str]:
+    return {"x-api-key": DEMO_KEY}
+
+
+def test_list_demo_templates_requires_demo_key() -> None:
+    r = client.get("/api/v1/demo/tenant-templates")
+    assert r.status_code == 401
+
+
+def test_list_demo_templates_ok() -> None:
+    r = client.get("/api/v1/demo/tenant-templates", headers=_demo_headers())
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data) == 3
+    keys = {x["key"] for x in data}
+    assert keys == {"kritis_energy", "industrial_sme", "tax_advisor"}
+
+
+def test_demo_seed_wrong_api_key() -> None:
+    r = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers={"x-api-key": "board-kpi-key"},
+        json={"template_key": "kritis_energy", "tenant_id": T1},
+    )
+    assert r.status_code == 401
+
+
+def test_demo_seed_tenant_not_allowlisted() -> None:
+    r = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers=_demo_headers(),
+        json={"template_key": "kritis_energy", "tenant_id": "production-tenant-xyz"},
+    )
+    assert r.status_code == 403
+
+
+def test_demo_seed_disabled_when_no_demo_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_DEMO_SEED_API_KEYS", "")
+    r = client.get("/api/v1/demo/tenant-templates", headers=_demo_headers())
+    assert r.status_code == 503
+
+
+def test_post_demo_seed_creates_expected_entities() -> None:
+    r = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers=_demo_headers(),
+        json={"template_key": "kritis_energy", "tenant_id": T1},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant_id"] == T1
+    assert body["template_key"] == "kritis_energy"
+    assert body["ai_systems_count"] == 4
+    assert body["governance_actions_count"] == 5
+    assert body["evidence_files_count"] == 3
+    assert body["nis2_kpi_rows_count"] == 6
+    assert body["policy_rows_count"] >= 1
+    assert body["classifications_count"] == 4
+    assert body["advisor_linked"] is False
+
+
+def test_post_demo_seed_idempotent_conflict() -> None:
+    r2 = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers=_demo_headers(),
+        json={"template_key": "industrial_sme", "tenant_id": T1},
+    )
+    assert r2.status_code == 409
+
+
+def test_demo_seed_tenant_isolation() -> None:
+    client.post(
+        "/api/v1/demo/tenants/seed",
+        headers=_demo_headers(),
+        json={"template_key": "tax_advisor", "tenant_id": TA},
+    )
+    listed = client.get(
+        "/api/v1/ai-systems",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": TB},
+    )
+    assert listed.status_code == 200
+    assert listed.json() == []
+
+
+def test_demo_seed_with_advisor_link() -> None:
+    adv = "demo-advisor@example.com"
+    r = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers=_demo_headers(),
+        json={"template_key": "industrial_sme", "tenant_id": T2, "advisor_id": adv},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["advisor_linked"] is True
+    s = SessionLocal()
+    try:
+        link = AdvisorTenantRepository(s).get_link(adv, T2)
+        assert link is not None
+        assert link.tenant_id == T2
+    finally:
+        s.close()
+
+
+def test_seed_demo_tenant_does_not_touch_other_tenant() -> None:
+    s = SessionLocal()
+    try:
+        ai = AISystemRepository(s)
+        ta_count_before = len(ai.list_for_tenant(TA))
+        assert ta_count_before > 0
+        seed_demo_tenant(
+            s,
+            "tax_advisor",
+            TD,
+            advisor_id=None,
+            ai_repo=ai,
+            cls_repo=ClassificationRepository(s),
+            nis2_repo=Nis2KritisKpiRepository(s),
+            policy_repo=PolicyRepository(s),
+            action_repo=AIGovernanceActionRepository(s),
+            evidence_repo=EvidenceFileRepository(s),
+        )
+        assert len(ai.list_for_tenant(TA)) == ta_count_before
+        assert len(ai.list_for_tenant(TD)) == 4
+    finally:
+        s.close()


### PR DESCRIPTION
- DemoTenantTemplate + seed_demo_tenant (KI, Klassifikation, NIS2-KPIs, Policies, Actions, Evidenz)
- GET /api/v1/demo/tenant-templates, POST /api/v1/demo/tenants/seed (Demo-Key + Tenant-Allowlist)
- Next.js-Proxy /api/demo/*, DemoTenantSetupPanel auf /advisor und /settings
- Tests und e2e-demo-flow-Doku

Made-with: Cursor