### PR TITLE
feat: Demo-Modus, Playground-Vorbereitung und erweiterter Demo-Seed

### DIFF
--- a/app/auth_dependencies.py
+++ b/app/auth_dependencies.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.db import get_session
+from app.demo_tenant_write_guard import ensure_tenant_writes_allowed_if_not_demo
 from app.repositories.tenant_api_keys import TenantApiKeyRepository
 from app.security import AuthContext, get_settings
 
@@ -50,20 +51,24 @@ def resolve_tenant_id_for_api_key(
 
 
 def get_api_key_and_tenant(
+    request: Request,
     session: Annotated[Session, Depends(get_session)],
     x_api_key: Annotated[str | None, Header(alias="x-api-key")] = None,
     x_tenant_id: Annotated[str | None, Header(alias="x-tenant-id")] = None,
 ) -> str:
     tid, _ = resolve_tenant_id_for_api_key(session, x_api_key, x_tenant_id)
+    ensure_tenant_writes_allowed_if_not_demo(request, session, tid)
     return tid
 
 
 def get_auth_context(
+    request: Request,
     session: Annotated[Session, Depends(get_session)],
     x_api_key: Annotated[str | None, Header(alias="x-api-key")] = None,
     x_tenant_id: Annotated[str | None, Header(alias="x-tenant-id")] = None,
 ) -> AuthContext:
     tid, key = resolve_tenant_id_for_api_key(session, x_api_key, x_tenant_id)
+    ensure_tenant_writes_allowed_if_not_demo(request, session, tid)
     return AuthContext(tenant_id=tid, api_key=key)
 
 

--- a/app/demo_models.py
+++ b/app/demo_models.py
@@ -25,3 +25,19 @@ class DemoSeedResponse(BaseModel):
     policy_rows_count: int
     classifications_count: int
     advisor_linked: bool
+    board_reports_count: int = 0
+    ai_kpi_value_rows_count: int = 0
+    cross_reg_control_rows_count: int = 0
+
+
+class TenantWorkspaceMetaResponse(BaseModel):
+    """Öffentliche Mandanten-Stammdaten für Workspace-UI (keine Secrets)."""
+
+    tenant_id: str
+    display_name: str
+    is_demo: bool
+    demo_playground: bool
+    demo_mode_feature_enabled: bool = Field(
+        default=False,
+        description="COMPLIANCEHUB_FEATURE_DEMO_MODE – spiegelt Server-ENV für UI-Kohärenz.",
+    )

--- a/app/demo_tenant_write_guard.py
+++ b/app/demo_tenant_write_guard.py
@@ -1,0 +1,25 @@
+"""Schreibschutz für Demo-Mandanten (is_demo), optional aufgehoben bei demo_playground."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+from sqlalchemy.orm import Session
+
+from app.repositories.tenant_registry import TenantRegistryRepository
+
+
+def ensure_tenant_writes_allowed_if_not_demo(
+    request: Request,
+    session: Session,
+    tenant_id: str,
+) -> None:
+    if request.method in ("GET", "HEAD", "OPTIONS", "TRACE"):
+        return
+    row = TenantRegistryRepository(session).get_by_id(tenant_id)
+    if row is None:
+        return
+    if row.is_demo and not row.demo_playground:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This demo tenant is read-only. Use a non-demo workspace to persist changes.",
+        )

--- a/app/feature_flags.py
+++ b/app/feature_flags.py
@@ -34,6 +34,7 @@ class FeatureFlag(StrEnum):
     ai_governance_setup_wizard = "ai_governance_setup_wizard"
     advisor_client_snapshot = "advisor_client_snapshot"
     readiness_score = "readiness_score"
+    demo_mode = "demo_mode"
 
 
 _FLAG_ENV_KEYS: dict[FeatureFlag, str] = {
@@ -61,6 +62,7 @@ _FLAG_ENV_KEYS: dict[FeatureFlag, str] = {
     FeatureFlag.ai_governance_setup_wizard: "COMPLIANCEHUB_FEATURE_AI_GOVERNANCE_SETUP_WIZARD",
     FeatureFlag.advisor_client_snapshot: "COMPLIANCEHUB_FEATURE_ADVISOR_CLIENT_SNAPSHOT",
     FeatureFlag.readiness_score: "COMPLIANCEHUB_FEATURE_READINESS_SCORE",
+    FeatureFlag.demo_mode: "COMPLIANCEHUB_FEATURE_DEMO_MODE",
 }
 
 # LLM master switch defaults off until keys and policies are configured.
@@ -69,6 +71,7 @@ _FLAG_DEFAULTS: dict[FeatureFlag, bool] = {
     FeatureFlag.llm_kpi_suggestions: False,
     FeatureFlag.llm_explain: False,
     FeatureFlag.llm_action_drafts: False,
+    FeatureFlag.demo_mode: False,
 }
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -120,8 +120,8 @@ from app.cross_regulation_models import (
     RequirementControlsDetailResponse,
 )
 from app.db import engine, get_session
-from app.demo_models import DemoSeedRequest, DemoSeedResponse
-from app.demo_templates import DemoTenantTemplate, list_demo_tenant_templates
+from app.demo_models import DemoSeedRequest, DemoSeedResponse, TenantWorkspaceMetaResponse
+from app.demo_templates import DemoTenantTemplate, get_demo_template, list_demo_tenant_templates
 from app.eu_ai_act_readiness_models import EUAIActReadinessOverview
 from app.evidence_models import EvidenceFile, EvidenceFileListResponse
 from app.explain_models import ExplainRequest, ExplainResponse
@@ -173,6 +173,7 @@ from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
 from app.repositories.policies import PolicyRepository
 from app.repositories.tenant_ai_governance_setup import TenantAIGovernanceSetupRepository
 from app.repositories.tenant_api_keys import TenantApiKeyRepository
+from app.repositories.tenant_registry import TenantRegistryRepository
 from app.repositories.violations import ViolationRepository
 from app.security import (
     AuthContext,
@@ -2910,6 +2911,19 @@ def post_demo_tenant_seed(
     Nur für tenant_id in COMPLIANCEHUB_DEMO_SEED_TENANT_IDS und mit Demo-Seed-API-Key.
     """
     ensure_demo_tenant_seed_allowed(body.tenant_id)
+    reg = TenantRegistryRepository(session)
+    if reg.get_by_id(body.tenant_id) is None:
+        tmpl = get_demo_template(body.template_key)
+        reg.create(
+            tenant_id=body.tenant_id,
+            display_name=(tmpl.name if tmpl else body.tenant_id)[:255],
+            industry=(tmpl.industry if tmpl else "Demo")[:128],
+            country=(tmpl.country if tmpl else "DE")[:64],
+            nis2_scope="in_scope",
+            ai_act_scope="in_scope",
+            is_demo=True,
+            demo_playground=False,
+        )
     try:
         result = seed_demo_tenant(
             session,
@@ -2954,6 +2968,26 @@ def get_tenant_compliance_overview(
     return compute_tenant_compliance_overview(
         tenant_id=auth_context.tenant_id,
         session=session,
+    )
+
+
+@app.get("/api/v1/workspace/tenant-meta", response_model=TenantWorkspaceMetaResponse)
+def get_workspace_tenant_meta(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+) -> TenantWorkspaceMetaResponse:
+    row = TenantRegistryRepository(session).get_by_id(auth_context.tenant_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not registered",
+        )
+    return TenantWorkspaceMetaResponse(
+        tenant_id=row.id,
+        display_name=row.display_name,
+        is_demo=bool(row.is_demo),
+        demo_playground=bool(row.demo_playground),
+        demo_mode_feature_enabled=is_feature_enabled(FeatureFlag.demo_mode),
     )
 
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -29,6 +29,8 @@ class TenantDB(Base):
     country: Mapped[str] = mapped_column(String(64), nullable=False, default="DE")
     nis2_scope: Mapped[str] = mapped_column(String(64), nullable=False, default="in_scope")
     ai_act_scope: Mapped[str] = mapped_column(String(64), nullable=False, default="in_scope")
+    is_demo: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    demo_playground: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     created_at_utc: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=datetime.utcnow,

--- a/app/repositories/tenant_registry.py
+++ b/app/repositories/tenant_registry.py
@@ -25,6 +25,8 @@ class TenantRegistryRepository:
         country: str,
         nis2_scope: str,
         ai_act_scope: str,
+        is_demo: bool = False,
+        demo_playground: bool = False,
     ) -> TenantDB:
         row = TenantDB(
             id=tenant_id,
@@ -33,6 +35,8 @@ class TenantRegistryRepository:
             country=country,
             nis2_scope=nis2_scope,
             ai_act_scope=ai_act_scope,
+            is_demo=is_demo,
+            demo_playground=demo_playground,
             created_at_utc=datetime.now(UTC),
         )
         self._session.add(row)

--- a/app/services/demo_tenant_seed_extras.py
+++ b/app/services/demo_tenant_seed_extras.py
@@ -1,0 +1,210 @@
+"""Zusatz-Seed für Demo-Mandanten: KPI-Zeitreihen, Cross-Reg-Coverage, Wizard, Board-Reports."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import NAMESPACE_DNS, uuid5
+
+from sqlalchemy import select
+
+from app.models_db import (
+    ComplianceControlDB,
+    ComplianceFrameworkDB,
+    ComplianceRequirementControlLinkDB,
+    ComplianceRequirementDB,
+)
+from app.repositories.ai_compliance_board_reports import AiComplianceBoardReportRepository
+from app.repositories.ai_kpis import AiKpiRepository
+from app.repositories.tenant_ai_governance_setup import TenantAIGovernanceSetupRepository
+from app.services.ai_kpi_seed import ensure_ai_kpi_definitions_seeded
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def _control_id(tenant_id: str, slug: str) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"compliancehub:demo:{tenant_id}:{slug}"))
+
+
+_DEMO_KPI_PERIODS: tuple[tuple[datetime, datetime], ...] = (
+    (datetime(2025, 10, 1, tzinfo=UTC), datetime(2025, 10, 31, 23, 59, 59, tzinfo=UTC)),
+    (datetime(2025, 11, 1, tzinfo=UTC), datetime(2025, 11, 30, 23, 59, 59, tzinfo=UTC)),
+)
+
+
+def _definition_ids_by_keys(session: Session, keys: tuple[str, ...]) -> dict[str, str]:
+    repo = AiKpiRepository(session)
+    defs = repo.list_definitions()
+    by_key = {d.key: str(d.id) for d in defs}
+    out: dict[str, str] = {}
+    for k in keys:
+        if k in by_key:
+            out[k] = by_key[k]
+    return out
+
+
+def _eu_ai_act_requirement_ids(session: Session, codes: tuple[str, ...]) -> dict[str, int]:
+    fw = session.scalars(
+        select(ComplianceFrameworkDB).where(ComplianceFrameworkDB.key == "eu_ai_act"),
+    ).one()
+    rows = session.scalars(
+        select(ComplianceRequirementDB).where(
+            ComplianceRequirementDB.framework_id == int(fw.id),
+            ComplianceRequirementDB.code.in_(codes),
+        ),
+    ).all()
+    return {r.code: int(r.id) for r in rows}
+
+
+def apply_demo_seed_extensions(
+    session: Session,
+    tenant_id: str,
+    *,
+    primary_ai_system_id: str,
+    secondary_ai_system_id: str,
+) -> dict[str, int]:
+    """
+    Idempotent genug für leere Mandanten nach dem Kern-Seed: legt fehlende Artefakte an.
+    """
+    ensure_ai_kpi_definitions_seeded(session)
+    kpi_repo = AiKpiRepository(session)
+    def_ids = _definition_ids_by_keys(session, ("incident_rate_ai", "drift_indicator"))
+    kpi_rows = 0
+    for key in ("incident_rate_ai", "drift_indicator"):
+        kid = def_ids.get(key)
+        if not kid:
+            continue
+        for idx, (ps, pe) in enumerate(_DEMO_KPI_PERIODS):
+            base = 1.2 + (0.35 * idx) if key == "incident_rate_ai" else 28.0 + (3.0 * idx)
+            kpi_repo.upsert_value(
+                tenant_id=tenant_id,
+                ai_system_id=primary_ai_system_id,
+                kpi_definition_id=kid,
+                period_start=ps,
+                period_end=pe,
+                value=float(base),
+                source="demo-seed",
+                comment="Demo trend",
+                new_id=str(uuid.uuid4()),
+            )
+            kpi_rows += 1
+
+    req_map = _eu_ai_act_requirement_ids(session, ("Art.9", "Art.11", "Art.12"))
+    ctrl_specs: list[tuple[str, str, str, str, list[tuple[str, str]]]] = [
+        (
+            _control_id(tenant_id, "rm"),
+            "Risikomanagement-Framework KI (Demo)",
+            "Rollen, Methodik und Nachweise zum EU-AI-Act-Art.-9-Bezug.",
+            "implemented",
+            [("Art.9", "partial")],
+        ),
+        (
+            _control_id(tenant_id, "tdoc"),
+            "Technische Dokumentation (Auszug)",
+            "Struktur und Freigabeprozess – noch nicht vollständig für alle Systeme.",
+            "planned",
+            [("Art.11", "partial")],
+        ),
+        (
+            _control_id(tenant_id, "log"),
+            "Logging & Aufbewahrung KI-Betrieb",
+            "Zentrale Vorgaben; Umsetzung für Teilsysteme offen.",
+            "planned",
+            [("Art.12", "partial")],
+        ),
+    ]
+    ctrl_count = 0
+    for cid, name, desc, st, links in ctrl_specs:
+        existing = session.get(ComplianceControlDB, cid)
+        if existing is None:
+            session.add(
+                ComplianceControlDB(
+                    id=cid,
+                    tenant_id=tenant_id,
+                    name=name,
+                    description=desc,
+                    control_type="process",
+                    owner_role="CISO",
+                    status=st,
+                ),
+            )
+            session.commit()
+            ctrl_count += 1
+        for code, level in links:
+            rid = req_map.get(code)
+            if rid is None:
+                continue
+            stmt = select(ComplianceRequirementControlLinkDB).where(
+                ComplianceRequirementControlLinkDB.requirement_id == rid,
+                ComplianceRequirementControlLinkDB.control_id == cid,
+            )
+            if session.execute(stmt).scalar_one_or_none() is None:
+                session.add(
+                    ComplianceRequirementControlLinkDB(
+                        requirement_id=rid,
+                        control_id=cid,
+                        coverage_level=level,
+                    ),
+                )
+                session.commit()
+
+    setup_repo = TenantAIGovernanceSetupRepository(session)
+    payload = {
+        "tenant_kind": "manufacturing_sme",
+        "compliance_scopes": ["eu_ai_act", "nis2", "iso_42001"],
+        "governance_roles": {"ciso": "demo.ciso@example.com", "dpo": "demo.dpo@example.com"},
+        "active_frameworks": ["eu_ai_act", "nis2", "iso_42001"],
+        "steps_marked_complete": [1, 2, 3, 4, 5],
+        "flags": {
+            "gap_assist_previewed": True,
+            "board_report_created": False,
+        },
+    }
+    setup_repo.upsert_payload(tenant_id, payload)
+
+    report_repo = AiComplianceBoardReportRepository(session)
+    existing_n = len(report_repo.list_for_tenant(tenant_id, limit=5))
+    board_n = 0
+    if existing_n < 2:
+        samples = [
+            (
+                "AI Compliance Board-Report (Demo) – Q1",
+                "board",
+                "## Executive Summary (Demo)\n\n"
+                "Mandant zeigt solide Grundlagen in Klassifikation und NIS2-KPIs; "
+                "Lücken bei Lieferketten-Nachweisen und technischer Dokumentation.\n\n"
+                "### Empfehlungen\n"
+                "- Supplier-Register für Hochrisiko-KI schließen.\n"
+                "- Logging-Konzept mit Fachbereich abstimmen.\n",
+            ),
+            (
+                "Management-Update KI-Governance (Demo)",
+                "management",
+                "## Kurzüberblick\n\n"
+                f"Fokus-KI-Systeme inkl. **{primary_ai_system_id}** und "
+                f"**{secondary_ai_system_id}**; Cross-Regulation-Gaps sind sichtbar "
+                "im Dashboard.\n",
+            ),
+        ]
+        for title, aud, md in samples[existing_n:]:
+            report_repo.create(
+                tenant_id=tenant_id,
+                created_by="demo-seed",
+                title=title,
+                audience_type=aud,
+                raw_payload={
+                    "version": 1,
+                    "demo": True,
+                    "primary_ai_system_id": primary_ai_system_id,
+                },
+                rendered_markdown=md,
+            )
+            board_n += 1
+
+    return {
+        "ai_kpi_value_rows_count": kpi_rows,
+        "cross_reg_control_rows_count": ctrl_count,
+        "board_reports_count": board_n,
+    }

--- a/app/services/demo_tenant_seeder.py
+++ b/app/services/demo_tenant_seeder.py
@@ -33,6 +33,7 @@ from app.repositories.classifications import ClassificationRepository
 from app.repositories.evidence_files import EvidenceFileRepository
 from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
 from app.repositories.policies import PolicyRepository
+from app.services.demo_tenant_seed_extras import apply_demo_seed_extensions
 from app.services.evidence_storage import EvidenceStorageBackend, get_evidence_storage
 
 
@@ -523,6 +524,13 @@ def seed_demo_tenant(
         or 0,
     )
 
+    extra = apply_demo_seed_extensions(
+        session,
+        tenant_id,
+        primary_ai_system_id=primary,
+        secondary_ai_system_id=secondary,
+    )
+
     return DemoSeedResponse(
         template_key=template_key,
         tenant_id=tenant_id,
@@ -533,4 +541,7 @@ def seed_demo_tenant(
         policy_rows_count=n_policies,
         classifications_count=n_class,
         advisor_linked=advisor_linked,
+        board_reports_count=int(extra.get("board_reports_count", 0)),
+        ai_kpi_value_rows_count=int(extra.get("ai_kpi_value_rows_count", 0)),
+        cross_reg_control_rows_count=int(extra.get("cross_reg_control_rows_count", 0)),
     )

--- a/app/services/tenant_provisioning.py
+++ b/app/services/tenant_provisioning.py
@@ -17,7 +17,7 @@ from app.repositories.tenant_api_keys import TenantApiKeyRepository
 from app.repositories.tenant_feature_overrides import TenantFeatureOverrideRepository
 from app.repositories.tenant_registry import TenantRegistryRepository
 
-_PILOT_DEFAULT_FLAGS: dict[str, bool] = {
+PILOT_TENANT_FEATURE_DEFAULTS: dict[str, bool] = {
     FeatureFlag.advisor_workspace.value: False,
     FeatureFlag.advisor_client_snapshot.value: True,
     FeatureFlag.readiness_score.value: True,
@@ -68,7 +68,7 @@ def provision_tenant(session: Session, body: ProvisionTenantRequest) -> Provisio
         ai_act_scope=body.ai_act_scope.strip() or "in_scope",
     )
 
-    flags_repo.set_many(tenant_id, dict(_PILOT_DEFAULT_FLAGS))
+    flags_repo.set_many(tenant_id, dict(PILOT_TENANT_FEATURE_DEFAULTS))
 
     key_row, plain = keys_repo.create_key(tenant_id=tenant_id, name=_INITIAL_KEY_NAME)
 

--- a/docs/demo-playground.md
+++ b/docs/demo-playground.md
@@ -1,0 +1,96 @@
+# Demo-Modus & Playground
+
+ComplianceHub unterstützt **geführte Demos** (Sales, Founder, Berater) und die Vorbereitung eines **read-only Playgrounds** für Website-Leads.
+
+## Aktivierung
+
+### Backend
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `COMPLIANCEHUB_FEATURE_DEMO_MODE=true` | Server-seitig: u. a. `demo_mode_feature_enabled` in `GET /api/v1/workspace/tenant-meta` |
+| `COMPLIANCEHUB_FEATURE_DEMO_SEEDING` | Demo-Seed-API (bestehend) |
+
+### Frontend
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `NEXT_PUBLIC_FEATURE_DEMO_MODE=true` | Banner, Demo-Guide, kontextuelle Demo-Hinweise |
+| `NEXT_PUBLIC_DEMO_WORKSPACE_TENANT_ID` | Optional: bei `?demo=1` wird der Workspace-Mandant per Cookie gesetzt |
+| `NEXT_PUBLIC_DEMO_DOCS_URL` | Optional: Link „Mehr zur Demo“ im Banner (Default: Platzhalter-URL) |
+
+### Session / Einstieg
+
+- Aufruf mit **`?demo=1`** (Next.js-Middleware setzt Cookie `ch_demo_mode`).
+- Mandanten mit **`is_demo=true`** in der Tabelle `tenants` lösen die Demo-UI aus, sobald `NEXT_PUBLIC_FEATURE_DEMO_MODE` aktiv ist (ohne Query-Parameter).
+
+## Demo-Mandanten anlegen
+
+### CLI (empfohlen)
+
+Voraussetzung: Datenbank erreichbar (`COMPLIANCEHUB_DB_URL`), Kataloge beim App-Start wie in Produktion geseedet.
+
+```bash
+# Ein Preset
+python scripts/seed_demo_tenant.py --preset mittelstand-ag
+
+# Beide Standard-Demos
+python scripts/seed_demo_tenant.py --all-presets
+
+# Ohne neuen API-Key
+python scripts/seed_demo_tenant.py --preset grc-consulting --no-api-key
+```
+
+Presets:
+
+- **mittelstand-ag** → Template `industrial_sme`, Tenant-ID `demo-mittelstand-ag`
+- **grc-consulting** → Template `tax_advisor`, Tenant-ID `demo-grc-consulting`
+
+Der Seed enthält u. a. KI-Systeme (Hochrisiko/NIS2), NIS2-KPIs, AI-KPI-Zeitreihen, Cross-Regulation-Controls mit realistischen Teilabdeckungen, Setup-Wizard-Payload (Schritte 1–5), zwei Board-Reports sowie den bisherigen Kern-Seed (Policies, Maßnahmen, Evidenzen).
+
+### API (bestehend)
+
+`POST /api/v1/demo/tenants/seed` mit Demo-Seed-Key – legt bei fehlendem Eintrag eine **`tenants`-Zeile mit `is_demo=true`** an und führt den gleichen Seed aus.
+
+## Schreibschutz
+
+- **`is_demo=true`** und **`demo_playground=false`**: schreibende HTTP-Methoden für diesen Mandanten werden mit **403** abgewiesen (über Auth-Dependencies).
+- **`demo_playground=true`**: Schreiben bleibt möglich (Sandbox-Variante, z. B. für spätere Aufräum-Jobs).
+
+## Demo-Guide (Storyline)
+
+Die App zeigt optional eine **schmale Demo-Guide-Leiste** (FAB + Schrittliste). Empfohlene Reihenfolge (entspricht den Steps im UI):
+
+1. **AI & Compliance Readiness Score** – `/board/kpis`
+2. **AI Governance Playbook** – `/tenant/ai-governance-playbook`
+3. **Cross-Regulation & Gap-Assist** – `/tenant/cross-regulation-dashboard`
+4. **Hochrisiko-KI & KPIs/KRIs** – erstes Hochrisiko-System aus `/tenant/ai-systems`
+5. **AI Compliance Board-Report** – `/board/ai-compliance-report`
+6. **Berater-Portfolio** – `/advisor`
+7. **Setup-Wizard** – `/tenant/ai-governance-setup`
+
+Kontextzeile: **„Demo-Hinweis · Schritt X von 7“** erscheint auf den passenden Routen, wenn die Demo-UI aktiv ist.
+
+## Playground / Leads (Ausblick)
+
+- Sandbox-Mandant mit `is_demo=true` und `demo_playground=true`, regelmäßiges **Reset-Job** (nicht im Kern-Repo beschrieben).
+- **LLM-Budget**: für öffentliche Playgrounds Rate-Limits und niedrige Token-Budgets empfohlen (`COMPLIANCEHUB_FEATURE_LLM_*`, Mandanten-Overrides).
+
+## API: Mandanten-Meta
+
+`GET /api/v1/workspace/tenant-meta` (mit `x-api-key`, `x-tenant-id`):
+
+- `is_demo`, `demo_playground`
+- `demo_mode_feature_enabled` (Spiegel von `COMPLIANCEHUB_FEATURE_DEMO_MODE`)
+
+## Berater & Sales
+
+- Mandanten mit Demo-Seed zeigen **realistische Lücken** (Cross-Reg, NIS2, Board-Report) ohne echte Kundendaten.
+- Berater können im **Advisor-Workspace** Portfolio und Snapshots zeigen; Demo-Mandanten sind in der Regel **read-only**, um Abweichungen während der Präsentation zu vermeiden.
+
+## Datenbank-Spalten `tenants`
+
+- `is_demo` (boolean, default false)
+- `demo_playground` (boolean, default false)
+
+Bei bestehenden PostgreSQL-Instanzen ohne Auto-Migrate: Spalten manuell ergänzen (analog zum SQLAlchemy-Modell in `app/models_db.py`).

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
 import React from "react";
 
+import { DemoContextualHint } from "@/components/demo/DemoContextualHint";
+import { DemoEnvironmentBanner } from "@/components/demo/DemoEnvironmentBanner";
+import { DemoGuide } from "@/components/demo/DemoGuide";
 import { SbsFooter } from "@/components/sbs/SbsFooter";
 import { SbsHeader } from "@/components/sbs/SbsHeader";
+import { isDemoUiDesiredForTenant } from "@/lib/workspaceDemoServer";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
 
 import "./globals.css";
 
@@ -12,21 +17,27 @@ export const metadata: Metadata = {
     "Mandantenfähige GRC-Plattform: EU AI Act, NIS2, ISO 42001, Board-KPIs und DATEV-ready Exporte – DSGVO-orientiert für den DACH-Markt.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const workspaceTenantId = await getWorkspaceTenantIdServer();
+  const showDemoUi = await isDemoUiDesiredForTenant(workspaceTenantId);
+
   return (
     <html lang="de" className="scroll-smooth scroll-pt-[7.5rem]">
       <body className="sbs-body flex min-h-screen flex-col bg-slate-50 antialiased">
         <SbsHeader />
+        <DemoEnvironmentBanner visible={showDemoUi} />
         <main
           id="app-main"
           className="mx-auto w-full min-w-0 max-w-7xl flex-1 px-4 pb-16 pt-8 md:px-6 md:pb-20 md:pt-10"
         >
+          <DemoContextualHint enabled={showDemoUi} />
           {children}
         </main>
+        <DemoGuide tenantId={workspaceTenantId} enabled={showDemoUi} />
         <SbsFooter />
       </body>
     </html>

--- a/frontend/src/components/demo/DemoContextualHint.tsx
+++ b/frontend/src/components/demo/DemoContextualHint.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import React from "react";
+
+import { DEMO_GUIDE_STEPS, demoStepIndexForPath } from "@/lib/demoGuideSteps";
+
+export function DemoContextualHint({ enabled }: { enabled: boolean }) {
+  const pathname = usePathname() || "";
+  if (!enabled) {
+    return null;
+  }
+  const idx = demoStepIndexForPath(pathname);
+  if (idx === null) {
+    return null;
+  }
+  const step = DEMO_GUIDE_STEPS[idx];
+  return (
+    <div className="mb-4 rounded-lg border border-sky-200/80 bg-sky-50/90 px-3 py-2 text-sm text-sky-950">
+      <span className="font-semibold text-sky-900">Demo-Hinweis · Schritt {idx + 1} von </span>
+      <span className="font-semibold text-sky-900">{DEMO_GUIDE_STEPS.length}</span>
+      <span className="text-sky-900/90"> — {step.hint}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoEnvironmentBanner.test.tsx
+++ b/frontend/src/components/demo/DemoEnvironmentBanner.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { DemoEnvironmentBanner } from "./DemoEnvironmentBanner";
+
+describe("DemoEnvironmentBanner", () => {
+  it("rendert nichts wenn visible false", () => {
+    const { container } = render(<DemoEnvironmentBanner visible={false} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("zeigt Demo-Hinweis wenn visible true", () => {
+    render(<DemoEnvironmentBanner visible />);
+    const el = screen.getByRole("status");
+    expect(el.textContent).toContain("Demo-Umgebung");
+    expect(el.textContent).toContain("zurückgesetzt");
+  });
+});

--- a/frontend/src/components/demo/DemoEnvironmentBanner.tsx
+++ b/frontend/src/components/demo/DemoEnvironmentBanner.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+const DOC_URL_RAW = process.env.NEXT_PUBLIC_DEMO_DOCS_URL?.trim();
+const DOC_URL = DOC_URL_RAW && DOC_URL_RAW.length > 0 ? DOC_URL_RAW : null;
+
+export function DemoEnvironmentBanner({ visible }: { visible: boolean }) {
+  if (!visible) {
+    return null;
+  }
+  return (
+    <div
+      className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-sm text-amber-950"
+      role="status"
+    >
+      <span className="font-medium">Demo-Umgebung</span>
+      <span className="text-amber-900/90">
+        {" "}
+        – Änderungen werden regelmäßig zurückgesetzt. Keine produktiven oder personenbezogenen Daten
+        verwenden.
+      </span>
+      {DOC_URL ? (
+        <>
+          {" "}
+          <a
+            href={DOC_URL}
+            className="font-medium text-amber-900 underline decoration-amber-600/80 underline-offset-2 hover:text-amber-950"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Mehr zur Demo
+          </a>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/demo/DemoGuide.test.tsx
+++ b/frontend/src/components/demo/DemoGuide.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DemoGuide } from "./DemoGuide";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/tenant/ai-governance-playbook",
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe("DemoGuide", () => {
+  it("rendert nichts wenn disabled", () => {
+    const { container } = render(<DemoGuide tenantId="t1" enabled={false} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("zeigt Demo-Guide Button wenn enabled", () => {
+    render(<DemoGuide tenantId="t1" enabled />);
+    expect(screen.getByRole("button", { name: /Demo-Guide/i })).toBeTruthy();
+  });
+});

--- a/frontend/src/components/demo/DemoGuide.tsx
+++ b/frontend/src/components/demo/DemoGuide.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import React, { useCallback, useMemo, useState } from "react";
+
+import { fetchTenantAISystems } from "@/lib/api";
+import { DEMO_GUIDE_STEPS, demoStepIndexForPath } from "@/lib/demoGuideSteps";
+
+function riskIsHigh(raw: string | undefined): boolean {
+  if (!raw) {
+    return false;
+  }
+  return raw.toLowerCase().includes("high") || raw.toLowerCase() === "high";
+}
+
+export function DemoGuide({ tenantId, enabled }: { tenantId: string; enabled: boolean }) {
+  const [open, setOpen] = useState(false);
+  const router = useRouter();
+  const pathname = usePathname() || "";
+  const currentIdx = useMemo(() => demoStepIndexForPath(pathname), [pathname]);
+
+  const goStep = useCallback(
+    async (path: string, resolveHr?: boolean) => {
+      if (!resolveHr) {
+        router.push(path);
+        setOpen(false);
+        return;
+      }
+      try {
+        const systems = await fetchTenantAISystems(tenantId);
+        const hr = systems.find((s) => riskIsHigh(s.risk_level ?? s.risklevel));
+        const pick = hr ?? systems[0];
+        if (pick?.id) {
+          router.push(`/tenant/ai-systems/${encodeURIComponent(pick.id)}`);
+        } else {
+          router.push("/tenant/ai-systems");
+        }
+      } catch {
+        router.push("/tenant/ai-systems");
+      }
+      setOpen(false);
+    },
+    [router, tenantId],
+  );
+
+  const goNext = useCallback(async () => {
+    if (currentIdx === null) {
+      await goStep(DEMO_GUIDE_STEPS[0].path, DEMO_GUIDE_STEPS[0].resolveHighRiskSystem);
+      return;
+    }
+    const next = DEMO_GUIDE_STEPS[(currentIdx + 1) % DEMO_GUIDE_STEPS.length];
+    await goStep(next.path, next.resolveHighRiskSystem);
+  }, [currentIdx, goStep]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="pointer-events-none fixed bottom-6 right-4 z-40 flex flex-col items-end gap-2 md:right-6">
+        <button
+          type="button"
+          className="pointer-events-auto rounded-full border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 shadow-md hover:bg-slate-50"
+          onClick={() => setOpen(true)}
+        >
+          Demo-Guide
+        </button>
+        {currentIdx !== null ? (
+          <button
+            type="button"
+            className="pointer-events-auto rounded-full border border-indigo-200 bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow-md hover:bg-indigo-700"
+            onClick={() => void goNext()}
+          >
+            Nächster Demo-Schritt
+          </button>
+        ) : null}
+      </div>
+
+      {open ? (
+        <div className="fixed inset-0 z-50 flex justify-end bg-slate-900/40" role="dialog">
+          <div className="flex h-full w-full max-w-md flex-col bg-white shadow-xl">
+            <div className="flex items-center justify-between border-b border-slate-200 px-4 py-3">
+              <h2 className="text-lg font-semibold text-slate-900">Geführte Demo</h2>
+              <button
+                type="button"
+                className="rounded px-2 py-1 text-sm text-slate-600 hover:bg-slate-100"
+                onClick={() => setOpen(false)}
+              >
+                Schließen
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto px-4 py-3">
+              <ol className="space-y-4">
+                {DEMO_GUIDE_STEPS.map((step, i) => (
+                  <li
+                    key={step.id}
+                    className={`rounded-lg border px-3 py-2 ${
+                      currentIdx === i ? "border-indigo-300 bg-indigo-50/80" : "border-slate-200"
+                    }`}
+                  >
+                    <div className="text-xs font-bold uppercase tracking-wide text-slate-500">
+                      Schritt {i + 1}
+                    </div>
+                    <div className="font-medium text-slate-900">{step.title}</div>
+                    <p className="mt-1 text-sm text-slate-600">{step.hint}</p>
+                    <button
+                      type="button"
+                      className="mt-2 text-sm font-semibold text-indigo-700 hover:text-indigo-900"
+                      onClick={() => void goStep(step.path, step.resolveHighRiskSystem)}
+                    >
+                      Diesen Schritt öffnen →
+                    </button>
+                  </li>
+                ))}
+              </ol>
+              <p className="mt-4 text-xs text-slate-500">
+                Kurzlink mit Session-Cookie:{" "}
+                <Link href="/?demo=1" className="text-indigo-700 underline">
+                  ?demo=1
+                </Link>{" "}
+                (optional{" "}
+                <code className="rounded bg-slate-100 px-1">NEXT_PUBLIC_DEMO_WORKSPACE_TENANT_ID</code>
+                ).
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -33,6 +33,18 @@ async function tenantApiFetch(path: string, tenantId: string, init?: RequestInit
   return res.json();
 }
 
+export interface TenantWorkspaceMetaDto {
+  tenant_id: string;
+  display_name: string;
+  is_demo: boolean;
+  demo_playground: boolean;
+  demo_mode_feature_enabled: boolean;
+}
+
+export async function fetchTenantWorkspaceMeta(tenantId: string): Promise<TenantWorkspaceMetaDto> {
+  return tenantApiFetch("/api/v1/workspace/tenant-meta", tenantId) as Promise<TenantWorkspaceMetaDto>;
+}
+
 async function apiFetch(path: string, init?: RequestInit) {
   const url = `${API_BASE_URL}${path}`;
   const res = await fetch(url, {

--- a/frontend/src/lib/config.test.ts
+++ b/frontend/src/lib/config.test.ts
@@ -11,6 +11,7 @@ import {
   featureAiKpiKri,
   featureAiGovernanceSetupWizard,
   featureApiKeysUi,
+  featureDemoMode,
   featureDemoSeeding,
   featureEvidencePreviewBadge,
   featureEvidenceUploads,
@@ -28,6 +29,7 @@ const envKeys = [
   "NEXT_PUBLIC_FEATURE_ADVISOR_WORKSPACE",
   "NEXT_PUBLIC_FEATURE_ADVISOR_CLIENT_SNAPSHOT",
   "NEXT_PUBLIC_FEATURE_READINESS_SCORE",
+  "NEXT_PUBLIC_FEATURE_DEMO_MODE",
   "NEXT_PUBLIC_FEATURE_DEMO_SEEDING",
   "NEXT_PUBLIC_FEATURE_EVIDENCE_UPLOADS",
   "NEXT_PUBLIC_FEATURE_GUIDED_SETUP",
@@ -75,6 +77,7 @@ describe("feature flags from env", () => {
     expect(featureAdvisorWorkspace()).toBe(true);
     expect(featureAdvisorClientSnapshot()).toBe(true);
     expect(featureReadinessScore()).toBe(true);
+    expect(featureDemoMode()).toBe(false);
     expect(featureDemoSeeding()).toBe(true);
     expect(featureEvidenceUploads()).toBe(true);
     expect(featureGuidedSetup()).toBe(true);

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -34,6 +34,11 @@ export function featureDemoSeeding(): boolean {
   return envBool(process.env.NEXT_PUBLIC_FEATURE_DEMO_SEEDING, true);
 }
 
+/** Demo-/Playground-UI: Banner, Demo-Guide, Hinweise (Backend COMPLIANCEHUB_FEATURE_DEMO_MODE). */
+export function featureDemoMode(): boolean {
+  return envBool(process.env.NEXT_PUBLIC_FEATURE_DEMO_MODE, false);
+}
+
 export function featureEvidenceUploads(): boolean {
   return envBool(process.env.NEXT_PUBLIC_FEATURE_EVIDENCE_UPLOADS, true);
 }

--- a/frontend/src/lib/demoGuideSteps.test.ts
+++ b/frontend/src/lib/demoGuideSteps.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { DEMO_GUIDE_STEPS, demoStepIndexForPath } from "./demoGuideSteps";
+
+describe("demoStepIndexForPath", () => {
+  it("matcht Board KPIs", () => {
+    expect(demoStepIndexForPath("/board/kpis")).toBe(0);
+  });
+
+  it("matcht Hochrisiko-System-Detail unter Präfix ai-systems", () => {
+    const idx = DEMO_GUIDE_STEPS.findIndex((s) => s.id === "highrisk");
+    expect(demoStepIndexForPath("/tenant/ai-systems/sys-1")).toBe(idx);
+  });
+});

--- a/frontend/src/lib/demoGuideSteps.ts
+++ b/frontend/src/lib/demoGuideSteps.ts
@@ -1,0 +1,69 @@
+export type DemoGuideStep = {
+  id: string;
+  title: string;
+  hint: string;
+  /** Statische Route oder Präfix für Step-Matching */
+  path: string;
+  /** Ersten Hochrisiko-Eintrag aus dem Register auflösen */
+  resolveHighRiskSystem?: boolean;
+};
+
+export const DEMO_GUIDE_STEPS: DemoGuideStep[] = [
+  {
+    id: "readiness",
+    title: "AI & Compliance Readiness Score",
+    hint: "Zeigen Sie den gewichteten Reifegrad aus Setup, Coverage, KPIs, Gaps und Reporting.",
+    path: "/board/kpis",
+  },
+  {
+    id: "playbook",
+    title: "AI Governance Playbook",
+    hint: "RACI, Phasen und operative Leitplanken für AI Act & ISO 42001.",
+    path: "/tenant/ai-governance-playbook",
+  },
+  {
+    id: "crossreg",
+    title: "Cross-Regulation & Gap-Assist",
+    hint: "Regelwerksgraph, Abdeckung und strukturierte Lücken über EU AI Act, NIS2, ISO.",
+    path: "/tenant/cross-regulation-dashboard",
+  },
+  {
+    id: "highrisk",
+    title: "Hochrisiko-KI & KPIs/KRIs",
+    hint: "Systemkontext, NIS2-KPIs und Performance-Kennzahlen je KI-System.",
+    path: "/tenant/ai-systems",
+    resolveHighRiskSystem: true,
+  },
+  {
+    id: "boardreport",
+    title: "AI Compliance Board-Report",
+    hint: "Vorstands- oder Management-Report aus Coverage und Top-Gaps.",
+    path: "/board/ai-compliance-report",
+  },
+  {
+    id: "advisor",
+    title: "Berater-Portfolio & Snapshot",
+    hint: "Mandantenüberblick, Readiness und Governance-Snapshot für Beratungsgespräche.",
+    path: "/advisor",
+  },
+  {
+    id: "wizard",
+    title: "Setup-Wizard",
+    hint: "So starten neue Kunden: Frameworks, Register, KPIs und Board-Follow-up.",
+    path: "/tenant/ai-governance-setup",
+  },
+];
+
+export function demoStepIndexForPath(pathname: string): number | null {
+  const p = pathname.split("?")[0] ?? pathname;
+  for (let i = 0; i < DEMO_GUIDE_STEPS.length; i++) {
+    const step = DEMO_GUIDE_STEPS[i];
+    if (step.resolveHighRiskSystem && p.startsWith("/tenant/ai-systems")) {
+      return i;
+    }
+    if (!step.resolveHighRiskSystem && (p === step.path || p.startsWith(`${step.path}/`))) {
+      return i;
+    }
+  }
+  return null;
+}

--- a/frontend/src/lib/workspaceDemoServer.ts
+++ b/frontend/src/lib/workspaceDemoServer.ts
@@ -1,0 +1,50 @@
+import { cookies } from "next/headers";
+
+import { featureDemoMode } from "@/lib/config";
+import { DEMO_MODE_SESSION_COOKIE } from "@/lib/workspaceTenantConstants";
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  process.env.COMPLIANCEHUB_API_BASE_URL ||
+  "http://localhost:8000";
+const API_KEY =
+  process.env.NEXT_PUBLIC_API_KEY ||
+  process.env.COMPLIANCEHUB_API_KEY ||
+  "tenant-overview-key";
+
+export type TenantWorkspaceMeta = {
+  tenant_id: string;
+  display_name: string;
+  is_demo: boolean;
+  demo_playground: boolean;
+  demo_mode_feature_enabled: boolean;
+};
+
+export async function fetchTenantWorkspaceMetaServer(
+  tenantId: string,
+): Promise<TenantWorkspaceMeta | null> {
+  const url = `${API_BASE_URL}/api/v1/workspace/tenant-meta`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-tenant-id": tenantId.trim(),
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    return null;
+  }
+  return (await res.json()) as TenantWorkspaceMeta;
+}
+
+export async function isDemoUiDesiredForTenant(tenantId: string): Promise<boolean> {
+  if (!featureDemoMode()) {
+    return false;
+  }
+  const jar = await cookies();
+  if (jar.get(DEMO_MODE_SESSION_COOKIE)?.value === "1") {
+    return true;
+  }
+  const meta = await fetchTenantWorkspaceMetaServer(tenantId).catch(() => null);
+  return Boolean(meta?.is_demo);
+}

--- a/frontend/src/lib/workspaceTenantConstants.ts
+++ b/frontend/src/lib/workspaceTenantConstants.ts
@@ -1,2 +1,5 @@
-/** Cookie-Name: aktiver Mandant im Workspace (Server + Client). */
+/** Cookie: aktiver Workspace-Mandant (Server + Client). */
 export const WORKSPACE_TENANT_COOKIE = "ch_workspace_tenant";
+
+/** Cookie: Demo-UI-Session (?demo=1), ergänzend zu is_demo am Mandanten. */
+export const DEMO_MODE_SESSION_COOKIE = "ch_demo_mode";

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,32 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+
+import {
+  DEMO_MODE_SESSION_COOKIE,
+  WORKSPACE_TENANT_COOKIE,
+} from "@/lib/workspaceTenantConstants";
+
+export function middleware(request: NextRequest) {
+  const res = NextResponse.next();
+  const demo = request.nextUrl.searchParams.get("demo");
+  if (demo === "1") {
+    res.cookies.set(DEMO_MODE_SESSION_COOKIE, "1", {
+      path: "/",
+      maxAge: 60 * 60 * 24 * 14,
+      sameSite: "lax",
+    });
+    const tid = process.env.NEXT_PUBLIC_DEMO_WORKSPACE_TENANT_ID?.trim();
+    if (tid) {
+      res.cookies.set(WORKSPACE_TENANT_COOKIE, encodeURIComponent(tid), {
+        path: "/",
+        maxAge: 60 * 60 * 24 * 90,
+        sameSite: "lax",
+      });
+    }
+  }
+  return res;
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)"],
+};

--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Legt Demo-Mandanten mit Pilot-Feature-Defaults an und führt den Demo-Daten-Seed aus.
+
+Beispiele:
+  python scripts/seed_demo_tenant.py --preset mittelstand-ag
+  python scripts/seed_demo_tenant.py --all-presets
+  python scripts/seed_demo_tenant.py --tenant-id demo-x \\
+      --template kritis_energy --display-name "Demo AG"
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from app.db import SessionLocal  # noqa: E402
+from app.feature_flags import FeatureFlag  # noqa: E402
+from app.repositories.ai_governance_actions import AIGovernanceActionRepository  # noqa: E402
+from app.repositories.ai_systems import AISystemRepository  # noqa: E402
+from app.repositories.classifications import ClassificationRepository  # noqa: E402
+from app.repositories.evidence_files import EvidenceFileRepository  # noqa: E402
+from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository  # noqa: E402
+from app.repositories.policies import PolicyRepository  # noqa: E402
+from app.repositories.tenant_api_keys import TenantApiKeyRepository  # noqa: E402
+from app.repositories.tenant_feature_overrides import TenantFeatureOverrideRepository  # noqa: E402
+from app.repositories.tenant_registry import TenantRegistryRepository  # noqa: E402
+from app.services.ai_kpi_seed import ensure_ai_kpi_definitions_seeded  # noqa: E402
+from app.services.cross_regulation_seed import ensure_cross_regulation_catalog_seeded  # noqa: E402
+from app.services.demo_tenant_seeder import seed_demo_tenant  # noqa: E402
+from app.services.tenant_provisioning import PILOT_TENANT_FEATURE_DEFAULTS  # noqa: E402
+
+DEMO_PRESETS: dict[str, dict[str, str]] = {
+    "mittelstand-ag": {
+        "tenant_id": "demo-mittelstand-ag",
+        "display_name": "Mittelstand AG",
+        "template_key": "industrial_sme",
+        "industry": "Manufacturing",
+        "country": "DE",
+    },
+    "grc-consulting": {
+        "tenant_id": "demo-grc-consulting",
+        "display_name": "GRC Consulting GmbH",
+        "template_key": "tax_advisor",
+        "industry": "Professional Services",
+        "country": "DE",
+    },
+}
+
+
+def _demo_feature_flags() -> dict[str, bool]:
+    d = dict(PILOT_TENANT_FEATURE_DEFAULTS)
+    d[FeatureFlag.demo_seeding.value] = True
+    return d
+
+
+def _ensure_tenant_and_seed(session, spec: dict[str, str], *, create_api_key: bool) -> None:
+    tid = spec["tenant_id"]
+    reg = TenantRegistryRepository(session)
+    row = reg.get_by_id(tid)
+    if row is None:
+        reg.create(
+            tenant_id=tid,
+            display_name=spec["display_name"][:255],
+            industry=spec["industry"][:128],
+            country=spec["country"][:64],
+            nis2_scope="in_scope",
+            ai_act_scope="in_scope",
+            is_demo=True,
+            demo_playground=False,
+        )
+        print(f"tenant registry: created {tid} (is_demo=True)")
+    else:
+        print(f"tenant registry: exists {tid}")
+
+    TenantFeatureOverrideRepository(session).set_many(tid, _demo_feature_flags())
+
+    ai = AISystemRepository(session)
+    if ai.list_for_tenant(tid):
+        print(f"skip seed: tenant {tid} already has AI systems")
+        return
+
+    result = seed_demo_tenant(
+        session,
+        spec["template_key"],
+        tid,
+        advisor_id=None,
+        ai_repo=ai,
+        cls_repo=ClassificationRepository(session),
+        nis2_repo=Nis2KritisKpiRepository(session),
+        policy_repo=PolicyRepository(session),
+        action_repo=AIGovernanceActionRepository(session),
+        evidence_repo=EvidenceFileRepository(session),
+    )
+    br = result.board_reports_count
+    kr = result.ai_kpi_value_rows_count
+    xr = result.cross_reg_control_rows_count
+    print(
+        f"seed ok: systems={result.ai_systems_count} board_reports={br} "
+        f"kpi_rows={kr} xref_ctrls={xr}",
+    )
+
+    if create_api_key:
+        keys = TenantApiKeyRepository(session).list_for_tenant(tid)
+        if not keys:
+            _, plain = TenantApiKeyRepository(session).create_key(
+                tenant_id=tid,
+                name="Demo Workspace Key",
+            )
+            print("created API key (store securely; shown once):")
+            print(plain)
+        else:
+            print(f"tenant already has {len(keys)} API key(s); omitting new key")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Seed demo tenants for ComplianceHub")
+    p.add_argument(
+        "--preset", choices=sorted(DEMO_PRESETS.keys()), help="Vordefiniertes Demo-Profil"
+    )
+    p.add_argument("--all-presets", action="store_true", help="Alle Presets nacheinander")
+    p.add_argument("--tenant-id", help="Eigene tenant_id (mit --template/--display-name)")
+    p.add_argument("--template", help="Template-Key (kritis_energy, industrial_sme, tax_advisor)")
+    p.add_argument("--display-name", help="Anzeigename")
+    p.add_argument("--industry", default="Demo", help="Branche (bei manueller Angabe)")
+    p.add_argument("--country", default="DE", help="Land")
+    p.add_argument("--no-api-key", action="store_true", help="Keinen Mandanten-API-Key erzeugen")
+    args = p.parse_args()
+
+    if args.all_presets:
+        specs = list(DEMO_PRESETS.values())
+    elif args.preset:
+        specs = [DEMO_PRESETS[args.preset]]
+    elif args.tenant_id and args.template and args.display_name:
+        specs = [
+            {
+                "tenant_id": args.tenant_id.strip(),
+                "template_key": args.template.strip(),
+                "display_name": args.display_name.strip(),
+                "industry": args.industry.strip(),
+                "country": args.country.strip(),
+            },
+        ]
+    else:
+        p.error(
+            "Nutzen Sie --preset, --all-presets oder --tenant-id mit --template und --display-name"
+        )
+
+    s = SessionLocal()
+    try:
+        ensure_cross_regulation_catalog_seeded(s)
+        ensure_ai_kpi_definitions_seeded(s)
+        for spec in specs:
+            print("---", spec["tenant_id"], "---")
+            _ensure_tenant_and_seed(s, spec, create_api_key=not args.no_api_key)
+    finally:
+        s.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_demo_tenant_readonly.py
+++ b/tests/test_demo_tenant_readonly.py
@@ -1,0 +1,85 @@
+"""Demo-Mandanten: Schreibschutz für is_demo (optional demo_playground)."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from app.ai_system_models import (
+    AIActCategory,
+    AISystemCriticality,
+    AISystemRiskLevel,
+    DataSensitivity,
+)
+from app.db import SessionLocal
+from app.main import app
+from app.repositories.tenant_registry import TenantRegistryRepository
+
+client = TestClient(app)
+
+
+def _ai_payload(suffix: str) -> dict:
+    return {
+        "id": f"demo-ro-ai-{suffix}",
+        "name": "Demo RO System",
+        "description": "x",
+        "business_unit": "IT",
+        "risk_level": AISystemRiskLevel.low.value,
+        "ai_act_category": AIActCategory.minimal_risk.value,
+        "gdpr_dpia_required": False,
+        "owner_email": "ro@example.com",
+        "criticality": AISystemCriticality.low.value,
+        "data_sensitivity": DataSensitivity.internal.value,
+        "has_incident_runbook": True,
+        "has_supplier_risk_register": True,
+        "has_backup_runbook": True,
+    }
+
+
+def test_demo_tenant_blocks_post_ai_system() -> None:
+    tid = f"demo-ro-{uuid.uuid4().hex[:10]}"
+    s = SessionLocal()
+    try:
+        TenantRegistryRepository(s).create(
+            tenant_id=tid,
+            display_name="RO Demo",
+            industry="IT",
+            country="DE",
+            nis2_scope="in_scope",
+            ai_act_scope="in_scope",
+            is_demo=True,
+            demo_playground=False,
+        )
+    finally:
+        s.close()
+
+    h = {"x-api-key": "board-kpi-key", "x-tenant-id": tid}
+    assert client.get("/api/v1/ai-systems", headers=h).status_code == 200
+
+    r = client.post("/api/v1/ai-systems", headers=h, json=_ai_payload(uuid.uuid4().hex[:8]))
+    assert r.status_code == 403
+    assert "read-only" in r.json()["detail"].lower()
+
+
+def test_demo_playground_allows_post_ai_system() -> None:
+    tid = f"demo-pg-{uuid.uuid4().hex[:10]}"
+    s = SessionLocal()
+    try:
+        TenantRegistryRepository(s).create(
+            tenant_id=tid,
+            display_name="PG Demo",
+            industry="IT",
+            country="DE",
+            nis2_scope="in_scope",
+            ai_act_scope="in_scope",
+            is_demo=True,
+            demo_playground=True,
+        )
+    finally:
+        s.close()
+
+    suf = uuid.uuid4().hex[:8]
+    h = {"x-api-key": "board-kpi-key", "x-tenant-id": tid}
+    r = client.post("/api/v1/ai-systems", headers=h, json=_ai_payload(suf))
+    assert r.status_code == 200, r.text

--- a/tests/test_demo_tenant_seed.py
+++ b/tests/test_demo_tenant_seed.py
@@ -85,6 +85,16 @@ def test_post_demo_seed_creates_expected_entities() -> None:
     assert body["policy_rows_count"] >= 1
     assert body["classifications_count"] == 4
     assert body["advisor_linked"] is False
+    assert int(body.get("board_reports_count", 0)) >= 2
+    assert int(body.get("ai_kpi_value_rows_count", 0)) >= 4
+    assert int(body.get("cross_reg_control_rows_count", 0)) >= 1
+
+    meta = client.get(
+        "/api/v1/workspace/tenant-meta",
+        headers={"x-api-key": "board-kpi-key", "x-tenant-id": T1},
+    )
+    assert meta.status_code == 200, meta.text
+    assert meta.json()["is_demo"] is True
 
 
 def test_post_demo_seed_idempotent_conflict() -> None:
@@ -126,6 +136,17 @@ def test_demo_seed_with_advisor_link() -> None:
         assert link.tenant_id == T2
     finally:
         s.close()
+
+
+def test_workspace_tenant_meta_not_registered() -> None:
+    r = client.get(
+        "/api/v1/workspace/tenant-meta",
+        headers={
+            "x-api-key": "board-kpi-key",
+            "x-tenant-id": "unregistered-tenant-meta-xyz",
+        },
+    )
+    assert r.status_code == 404
 
 
 def test_seed_demo_tenant_does_not_touch_other_tenant() -> None:

--- a/tests/test_feature_flags_and_usage.py
+++ b/tests/test_feature_flags_and_usage.py
@@ -36,6 +36,7 @@ def advisor_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_feature_flag_defaults_true() -> None:
     assert is_feature_enabled(FeatureFlag.advisor_workspace) is True
     assert is_feature_enabled(FeatureFlag.demo_seeding) is True
+    assert is_feature_enabled(FeatureFlag.demo_mode) is False
     assert is_feature_enabled(FeatureFlag.ai_governance_playbook) is True
     assert is_feature_enabled(FeatureFlag.cross_regulation_dashboard) is True
     assert is_feature_enabled(FeatureFlag.cross_regulation_llm_assist) is True

--- a/tests/test_pilot_onboarding.py
+++ b/tests/test_pilot_onboarding.py
@@ -46,6 +46,7 @@ def test_provision_tenant_sets_defaults_and_initial_key() -> None:
     assert flags.get("llm_kpi_suggestions") is False
     assert flags.get("llm_explain") is False
     assert flags.get("llm_action_drafts") is False
+    assert flags.get("demo_mode") is False
     ikey = body["initial_api_key"]
     assert ikey["name"] == "Initial Pilot Key"
     assert len(ikey["plain_key"]) > 20


### PR DESCRIPTION
- tenants: is_demo, demo_playground; Registry-API; Read-only für Demo-Mandanten
- Feature-Flag demo_mode (ENV); GET /api/v1/workspace/tenant-meta
- Demo-Seed: KPI-Zeitreihen, Cross-Reg-Controls, Wizard-Payload, Board-Reports
- CLI scripts/seed_demo_tenant.py (Mittelstand AG, GRC Consulting)
- Frontend: NEXT_PUBLIC_FEATURE_DEMO_MODE, Middleware ?demo=1, Banner, Demo-Guide
- Doku docs/demo-playground.md; Tests Backend/Frontend

Made-with: Cursor