### PR TITLE
feat(llm): enterprise router with tenant policies and observability

### DIFF
--- a/app/advisor_models.py
+++ b/app/advisor_models.py
@@ -58,3 +58,10 @@ class AdvisorTenantReport(BaseModel):
         default_factory=list,
         description="Noch offene Guided-Setup-Schritte (Kurzlabels).",
     )
+    executive_summary_narrative: str | None = Field(
+        default=None,
+        description=(
+            "Optional sprachlich verdichtete Kurzfassung aus deterministischen Kennzahlen "
+            "(LLM-Assist); keine neuen Fakten gegenüber den strukturierten Feldern."
+        ),
+    )

--- a/app/feature_flags.py
+++ b/app/feature_flags.py
@@ -19,6 +19,11 @@ class FeatureFlag(StrEnum):
     evidence_uploads = "evidence_uploads"
     guided_setup = "guided_setup"
     pilot_runbook = "pilot_runbook"
+    llm_enabled = "llm_enabled"
+    llm_legal_reasoning = "llm_legal_reasoning"
+    llm_report_assistant = "llm_report_assistant"
+    llm_classification_tagging = "llm_classification_tagging"
+    llm_chat_assistant = "llm_chat_assistant"
 
 
 _FLAG_ENV_KEYS: dict[FeatureFlag, str] = {
@@ -28,6 +33,16 @@ _FLAG_ENV_KEYS: dict[FeatureFlag, str] = {
     FeatureFlag.evidence_uploads: "COMPLIANCEHUB_FEATURE_EVIDENCE_UPLOADS",
     FeatureFlag.guided_setup: "COMPLIANCEHUB_FEATURE_GUIDED_SETUP",
     FeatureFlag.pilot_runbook: "COMPLIANCEHUB_FEATURE_PILOT_RUNBOOK",
+    FeatureFlag.llm_enabled: "COMPLIANCEHUB_FEATURE_LLM_ENABLED",
+    FeatureFlag.llm_legal_reasoning: "COMPLIANCEHUB_FEATURE_LLM_LEGAL_REASONING",
+    FeatureFlag.llm_report_assistant: "COMPLIANCEHUB_FEATURE_LLM_REPORT_ASSISTANT",
+    FeatureFlag.llm_classification_tagging: "COMPLIANCEHUB_FEATURE_LLM_CLASSIFICATION_TAGGING",
+    FeatureFlag.llm_chat_assistant: "COMPLIANCEHUB_FEATURE_LLM_CHAT_ASSISTANT",
+}
+
+# LLM master switch defaults off until keys and policies are configured.
+_FLAG_DEFAULTS: dict[FeatureFlag, bool] = {
+    FeatureFlag.llm_enabled: False,
 }
 
 
@@ -58,8 +73,8 @@ def is_feature_enabled(
             return override
 
     env_key = _FLAG_ENV_KEYS[flag]
-    # Standard: an, damit bestehende Umgebungen und Tests ohne neue ENV-Variablen funktionieren.
-    return _parse_env_bool(env_key, default=True)
+    default = _FLAG_DEFAULTS.get(flag, True)
+    return _parse_env_bool(env_key, default=default)
 
 
 def create_feature_guard(flag: FeatureFlag):

--- a/app/llm_models.py
+++ b/app/llm_models.py
@@ -1,0 +1,128 @@
+"""Domain model for LLM routing: task types, providers, tenant policies, responses."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class LLMTaskType(StrEnum):
+    """Use-case categories for model selection and governance."""
+
+    LEGAL_REASONING = "legal_reasoning"
+    STRUCTURED_OUTPUT = "structured_output"
+    CLASSIFICATION_TAGGING = "classification_tagging"
+    CHAT_ASSISTANT = "chat_assistant"
+    EMBEDDING_RETRIEVAL = "embedding_retrieval"
+    ON_PREM_SENSITIVE = "on_prem_sensitive"
+
+
+class LLMProvider(StrEnum):
+    CLAUDE = "claude"
+    OPENAI = "openai"
+    GEMINI = "gemini"
+    LLAMA = "llama"
+
+
+class DataResidencyPolicy(StrEnum):
+    """
+    Where tenant data may be processed by model APIs.
+
+    Assumptions (documented in docs/llm-routing.md):
+    - OPENAI / GEMINI vendor APIs are treated as US-cloud for routing unless you deploy
+      EU data residency offerings and set COMPLIANCEHUB_LLM_US_CLOUD_OK=true.
+    - Anthropic (CLAUDE) may process in multiple regions; for strict EU_ONLY we only allow
+      CLAUDE if COMPLIANCEHUB_LLM_ASSUME_CLAUDE_EU=true (operator attestation).
+    - LLAMA is the default path for EU_ONLY / no public API when an on-prem URL is set.
+    """
+
+    US_CLOUD_ALLOWED = "us_cloud_allowed"
+    EU_ONLY = "eu_only"
+
+
+class PublicApiPolicy(StrEnum):
+    """Whether calls may leave the tenant-controlled network to public SaaS LLM APIs."""
+
+    PUBLIC_API_ALLOWED = "public_api_allowed"
+    ON_PREM_ONLY = "on_prem_only"
+
+
+class CostSensitivity(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class LatencySensitivity(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class TenantLLMPolicy(BaseModel):
+    """Per-tenant LLM routing and compliance constraints."""
+
+    tenant_id: str = Field(..., min_length=1)
+    allowed_providers: list[LLMProvider] = Field(
+        default_factory=lambda: list(LLMProvider),
+        description="Providers permitted for this tenant after residency/public-API filters.",
+    )
+    default_provider_by_task: dict[LLMTaskType, LLMProvider] = Field(default_factory=dict)
+    require_on_prem_for_sensitive: bool = Field(
+        default=False,
+        description="If true, ON_PREM_SENSITIVE must use on-prem stack (LLAMA).",
+    )
+    cost_sensitivity: CostSensitivity = CostSensitivity.MEDIUM
+    latency_sensitivity: LatencySensitivity = LatencySensitivity.MEDIUM
+    data_residency: DataResidencyPolicy = DataResidencyPolicy.US_CLOUD_ALLOWED
+    public_api_policy: PublicApiPolicy = PublicApiPolicy.PUBLIC_API_ALLOWED
+
+    @field_validator("default_provider_by_task", mode="before")
+    @classmethod
+    def _coerce_task_provider_keys(
+        cls,
+        v: Any,
+    ) -> dict[LLMTaskType, LLMProvider]:
+        if not isinstance(v, dict):
+            return {}
+        out: dict[LLMTaskType, LLMProvider] = {}
+        for k, val in v.items():
+            kt = LLMTaskType(str(k)) if not isinstance(k, LLMTaskType) else k
+            pv = LLMProvider(str(val)) if not isinstance(val, LLMProvider) else val
+            out[kt] = pv
+        return out
+
+    @field_validator("allowed_providers", mode="before")
+    @classmethod
+    def _coerce_providers(cls, v: Any) -> list[LLMProvider]:
+        if v is None:
+            return list(LLMProvider)
+        if not isinstance(v, list):
+            return list(LLMProvider)
+        return [LLMProvider(str(p)) if not isinstance(p, LLMProvider) else p for p in v]
+
+
+class LLMResponse(BaseModel):
+    """Provider-agnostic completion result (no persistence of raw content in router logs)."""
+
+    text: str
+    provider: LLMProvider
+    model_id: str
+    input_tokens_est: int = Field(ge=0, default=0)
+    output_tokens_est: int = Field(ge=0, default=0)
+
+
+class LLMCallMetadataRecord(BaseModel):
+    """Metadata persisted per router invocation (no prompt/response body)."""
+
+    tenant_id: str
+    task_type: LLMTaskType
+    provider: LLMProvider
+    model_id: str
+    prompt_length: int = Field(ge=0)
+    response_length: int = Field(ge=0)
+    latency_ms: int = Field(ge=0)
+    estimated_input_tokens: int = Field(ge=0)
+    estimated_output_tokens: int = Field(ge=0)

--- a/app/main.py
+++ b/app/main.py
@@ -84,6 +84,7 @@ from app.eu_ai_act_readiness_models import EUAIActReadinessOverview
 from app.evidence_models import EvidenceFile, EvidenceFileListResponse
 from app.feature_flags import FeatureFlag, create_feature_guard
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
+from app.llm_models import LLMTaskType
 from app.models import (
     ComplianceAction,
     DocumentIngestRequest,
@@ -127,12 +128,14 @@ from app.security import (
     require_advisor_api_access,
     require_demo_seed_api_key,
 )
+from app.services import llm_client as llm_client_mod
 from app.services import usage_event_logger as usage_event_logger
 from app.services.advisor_portfolio import (
     advisor_portfolio_to_csv,
     advisor_portfolio_to_json_bytes,
     build_advisor_portfolio,
 )
+from app.services.advisor_report_llm_enrichment import maybe_enrich_advisor_report_with_llm_summary
 from app.services.advisor_tenant_report import build_advisor_tenant_report
 from app.services.advisor_tenant_report_markdown import render_tenant_report_markdown
 from app.services.ai_board_alerts import compute_board_alerts
@@ -183,6 +186,7 @@ from app.services.evidence_service import (
 )
 from app.services.evidence_storage import get_evidence_storage
 from app.services.high_risk_scenarios import list_high_risk_scenarios
+from app.services.llm_router import LLMRouter
 from app.services.nis2_kritis_alert_signals import build_nis2_kritis_alert_signals
 from app.services.nis2_kritis_drilldown import build_nis2_kritis_kpi_drilldown
 from app.services.nis2_kritis_kpis import recommended_kpis_for_ai_system
@@ -202,6 +206,19 @@ from app.usage_metrics_models import TenantUsageMetricsResponse
 
 APP_VERSION = os.getenv("COMPLIANCEHUB_VERSION", "0.1.0")
 APP_ENVIRONMENT = os.getenv("COMPLIANCEHUB_ENV", "dev")
+
+
+class LLMInvokeRequest(BaseModel):
+    task_type: LLMTaskType
+    prompt: str = Field(..., min_length=1, max_length=48000)
+
+
+class LLMInvokeResponse(BaseModel):
+    text: str
+    provider: str
+    model_id: str
+    input_tokens_est: int = Field(default=0, ge=0)
+    output_tokens_est: int = Field(default=0, ge=0)
 
 
 @asynccontextmanager
@@ -1814,6 +1831,45 @@ def get_tenant_usage_metrics_endpoint(
     return compute_tenant_usage_metrics(session, tenant_id)
 
 
+@app.post(
+    "/api/v1/llm/invoke",
+    response_model=LLMInvokeResponse,
+    tags=["llm"],
+)
+def post_llm_invoke(
+    _ff_llm: Annotated[None, Depends(create_feature_guard(FeatureFlag.llm_enabled))],
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    body: LLMInvokeRequest,
+) -> LLMInvokeResponse:
+    """Mandanten-gebundener LLM-Aufruf über den Router (Task-Flags + Policy)."""
+    router = LLMRouter(session=session)
+    try:
+        resp = router.route_and_call(body.task_type, body.prompt, auth_context.tenant_id)
+    except PermissionError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=str(exc),
+        ) from exc
+    except llm_client_mod.LLMConfigurationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=str(exc),
+        ) from exc
+    except llm_client_mod.LLMProviderHTTPError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=str(exc),
+        ) from exc
+    return LLMInvokeResponse(
+        text=resp.text,
+        provider=resp.provider.value,
+        model_id=resp.model_id,
+        input_tokens_est=resp.input_tokens_est,
+        output_tokens_est=resp.output_tokens_est,
+    )
+
+
 def _api_key_row_to_read(row: TenantApiKeyDB) -> TenantApiKeyRead:
     created = row.created_at_utc
     created_s = created.isoformat() if hasattr(created, "isoformat") else str(created)
@@ -2102,6 +2158,7 @@ def get_advisor_tenant_report(
         violation_repo=violation_repo,
         action_repo=action_repo,
     )
+    report = maybe_enrich_advisor_report_with_llm_summary(session, tenant_id, report)
     if export_format == "markdown":
         md = render_tenant_report_markdown(report)
         fname = f"tenant-report-{tenant_id}.md"

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -366,3 +366,41 @@ class UsageEventTable(Base):
         nullable=False,
         index=True,
     )
+
+
+class TenantLLMPolicyOverrideDB(Base):
+    """JSON-Override für Mandanten-LLM-Richtlinien (merged mit Standard-Policy)."""
+
+    __tablename__ = "tenant_llm_policy_overrides"
+
+    tenant_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    policy_json: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        onupdate=datetime.utcnow,
+        nullable=False,
+    )
+
+
+class LLMCallMetadataDB(Base):
+    """Metadaten je LLM-Aufruf (ohne Prompt/Response-Inhalt, DSGVO-minimierend)."""
+
+    __tablename__ = "llm_call_metadata"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    task_type: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    model_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    prompt_length: Mapped[int] = mapped_column(Integer, nullable=False)
+    response_length: Mapped[int] = mapped_column(Integer, nullable=False)
+    latency_ms: Mapped[int] = mapped_column(Integer, nullable=False)
+    estimated_input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    estimated_output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=datetime.utcnow,
+        nullable=False,
+        index=True,
+    )

--- a/app/repositories/llm_call_metadata.py
+++ b/app/repositories/llm_call_metadata.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.llm_models import LLMCallMetadataRecord
+from app.models_db import LLMCallMetadataDB
+
+
+class LLMCallMetadataRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def insert(self, row: LLMCallMetadataRecord) -> None:
+        rec = LLMCallMetadataDB(
+            id=str(uuid4()),
+            tenant_id=row.tenant_id,
+            task_type=row.task_type.value,
+            provider=row.provider.value,
+            model_id=row.model_id,
+            prompt_length=row.prompt_length,
+            response_length=row.response_length,
+            latency_ms=row.latency_ms,
+            estimated_input_tokens=row.estimated_input_tokens,
+            estimated_output_tokens=row.estimated_output_tokens,
+            created_at_utc=datetime.now(UTC),
+        )
+        self._session.add(rec)
+        self._session.commit()
+
+    def count_since(self, tenant_id: str, *, since: datetime) -> int:
+        stmt = select(func.count()).where(
+            LLMCallMetadataDB.tenant_id == tenant_id,
+            LLMCallMetadataDB.created_at_utc >= since,
+        )
+        n = self._session.execute(stmt).scalar_one()
+        return int(n or 0)
+
+    def count_by_task_since(self, tenant_id: str, *, since: datetime) -> dict[str, int]:
+        stmt = (
+            select(LLMCallMetadataDB.task_type, func.count())
+            .where(
+                LLMCallMetadataDB.tenant_id == tenant_id,
+                LLMCallMetadataDB.created_at_utc >= since,
+            )
+            .group_by(LLMCallMetadataDB.task_type)
+        )
+        rows = self._session.execute(stmt).all()
+        return {str(tt): int(cnt) for tt, cnt in rows}

--- a/app/repositories/tenant_llm_policy_override.py
+++ b/app/repositories/tenant_llm_policy_override.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models_db import TenantLLMPolicyOverrideDB
+
+
+class TenantLLMPolicyOverrideRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def get_policy_json(self, tenant_id: str) -> str | None:
+        stmt = select(TenantLLMPolicyOverrideDB.policy_json).where(
+            TenantLLMPolicyOverrideDB.tenant_id == tenant_id,
+        )
+        raw = self._session.execute(stmt).scalar_one_or_none()
+        return str(raw) if raw is not None else None
+
+    def get_partial_dict(self, tenant_id: str) -> dict | None:
+        raw = self.get_policy_json(tenant_id)
+        if raw is None or not raw.strip():
+            return None
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return None
+        return data if isinstance(data, dict) else None

--- a/app/services/advisor_report_llm_enrichment.py
+++ b/app/services/advisor_report_llm_enrichment.py
@@ -1,0 +1,74 @@
+"""Optional LLM-Formulierung für Advisor-Steckbrief (nur aus strukturierten Kennzahlen)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from app.advisor_models import AdvisorTenantReport
+from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.llm_models import LLMTaskType
+from app.services.llm_router import LLMRouter
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _deterministic_facts_payload(report: AdvisorTenantReport) -> dict:
+    return {
+        "tenant_id": report.tenant_id,
+        "tenant_name": report.tenant_name,
+        "ai_systems_total": report.ai_systems_total,
+        "high_risk_systems_count": report.high_risk_systems_count,
+        "high_risk_with_full_controls_count": report.high_risk_with_full_controls_count,
+        "eu_ai_act_readiness_score": report.eu_ai_act_readiness_score,
+        "eu_ai_act_deadline": report.eu_ai_act_deadline,
+        "eu_ai_act_days_remaining": report.eu_ai_act_days_remaining,
+        "nis2_incident_readiness_percent": report.nis2_incident_readiness_percent,
+        "nis2_supplier_risk_coverage_percent": report.nis2_supplier_risk_coverage_percent,
+        "nis2_ot_it_segregation_mean_percent": report.nis2_ot_it_segregation_mean_percent,
+        "nis2_critical_focus_systems_count": report.nis2_critical_focus_systems_count,
+        "governance_open_actions_count": report.governance_open_actions_count,
+        "governance_overdue_actions_count": report.governance_overdue_actions_count,
+        "top_critical_requirements": [c.model_dump() for c in report.top_critical_requirements],
+        "setup_completed_steps": report.setup_completed_steps,
+        "setup_total_steps": report.setup_total_steps,
+        "setup_open_step_labels": list(report.setup_open_step_labels),
+    }
+
+
+def maybe_enrich_advisor_report_with_llm_summary(
+    session: Session,
+    tenant_id: str,
+    report: AdvisorTenantReport,
+) -> AdvisorTenantReport:
+    """
+    Wenn LLM-Features aktiv sind und der Router erfolgreich antwortet, ergänzt eine
+    Executive-Summary-Formulierung; bei Fehler oder deaktiviertem Feature unverändert.
+    """
+    if not is_feature_enabled(FeatureFlag.llm_enabled, tenant_id, session=session):
+        return report
+    if not is_feature_enabled(FeatureFlag.llm_report_assistant, tenant_id, session=session):
+        return report
+
+    facts = _deterministic_facts_payload(report)
+    prompt = (
+        "Formuliere eine Executive Summary auf Deutsch in 3–5 kurzen Sätzen, sachlich und "
+        "ohne Superlative. Nutze ausschließlich die folgenden JSON-Fakten; erfinde keine "
+        "neuen Zahlen, keine neuen regulatorischen Behauptungen und keine Systemnamen, "
+        "die nicht in den Fakten stehen.\n\n"
+        f"{json.dumps(facts, ensure_ascii=False)}"
+    )
+    try:
+        router = LLMRouter(session=session)
+        resp = router.route_and_call(LLMTaskType.STRUCTURED_OUTPUT, prompt, tenant_id)
+    except Exception:
+        logger.exception("advisor_report_llm_enrichment_failed tenant=%s", tenant_id)
+        return report
+    text = (resp.text or "").strip()
+    if not text:
+        return report
+    return report.model_copy(update={"executive_summary_narrative": text})

--- a/app/services/advisor_tenant_report_markdown.py
+++ b/app/services/advisor_tenant_report_markdown.py
@@ -38,11 +38,18 @@ def render_tenant_report_markdown(report: AdvisorTenantReport) -> str:
         "Daten aus Register, Readiness und KPIs.*"
     )
 
+    narrative_block = ""
+    if report.executive_summary_narrative:
+        narrative_block = (
+            "\n## Executive Summary (sprachliche Kurzfassung)\n\n"
+            f"{report.executive_summary_narrative.strip()}\n"
+        )
+
     return f"""# Compliance Hub Mandanten-Steckbrief – {report.tenant_name}
 
 **Mandanten-ID:** `{report.tenant_id}`  
 **Stand (UTC):** {report.generated_at_utc.isoformat()}
-
+{narrative_block}
 ## Profil
 
 - Branche / Region: {loc}

--- a/app/services/classification_engine.py
+++ b/app/services/classification_engine.py
@@ -15,6 +15,9 @@ def classify_ai_system(
 ) -> RiskClassification:
     """Decision-tree classification per EU AI Act Art. 6.
 
+    Optional LLM-gestützte Freitext-Hinweise (ohne Ersetzung dieser Logik):
+    ``app.services.llm_compliance_tasks.draft_classification_assist``.
+
     Order:
     1. Prohibited check
     2. Annex I (safety component) path

--- a/app/services/llm_client.py
+++ b/app/services/llm_client.py
@@ -1,0 +1,293 @@
+"""HTTP-based LLM clients (httpx); keys and base URLs from environment."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+import httpx
+
+from app.llm_models import LLMProvider, LLMResponse
+
+
+class LLMConfigurationError(RuntimeError):
+    """Missing API key, base URL, or local endpoint."""
+
+
+class LLMProviderHTTPError(RuntimeError):
+    """Upstream LLM API returned an error response."""
+
+
+def _env(name: str, default: str | None = None) -> str | None:
+    raw = os.getenv(name)
+    if raw is None or not str(raw).strip():
+        return default
+    return str(raw).strip()
+
+
+def _estimate_tokens(text: str) -> int:
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+def chat_model_id(provider: LLMProvider) -> str:
+    defaults = {
+        LLMProvider.CLAUDE: "claude-sonnet-4-20250514",
+        LLMProvider.OPENAI: "gpt-4o",
+        LLMProvider.GEMINI: "gemini-2.0-flash",
+        LLMProvider.LLAMA: "llama-3.1-8b-instruct",
+    }
+    env_keys = {
+        LLMProvider.CLAUDE: "COMPLIANCEHUB_CLAUDE_MODEL",
+        LLMProvider.OPENAI: "COMPLIANCEHUB_OPENAI_MODEL",
+        LLMProvider.GEMINI: "COMPLIANCEHUB_GEMINI_MODEL",
+        LLMProvider.LLAMA: "COMPLIANCEHUB_LLAMA_MODEL",
+    }
+    key = env_keys[provider]
+    return _env(key) or defaults[provider]
+
+
+def embedding_model_id(provider: LLMProvider) -> str:
+    if provider == LLMProvider.OPENAI:
+        return _env("COMPLIANCEHUB_OPENAI_EMBEDDING_MODEL") or "text-embedding-3-small"
+    if provider == LLMProvider.LLAMA:
+        return _env("COMPLIANCEHUB_LLAMA_EMBEDDING_MODEL") or chat_model_id(LLMProvider.LLAMA)
+    return chat_model_id(provider)
+
+
+def is_provider_configured(provider: LLMProvider) -> bool:
+    if provider == LLMProvider.CLAUDE:
+        return bool(_env("CLAUDE_API_KEY") or _env("ANTHROPIC_API_KEY"))
+    if provider == LLMProvider.OPENAI:
+        return bool(_env("OPENAI_API_KEY"))
+    if provider == LLMProvider.GEMINI:
+        return bool(_env("GEMINI_API_KEY") or _env("GOOGLE_API_KEY"))
+    if provider == LLMProvider.LLAMA:
+        return bool(_env("LLAMA_BASE_URL"))
+    return False
+
+
+def _anthropic_key() -> str:
+    k = _env("CLAUDE_API_KEY") or _env("ANTHROPIC_API_KEY")
+    if not k:
+        raise LLMConfigurationError("CLAUDE_API_KEY or ANTHROPIC_API_KEY is not set")
+    return k
+
+
+def _call_claude(model_id: str, prompt: str, **kwargs: Any) -> LLMResponse:
+    max_tokens = int(kwargs.get("max_tokens") or 1024)
+    base = _env("ANTHROPIC_API_URL", "https://api.anthropic.com")
+    url = f"{base.rstrip('/')}/v1/messages"
+    payload = {
+        "model": model_id,
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    headers = {
+        "x-api-key": _anthropic_key(),
+        "anthropic-version": "2023-06-01",
+        "content-type": "application/json",
+    }
+    with httpx.Client(timeout=120.0) as client:
+        r = client.post(url, json=payload, headers=headers)
+    if r.status_code >= 400:
+        raise LLMProviderHTTPError(f"Anthropic HTTP {r.status_code}: {r.text[:500]}")
+    data = r.json()
+    parts = data.get("content") or []
+    texts: list[str] = []
+    for block in parts:
+        if isinstance(block, dict) and block.get("type") == "text":
+            texts.append(str(block.get("text", "")))
+    text = "\n".join(texts).strip()
+    in_tok = int(data.get("usage", {}).get("input_tokens") or _estimate_tokens(prompt))
+    out_tok = int(data.get("usage", {}).get("output_tokens") or _estimate_tokens(text))
+    return LLMResponse(
+        text=text,
+        provider=LLMProvider.CLAUDE,
+        model_id=model_id,
+        input_tokens_est=in_tok,
+        output_tokens_est=out_tok,
+    )
+
+
+def _openai_key() -> str:
+    k = _env("OPENAI_API_KEY")
+    if not k:
+        raise LLMConfigurationError("OPENAI_API_KEY is not set")
+    return k
+
+
+def _call_openai_chat(model_id: str, prompt: str, **kwargs: Any) -> LLMResponse:
+    base = _env("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    url = f"{base.rstrip('/')}/chat/completions"
+    payload: dict[str, Any] = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    if kwargs.get("response_format") == "json_object":
+        payload["response_format"] = {"type": "json_object"}
+    headers = {"authorization": f"Bearer {_openai_key()}", "content-type": "application/json"}
+    with httpx.Client(timeout=120.0) as client:
+        r = client.post(url, json=payload, headers=headers)
+    if r.status_code >= 400:
+        raise LLMProviderHTTPError(f"OpenAI HTTP {r.status_code}: {r.text[:500]}")
+    data = r.json()
+    choice0 = (data.get("choices") or [{}])[0]
+    msg = choice0.get("message") or {}
+    text = str(msg.get("content") or "").strip()
+    usage = data.get("usage") or {}
+    in_tok = int(usage.get("prompt_tokens") or _estimate_tokens(prompt))
+    out_tok = int(usage.get("completion_tokens") or _estimate_tokens(text))
+    return LLMResponse(
+        text=text,
+        provider=LLMProvider.OPENAI,
+        model_id=model_id,
+        input_tokens_est=in_tok,
+        output_tokens_est=out_tok,
+    )
+
+
+def _gemini_key() -> str:
+    k = _env("GEMINI_API_KEY") or _env("GOOGLE_API_KEY")
+    if not k:
+        raise LLMConfigurationError("GEMINI_API_KEY or GOOGLE_API_KEY is not set")
+    return k
+
+
+def _call_gemini(model_id: str, prompt: str, **kwargs: Any) -> LLMResponse:
+    key = _gemini_key()
+    base = _env("GEMINI_API_URL", "https://generativelanguage.googleapis.com/v1beta")
+    url = f"{base.rstrip('/')}/models/{model_id}:generateContent"
+    payload = {"contents": [{"parts": [{"text": prompt}]}]}
+    with httpx.Client(timeout=120.0) as client:
+        r = client.post(url, params={"key": key}, json=payload)
+    if r.status_code >= 400:
+        raise LLMProviderHTTPError(f"Gemini HTTP {r.status_code}: {r.text[:500]}")
+    data = r.json()
+    candidates = data.get("candidates") or []
+    text = ""
+    if candidates:
+        parts = (candidates[0].get("content") or {}).get("parts") or []
+        text = "".join(str(p.get("text", "")) for p in parts if isinstance(p, dict)).strip()
+    meta = data.get("usageMetadata") or {}
+    in_tok = int(meta.get("promptTokenCount") or _estimate_tokens(prompt))
+    out_tok = int(meta.get("candidatesTokenCount") or _estimate_tokens(text))
+    return LLMResponse(
+        text=text,
+        provider=LLMProvider.GEMINI,
+        model_id=model_id,
+        input_tokens_est=in_tok,
+        output_tokens_est=out_tok,
+    )
+
+
+def _llama_base() -> str:
+    u = _env("LLAMA_BASE_URL")
+    if not u:
+        raise LLMConfigurationError("LLAMA_BASE_URL is not set")
+    return u.rstrip("/")
+
+
+def _call_llama_chat(model_id: str, prompt: str, **kwargs: Any) -> LLMResponse:
+    url = f"{_llama_base()}/v1/chat/completions"
+    headers: dict[str, str] = {"content-type": "application/json"}
+    lk = _env("LLAMA_API_KEY")
+    if lk:
+        headers["authorization"] = f"Bearer {lk}"
+    payload = {
+        "model": model_id,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    with httpx.Client(timeout=120.0) as client:
+        r = client.post(url, json=payload, headers=headers)
+    if r.status_code >= 400:
+        raise LLMProviderHTTPError(f"Llama HTTP {r.status_code}: {r.text[:500]}")
+    data = r.json()
+    choice0 = (data.get("choices") or [{}])[0]
+    msg = choice0.get("message") or {}
+    text = str(msg.get("content") or "").strip()
+    usage = data.get("usage") or {}
+    in_tok = int(usage.get("prompt_tokens") or _estimate_tokens(prompt))
+    out_tok = int(usage.get("completion_tokens") or _estimate_tokens(text))
+    return LLMResponse(
+        text=text,
+        provider=LLMProvider.LLAMA,
+        model_id=model_id,
+        input_tokens_est=in_tok,
+        output_tokens_est=out_tok,
+    )
+
+
+def call_model(provider: LLMProvider, model_id: str, prompt: str, **kwargs: Any) -> LLMResponse:
+    """
+    Dispatch chat completion to the selected provider.
+
+    Optional kwargs: max_tokens, response_format (OpenAI: json_object).
+    """
+    if provider == LLMProvider.CLAUDE:
+        return _call_claude(model_id, prompt, **kwargs)
+    if provider == LLMProvider.OPENAI:
+        return _call_openai_chat(model_id, prompt, **kwargs)
+    if provider == LLMProvider.GEMINI:
+        return _call_gemini(model_id, prompt, **kwargs)
+    if provider == LLMProvider.LLAMA:
+        return _call_llama_chat(model_id, prompt, **kwargs)
+    raise LLMConfigurationError(f"Unsupported provider: {provider}")
+
+
+def call_embedding(provider: LLMProvider, model_id: str, input_text: str) -> LLMResponse:
+    """
+    Embeddings for RAG-style tasks. Returns JSON array string in ``text`` (for downstream use).
+    """
+    if not input_text.strip():
+        return LLMResponse(
+            text="[]",
+            provider=provider,
+            model_id=model_id,
+            input_tokens_est=0,
+            output_tokens_est=0,
+        )
+    if provider == LLMProvider.LLAMA:
+        url = f"{_llama_base()}/v1/embeddings"
+        headers: dict[str, str] = {"content-type": "application/json"}
+        lk = _env("LLAMA_API_KEY")
+        if lk:
+            headers["authorization"] = f"Bearer {lk}"
+        payload = {"model": model_id, "input": input_text}
+        with httpx.Client(timeout=120.0) as client:
+            r = client.post(url, json=payload, headers=headers)
+        if r.status_code >= 400:
+            raise LLMProviderHTTPError(f"Llama embeddings HTTP {r.status_code}: {r.text[:500]}")
+        data = r.json()
+        vec = (data.get("data") or [{}])[0].get("embedding") or []
+        text = json.dumps(vec)
+        return LLMResponse(
+            text=text,
+            provider=LLMProvider.LLAMA,
+            model_id=model_id,
+            input_tokens_est=_estimate_tokens(input_text),
+            output_tokens_est=len(vec),
+        )
+    if provider == LLMProvider.OPENAI:
+        base = _env("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        url = f"{base.rstrip('/')}/embeddings"
+        headers = {"authorization": f"Bearer {_openai_key()}", "content-type": "application/json"}
+        payload = {"model": model_id, "input": input_text}
+        with httpx.Client(timeout=120.0) as client:
+            r = client.post(url, json=payload, headers=headers)
+        if r.status_code >= 400:
+            raise LLMProviderHTTPError(f"OpenAI embeddings HTTP {r.status_code}: {r.text[:500]}")
+        data = r.json()
+        vec = (data.get("data") or [{}])[0].get("embedding") or []
+        text = json.dumps(vec)
+        return LLMResponse(
+            text=text,
+            provider=LLMProvider.OPENAI,
+            model_id=model_id,
+            input_tokens_est=int((data.get("usage") or {}).get("prompt_tokens") or 0)
+            or _estimate_tokens(input_text),
+            output_tokens_est=len(vec),
+        )
+    raise LLMConfigurationError(f"Embeddings not implemented for provider: {provider}")

--- a/app/services/llm_compliance_tasks.py
+++ b/app/services/llm_compliance_tasks.py
@@ -1,0 +1,72 @@
+"""
+Integration hooks für EU AI Act / NIS2 / ISO-42001-Reasoning über den LLMRouter.
+
+Die Klassifikations-Engine bleibt deterministisch (Entscheidungsbaum); diese Funktionen
+dienen optionaler Textanalyse, sobald Features und Provider konfiguriert sind.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.llm_models import LLMTaskType
+from app.services.llm_router import LLMRouter
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def draft_legal_norm_analysis(
+    tenant_id: str,
+    source_text: str,
+    *,
+    session: Session | None = None,
+) -> str:
+    """Kurzanalyse / Norm-Bezug aus Freitext (LEGAL_REASONING, Claude-first)."""
+    router = LLMRouter(session=session)
+    prompt = (
+        "Analysiere den folgenden Text im Kontext EU AI Act und NIS2-relevanter "
+        "Governance-Pflichten. Antwort strukturiert mit kurzen Absätzen, auf Deutsch.\n\n"
+        f"{source_text}"
+    )
+    return router.route_and_call(LLMTaskType.LEGAL_REASONING, prompt, tenant_id).text
+
+
+def draft_structured_report_snippet(
+    tenant_id: str,
+    instruction_and_facts: str,
+    *,
+    session: Session | None = None,
+    response_json: bool = False,
+) -> str:
+    """JSON/Markdown- oder Berichtsfragmente (STRUCTURED_OUTPUT, GPT-4o-first)."""
+    router = LLMRouter(session=session)
+    kwargs: dict = {}
+    if response_json:
+        kwargs["response_format"] = "json_object"
+    return router.route_and_call(
+        LLMTaskType.STRUCTURED_OUTPUT,
+        instruction_and_facts,
+        tenant_id,
+        **kwargs,
+    ).text
+
+
+def draft_classification_assist(
+    tenant_id: str,
+    system_description: str,
+    *,
+    session: Session | None = None,
+) -> str:
+    """Heuristische Tags/Vorschläge – ersetzt nicht die deterministische Klassifikation."""
+    router = LLMRouter(session=session)
+    prompt = (
+        "Schlage kompakte Stichworte und Risiko-Hinweise vor (keine finale Rechtsbewertung). "
+        "Antwort als kurze Bullet-Liste, Deutsch.\n\n"
+        f"{system_description}"
+    )
+    return router.route_and_call(
+        LLMTaskType.CLASSIFICATION_TAGGING,
+        prompt,
+        tenant_id,
+    ).text

--- a/app/services/llm_router.py
+++ b/app/services/llm_router.py
@@ -1,0 +1,263 @@
+"""Task-aware LLM routing with tenant policy, residency rules, and metadata logging."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from app.llm_models import (
+    CostSensitivity,
+    DataResidencyPolicy,
+    LatencySensitivity,
+    LLMCallMetadataRecord,
+    LLMProvider,
+    LLMResponse,
+    LLMTaskType,
+    PublicApiPolicy,
+    TenantLLMPolicy,
+)
+from app.services import llm_client
+from app.services.llm_task_flags import is_llm_task_feature_enabled
+from app.services.tenant_llm_policy import get_tenant_llm_policy
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_env_bool(key: str) -> bool:
+    raw = os.getenv(key)
+    if raw is None or not str(raw).strip():
+        return False
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _us_cloud_eu_exception_allowed() -> bool:
+    """Operator attestation: vendor API used under EU data residency / DPA."""
+    return _parse_env_bool("COMPLIANCEHUB_LLM_US_CLOUD_OK")
+
+
+def _claude_eu_attested() -> bool:
+    """Operator attestation: Claude traffic stays in approved EU/EEA processing."""
+    return _parse_env_bool("COMPLIANCEHUB_LLM_ASSUME_CLAUDE_EU")
+
+
+def _static_fallback_chain(task_type: LLMTaskType) -> list[LLMProvider]:
+    if task_type == LLMTaskType.LEGAL_REASONING:
+        return [LLMProvider.CLAUDE, LLMProvider.OPENAI, LLMProvider.GEMINI, LLMProvider.LLAMA]
+    if task_type == LLMTaskType.STRUCTURED_OUTPUT:
+        return [LLMProvider.OPENAI, LLMProvider.CLAUDE, LLMProvider.GEMINI, LLMProvider.LLAMA]
+    if task_type == LLMTaskType.CLASSIFICATION_TAGGING:
+        return [LLMProvider.GEMINI, LLMProvider.OPENAI, LLMProvider.CLAUDE, LLMProvider.LLAMA]
+    if task_type == LLMTaskType.CHAT_ASSISTANT:
+        return [LLMProvider.OPENAI, LLMProvider.CLAUDE, LLMProvider.GEMINI, LLMProvider.LLAMA]
+    if task_type == LLMTaskType.EMBEDDING_RETRIEVAL:
+        return [LLMProvider.LLAMA, LLMProvider.OPENAI]
+    if task_type == LLMTaskType.ON_PREM_SENSITIVE:
+        return [LLMProvider.LLAMA]
+    return list(LLMProvider)
+
+
+def _prefer_low_cost_gemini(
+    task_type: LLMTaskType,
+    policy: TenantLLMPolicy,
+) -> bool:
+    if policy.cost_sensitivity != CostSensitivity.HIGH:
+        return False
+    return task_type in (
+        LLMTaskType.CLASSIFICATION_TAGGING,
+        LLMTaskType.CHAT_ASSISTANT,
+    )
+
+
+def _prefer_low_latency_gemini(
+    task_type: LLMTaskType,
+    policy: TenantLLMPolicy,
+) -> bool:
+    if policy.latency_sensitivity != LatencySensitivity.HIGH:
+        return False
+    return task_type in (
+        LLMTaskType.CLASSIFICATION_TAGGING,
+        LLMTaskType.CHAT_ASSISTANT,
+    )
+
+
+def _reorder_gemini_first(chain: list[LLMProvider]) -> list[LLMProvider]:
+    if LLMProvider.GEMINI not in chain:
+        return chain
+    rest = [p for p in chain if p != LLMProvider.GEMINI]
+    return [LLMProvider.GEMINI] + rest
+
+
+def preference_chain(task_type: LLMTaskType, policy: TenantLLMPolicy) -> list[LLMProvider]:
+    base = list(_static_fallback_chain(task_type))
+    explicit = policy.default_provider_by_task.get(task_type)
+    if explicit is not None:
+        rest = [p for p in base if p != explicit]
+        chain = [explicit] + rest
+    else:
+        chain = base
+    if _prefer_low_cost_gemini(task_type, policy) or _prefer_low_latency_gemini(task_type, policy):
+        chain = _reorder_gemini_first(chain)
+    return chain
+
+
+def _allowed_by_residency(provider: LLMProvider, policy: TenantLLMPolicy) -> bool:
+    if policy.data_residency == DataResidencyPolicy.US_CLOUD_ALLOWED:
+        return True
+    if provider == LLMProvider.LLAMA:
+        return True
+    if provider == LLMProvider.CLAUDE and _claude_eu_attested():
+        return True
+    if provider in (LLMProvider.OPENAI, LLMProvider.GEMINI) and _us_cloud_eu_exception_allowed():
+        return True
+    return False
+
+
+def _allowed_by_public_api(provider: LLMProvider, policy: TenantLLMPolicy) -> bool:
+    if policy.public_api_policy == PublicApiPolicy.PUBLIC_API_ALLOWED:
+        return True
+    return provider == LLMProvider.LLAMA
+
+
+def filter_candidates(policy: TenantLLMPolicy, ordered: list[LLMProvider]) -> list[LLMProvider]:
+    allowed_set = set(policy.allowed_providers)
+    out: list[LLMProvider] = []
+    seen: set[LLMProvider] = set()
+    for p in ordered:
+        if p in seen:
+            continue
+        if p not in allowed_set:
+            continue
+        if not _allowed_by_residency(p, policy):
+            continue
+        if not _allowed_by_public_api(p, policy):
+            continue
+        if not llm_client.is_provider_configured(p):
+            continue
+        out.append(p)
+        seen.add(p)
+    return out
+
+
+class LLMRouter:
+    def __init__(
+        self,
+        session: Session | None = None,
+        *,
+        call_model_fn: Callable[..., LLMResponse] | None = None,
+        call_embedding_fn: Callable[..., LLMResponse] | None = None,
+    ) -> None:
+        self._session = session
+        self._call_model = call_model_fn or llm_client.call_model
+        self._call_embedding = call_embedding_fn or llm_client.call_embedding
+
+    def route_and_call(
+        self,
+        task_type: LLMTaskType,
+        prompt: str,
+        tenant_id: str,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        if not is_llm_task_feature_enabled(task_type, tenant_id, session=self._session):
+            raise PermissionError("LLM task is disabled by feature flags for this tenant")
+
+        policy = get_tenant_llm_policy(tenant_id, self._session)
+        ordered = preference_chain(task_type, policy)
+        if task_type == LLMTaskType.ON_PREM_SENSITIVE:
+            if not llm_client.is_provider_configured(LLMProvider.LLAMA):
+                raise llm_client.LLMConfigurationError(
+                    "ON_PREM_SENSITIVE requires LLAMA_BASE_URL and a reachable on-prem model",
+                )
+            ordered = [LLMProvider.LLAMA]
+        elif policy.require_on_prem_for_sensitive and task_type == LLMTaskType.LEGAL_REASONING:
+            ordered = [LLMProvider.LLAMA] + [p for p in ordered if p != LLMProvider.LLAMA]
+
+        candidates = filter_candidates(policy, ordered)
+        if not candidates:
+            raise llm_client.LLMConfigurationError(
+                "No LLM provider available for this tenant, task type, and policy "
+                f"(task={task_type.value})",
+            )
+
+        last_err: Exception | None = None
+        t0 = time.perf_counter()
+        for provider in candidates:
+            model_id = (
+                llm_client.embedding_model_id(provider)
+                if task_type == LLMTaskType.EMBEDDING_RETRIEVAL
+                else llm_client.chat_model_id(provider)
+            )
+            try:
+                if task_type == LLMTaskType.EMBEDDING_RETRIEVAL:
+                    resp = self._call_embedding(provider, model_id, prompt)
+                else:
+                    resp = self._call_model(provider, model_id, prompt, **kwargs)
+                latency_ms = int((time.perf_counter() - t0) * 1000)
+                self._log_metadata(
+                    tenant_id=tenant_id,
+                    task_type=task_type,
+                    provider=resp.provider,
+                    model_id=resp.model_id,
+                    prompt_length=len(prompt),
+                    response_length=len(resp.text),
+                    latency_ms=latency_ms,
+                    in_tok=resp.input_tokens_est,
+                    out_tok=resp.output_tokens_est,
+                )
+                return resp
+            except Exception as exc:
+                last_err = exc
+                logger.info(
+                    "llm_provider_fallback tenant=%s task=%s failed_provider=%s err=%s",
+                    tenant_id,
+                    task_type.value,
+                    provider.value,
+                    type(exc).__name__,
+                )
+                continue
+
+        if last_err is not None:
+            raise last_err
+        raise llm_client.LLMConfigurationError(
+            f"No LLM provider attempt completed for task {task_type.value}",
+        )
+
+    def _log_metadata(
+        self,
+        *,
+        tenant_id: str,
+        task_type: LLMTaskType,
+        provider: LLMProvider,
+        model_id: str,
+        prompt_length: int,
+        response_length: int,
+        latency_ms: int,
+        in_tok: int,
+        out_tok: int,
+    ) -> None:
+        if self._session is None:
+            return
+        try:
+            from app.repositories.llm_call_metadata import LLMCallMetadataRepository
+
+            repo = LLMCallMetadataRepository(self._session)
+            repo.insert(
+                LLMCallMetadataRecord(
+                    tenant_id=tenant_id,
+                    task_type=task_type,
+                    provider=provider,
+                    model_id=model_id,
+                    prompt_length=prompt_length,
+                    response_length=response_length,
+                    latency_ms=latency_ms,
+                    estimated_input_tokens=in_tok,
+                    estimated_output_tokens=out_tok,
+                ),
+            )
+        except Exception:
+            logger.exception("llm_metadata_log_failed tenant=%s", tenant_id)

--- a/app/services/llm_task_flags.py
+++ b/app/services/llm_task_flags.py
@@ -1,0 +1,33 @@
+"""Map LLMTaskType to FeatureFlag entries (global + per-task toggles)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.llm_models import LLMTaskType
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def is_llm_task_feature_enabled(
+    task_type: LLMTaskType,
+    tenant_id: str,
+    *,
+    session: Session | None = None,
+) -> bool:
+    if not is_feature_enabled(FeatureFlag.llm_enabled, tenant_id, session=session):
+        return False
+    task_flag = _TASK_FLAG.get(task_type)
+    if task_flag is None:
+        return True
+    return is_feature_enabled(task_flag, tenant_id, session=session)
+
+
+_TASK_FLAG: dict[LLMTaskType, FeatureFlag] = {
+    LLMTaskType.LEGAL_REASONING: FeatureFlag.llm_legal_reasoning,
+    LLMTaskType.STRUCTURED_OUTPUT: FeatureFlag.llm_report_assistant,
+    LLMTaskType.CLASSIFICATION_TAGGING: FeatureFlag.llm_classification_tagging,
+    LLMTaskType.CHAT_ASSISTANT: FeatureFlag.llm_chat_assistant,
+}

--- a/app/services/tenant_llm_policy.py
+++ b/app/services/tenant_llm_policy.py
@@ -1,0 +1,100 @@
+"""Resolve TenantLLMPolicy: defaults, ENV map, optional DB override."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+from app.llm_models import (
+    DataResidencyPolicy,
+    LLMProvider,
+    LLMTaskType,
+    PublicApiPolicy,
+    TenantLLMPolicy,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+_ENV_TENANT_POLICIES = "COMPLIANCEHUB_LLM_TENANT_POLICIES_JSON"
+
+
+def _default_provider_by_task() -> dict[LLMTaskType, LLMProvider]:
+    return {
+        LLMTaskType.LEGAL_REASONING: LLMProvider.CLAUDE,
+        LLMTaskType.STRUCTURED_OUTPUT: LLMProvider.OPENAI,
+        LLMTaskType.CLASSIFICATION_TAGGING: LLMProvider.GEMINI,
+        LLMTaskType.CHAT_ASSISTANT: LLMProvider.OPENAI,
+        LLMTaskType.EMBEDDING_RETRIEVAL: LLMProvider.LLAMA,
+        LLMTaskType.ON_PREM_SENSITIVE: LLMProvider.LLAMA,
+    }
+
+
+def default_tenant_llm_policy(tenant_id: str) -> TenantLLMPolicy:
+    return TenantLLMPolicy(
+        tenant_id=tenant_id,
+        allowed_providers=list(LLMProvider),
+        default_provider_by_task=_default_provider_by_task(),
+        require_on_prem_for_sensitive=False,
+        data_residency=DataResidencyPolicy.US_CLOUD_ALLOWED,
+        public_api_policy=PublicApiPolicy.PUBLIC_API_ALLOWED,
+    )
+
+
+def _deep_merge_dict(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    out = dict(base)
+    for k, v in override.items():
+        if k in out and isinstance(out[k], dict) and isinstance(v, dict):
+            out[k] = _deep_merge_dict(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def _load_env_tenant_fragment(tenant_id: str) -> dict[str, Any] | None:
+    raw = os.getenv(_ENV_TENANT_POLICIES)
+    if not raw or not str(raw).strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("invalid_json_for_%s", _ENV_TENANT_POLICIES)
+        return None
+    if not isinstance(data, dict):
+        return None
+    frag = data.get(tenant_id)
+    return frag if isinstance(frag, dict) else None
+
+
+def _policy_from_merged_dict(tenant_id: str, merged: dict[str, Any]) -> TenantLLMPolicy:
+    payload = {**merged, "tenant_id": tenant_id}
+    return TenantLLMPolicy.model_validate(payload)
+
+
+def get_tenant_llm_policy(tenant_id: str, session: Session | None = None) -> TenantLLMPolicy:
+    """
+    Standard-Policy für alle Provider; Merge-Reihenfolge:
+    1) default_tenant_llm_policy
+    2) COMPLIANCEHUB_LLM_TENANT_POLICIES_JSON[tenant_id]
+    3) tenant_llm_policy_overrides.policy_json (wenn session und Zeile vorhanden)
+    """
+    base = default_tenant_llm_policy(tenant_id).model_dump(mode="json")
+    merged = dict(base)
+
+    env_frag = _load_env_tenant_fragment(tenant_id)
+    if env_frag:
+        merged = _deep_merge_dict(merged, env_frag)
+
+    if session is not None:
+        from app.repositories.tenant_llm_policy_override import TenantLLMPolicyOverrideRepository
+
+        repo = TenantLLMPolicyOverrideRepository(session)
+        db_frag = repo.get_partial_dict(tenant_id)
+        if db_frag:
+            merged = _deep_merge_dict(merged, db_frag)
+
+    return _policy_from_merged_dict(tenant_id, merged)

--- a/app/services/tenant_provisioning.py
+++ b/app/services/tenant_provisioning.py
@@ -24,6 +24,11 @@ _PILOT_DEFAULT_FLAGS: dict[str, bool] = {
     FeatureFlag.guided_setup.value: True,
     FeatureFlag.pilot_runbook.value: True,
     FeatureFlag.api_keys_ui.value: True,
+    FeatureFlag.llm_enabled.value: False,
+    FeatureFlag.llm_legal_reasoning.value: False,
+    FeatureFlag.llm_report_assistant.value: False,
+    FeatureFlag.llm_classification_tagging.value: False,
+    FeatureFlag.llm_chat_assistant.value: False,
 }
 
 _INITIAL_KEY_NAME = "Initial Pilot Key"

--- a/app/services/tenant_usage_metrics.py
+++ b/app/services/tenant_usage_metrics.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
+from app.llm_models import LLMTaskType
+from app.repositories.llm_call_metadata import LLMCallMetadataRepository
 from app.repositories.usage_events import UsageEventRepository
 from app.services import usage_event_logger as uel
 from app.usage_metrics_models import TenantUsageMetricsResponse
@@ -28,6 +30,14 @@ def compute_tenant_usage_metrics(session: Session, tenant_id: str) -> TenantUsag
     evidence = int(counts.get(uel.EVIDENCE_UPLOADED, 0))
     actions = int(counts.get(uel.GOVERNANCE_ACTION_CREATED, 0))
     last_at = repo.last_event_at(tenant_id)
+
+    llm_repo = LLMCallMetadataRepository(session)
+    llm_by_task = llm_repo.count_by_task_since(tenant_id, since=since)
+    llm_total = sum(llm_by_task.values())
+
+    def _tc(tt: LLMTaskType) -> int:
+        return int(llm_by_task.get(tt.value, 0))
+
     return TenantUsageMetricsResponse(
         tenant_id=tenant_id,
         last_active_at=last_at,
@@ -35,4 +45,11 @@ def compute_tenant_usage_metrics(session: Session, tenant_id: str) -> TenantUsag
         advisor_views_last_30d=advisor,
         evidence_uploads_last_30d=evidence,
         actions_created_last_30d=actions,
+        llm_calls_last_30d=llm_total,
+        llm_legal_reasoning_calls_last_30d=_tc(LLMTaskType.LEGAL_REASONING),
+        llm_structured_output_calls_last_30d=_tc(LLMTaskType.STRUCTURED_OUTPUT),
+        llm_classification_calls_last_30d=_tc(LLMTaskType.CLASSIFICATION_TAGGING),
+        llm_chat_assistant_calls_last_30d=_tc(LLMTaskType.CHAT_ASSISTANT),
+        llm_embedding_calls_last_30d=_tc(LLMTaskType.EMBEDDING_RETRIEVAL),
+        llm_on_prem_sensitive_calls_last_30d=_tc(LLMTaskType.ON_PREM_SENSITIVE),
     )

--- a/app/usage_metrics_models.py
+++ b/app/usage_metrics_models.py
@@ -17,3 +17,14 @@ class TenantUsageMetricsResponse(BaseModel):
     advisor_views_last_30d: int = Field(ge=0)
     evidence_uploads_last_30d: int = Field(ge=0)
     actions_created_last_30d: int = Field(ge=0)
+    llm_calls_last_30d: int = Field(
+        default=0,
+        ge=0,
+        description="Anzahl LLM-Router-Aufrufe (nur Metadaten geloggt), letzte 30 Tage.",
+    )
+    llm_legal_reasoning_calls_last_30d: int = Field(default=0, ge=0)
+    llm_structured_output_calls_last_30d: int = Field(default=0, ge=0)
+    llm_classification_calls_last_30d: int = Field(default=0, ge=0)
+    llm_chat_assistant_calls_last_30d: int = Field(default=0, ge=0)
+    llm_embedding_calls_last_30d: int = Field(default=0, ge=0)
+    llm_on_prem_sensitive_calls_last_30d: int = Field(default=0, ge=0)

--- a/docs/llm-routing.md
+++ b/docs/llm-routing.md
@@ -1,0 +1,79 @@
+# LLM-Routing in Compliance Hub
+
+Enterprise-Router für mandantenfähige Modellwahl (Qualität, Kosten, Datenschutz) mit Feature-Flags und Metadaten-Logging **ohne** Speicherung von Prompt- oder Response-Inhalten.
+
+## Task-Typen (`LLMTaskType`)
+
+| Task | Typische Nutzung | Standard-Präferenz (wenn Policy nichts anderes vorgibt) |
+|------|------------------|---------------------------------------------------------|
+| `legal_reasoning` | Norm-Mapping, Art.-Analysen, Audit-Texte | Claude, dann OpenAI |
+| `structured_output` | JSON/Markdown, Reports, Exporte | OpenAI (GPT-4o), dann Claude |
+| `classification_tagging` | Kategorien, Stichworte, Heuristiken | Gemini, dann OpenAI |
+| `chat_assistant` | Interaktive UI-Hilfe | OpenAI, dann Claude |
+| `embedding_retrieval` | RAG-Embeddings | Llama (on-prem), dann OpenAI Embeddings |
+| `on_prem_sensitive` | Daten ohne Public-Internet | **nur** Llama; Fehler ohne `LLAMA_BASE_URL` |
+
+Bei `cost_sensitivity=high` oder `latency_sensitivity=high` werden für `classification_tagging` und `chat_assistant` Gemini bevorzugt.
+
+## Provider (`LLMProvider`)
+
+- `claude` – Anthropic Messages API (`CLAUDE_API_KEY` oder `ANTHROPIC_API_KEY`)
+- `openai` – Chat Completions / Embeddings (`OPENAI_API_KEY`, optional `OPENAI_BASE_URL`)
+- `gemini` – Google Generative Language API (`GEMINI_API_KEY` oder `GOOGLE_API_KEY`)
+- `llama` – OpenAI-kompatibler Endpunkt (`LLAMA_BASE_URL`, optional `LLAMA_API_KEY`)
+
+Modelle (überschreibbar): `COMPLIANCEHUB_CLAUDE_MODEL`, `COMPLIANCEHUB_OPENAI_MODEL`, `COMPLIANCEHUB_GEMINI_MODEL`, `COMPLIANCEHUB_LLAMA_MODEL`, `COMPLIANCEHUB_OPENAI_EMBEDDING_MODEL`, `COMPLIANCEHUB_LLAMA_EMBEDDING_MODEL`.
+
+## Mandanten-Policy (`TenantLLMPolicy`)
+
+Felder (Auszug):
+
+- `allowed_providers` – erlaubte Provider
+- `default_provider_by_task` – Override der Standardkette pro Task
+- `require_on_prem_for_sensitive` – wenn `true`, wird `legal_reasoning` mit Llama **zuerst** versucht
+- `cost_sensitivity` / `latency_sensitivity` – `low` | `medium` | `high`
+- `data_residency` – `us_cloud_allowed` | `eu_only`
+- `public_api_policy` – `public_api_allowed` | `on_prem_only`
+
+### Konfiguration
+
+1. **Standard** – alle Provider erlaubt (siehe `app/services/tenant_llm_policy.py`).
+2. **ENV-Map** – `COMPLIANCEHUB_LLM_TENANT_POLICIES_JSON`: JSON-Objekt `{ "<tenant_id>": { ...partial policy... } }` (deep-merge mit Standard).
+3. **Datenbank** – Tabelle `tenant_llm_policy_overrides`: Spalte `policy_json` (Partial-JSON, gleiches Merge-Verhalten), wenn eine `Session` an `get_tenant_llm_policy` übergeben wird.
+
+## Datenschutz / Region (Annahmen)
+
+- `eu_only`: Ohne weitere Freigabe werden nur **Llama**-Routen genutzt (on-prem unter Ihrer Kontrolle).
+- Optional: `COMPLIANCEHUB_LLM_ASSUME_CLAUDE_EU=true` – Betreiber bestätigt EU-konforme Claude-Verarbeitung.
+- Optional: `COMPLIANCEHUB_LLM_US_CLOUD_OK=true` – Betreiber bestätigt zulässige Nutzung von US-SaaS-APIs (OpenAI/Gemini) trotz `eu_only` (z. B. eigene EU-Residency-Verträge).
+
+`public_api_policy=on_prem_only` erlaubt nur noch **Llama** (sofern konfiguriert).
+
+## Feature-Flags
+
+Backend (`COMPLIANCEHUB_FEATURE_*`, Standard siehe `app/feature_flags.py`):
+
+- `COMPLIANCEHUB_FEATURE_LLM_ENABLED` – **Standard: aus** (`false`)
+- `COMPLIANCEHUB_FEATURE_LLM_LEGAL_REASONING`
+- `COMPLIANCEHUB_FEATURE_LLM_REPORT_ASSISTANT` (u. a. strukturierte Outputs / Advisor-Summary)
+- `COMPLIANCEHUB_FEATURE_LLM_CLASSIFICATION_TAGGING`
+- `COMPLIANCEHUB_FEATURE_LLM_CHAT_ASSISTANT`
+
+Frontend-Hinweis: `NEXT_PUBLIC_FEATURE_LLM_ENABLED` (Standard aus).
+
+## API
+
+- `POST /api/v1/llm/invoke` – Body `{ "task_type": "<LLMTaskType>", "prompt": "..." }`, Mandanten-Auth wie üblich. Erfordert `llm_enabled` und das jeweilige Task-Flag.
+
+## Observability
+
+- Tabelle `llm_call_metadata`: `tenant_id`, `task_type`, `provider`, `model_id`, Längen, Latenz, Token-Schätzungen – **keine** Inhalte.
+- Usage-Metriken (`GET .../usage-metrics`): `llm_calls_last_30d` und Aufschlüsselung nach Task-Typ.
+
+## Integration im Produktcode
+
+- Router: `LLMRouter(session=...).route_and_call(task_type, prompt, tenant_id, **kwargs)`
+- Hooks: `app/services/llm_compliance_tasks.py` (Legal/Structured/Classification-Assist)
+- Advisor-Steckbrief: optional `executive_summary_narrative` aus denselben Kennzahlen (Feature `llm_report_assistant`)
+
+Die deterministische EU-AI-Act-Klassifikation (`classification_engine`) bleibt unverändert; LLM liefert höchstens ergänzende Textvorschläge.

--- a/frontend/src/lib/config.test.ts
+++ b/frontend/src/lib/config.test.ts
@@ -7,6 +7,7 @@ import {
   featureEvidencePreviewBadge,
   featureEvidenceUploads,
   featureGuidedSetup,
+  featureLlmEnabled,
   featurePilotRunbook,
 } from "./config";
 
@@ -18,6 +19,7 @@ const envKeys = [
   "NEXT_PUBLIC_FEATURE_EVIDENCE_PREVIEW_BADGE",
   "NEXT_PUBLIC_FEATURE_PILOT_RUNBOOK",
   "NEXT_PUBLIC_FEATURE_API_KEYS_UI",
+  "NEXT_PUBLIC_FEATURE_LLM_ENABLED",
 ] as const;
 
 describe("feature flags from env", () => {
@@ -51,6 +53,7 @@ describe("feature flags from env", () => {
     expect(featureEvidencePreviewBadge()).toBe(false);
     expect(featurePilotRunbook()).toBe(true);
     expect(featureApiKeysUi()).toBe(true);
+    expect(featureLlmEnabled()).toBe(false);
   });
 
   it("parses common false/true tokens", () => {

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -46,3 +46,8 @@ export function featurePilotRunbook(): boolean {
 export function featureApiKeysUi(): boolean {
   return envBool(process.env.NEXT_PUBLIC_FEATURE_API_KEYS_UI, true);
 }
+
+/** Globaler Schalter für LLM-/Router-Funktionen (Client-Hinweise; Backend erzwingt separat). */
+export function featureLlmEnabled(): boolean {
+  return envBool(process.env.NEXT_PUBLIC_FEATURE_LLM_ENABLED, false);
+}

--- a/tests/test_llm_router.py
+++ b/tests/test_llm_router.py
@@ -1,0 +1,180 @@
+"""LLM-Router: Policies, Residency, Fallbacks, Metadaten-Logging."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import SessionLocal
+from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.llm_models import (
+    CostSensitivity,
+    DataResidencyPolicy,
+    LLMProvider,
+    LLMResponse,
+    LLMTaskType,
+    PublicApiPolicy,
+)
+from app.main import app
+from app.repositories.llm_call_metadata import LLMCallMetadataRepository
+from app.services import llm_client, tenant_llm_policy
+from app.services.llm_router import LLMRouter, filter_candidates, preference_chain
+from app.services.tenant_llm_policy import default_tenant_llm_policy
+
+client = TestClient(app)
+
+
+def test_llm_master_feature_defaults_off() -> None:
+    assert is_feature_enabled(FeatureFlag.llm_enabled) is False
+
+
+def test_preference_chain_legal_reasoning_claude_first() -> None:
+    p = default_tenant_llm_policy("t1")
+    chain = preference_chain(LLMTaskType.LEGAL_REASONING, p)
+    assert chain[0] == LLMProvider.CLAUDE
+
+
+def test_preference_chain_structured_output_openai_first() -> None:
+    p = default_tenant_llm_policy("t1")
+    chain = preference_chain(LLMTaskType.STRUCTURED_OUTPUT, p)
+    assert chain[0] == LLMProvider.OPENAI
+
+
+def test_cost_sensitivity_high_gemini_first_for_classification() -> None:
+    p = default_tenant_llm_policy("t1")
+    p = p.model_copy(update={"cost_sensitivity": CostSensitivity.HIGH})
+    chain = preference_chain(LLMTaskType.CLASSIFICATION_TAGGING, p)
+    assert chain[0] == LLMProvider.GEMINI
+
+
+def test_filter_eu_only_keeps_llama_without_us_attestation(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COMPLIANCEHUB_LLM_ASSUME_CLAUDE_EU", raising=False)
+    monkeypatch.delenv("COMPLIANCEHUB_LLM_US_CLOUD_OK", raising=False)
+    monkeypatch.setenv("LLAMA_BASE_URL", "http://127.0.0.1:11434")
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    p = default_tenant_llm_policy("t1").model_copy(
+        update={"data_residency": DataResidencyPolicy.EU_ONLY},
+    )
+    ordered = preference_chain(LLMTaskType.LEGAL_REASONING, p)
+    c = filter_candidates(p, ordered)
+    assert c == [LLMProvider.LLAMA]
+
+
+def test_filter_on_prem_only_public_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("LLAMA_BASE_URL", "http://127.0.0.1:11434")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-x")
+    p = default_tenant_llm_policy("t1").model_copy(
+        update={"public_api_policy": PublicApiPolicy.ON_PREM_ONLY},
+    )
+    ordered = preference_chain(LLMTaskType.CHAT_ASSISTANT, p)
+    c = filter_candidates(p, ordered)
+    assert c == [LLMProvider.LLAMA]
+
+
+def test_router_skips_unconfigured_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_LEGAL_REASONING", "true")
+    monkeypatch.delenv("CLAUDE_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    def fake_call(
+        provider: LLMProvider,
+        model_id: str,
+        prompt: str,
+        **kwargs: object,
+    ) -> LLMResponse:
+        return LLMResponse(text="ok", provider=provider, model_id=model_id)
+
+    router = LLMRouter(session=None, call_model_fn=fake_call)
+    resp = router.route_and_call(LLMTaskType.LEGAL_REASONING, "ping", "tenant-routing-1")
+    assert resp.text == "ok"
+    assert resp.provider == LLMProvider.OPENAI
+
+
+def test_router_fallback_on_provider_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_LEGAL_REASONING", "true")
+    monkeypatch.setenv("CLAUDE_API_KEY", "k")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    def fake_call(
+        provider: LLMProvider,
+        model_id: str,
+        prompt: str,
+        **kwargs: object,
+    ) -> LLMResponse:
+        if provider == LLMProvider.CLAUDE:
+            raise llm_client.LLMProviderHTTPError("upstream")
+        return LLMResponse(text="fallback", provider=provider, model_id=model_id)
+
+    router = LLMRouter(session=None, call_model_fn=fake_call)
+    resp = router.route_and_call(LLMTaskType.LEGAL_REASONING, "ping", "tenant-routing-2")
+    assert resp.provider == LLMProvider.OPENAI
+    assert resp.text == "fallback"
+
+
+def test_on_prem_sensitive_requires_llama_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.delenv("LLAMA_BASE_URL", raising=False)
+    router = LLMRouter(session=None)
+    with pytest.raises(llm_client.LLMConfigurationError, match="ON_PREM_SENSITIVE"):
+        router.route_and_call(LLMTaskType.ON_PREM_SENSITIVE, "x", "t-prem")
+
+
+def test_metadata_inserted_when_session_provided(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_CLASSIFICATION_TAGGING", "true")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key-for-routing")
+
+    def fake_call(
+        provider: LLMProvider,
+        model_id: str,
+        prompt: str,
+        **kwargs: object,
+    ) -> LLMResponse:
+        return LLMResponse(text="abc", provider=provider, model_id=model_id)
+
+    tid = "llm-meta-tenant"
+    s = SessionLocal()
+    try:
+        router = LLMRouter(session=s, call_model_fn=fake_call)
+        router.route_and_call(LLMTaskType.CLASSIFICATION_TAGGING, "hello-world", tid)
+        repo = LLMCallMetadataRepository(s)
+        since = datetime.now(UTC) - timedelta(minutes=5)
+        assert repo.count_since(tid, since=since) >= 1
+    finally:
+        s.close()
+
+
+def test_get_tenant_llm_policy_from_env_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(
+        "COMPLIANCEHUB_LLM_TENANT_POLICIES_JSON",
+        json.dumps(
+            {
+                "tenant-pol-env": {
+                    "allowed_providers": ["openai"],
+                    "default_provider_by_task": {"legal_reasoning": "openai"},
+                },
+            },
+        ),
+    )
+    p = tenant_llm_policy.get_tenant_llm_policy("tenant-pol-env", None)
+    assert p.allowed_providers == [LLMProvider.OPENAI]
+    assert p.default_provider_by_task[LLMTaskType.LEGAL_REASONING] == LLMProvider.OPENAI
+
+
+def test_llm_invoke_forbidden_when_master_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "false")
+    r = client.post(
+        "/api/v1/llm/invoke",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": "llm-api-tenant"},
+        json={"task_type": "chat_assistant", "prompt": "hi"},
+    )
+    assert r.status_code == 403

--- a/tests/test_pilot_onboarding.py
+++ b/tests/test_pilot_onboarding.py
@@ -37,6 +37,8 @@ def test_provision_tenant_sets_defaults_and_initial_key() -> None:
     assert flags["evidence_uploads"] is True
     assert flags.get("pilot_runbook") is True
     assert flags.get("api_keys_ui") is True
+    assert flags.get("llm_enabled") is False
+    assert flags.get("llm_legal_reasoning") is False
     ikey = body["initial_api_key"]
     assert ikey["name"] == "Initial Pilot Key"
     assert len(ikey["plain_key"]) > 20


### PR DESCRIPTION
Add typed LLMTaskType/LLMProvider domain model, TenantLLMPolicy (ENV + DB overrides), httpx-based multi-provider client, and LLMRouter with residency and cost/latency heuristics. Persist call metadata only (no prompt/response content), extend usage metrics, feature flags (llm master off by default), optional advisor executive summary, POST /api/v1/llm/invoke, and docs.

Made-with: Cursor