### PR TITLE
refactor(telemetry): unified emit_workspace_event schema and extra sa…

### DIFF
--- a/app/services/workspace_telemetry.py
+++ b/app/services/workspace_telemetry.py
@@ -1,17 +1,55 @@
-"""Workspace-Nutzungstelemetrie (NIS2/ISO-tauglich, strukturiert, ohne PII).
+"""Workspace-Nutzungstelemetrie (NIS2/ISO, SIEM-tauglich, ohne PII).
 
-Zentrale Hilfsfunktionen auf Basis von usage_events + log_usage_event.
+Zentrale API: ``emit_workspace_event`` → ``usage_events`` (+ optional strukturiertes App-Log).
+Alle Emissionen sind **best-effort** (Fehler brechen den Request nicht).
 """
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import re
+from datetime import UTC, datetime
 from typing import Any, Literal
 
 from sqlalchemy.orm import Session
 
 from app.services import usage_event_logger
 
+logger = logging.getLogger(__name__)
+
 ActorTypeTelemetry = Literal["tenant", "advisor", "system", "unknown"]
+
+# Schlüssel, die typischerweise PII oder Rohinhalte anzeigen (keine Aufnahme in extra)
+_EXTRA_KEY_DENYLIST_SUBSTRINGS = (
+    "email",
+    "mail",
+    "phone",
+    "password",
+    "token",
+    "secret",
+    "payload",
+    "body",
+    "content",
+    "prompt",
+    "message",
+    "firstname",
+    "lastname",
+    "address",
+    "ip",
+    "user_name",
+    "username",
+    "displayname",
+)
+
+# Erlaubte Zeichen in extra-Stringwerten (IDs, Keys, Enums) — kein Freitext
+_EXTRA_STR_VALUE_PATTERN = re.compile(r"^[a-zA-Z0-9_.:/\-]{1,128}$")
+
+
+def _env_truthy(key: str) -> bool:
+    raw = os.getenv(key, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
 
 
 def actor_type_for_request_path(path: str) -> ActorTypeTelemetry:
@@ -22,20 +60,50 @@ def actor_type_for_request_path(path: str) -> ActorTypeTelemetry:
     return "tenant"
 
 
-def build_workspace_event_payload(
+def _sanitize_extra(extra: dict[str, Any] | None) -> dict[str, Any]:
+    """Nur nicht-sensitive Kontextfelder (z. B. framework_key, ai_system_id)."""
+    if not extra:
+        return {}
+    out: dict[str, Any] = {}
+    for k, v in extra.items():
+        if not isinstance(k, str) or not k.strip():
+            continue
+        kl = k.lower().replace("-", "_")
+        if any(bad in kl for bad in _EXTRA_KEY_DENYLIST_SUBSTRINGS):
+            continue
+        if isinstance(v, bool):
+            out[k] = v
+        elif isinstance(v, int) and -1_000_000_000 <= v <= 1_000_000_000:
+            out[k] = v
+        elif isinstance(v, str) and _EXTRA_STR_VALUE_PATTERN.fullmatch(v):
+            out[k] = v
+    return out
+
+
+def build_workspace_event_body(
     *,
+    event_type: str,
+    tenant_id: str,
     workspace_mode: str,
     actor_type: str,
-    result: str | None = None,
     feature_name: str | None = None,
+    result: str | None = None,
     route: str | None = None,
     method: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Minimales, stabiles JSON-Schema für Workspace-Events (ohne Payloads/PII)."""
+    """
+    Gemeinsames JSON-Schema für Export (eine Zeile payload_json + Spalten in usage_events).
+
+    Immer gesetzt: event_type, tenant_id, workspace_mode, actor_type, timestamp (ISO-UTC).
+    """
+    ts = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     data: dict[str, Any] = {
+        "event_type": event_type,
+        "tenant_id": tenant_id,
         "workspace_mode": workspace_mode,
         "actor_type": actor_type,
+        "timestamp": ts,
     }
     if result is not None:
         data["result"] = result
@@ -44,12 +112,55 @@ def build_workspace_event_payload(
     if route is not None:
         data["route"] = route
     if method is not None:
-        data["method"] = method
-    if extra:
-        for k, v in extra.items():
-            if v is not None and k not in data:
-                data[k] = v
+        data["method"] = str(method).upper()
+    data.update(_sanitize_extra(extra))
     return data
+
+
+def emit_workspace_event(
+    session: Session,
+    event_type: str,
+    tenant_id: str,
+    *,
+    workspace_mode: str,
+    actor_type: str,
+    feature_name: str | None = None,
+    result: str | None = None,
+    route: str | None = None,
+    method: str | None = None,
+    extra: dict[str, Any] | None = None,
+    dedupe_same_type_hours: float | None = None,
+) -> None:
+    """
+    Zentrale Workspace-Telemetrie (synchron, ORM-Session).
+
+    - Wirft **nie** nach außen: Fehler nur intern geloggt (wie ``log_usage_event``).
+    - Kein async nötig: Aufruf aus FastAPI-Sync-Routen/Dependencies; Latenz = ein DB-Insert.
+      (Background-Tasks wären möglich, erfordern aber separate Session-Pro Session.)
+    """
+    body = build_workspace_event_body(
+        event_type=event_type,
+        tenant_id=tenant_id,
+        workspace_mode=workspace_mode,
+        actor_type=actor_type,
+        feature_name=feature_name,
+        result=result,
+        route=route,
+        method=method,
+        extra=extra,
+    )
+    usage_event_logger.log_usage_event(
+        session,
+        tenant_id,
+        event_type,
+        body,
+        dedupe_same_type_hours=dedupe_same_type_hours,
+    )
+    if _env_truthy("COMPLIANCEHUB_WORKSPACE_TELEMETRY_STRUCTURED_LOG"):
+        try:
+            logger.info("workspace_telemetry %s", json.dumps(body, separators=(",", ":")))
+        except Exception:
+            logger.exception("workspace_telemetry_structured_log_failed")
 
 
 def log_workspace_session_started(
@@ -60,15 +171,13 @@ def log_workspace_session_started(
     request_path: str,
     dedupe_same_type_hours: float | None = 24.0,
 ) -> None:
-    usage_event_logger.log_usage_event(
+    emit_workspace_event(
         session,
-        tenant_id,
         usage_event_logger.WORKSPACE_SESSION_STARTED,
-        build_workspace_event_payload(
-            workspace_mode=workspace_mode,
-            actor_type=actor_type_for_request_path(request_path),
-            result="success",
-        ),
+        tenant_id,
+        workspace_mode=workspace_mode,
+        actor_type=actor_type_for_request_path(request_path),
+        result="success",
         dedupe_same_type_hours=dedupe_same_type_hours,
     )
 
@@ -80,17 +189,17 @@ def log_workspace_feature_used(
     workspace_mode: str,
     feature_name: str,
     request_path: str,
+    extra: dict[str, Any] | None = None,
 ) -> None:
-    usage_event_logger.log_usage_event(
+    emit_workspace_event(
         session,
-        tenant_id,
         usage_event_logger.WORKSPACE_FEATURE_USED,
-        build_workspace_event_payload(
-            workspace_mode=workspace_mode,
-            actor_type=actor_type_for_request_path(request_path),
-            feature_name=feature_name,
-            result="success",
-        ),
+        tenant_id,
+        workspace_mode=workspace_mode,
+        actor_type=actor_type_for_request_path(request_path),
+        feature_name=feature_name,
+        result="success",
+        extra=extra,
     )
 
 
@@ -102,16 +211,18 @@ def log_workspace_mutation_blocked(
     http_method: str,
     route: str,
     request_path: str,
+    feature_name: str | None = None,
+    extra: dict[str, Any] | None = None,
 ) -> None:
-    usage_event_logger.log_usage_event(
+    emit_workspace_event(
         session,
-        tenant_id,
         usage_event_logger.WORKSPACE_MUTATION_BLOCKED,
-        build_workspace_event_payload(
-            workspace_mode=workspace_mode,
-            actor_type=actor_type_for_request_path(request_path),
-            result="forbidden_demo_readonly",
-            route=route,
-            method=http_method.upper(),
-        ),
+        tenant_id,
+        workspace_mode=workspace_mode,
+        actor_type=actor_type_for_request_path(request_path),
+        result="forbidden_demo_readonly",
+        route=route,
+        method=http_method,
+        feature_name=feature_name,
+        extra=extra,
     )

--- a/docs/workspace-telemetry-compliance.md
+++ b/docs/workspace-telemetry-compliance.md
@@ -16,14 +16,27 @@ Internes Referenzdokument für GRC, Security Operations und Enterprise-Kunden (S
 
 ### Payload-Felder (JSON, ohne PII)
 
+Jedes Event enthält mindestens:
+
 | Feld | Bedeutung |
 |------|-----------|
+| `event_type` | Gleich DB-Spalte `event_type` (SIEM-Export als Ein-Blob) |
+| `tenant_id` | Mandanten-ID (wie DB-Spalte) |
 | `workspace_mode` | `production` \| `demo` \| `playground` \| `unknown` |
 | `actor_type` | `tenant` (Mandanten-API-Key) \| `advisor` (Pfad unter `/api/v1/advisors/`) |
+| `timestamp` | ISO-8601 UTC (z. B. `2026-03-25T12:00:00Z`) |
+
+Optional:
+
+| Feld | Bedeutung |
+|------|-----------|
 | `result` | `success` \| `forbidden_demo_readonly` |
-| `feature_name` | Optionales UI-/Feature-Tag (snake_case), z. B. `board_ai_compliance_report` |
+| `feature_name` | UI-/Feature-Tag (snake_case), z. B. `board_ai_compliance_report` |
 | `route` | OpenAPI-Pfad-Template, z. B. `/api/v1/ai-systems` |
 | `method` | HTTP-Methode in Großbuchstaben |
+| weitere Schlüssel | Nur über `extra`, nach Allowlist/Denylist (keine E-Mails, kein Freitext) |
+
+**Sink:** Postgres-Tabelle `usage_events` (bestehend). Zusätzlich optional **`COMPLIANCEHUB_WORKSPACE_TELEMETRY_STRUCTURED_LOG=true`** → eine JSON-Zeile pro Event im App-Logger (PostHog/Collector-seitig abgreifbar).
 
 **Bewusst nicht enthalten (DSGVO / Datenminimierung):** IP-Adresse, User-Agent, API-Key-Wert, Korrelations-IDs, AI-System-Namen, Freitext aus Bodies.  
 **Ergänzung für strengere ISO/NIS2-Audits (Roadmap):** optionale `correlation_id` (technisch, keine PII), `high_risk_context` (bool oder Enum), Export in separates **Audit-Log** (immutabel) vs. **Usage-Telemetrie**.
@@ -47,8 +60,11 @@ Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_bloc
 
 ```json
 {
+  "event_type": "workspace_session_started",
+  "tenant_id": "demo-seed-tenant-1",
   "workspace_mode": "demo",
   "actor_type": "tenant",
+  "timestamp": "2026-03-25T12:00:00Z",
   "result": "success"
 }
 ```
@@ -57,8 +73,11 @@ Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_bloc
 
 ```json
 {
+  "event_type": "workspace_feature_used",
+  "tenant_id": "demo-seed-tenant-1",
   "workspace_mode": "demo",
   "actor_type": "tenant",
+  "timestamp": "2026-03-25T12:01:00Z",
   "feature_name": "board_ai_compliance_report",
   "result": "success"
 }
@@ -68,8 +87,11 @@ Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_bloc
 
 ```json
 {
+  "event_type": "workspace_mutation_blocked",
+  "tenant_id": "demo-seed-tenant-1",
   "workspace_mode": "demo",
   "actor_type": "tenant",
+  "timestamp": "2026-03-25T12:02:00Z",
   "result": "forbidden_demo_readonly",
   "route": "/api/v1/ai-systems",
   "method": "POST"
@@ -80,8 +102,11 @@ Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_bloc
 
 ```json
 {
+  "event_type": "workspace_session_started",
+  "tenant_id": "prod-tenant-1",
   "workspace_mode": "production",
   "actor_type": "tenant",
+  "timestamp": "2026-03-25T12:00:00Z",
   "result": "success"
 }
 ```
@@ -105,7 +130,8 @@ Alte Konstanten `demo_session_started`, `demo_feature_used`, `demo_mutation_bloc
 
 ## 5. Backend-Implementierung (Ist)
 
-- **Zentral:** `app/services/workspace_telemetry.py` – baut Payloads und ruft `log_usage_event` auf.
+- **Zentral:** `app/services/workspace_telemetry.py` – `emit_workspace_event` (Schema + optional strukturiertes Log), Wrapper `log_workspace_*`.
+- **Fehler / Performance:** synchroner Insert in derselben Request-Session; Fehler werden geschluckt (`log_usage_event`). Kein Blockieren durch Telemetrie-Timeouts außerhalb DB.
 - **Integration:** `GET /workspace/tenant-meta` (Demo) → `workspace_session_started`; `GET /workspace/feature-used` (Alias: `demo-feature-used`) → `workspace_feature_used`; Demo-Guard → `workspace_mutation_blocked`.
 - **Middleware:** bewusst nicht global; Guard + explizite Hooks halten die Pipeline schlank und vermeiden Doppelzählung.
 

--- a/tests/test_demo_mutation_blocked_telemetry.py
+++ b/tests/test_demo_mutation_blocked_telemetry.py
@@ -88,10 +88,13 @@ def test_post_ai_system_emits_workspace_mutation_blocked() -> None:
         )
         assert len(rows) == n0_count + 1
         payload = json.loads(rows[-1])
+        assert payload.get("event_type") == usage_event_logger.WORKSPACE_MUTATION_BLOCKED
+        assert payload.get("tenant_id") == tid
         assert payload["workspace_mode"] == "demo"
         assert payload["method"] == "POST"
         assert payload["result"] == "forbidden_demo_readonly"
         assert payload.get("actor_type") == "tenant"
         assert "/api/v1/ai-systems" in payload["route"]
+        assert payload.get("timestamp")
     finally:
         s2.close()

--- a/tests/test_demo_workspace_telemetry.py
+++ b/tests/test_demo_workspace_telemetry.py
@@ -69,9 +69,12 @@ def test_tenant_meta_logs_demo_session_started_deduped(demo_tenant_id: str) -> N
             UsageEventTable.event_type == usage_event_logger.DEMO_SESSION_STARTED,
         )
         payload = json.loads(s.execute(stmt).scalars().first() or "{}")
+        assert payload.get("event_type") == usage_event_logger.WORKSPACE_SESSION_STARTED
+        assert payload.get("tenant_id") == demo_tenant_id
         assert payload.get("workspace_mode") == "demo"
         assert payload.get("actor_type") == "tenant"
         assert payload.get("result") == "success"
+        assert payload.get("timestamp")
     finally:
         s.close()
 
@@ -94,10 +97,13 @@ def test_workspace_feature_used_inserts_event(demo_tenant_id: str) -> None:
         rows = s.execute(stmt).scalars().all()
         assert len(rows) >= 1
         payload = json.loads(rows[-1])
+        assert payload.get("event_type") == usage_event_logger.WORKSPACE_FEATURE_USED
+        assert payload.get("tenant_id") == demo_tenant_id
         assert payload["feature_name"] == "board_ai_compliance_report"
         assert payload.get("workspace_mode") == "demo"
         assert payload.get("actor_type") == "tenant"
         assert payload.get("result") == "success"
+        assert payload.get("timestamp")
     finally:
         s.close()
 

--- a/tests/test_workspace_telemetry.py
+++ b/tests/test_workspace_telemetry.py
@@ -1,11 +1,9 @@
-"""Unit-Tests: workspace_telemetry Payload und actor_type (ohne HTTP)."""
+"""Unit-Tests: workspace_telemetry Schema, Sanitizing, actor_type (ohne HTTP)."""
 
 from __future__ import annotations
 
-from app.services.workspace_telemetry import (
-    actor_type_for_request_path,
-    build_workspace_event_payload,
-)
+from app.services import usage_event_logger
+from app.services.workspace_telemetry import actor_type_for_request_path, build_workspace_event_body
 
 
 def test_actor_type_advisor_path() -> None:
@@ -16,20 +14,44 @@ def test_actor_type_tenant_path() -> None:
     assert actor_type_for_request_path("/api/v1/workspace/tenant-meta") == "tenant"
 
 
-def test_build_payload_includes_only_known_keys() -> None:
-    p = build_workspace_event_payload(
+def test_build_workspace_event_body_core_schema() -> None:
+    p = build_workspace_event_body(
+        event_type=usage_event_logger.WORKSPACE_FEATURE_USED,
+        tenant_id="t-1",
         workspace_mode="demo",
         actor_type="tenant",
         result="success",
-        feature_name="wizard",
+        feature_name="ai_governance_playbook",
         route="/api/v1/x",
-        method="GET",
+        method="get",
     )
-    assert p == {
-        "workspace_mode": "demo",
-        "actor_type": "tenant",
-        "result": "success",
-        "feature_name": "wizard",
-        "route": "/api/v1/x",
-        "method": "GET",
-    }
+    assert p["event_type"] == usage_event_logger.WORKSPACE_FEATURE_USED
+    assert p["tenant_id"] == "t-1"
+    assert p["workspace_mode"] == "demo"
+    assert p["actor_type"] == "tenant"
+    assert p["result"] == "success"
+    assert p["feature_name"] == "ai_governance_playbook"
+    assert p["route"] == "/api/v1/x"
+    assert p["method"] == "GET"
+    assert "timestamp" in p and p["timestamp"].endswith("Z")
+
+
+def test_build_body_extra_sanitizes_keys_and_values() -> None:
+    p = build_workspace_event_body(
+        event_type=usage_event_logger.WORKSPACE_FEATURE_USED,
+        tenant_id="t1",
+        workspace_mode="demo",
+        actor_type="tenant",
+        extra={
+            "framework_key": "eu_ai_act",
+            "owner_email": "x@y.com",
+            "user_message": "hello",
+            "ai_system_id": "sys-uuid-001",
+            "note": "contains spaces bad",
+        },
+    )
+    assert p.get("framework_key") == "eu_ai_act"
+    assert p.get("ai_system_id") == "sys-uuid-001"
+    assert "owner_email" not in p
+    assert "user_message" not in p
+    assert "note" not in p


### PR DESCRIPTION
…nitization

- build_workspace_event_body: event_type, tenant_id, timestamp in every payload
- emit_workspace_event central sink; optional COMPLIANCEHUB_WORKSPACE_TELEMETRY_STRUCTURED_LOG
- Sanitize extra keys/values (no PII patterns); log_workspace_* wrappers unchanged
- Update compliance doc and integration/unit tests

Made-with: Cursor