### PR TITLE
feat(telemetry): normalize workspace events for NIS2/ISO alignment

### DIFF
--- a/app/demo_tenant_guard.py
+++ b/app/demo_tenant_guard.py
@@ -9,7 +9,7 @@ from fastapi import HTTPException, Request, status
 from sqlalchemy.orm import Session
 
 from app.repositories.tenant_registry import TenantRegistryRepository
-from app.services import usage_event_logger
+from app.services import workspace_telemetry
 
 DEMO_TENANT_READONLY_CODE = "demo_tenant_readonly"
 
@@ -133,15 +133,13 @@ def demo_readonly_http_exception() -> HTTPException:
 
 
 def _log_demo_mutation_blocked(session: Session, tenant_id: str, request: Request) -> None:
-    usage_event_logger.log_usage_event(
+    workspace_telemetry.log_workspace_mutation_blocked(
         session,
         tenant_id,
-        usage_event_logger.DEMO_MUTATION_BLOCKED,
-        {
-            "http_method": str(request.method).upper(),
-            "route": route_template_for_request(request),
-            "workspace_mode": workspace_mode_for_telemetry(session, tenant_id),
-        },
+        workspace_mode=workspace_mode_for_telemetry(session, tenant_id),
+        http_method=str(request.method),
+        route=route_template_for_request(request),
+        request_path=request.url.path,
     )
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -192,6 +192,7 @@ from app.security import (
 )
 from app.services import llm_client as llm_client_mod
 from app.services import usage_event_logger as usage_event_logger
+from app.services import workspace_telemetry
 from app.services.advisor_board_reports import (
     get_board_report_detail_for_advisor,
     list_advisor_portfolio_board_reports,
@@ -2987,6 +2988,7 @@ def get_tenant_compliance_overview(
 
 @app.get("/api/v1/workspace/tenant-meta", response_model=TenantWorkspaceMetaResponse)
 def get_workspace_tenant_meta(
+    request: Request,
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
     session: Annotated[Session, Depends(get_session)],
 ) -> TenantWorkspaceMetaResponse:
@@ -3004,11 +3006,11 @@ def get_workspace_tenant_meta(
         mutation_blocked=mut_blocked,
     )
     if row.is_demo:
-        usage_event_logger.log_usage_event(
+        workspace_telemetry.log_workspace_session_started(
             session,
             tid,
-            usage_event_logger.DEMO_SESSION_STARTED,
-            {"workspace_mode": workspace_mode_for_telemetry(session, tid)},
+            workspace_mode=workspace_mode_for_telemetry(session, tid),
+            request_path=request.url.path,
             dedupe_same_type_hours=24,
         )
     return TenantWorkspaceMetaResponse(
@@ -3024,27 +3026,27 @@ def get_workspace_tenant_meta(
     )
 
 
+@app.get("/api/v1/workspace/feature-used", tags=["workspace"])
 @app.get("/api/v1/workspace/demo-feature-used", tags=["workspace"])
-def log_demo_feature_used(
+def log_workspace_feature_used(
+    request: Request,
     feature_key: Annotated[str, Query(min_length=1, max_length=64, pattern=r"^[a-z0-9_]+$")],
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
     session: Annotated[Session, Depends(get_session)],
 ) -> dict[str, bool]:
-    """Telemetrie für Demo-Story (keine PII, nur feature_key). GET vermeidet Read-only-Konflikt."""
+    """workspace_feature_used (keine PII). GET; nur is_demo-Mandanten (read-only-kompatibel)."""
     row = TenantRegistryRepository(session).get_by_id(auth_context.tenant_id)
     if row is None or not row.is_demo:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Demo telemetry only for registered demo tenants",
         )
-    usage_event_logger.log_usage_event(
+    workspace_telemetry.log_workspace_feature_used(
         session,
         auth_context.tenant_id,
-        usage_event_logger.DEMO_FEATURE_USED,
-        {
-            "feature_key": feature_key,
-            "workspace_mode": workspace_mode_for_telemetry(session, auth_context.tenant_id),
-        },
+        workspace_mode=workspace_mode_for_telemetry(session, auth_context.tenant_id),
+        feature_name=feature_key,
+        request_path=request.url.path,
     )
     return {"ok": True}
 

--- a/app/services/usage_event_logger.py
+++ b/app/services/usage_event_logger.py
@@ -27,9 +27,17 @@ LLM_KPI_SUGGESTION_REQUESTED = "llm_kpi_suggestion_requested"
 LLM_EXPLAIN_REQUESTED = "llm_explain_requested"
 LLM_ACTION_DRAFT_REQUESTED = "llm_action_draft_requested"
 LLM_AI_ACT_DOC_DRAFT_REQUESTED = "llm_ai_act_doc_draft_requested"
-DEMO_SESSION_STARTED = "demo_session_started"
-DEMO_FEATURE_USED = "demo_feature_used"
-DEMO_MUTATION_BLOCKED = "demo_mutation_blocked"
+# Kanonische Workspace-Telemetrie (SIEM / ISO-Nachweis)
+WORKSPACE_SESSION_STARTED = "workspace_session_started"
+WORKSPACE_FEATURE_USED = "workspace_feature_used"
+WORKSPACE_MUTATION_BLOCKED = "workspace_mutation_blocked"
+# Reserviert, noch ohne Emission im Kern
+WORKSPACE_INCIDENT_FLAGGED = "workspace_incident_flagged"
+
+# Abwärtskompatibel: gleiche Strings wie WORKSPACE_* (historische Imports/Tests)
+DEMO_SESSION_STARTED = WORKSPACE_SESSION_STARTED
+DEMO_FEATURE_USED = WORKSPACE_FEATURE_USED
+DEMO_MUTATION_BLOCKED = WORKSPACE_MUTATION_BLOCKED
 
 
 def _parse_tracking_enabled() -> bool:

--- a/app/services/workspace_telemetry.py
+++ b/app/services/workspace_telemetry.py
@@ -1,0 +1,117 @@
+"""Workspace-Nutzungstelemetrie (NIS2/ISO-tauglich, strukturiert, ohne PII).
+
+Zentrale Hilfsfunktionen auf Basis von usage_events + log_usage_event.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from sqlalchemy.orm import Session
+
+from app.services import usage_event_logger
+
+ActorTypeTelemetry = Literal["tenant", "advisor", "system", "unknown"]
+
+
+def actor_type_for_request_path(path: str) -> ActorTypeTelemetry:
+    """Ableitung aus URL-Pfad (keine PII)."""
+    p = path.split("?", 1)[0]
+    if p.startswith("/api/v1/advisors/"):
+        return "advisor"
+    return "tenant"
+
+
+def build_workspace_event_payload(
+    *,
+    workspace_mode: str,
+    actor_type: str,
+    result: str | None = None,
+    feature_name: str | None = None,
+    route: str | None = None,
+    method: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Minimales, stabiles JSON-Schema für Workspace-Events (ohne Payloads/PII)."""
+    data: dict[str, Any] = {
+        "workspace_mode": workspace_mode,
+        "actor_type": actor_type,
+    }
+    if result is not None:
+        data["result"] = result
+    if feature_name is not None:
+        data["feature_name"] = feature_name
+    if route is not None:
+        data["route"] = route
+    if method is not None:
+        data["method"] = method
+    if extra:
+        for k, v in extra.items():
+            if v is not None and k not in data:
+                data[k] = v
+    return data
+
+
+def log_workspace_session_started(
+    session: Session,
+    tenant_id: str,
+    *,
+    workspace_mode: str,
+    request_path: str,
+    dedupe_same_type_hours: float | None = 24.0,
+) -> None:
+    usage_event_logger.log_usage_event(
+        session,
+        tenant_id,
+        usage_event_logger.WORKSPACE_SESSION_STARTED,
+        build_workspace_event_payload(
+            workspace_mode=workspace_mode,
+            actor_type=actor_type_for_request_path(request_path),
+            result="success",
+        ),
+        dedupe_same_type_hours=dedupe_same_type_hours,
+    )
+
+
+def log_workspace_feature_used(
+    session: Session,
+    tenant_id: str,
+    *,
+    workspace_mode: str,
+    feature_name: str,
+    request_path: str,
+) -> None:
+    usage_event_logger.log_usage_event(
+        session,
+        tenant_id,
+        usage_event_logger.WORKSPACE_FEATURE_USED,
+        build_workspace_event_payload(
+            workspace_mode=workspace_mode,
+            actor_type=actor_type_for_request_path(request_path),
+            feature_name=feature_name,
+            result="success",
+        ),
+    )
+
+
+def log_workspace_mutation_blocked(
+    session: Session,
+    tenant_id: str,
+    *,
+    workspace_mode: str,
+    http_method: str,
+    route: str,
+    request_path: str,
+) -> None:
+    usage_event_logger.log_usage_event(
+        session,
+        tenant_id,
+        usage_event_logger.WORKSPACE_MUTATION_BLOCKED,
+        build_workspace_event_payload(
+            workspace_mode=workspace_mode,
+            actor_type=actor_type_for_request_path(request_path),
+            result="forbidden_demo_readonly",
+            route=route,
+            method=http_method.upper(),
+        ),
+    )

--- a/docs/demo-playground.md
+++ b/docs/demo-playground.md
@@ -2,6 +2,8 @@
 
 ComplianceHub unterstützt **geführte Demos** (Sales, Founder, Berater) und die Vorbereitung eines **read-only Playgrounds** für Website-Leads.
 
+**Workspace-Telemetrie (NIS2/ISO):** siehe [workspace-telemetry-compliance.md](./workspace-telemetry-compliance.md) (Event-Schema, SIEM-Beispiele, Audit-Lücken).
+
 ## Aktivierung
 
 ### Backend
@@ -91,28 +93,25 @@ Kontextzeile: **„Demo-Hinweis · Schritt X von 7“** erscheint auf den passen
 
 Frontend: Hook **`useWorkspaceMode`** kapselt Meta und ersetzt verstreute Demo-Flags.
 
-Bei **`is_demo=true`** wird (sofern `COMPLIANCEHUB_USAGE_TRACKING` nicht deaktiviert ist) höchstens einmal pro 24h **`demo_session_started`** geschrieben (Dedupe), Payload nur: `{"workspace_mode": "demo"|"playground"}`.
+Bei **`is_demo=true`** wird (sofern `COMPLIANCEHUB_USAGE_TRACKING` nicht deaktiviert ist) höchstens einmal pro 24h **`workspace_session_started`** geschrieben (Dedupe), Payload u. a. `workspace_mode`, `actor_type`, `result` (siehe Compliance-Doc).
 
 ### Blockierte Schreibversuche (Usage, kein Audit-Log)
 
-Bei **403** durch Demo-Schreibschutz wird **`demo_mutation_blocked`** protokolliert mit:
+Bei **403** durch Demo-Schreibschutz wird **`workspace_mutation_blocked`** protokolliert mit u. a. `method`, `route`, `workspace_mode`, `actor_type`, `result=forbidden_demo_readonly`.
 
-- `http_method`, `route` (OpenAPI-Pfad-Template, z. B. `/api/v1/ai-systems/{aisystem_id}`),
-- `workspace_mode` (`production` | `demo` | `playground` — Klassifikation des Mandanten, keine PII).
+### Feature-Telemetrie (ohne PII)
 
-### Demo-Feature-Telemetrie (ohne PII)
-
-`GET /api/v1/workspace/demo-feature-used?feature_key=<snake_case>` (nur **`is_demo=true`**): **`demo_feature_used`** mit `feature_key` und `workspace_mode`. **GET** vermeidet Konflikt mit read-only.
+`GET /api/v1/workspace/feature-used?feature_key=<snake_case>` (kanonisch; Alias **`/workspace/demo-feature-used`**) — nur **`is_demo=true`**: **`workspace_feature_used`** mit `feature_name`, `workspace_mode`, `actor_type`, `result`. **GET** vermeidet Konflikt mit read-only.
 
 ### Interpretation für GTM / Compliance-Monitoring
 
 | Event | Nutzen |
 |-------|--------|
-| `demo_session_started` | Reichweite Demo-/Pilot-Mandanten (Dedupe 24h) |
-| `demo_feature_used` | Welche Story-Module in Demos geöffnet werden |
-| `demo_mutation_blocked` | Verhinderte Schreibversuche (Sicherheits-Story, keine Inhalte/PII) |
+| `workspace_session_started` | Reichweite Demo-/Pilot-Mandanten (Dedupe 24h) |
+| `workspace_feature_used` | Welche Story-Module in Demos geöffnet werden |
+| `workspace_mutation_blocked` | Verhinderte Schreibversuche (Sicherheits-Story, keine Inhalte/PII) |
 
-KPI-Idee: Verhältnis `demo_mutation_blocked` zu Demo-Sessions zeigt, ob Nutzer verstehen, dass der Mandant read-only ist.
+KPI-Idee: Verhältnis `workspace_mutation_blocked` zu `workspace_session_started` zeigt, ob Nutzer read-only verstehen.
 
 ## Berater & Sales
 

--- a/docs/workspace-telemetry-compliance.md
+++ b/docs/workspace-telemetry-compliance.md
@@ -1,0 +1,139 @@
+# Workspace-Telemetrie: Event-Modell, NIS2/ISO-Bezug, SIEM
+
+Internes Referenzdokument für GRC, Security Operations und Enterprise-Kunden (SAP/BTP-Deployments).  
+**Keine PII** in `usage_events`-Payloads: nur `tenant_id` als Spalte, strukturiertes JSON ohne Namen, E-Mails oder Request-Bodies.
+
+## 1. Normalisiertes Event-Modell
+
+### Kernfelder (konzeptionell)
+
+| Feld | Quelle | Hinweis |
+|------|--------|---------|
+| `tenant_id` | DB-Spalte `usage_events.tenant_id` | Mandantenbezug für Multi-Tenant-Auswertung |
+| `event_type` | DB-Spalte | Stabiler Name für SIEM-Regeln |
+| `payload_json` | Strukturiertes JSON | Siehe Schema pro Event |
+| `created_at_utc` | DB-Zeitstempel | UTC |
+
+### Payload-Felder (JSON, ohne PII)
+
+| Feld | Bedeutung |
+|------|-----------|
+| `workspace_mode` | `production` \| `demo` \| `playground` \| `unknown` |
+| `actor_type` | `tenant` (Mandanten-API-Key) \| `advisor` (Pfad unter `/api/v1/advisors/`) |
+| `result` | `success` \| `forbidden_demo_readonly` |
+| `feature_name` | Optionales UI-/Feature-Tag (snake_case), z. B. `board_ai_compliance_report` |
+| `route` | OpenAPI-Pfad-Template, z. B. `/api/v1/ai-systems` |
+| `method` | HTTP-Methode in Großbuchstaben |
+
+**Bewusst nicht enthalten (DSGVO / Datenminimierung):** IP-Adresse, User-Agent, API-Key-Wert, Korrelations-IDs, AI-System-Namen, Freitext aus Bodies.  
+**Ergänzung für strengere ISO/NIS2-Audits (Roadmap):** optionale `correlation_id` (technisch, keine PII), `high_risk_context` (bool oder Enum), Export in separates **Audit-Log** (immutabel) vs. **Usage-Telemetrie**.
+
+## 2. Kanonische Event-Typen
+
+| `event_type` | Zweck |
+|--------------|--------|
+| `workspace_session_started` | Modus-bewusster Session-Start (derzeit: Demo-Mandant bei `GET /workspace/tenant-meta`, Dedupe 24h) |
+| `workspace_feature_used` | Nutzung eines Demo-Story-Features (`GET /workspace/feature-used?feature_key=…`) |
+| `workspace_mutation_blocked` | Schreibversuch in read-only Demo/Playground (Policy), inkl. Route/Methode |
+| `workspace_incident_flagged` | **Reserviert** – noch keine Emission; für AI-Governance-/Security-Incidents |
+
+### Migration von früheren Namen
+
+Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_blocked` sind im Code **Aliase auf dieselben String-Werte** wie die `workspace_*`-Typen (keine doppelten Events). Bestehende SIEM-Regeln sollten auf die neuen Namen umgestellt werden.
+
+## 3. Beispiel-JSON
+
+### workspace_session_started (Demo-Mandant)
+
+```json
+{
+  "workspace_mode": "demo",
+  "actor_type": "tenant",
+  "result": "success"
+}
+```
+
+### workspace_feature_used
+
+```json
+{
+  "workspace_mode": "demo",
+  "actor_type": "tenant",
+  "feature_name": "board_ai_compliance_report",
+  "result": "success"
+}
+```
+
+### workspace_mutation_blocked
+
+```json
+{
+  "workspace_mode": "demo",
+  "actor_type": "tenant",
+  "result": "forbidden_demo_readonly",
+  "route": "/api/v1/ai-systems",
+  "method": "POST"
+}
+```
+
+### workspace_session_started (Produktiv – sobald ausgeweitet)
+
+```json
+{
+  "workspace_mode": "production",
+  "actor_type": "tenant",
+  "result": "success"
+}
+```
+
+*Hinweis: Session-Telemetrie für reine Produktiv-Mandanten ist aktuell nicht aktiv (nur `is_demo` bei tenant-meta); Schema ist dafür vorbereitet.*
+
+## 4. NIS2 / ISO 27001 / ISO 42001 – Mapping (hochlevel)
+
+| Anforderung / Kontrollidee | Relevanz dieser Events |
+|----------------------------|------------------------|
+| **NIS2** – Überwachung von Zugriffen und ungewöhnlichem Verhalten | `workspace_mutation_blocked` zeigt verweigerte Schreibzugriffe (Policy durchgesetzt); Häufung pro Mandant/Route als Indikator |
+| **ISO 27001 A.8.x / Logging** | Strukturierte, zeitgestempelte Ereignisse ohne PII; Export aus `usage_events` in SIEM |
+| **ISO 27001 A.9** Zugriffskontrolle | `actor_type` unterscheidet Berater- vs. Mandanten-Pfade auf API-Ebene |
+| **ISO 42001** AI-Governance-Überwachung | `feature_name` + `workspace_mode` für Demo/Story vs. Produktion; **Konfigurationsänderungen** an Hochrisiko-KI sollten künftig über **Audit-Log** + optionale `workspace_incident_flagged` / dedizierte Events abgebildet werden |
+
+### Typische Lücken für ein formales Audit
+
+- **Kein** vollständiges Benutzer-Identitäts-Mapping (nur API-Mandant) – für Enterprise oft Ergänzung durch IdP-Logs (SAP IAS, Azure AD).
+- **Keine** IP/User-Agent in Usage-Events – bei Bedarf nur in **Edge/WAF**-Logs mit strenger Aufbewahrungsrichtlinie.
+- **Hochrisiko-KI-Kontext** (welches System) bei Mutationen: aktuell nicht in Telemetry-Payload; Audit-Trail über `audit_logs` / Domain-Repositories.
+
+## 5. Backend-Implementierung (Ist)
+
+- **Zentral:** `app/services/workspace_telemetry.py` – baut Payloads und ruft `log_usage_event` auf.
+- **Integration:** `GET /workspace/tenant-meta` (Demo) → `workspace_session_started`; `GET /workspace/feature-used` (Alias: `demo-feature-used`) → `workspace_feature_used`; Demo-Guard → `workspace_mutation_blocked`.
+- **Middleware:** bewusst nicht global; Guard + explizite Hooks halten die Pipeline schlank und vermeiden Doppelzählung.
+
+## 6. Frontend-Vertrag
+
+- **Primär serverseitig:** Modus kommt aus dem Backend (`workspace_mode` in Meta); keine parallele „Wahrheit“ im Client.
+- **Client:** `useWorkspaceMode` für UX; `logDemoFeatureUsed` / `feature-used` sendet nur `feature_key` (Query) – Server ergänzt `workspace_mode`, `actor_type`, `result`.
+- **Kein** Ersatz für Audit-Log: UI-Telemetrie ergänzt keine GoBD-/ISO-Nachweise für Inhaltsänderungen.
+
+## 7. Beispiel-Auswertungen (SQL-artig / SIEM)
+
+**Alle blockierten Schreibversuche in Demo-Mandanten (letzte 30 Tage):**
+
+- Filter: `event_type = workspace_mutation_blocked` AND `payload.workspace_mode = demo` AND `result = forbidden_demo_readonly`
+
+**Demo-Feature-Reichweite (Sales/GTM):**
+
+- Filter: `event_type = workspace_feature_used` GROUP BY `payload.feature_name`
+
+**Berater vs. Mandant (Zugriffsmuster):**
+
+- Filter: `event_type IN (workspace_session_started, workspace_feature_used, workspace_mutation_blocked)` GROUP BY `payload.actor_type`
+
+**Konfigurationsänderungen Hochrisiko-KI (Zielbild):**
+
+- Heute: über **Audit-Log-Tabellen** / dedizierte API-Audit-Events, nicht über `usage_events` allein.
+- Roadmap: `workspace_incident_flagged` oder Domänen-Event `ai_system_config_changed` mit `risk_level=high` (ohne PII im Payload).
+
+---
+
+*Pflege: Bei neuen Events `usage_event_logger` / `workspace_telemetry` erweitern und dieses Dokument anpassen.*

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -51,10 +51,10 @@ export async function fetchTenantWorkspaceMeta(tenantId: string): Promise<Tenant
   return tenantApiFetch("/api/v1/workspace/tenant-meta", tenantId) as Promise<TenantWorkspaceMetaDto>;
 }
 
-/** Demo-Telemetrie (GET, kein Schreibkonflikt mit read-only Demo-Mandanten). */
+/** Workspace-Feature-Telemetrie (GET → workspace_feature_used; Server setzt workspace_mode/actor_type). */
 export async function logDemoFeatureUsed(tenantId: string, featureKey: string): Promise<void> {
   const k = encodeURIComponent(featureKey);
-  await tenantApiFetch(`/api/v1/workspace/demo-feature-used?feature_key=${k}`, tenantId);
+  await tenantApiFetch(`/api/v1/workspace/feature-used?feature_key=${k}`, tenantId);
 }
 
 async function apiFetch(path: string, init?: RequestInit) {

--- a/tests/test_demo_mutation_blocked_telemetry.py
+++ b/tests/test_demo_mutation_blocked_telemetry.py
@@ -1,4 +1,4 @@
-"""Telemetrie demo_mutation_blocked bei 403 durch Demo-Schreibschutz."""
+"""Telemetrie workspace_mutation_blocked bei 403 durch Demo-Schreibschutz."""
 
 from __future__ import annotations
 
@@ -41,7 +41,7 @@ def _ai_payload(suffix: str) -> dict:
     }
 
 
-def test_post_ai_system_emits_demo_mutation_blocked() -> None:
+def test_post_ai_system_emits_workspace_mutation_blocked() -> None:
     tid = f"demo-mut-tel-{uuid.uuid4().hex[:10]}"
     s = SessionLocal()
     try:
@@ -89,7 +89,9 @@ def test_post_ai_system_emits_demo_mutation_blocked() -> None:
         assert len(rows) == n0_count + 1
         payload = json.loads(rows[-1])
         assert payload["workspace_mode"] == "demo"
-        assert payload["http_method"] == "POST"
+        assert payload["method"] == "POST"
+        assert payload["result"] == "forbidden_demo_readonly"
+        assert payload.get("actor_type") == "tenant"
         assert "/api/v1/ai-systems" in payload["route"]
     finally:
         s2.close()

--- a/tests/test_demo_workspace_telemetry.py
+++ b/tests/test_demo_workspace_telemetry.py
@@ -1,4 +1,4 @@
-"""Demo-Workspace-Telemetrie: tenant-meta (demo_session_started) und demo-feature-used (GET)."""
+"""Workspace-Telemetrie: workspace_session_started und workspace_feature_used (GET)."""
 
 from __future__ import annotations
 
@@ -70,13 +70,15 @@ def test_tenant_meta_logs_demo_session_started_deduped(demo_tenant_id: str) -> N
         )
         payload = json.loads(s.execute(stmt).scalars().first() or "{}")
         assert payload.get("workspace_mode") == "demo"
+        assert payload.get("actor_type") == "tenant"
+        assert payload.get("result") == "success"
     finally:
         s.close()
 
 
-def test_demo_feature_used_inserts_event(demo_tenant_id: str) -> None:
+def test_workspace_feature_used_inserts_event(demo_tenant_id: str) -> None:
     r = client.get(
-        "/api/v1/workspace/demo-feature-used",
+        "/api/v1/workspace/feature-used",
         params={"feature_key": "board_ai_compliance_report"},
         headers=_headers(demo_tenant_id),
     )
@@ -92,8 +94,10 @@ def test_demo_feature_used_inserts_event(demo_tenant_id: str) -> None:
         rows = s.execute(stmt).scalars().all()
         assert len(rows) >= 1
         payload = json.loads(rows[-1])
-        assert payload["feature_key"] == "board_ai_compliance_report"
+        assert payload["feature_name"] == "board_ai_compliance_report"
         assert payload.get("workspace_mode") == "demo"
+        assert payload.get("actor_type") == "tenant"
+        assert payload.get("result") == "success"
     finally:
         s.close()
 

--- a/tests/test_workspace_telemetry.py
+++ b/tests/test_workspace_telemetry.py
@@ -1,0 +1,35 @@
+"""Unit-Tests: workspace_telemetry Payload und actor_type (ohne HTTP)."""
+
+from __future__ import annotations
+
+from app.services.workspace_telemetry import (
+    actor_type_for_request_path,
+    build_workspace_event_payload,
+)
+
+
+def test_actor_type_advisor_path() -> None:
+    assert actor_type_for_request_path("/api/v1/advisors/a@x/tenants/t1/report") == "advisor"
+
+
+def test_actor_type_tenant_path() -> None:
+    assert actor_type_for_request_path("/api/v1/workspace/tenant-meta") == "tenant"
+
+
+def test_build_payload_includes_only_known_keys() -> None:
+    p = build_workspace_event_payload(
+        workspace_mode="demo",
+        actor_type="tenant",
+        result="success",
+        feature_name="wizard",
+        route="/api/v1/x",
+        method="GET",
+    )
+    assert p == {
+        "workspace_mode": "demo",
+        "actor_type": "tenant",
+        "result": "success",
+        "feature_name": "wizard",
+        "route": "/api/v1/x",
+        "method": "GET",
+    }


### PR DESCRIPTION
- workspace_session_started, workspace_feature_used, workspace_mutation_blocked
- workspace_telemetry helper; actor_type, result, feature_name in payloads
- GET /workspace/feature-used (alias demo-feature-used); demo_* constants as aliases
- docs/workspace-telemetry-compliance.md; update demo-playground.md
- Frontend calls canonical feature-used endpoint

Made-with: Cursor