### PR TITLE
feat(oami): harden runtime ingest, governance maturity, board/advisor

### DIFF
--- a/app/advisor_client_snapshot_models.py
+++ b/app/advisor_client_snapshot_models.py
@@ -94,6 +94,17 @@ class AdvisorTenantGovernanceBrief(BaseModel):
     nis2_critical_ai_count: int = Field(ge=0)
 
 
+class OperationalAiMonitoringSnapshot(BaseModel):
+    """OAMI (90 Tage), ohne PII – für Berater-Snapshot und LLM-Kontext."""
+
+    index_90d: int | None = Field(default=None, ge=0, le=100)
+    level: str | None = Field(default=None, description="low | medium | high")
+    has_runtime_data: bool = False
+    systems_scored: int = Field(ge=0)
+    narrative_de: str = ""
+    drivers_de: list[str] = Field(default_factory=list, max_length=12)
+
+
 class AdvisorClientGovernanceSnapshotResponse(BaseModel):
     advisor_id: str
     client_tenant_id: str
@@ -109,6 +120,10 @@ class AdvisorClientGovernanceSnapshotResponse(BaseModel):
     readiness: ReadinessScoreResponse | None = Field(
         default=None,
         description="Optional: AI & Compliance Readiness (FEATURE_READINESS_SCORE).",
+    )
+    operational_ai_monitoring: OperationalAiMonitoringSnapshot | None = Field(
+        default=None,
+        description="Optional: OAMI / Laufzeit-Signale (KI-Register + Runtime-Events).",
     )
 
 

--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -151,6 +151,18 @@ class AIKpiAlertExport(BaseModel):
     alerts: list[AIKpiAlert]
 
 
+class BoardOperationalMonitoringSection(BaseModel):
+    """OAMI-Zusammenfassung für Board (90-Tage-Fenster, mandantenweit)."""
+
+    index_value: int = Field(ge=0, le=100)
+    level: str = Field(description="low | medium | high")
+    window_days: int = Field(default=90, ge=1, le=366)
+    has_data: bool = False
+    systems_scored: int = Field(ge=0)
+    summary_de: str = ""
+    drivers_de: list[str] = Field(default_factory=list, max_length=12)
+
+
 class AIBoardGovernanceReport(BaseModel):
     """Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt (PDF/Word-Mapping)."""
 
@@ -162,6 +174,7 @@ class AIBoardGovernanceReport(BaseModel):
     incidents_overview: AIIncidentOverview
     supplier_risk_overview: AISupplierRiskOverview
     alerts: list[AIKpiAlert]
+    operational_monitoring: BoardOperationalMonitoringSection | None = None
 
 
 # Export-Job für PDF-/DMS-Integration (Webhook, SAP BTP, DMS)

--- a/app/feature_flags.py
+++ b/app/feature_flags.py
@@ -34,6 +34,7 @@ class FeatureFlag(StrEnum):
     ai_governance_setup_wizard = "ai_governance_setup_wizard"
     advisor_client_snapshot = "advisor_client_snapshot"
     readiness_score = "readiness_score"
+    governance_maturity = "governance_maturity"
     demo_mode = "demo_mode"
 
 
@@ -62,6 +63,7 @@ _FLAG_ENV_KEYS: dict[FeatureFlag, str] = {
     FeatureFlag.ai_governance_setup_wizard: "COMPLIANCEHUB_FEATURE_AI_GOVERNANCE_SETUP_WIZARD",
     FeatureFlag.advisor_client_snapshot: "COMPLIANCEHUB_FEATURE_ADVISOR_CLIENT_SNAPSHOT",
     FeatureFlag.readiness_score: "COMPLIANCEHUB_FEATURE_READINESS_SCORE",
+    FeatureFlag.governance_maturity: "COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY",
     FeatureFlag.demo_mode: "COMPLIANCEHUB_FEATURE_DEMO_MODE",
 }
 
@@ -72,6 +74,7 @@ _FLAG_DEFAULTS: dict[FeatureFlag, bool] = {
     FeatureFlag.llm_explain: False,
     FeatureFlag.llm_action_drafts: False,
     FeatureFlag.demo_mode: False,
+    FeatureFlag.governance_maturity: True,
 }
 
 

--- a/app/governance_maturity_models.py
+++ b/app/governance_maturity_models.py
@@ -1,0 +1,56 @@
+"""Governance Maturity Lens: Readiness + GAI + OAMI (API-Antworten)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+GaiLevel = Literal["low", "medium", "high"]
+OamiStatus = Literal["active", "not_configured"]
+
+
+class GovernanceActivityIndexComponents(BaseModel):
+    s_D: float = Field(ge=0.0, le=1.0)
+    s_F: float = Field(ge=0.0, le=1.0)
+    s_K: float = Field(ge=0.0, le=1.0)
+    s_E: float = Field(ge=0.0, le=1.0)
+    D: int = Field(ge=0)
+    F_eff: int = Field(ge=0)
+    K: int = Field(ge=0, le=5)
+    S: int = Field(ge=0)
+
+
+class GovernanceReadinessBlock(BaseModel):
+    score: int = Field(ge=0, le=100)
+    level: str
+    interpretation: str = ""
+
+
+class GovernanceActivityBlock(BaseModel):
+    index: int = Field(ge=0, le=100)
+    level: GaiLevel
+    window_days: int = 90
+    last_computed_at: datetime
+    components: GovernanceActivityIndexComponents | None = None
+
+
+class OperationalAiMonitoringBlock(BaseModel):
+    status: OamiStatus
+    index: int | None = Field(default=None, ge=0, le=100)
+    level: Literal["low", "medium", "high"] | None = None
+    window_days: int | None = None
+    message_de: str = ""
+    drivers_de: list[str] = Field(default_factory=list, max_length=12)
+
+
+class GovernanceMaturityResponse(BaseModel):
+    tenant_id: str
+    computed_at: datetime
+    readiness: GovernanceReadinessBlock | None = None
+    governance_activity: GovernanceActivityBlock
+    operational_ai_monitoring: OperationalAiMonitoringBlock
+    narrative_tag_ids: list[str] = Field(default_factory=list)
+    readiness_display_score: int | None = Field(default=None, ge=0, le=100)
+    readiness_score_adjustment_note: str | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import logging
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -61,6 +62,7 @@ from app.ai_governance_models import (
     AIKpiAlertExport,
     BoardKpiExportJob,
     BoardKpiExportJobCreate,
+    BoardOperationalMonitoringSection,
     BoardReportAuditRecord,
     BoardReportAuditRecordCreate,
     BoardReportAuditRecordWithJobs,
@@ -138,6 +140,7 @@ from app.feature_flags import (
     is_feature_enabled,
     require_tenant_llm_features,
 )
+from app.governance_maturity_models import GovernanceMaturityResponse
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
 from app.llm_models import LLMTaskType
 from app.models import (
@@ -291,18 +294,21 @@ from app.services.evidence_service import (
     upload_evidence as upload_evidence_file,
 )
 from app.services.evidence_storage import get_evidence_storage
+from app.services.governance_maturity_service import build_governance_maturity_response
 from app.services.high_risk_scenarios import list_high_risk_scenarios
 from app.services.llm_router import LLMRouter
 from app.services.nis2_kritis_ai_assist import generate_nis2_kpi_suggestions
 from app.services.nis2_kritis_alert_signals import build_nis2_kritis_alert_signals
 from app.services.nis2_kritis_drilldown import build_nis2_kritis_kpi_drilldown
 from app.services.nis2_kritis_kpis import recommended_kpis_for_ai_system
+from app.services.oami_explanation import explain_tenant_oami_de
 from app.services.operational_monitoring_index import (
     compute_system_monitoring_index,
     compute_tenant_operational_monitoring_index,
 )
 from app.services.readiness_score_explain import explain_readiness_score
 from app.services.readiness_score_service import compute_readiness_score
+from app.services.runtime_events_demo_guard import ensure_runtime_events_api_ingest_allowed
 from app.services.runtime_events_ingest import ingest_runtime_events
 from app.services.setup_status import compute_tenant_setup_status
 from app.services.tenant_ai_governance_setup import (
@@ -366,6 +372,8 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class DocumentIntakeRequest(BaseModel):
@@ -729,6 +737,7 @@ def post_ai_system_runtime_events(
     """Batch-Ingest kanonisierter Laufzeit-Events (SAP AI Core u. a.), mandantenisoliert."""
     tenant_id = auth_context.tenant_id
     raise_if_demo_tenant_readonly(session, tenant_id, request=request)
+    ensure_runtime_events_api_ingest_allowed(session, tenant_id)
     if ai_repo.get_by_id(tenant_id=tenant_id, aisystem_id=ai_system_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AI system not found")
     return ingest_runtime_events(
@@ -1793,6 +1802,7 @@ def get_board_alerts_export(
 )
 def get_board_governance_report(
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
     ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
     cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
     gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
@@ -1802,6 +1812,7 @@ def get_board_governance_report(
 ) -> AIBoardGovernanceReport:
     """Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt (nur JSON)."""
     return _build_board_report(
+        session,
         tenant_id=auth_context.tenant_id,
         ai_repo=ai_repo,
         cls_repo=cls_repo,
@@ -1818,6 +1829,7 @@ def get_board_governance_report(
 )
 def get_board_governance_report_markdown(
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
     ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
     cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
     gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
@@ -1827,6 +1839,7 @@ def get_board_governance_report_markdown(
 ) -> Response:
     """Board-Report als Markdown (template-fähig, für PDF/Word-Weiterverarbeitung)."""
     report = _build_board_report(
+        session,
         tenant_id=auth_context.tenant_id,
         ai_repo=ai_repo,
         cls_repo=cls_repo,
@@ -1914,6 +1927,7 @@ def get_board_kpi_export_job(
 
 
 def _build_board_report(
+    session: Session,
     tenant_id: str,
     ai_repo: AISystemRepository,
     cls_repo: ClassificationRepository,
@@ -1953,6 +1967,27 @@ def _build_board_report(
         compliance_overview=compliance_overview,
         nis2_kritis_signals=_nis2_kritis_board_alert_signals(tenant_id, nis2_repo),
     )
+    operational_monitoring: BoardOperationalMonitoringSection | None = None
+    try:
+        to = compute_tenant_operational_monitoring_index(
+            session,
+            tenant_id,
+            window_days=90,
+            persist_snapshot=False,
+        )
+        ex = explain_tenant_oami_de(to)
+        operational_monitoring = BoardOperationalMonitoringSection(
+            index_value=to.operational_monitoring_index,
+            level=str(to.level),
+            window_days=90,
+            has_data=to.has_any_runtime_data,
+            systems_scored=to.systems_scored,
+            summary_de=ex.summary_de,
+            drivers_de=list(ex.drivers_de)[:8],
+        )
+    except Exception:
+        logger.exception("board_report_operational_monitoring_failed tenant_id=%s", tenant_id)
+
     return AIBoardGovernanceReport(
         tenant_id=tenant_id,
         generated_at=generated_at,
@@ -1962,6 +1997,7 @@ def _build_board_report(
         incidents_overview=incidents_overview,
         supplier_risk_overview=supplier_risk_overview,
         alerts=alerts,
+        operational_monitoring=operational_monitoring,
     )
 
 
@@ -1972,6 +2008,7 @@ def _build_board_report(
 )
 def create_board_report_export_job(
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
     ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
     cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
     gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
@@ -1998,6 +2035,7 @@ def create_board_report_export_job(
         )
     tenant_id = auth_context.tenant_id
     report = _build_board_report(
+        session,
         tenant_id=tenant_id,
         ai_repo=ai_repo,
         cls_repo=cls_repo,
@@ -2038,6 +2076,7 @@ def get_board_report_export_job(
 )
 def create_board_report_audit_record(
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
     ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
     cls_repo: Annotated[ClassificationRepository, Depends(get_classification_repository)],
     gap_repo: Annotated[ComplianceGapRepository, Depends(get_compliance_gap_repository)],
@@ -2050,6 +2089,7 @@ def create_board_report_audit_record(
     tenant_id = auth_context.tenant_id
     created_by = (auth_context.api_key[:8] + "…") if auth_context.api_key else "api"
     report = _build_board_report(
+        session,
         tenant_id=tenant_id,
         ai_repo=ai_repo,
         cls_repo=cls_repo,
@@ -2817,6 +2857,28 @@ def get_advisor_tenant_readiness_score(
             detail="Tenant not linked to this advisor",
         )
     return compute_readiness_score(session, tenant_id)
+
+
+@app.get(
+    "/api/v1/advisors/{advisor_id}/tenants/{tenant_id}/governance-maturity",
+    response_model=GovernanceMaturityResponse,
+    tags=["advisors"],
+)
+def get_advisor_tenant_governance_maturity(
+    _ff_gm: Annotated[None, Depends(create_feature_guard(FeatureFlag.governance_maturity))],
+    _ff_adv: Annotated[None, Depends(create_feature_guard(FeatureFlag.advisor_workspace))],
+    advisor_id: Annotated[str, Depends(require_advisor_api_access)],
+    tenant_id: str,
+    session: Annotated[Session, Depends(get_session)],
+    advisor_repo: Annotated[AdvisorTenantRepository, Depends(get_advisor_tenant_repository)],
+    window_days: Annotated[int, Query(ge=30, le=90)] = 90,
+) -> GovernanceMaturityResponse:
+    if advisor_repo.get_link(advisor_id, tenant_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not linked to this advisor",
+        )
+    return build_governance_maturity_response(session, tenant_id, window_days=window_days)
 
 
 @app.get(
@@ -3701,6 +3763,7 @@ def post_tenant_ai_system_runtime_events(
     """Alias zu POST /api/v1/ai-systems/{id}/runtime-events (expliziter Mandant im Pfad)."""
     require_path_tenant_matches_auth(tenant_id, auth_context)
     raise_if_demo_tenant_readonly(session, tenant_id, request=request)
+    ensure_runtime_events_api_ingest_allowed(session, tenant_id)
     if ai_repo.get_by_id(tenant_id=tenant_id, aisystem_id=ai_system_id) is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="AI system not found")
     return ingest_runtime_events(
@@ -3801,6 +3864,24 @@ def get_tenant_operational_monitoring_index(
         window_days=window_days,
         persist_snapshot=False,
     )
+
+
+@app.get(
+    "/api/v1/tenants/{tenant_id}/governance-maturity",
+    response_model=GovernanceMaturityResponse,
+    tags=["tenants"],
+)
+def get_tenant_governance_maturity(
+    tenant_id: str,
+    _ff_gm: Annotated[None, Depends(create_feature_guard(FeatureFlag.governance_maturity))],
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    window_days: Annotated[int, Query(ge=30, le=90)] = 90,
+) -> GovernanceMaturityResponse:
+    """Governance Maturity Lens: Readiness, GAI (Telemetrie), OAMI (Laufzeit)."""
+    if tenant_id != auth_context.tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Tenant mismatch")
+    return build_governance_maturity_response(session, tenant_id, window_days=window_days)
 
 
 @app.post(

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -727,7 +727,12 @@ class AiRuntimeEventTable(Base):
 
     __tablename__ = "ai_runtime_events"
     __table_args__ = (
-        UniqueConstraint("tenant_id", "source_event_id", name="uq_ai_runtime_events_idempotent"),
+        UniqueConstraint(
+            "tenant_id",
+            "source",
+            "source_event_id",
+            name="uq_ai_runtime_events_tenant_source_event",
+        ),
         Index(
             "ix_ai_runtime_events_tenant_system_occurred",
             "tenant_id",

--- a/app/operational_monitoring_models.py
+++ b/app/operational_monitoring_models.py
@@ -47,10 +47,25 @@ class RuntimeEventsBatchIn(BaseModel):
     events: list[RuntimeEventIn] = Field(min_length=1, max_length=500)
 
 
+class RuntimeEventRejection(BaseModel):
+    index: int = Field(ge=0, description="0-basierter Index im Batch")
+    source_event_id: str = Field(max_length=128)
+    code: str = Field(max_length=64)
+    message: str = Field(max_length=512)
+
+
 class RuntimeEventsIngestResult(BaseModel):
     inserted: int
     skipped_duplicate: int
     kpi_updates: int = 0
+    rejected_invalid: int = 0
+    rejections: list[RuntimeEventRejection] = Field(default_factory=list)
+
+
+class OamiExplanationOut(BaseModel):
+    summary_de: str
+    drivers_de: list[str] = Field(default_factory=list, max_length=12)
+    monitoring_gap_de: str | None = None
 
 
 class OamiComponentsOut(BaseModel):
@@ -77,6 +92,7 @@ class SystemMonitoringIndexOut(BaseModel):
     metric_threshold_breach_count: int = 0
     distinct_active_days: int = 0
     components: OamiComponentsOut
+    explanation: OamiExplanationOut | None = None
 
 
 class TenantOperationalMonitoringIndexOut(BaseModel):
@@ -87,3 +103,4 @@ class TenantOperationalMonitoringIndexOut(BaseModel):
     systems_scored: int
     has_any_runtime_data: bool
     components: OamiComponentsOut | None = None
+    explanation: OamiExplanationOut | None = None

--- a/app/repositories/ai_runtime_events.py
+++ b/app/repositories/ai_runtime_events.py
@@ -20,12 +20,18 @@ class AiRuntimeEventRepository:
     def __init__(self, session: Session) -> None:
         self._session = session
 
-    def exists_by_source_event_id(self, tenant_id: str, source_event_id: str) -> bool:
+    def exists_by_tenant_source_event_id(
+        self,
+        tenant_id: str,
+        source: str,
+        source_event_id: str,
+    ) -> bool:
         stmt = (
             select(func.count())
             .select_from(AiRuntimeEventTable)
             .where(
                 AiRuntimeEventTable.tenant_id == tenant_id,
+                AiRuntimeEventTable.source == source,
                 AiRuntimeEventTable.source_event_id == source_event_id,
             )
         )

--- a/app/repositories/usage_events.py
+++ b/app/repositories/usage_events.py
@@ -72,3 +72,26 @@ class UsageEventRepository:
         )
         raw = self._session.execute(stmt).scalar_one_or_none()
         return raw if isinstance(raw, datetime) else None
+
+    def list_payloads_in_window(
+        self,
+        tenant_id: str,
+        *,
+        since: datetime,
+        until: datetime,
+        event_types: list[str] | None = None,
+    ) -> list[tuple[datetime, str, str]]:
+        """(created_at_utc, event_type, payload_json) für GAI / Aggregation."""
+        stmt = select(
+            UsageEventTable.created_at_utc,
+            UsageEventTable.event_type,
+            UsageEventTable.payload_json,
+        ).where(
+            UsageEventTable.tenant_id == tenant_id,
+            UsageEventTable.created_at_utc >= since,
+            UsageEventTable.created_at_utc <= until,
+        )
+        if event_types:
+            stmt = stmt.where(UsageEventTable.event_type.in_(event_types))
+        rows = self._session.execute(stmt).all()
+        return [(r[0], str(r[1]), str(r[2] if r[2] is not None else "{}")) for r in rows]

--- a/app/runtime_event_catalog.py
+++ b/app/runtime_event_catalog.py
@@ -1,0 +1,94 @@
+"""Kanonische Werte für AI-Runtime-Event-Ingest (Validierung, Normalisierung)."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Final
+
+from app.operational_monitoring_models import RuntimeEventIn
+
+# event_type (kleingeschrieben persistiert)
+CANONICAL_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "incident",
+        "metric_threshold_breach",
+        "deployment_change",
+        "heartbeat",
+        "metric_snapshot",
+    },
+)
+
+CANONICAL_SEVERITIES: Final[frozenset[str]] = frozenset(
+    {"info", "low", "medium", "high", "critical"},
+)
+
+CANONICAL_SOURCES: Final[frozenset[str]] = frozenset(
+    {
+        "sap_ai_core",
+        "sap_btp_event_mesh",
+        "manual_import",
+        "other_provider",
+        "synthetic_demo_seed",
+    },
+)
+
+_SOURCE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+_TECH_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_.:\-]{1,128}$")
+
+_REJECTION_MESSAGES_EN: Final[dict[str, str]] = {
+    "invalid_source": "Invalid or disallowed source identifier",
+    "invalid_event_type": "event_type is not a known canonical type",
+    "invalid_severity": "severity is not in the allowed set",
+    "invalid_metric_key": "metric_key has invalid format (allowed: technical id pattern)",
+    "invalid_incident_code": "incident_code has invalid format (allowed: technical id pattern)",
+}
+
+
+@dataclass(frozen=True)
+class ValidatedRuntimeFields:
+    source: str
+    event_type: str
+    severity: str | None
+    metric_key: str | None
+    incident_code: str | None
+
+
+def rejection_message_en(code: str) -> str:
+    return _REJECTION_MESSAGES_EN.get(code, "Validation failed")
+
+
+def validate_runtime_event_fields(
+    ev: RuntimeEventIn,
+) -> tuple[ValidatedRuntimeFields | None, str | None]:
+    """
+    Liefert (ValidatedRuntimeFields, None) oder (None, error_code).
+    error_code: invalid_source | invalid_event_type | invalid_severity | ...
+    """
+    src = str(ev.source).strip().lower()[:64]
+    if not src or (src not in CANONICAL_SOURCES and _SOURCE_PATTERN.fullmatch(src) is None):
+        return None, "invalid_source"
+
+    et = str(ev.event_type).strip().lower()[:64]
+    if et not in CANONICAL_EVENT_TYPES:
+        return None, "invalid_event_type"
+
+    sev: str | None = None
+    if ev.severity is not None and str(ev.severity).strip():
+        sev = str(ev.severity).strip().lower()[:32]
+        if sev not in CANONICAL_SEVERITIES:
+            return None, "invalid_severity"
+
+    mk: str | None = None
+    if ev.metric_key is not None and str(ev.metric_key).strip():
+        mk = str(ev.metric_key).strip()[:128]
+        if _TECH_KEY_PATTERN.fullmatch(mk) is None:
+            return None, "invalid_metric_key"
+
+    ic: str | None = None
+    if ev.incident_code is not None and str(ev.incident_code).strip():
+        ic = str(ev.incident_code).strip()[:128]
+        if _TECH_KEY_PATTERN.fullmatch(ic) is None:
+            return None, "invalid_incident_code"
+
+    return ValidatedRuntimeFields(src, et, sev, mk, ic), None

--- a/app/services/advisor_client_governance_snapshot.py
+++ b/app/services/advisor_client_governance_snapshot.py
@@ -17,6 +17,7 @@ from app.advisor_client_snapshot_models import (
     FrameworkScopeSnapshot,
     GapAssistSnapshot,
     KpiSummarySnapshot,
+    OperationalAiMonitoringSnapshot,
     ReportsSummarySnapshot,
     SetupStatusSnapshot,
 )
@@ -34,6 +35,8 @@ from app.services.ai_kpi_service import build_ai_kpi_summary
 from app.services.cross_regulation import build_cross_regulation_summary
 from app.services.cross_regulation_gaps import compute_cross_regulation_gaps
 from app.services.llm_router import LLMRouter
+from app.services.oami_explanation import explain_tenant_oami_de
+from app.services.operational_monitoring_index import compute_tenant_operational_monitoring_index
 from app.services.readiness_score_service import compute_readiness_score
 from app.services.setup_status import compute_tenant_setup_status
 from app.services.tenant_ai_governance_setup import build_setup_response, normalize_payload
@@ -240,6 +243,26 @@ def build_client_governance_snapshot(
             logger.exception("snapshot_readiness_failed tenant=%s", client_tenant_id)
             readiness = None
 
+    oami_snap: OperationalAiMonitoringSnapshot | None = None
+    try:
+        oami = compute_tenant_operational_monitoring_index(
+            session,
+            client_tenant_id,
+            window_days=90,
+            persist_snapshot=False,
+        )
+        expl = explain_tenant_oami_de(oami)
+        oami_snap = OperationalAiMonitoringSnapshot(
+            index_90d=oami.operational_monitoring_index if oami.has_any_runtime_data else None,
+            level=str(oami.level) if oami.has_any_runtime_data else None,
+            has_runtime_data=oami.has_any_runtime_data,
+            systems_scored=oami.systems_scored,
+            narrative_de=expl.summary_de,
+            drivers_de=list(expl.drivers_de)[:12],
+        )
+    except Exception:
+        logger.exception("snapshot_oami_failed tenant=%s", client_tenant_id)
+
     return AdvisorClientGovernanceSnapshotResponse(
         advisor_id=advisor_id,
         client_tenant_id=client_tenant_id,
@@ -261,6 +284,7 @@ def build_client_governance_snapshot(
         gap_assist=gap_assist,
         reports_summary=reports,
         readiness=readiness,
+        operational_ai_monitoring=oami_snap,
     )
 
 

--- a/app/services/board_report_markdown.py
+++ b/app/services/board_report_markdown.py
@@ -75,6 +75,18 @@ def render_board_report_markdown(report: AIBoardGovernanceReport) -> str:
         lines.append(f"- **{len(report.alerts)} Alert(s)** (davon {critical} kritisch).")
     else:
         lines.append("- Keine aktuellen Alerts.")
+    om = report.operational_monitoring
+    if om is not None:
+        lines.append("")
+        lines.append(
+            f"- **Operatives KI-Monitoring (OAMI, {om.window_days} Tage):** "
+            f"{om.index_value}/100 ({om.level}), "
+            f"{'Signale vorhanden' if om.has_data else 'keine Laufzeitdaten'} "
+            f"({om.systems_scored} Systeme mit Daten)."
+        )
+        lines.append(f"  - Kurzfassung: {om.summary_de}")
+        for d in om.drivers_de[:5]:
+            lines.append(f"  - Treiber: {d}")
     lines.extend(["", "---", "", "## 2. KPIs", ""])
 
     # KPIs als Tabelle
@@ -178,5 +190,36 @@ def render_board_report_markdown(report: AIBoardGovernanceReport) -> str:
     else:
         lines.append("Keine offenen Alerts.")
         lines.append("")
+
+    lines.extend(
+        [
+            "---",
+            "",
+            "## 7. Ausblick (operatives Monitoring & nächste Schritte)",
+            "",
+        ],
+    )
+    if om is not None:
+        if om.has_data:
+            lines.append(
+                "Die aggregierte Laufzeitlage stützt EU-AI-Act-Post-Market- und "
+                "ISO-42001-Überwachungsnachweise; Priorität: wiederkehrende Signale und "
+                "saubere Eskalation bei Incidents."
+            )
+        else:
+            lines.append(
+                "Ohne sichtbare Laufzeit-Signale sollten Anbindungen (z. B. SAP AI Core/BTP) "
+                "oder definierte manuelle Meldewege priorisiert werden."
+            )
+        if om.drivers_de:
+            lines.append("")
+            lines.append("**Konkrete Hinweise aus dem OAMI:**")
+            for d in om.drivers_de[:6]:
+                lines.append(f"- {d}")
+    else:
+        lines.append(
+            "Operatives Monitoring-Abschnitt nicht verfügbar; technische Auswertung prüfen."
+        )
+    lines.append("")
 
     return "\n".join(lines)

--- a/app/services/governance_activity_index.py
+++ b/app/services/governance_activity_index.py
@@ -1,0 +1,131 @@
+"""Governance Activity Index (GAI) aus usage_events – gemäß docs/governance-activity-index.md."""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.governance_maturity_models import (
+    GovernanceActivityBlock,
+    GovernanceActivityIndexComponents,
+)
+from app.repositories.usage_events import UsageEventRepository
+from app.services.usage_event_logger import WORKSPACE_FEATURE_USED, WORKSPACE_SESSION_STARTED
+
+logger = logging.getLogger(__name__)
+
+
+def _occurred_at_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+GAI_GOVERNANCE_FEATURE_NAMES: frozenset[str] = frozenset(
+    {
+        "playbook_overview",
+        "ai_governance_playbook",
+        "cross_regulation_summary",
+        "cross_regulation_dashboard",
+        "board_reports_overview",
+        "board_report_detail",
+        "ai_system_detail",
+        "advisor_governance_snapshot",
+    },
+)
+
+_K_MAX = 5
+
+
+def _gai_level(idx: int) -> str:
+    if idx < 40:
+        return "low"
+    if idx < 70:
+        return "medium"
+    return "high"
+
+
+def compute_governance_activity_index(
+    session: Session,
+    tenant_id: str,
+    *,
+    window_days: int = 90,
+    as_of: datetime | None = None,
+) -> GovernanceActivityBlock:
+    now = as_of or datetime.now(UTC)
+    since = now - timedelta(days=window_days)
+    repo = UsageEventRepository(session)
+    rows = repo.list_payloads_in_window(
+        tenant_id,
+        since=since,
+        until=now,
+        event_types=[WORKSPACE_SESSION_STARTED, WORKSPACE_FEATURE_USED],
+    )
+
+    active_days: set[str] = set()
+    F_raw = 0
+    feature_names_hit: set[str] = set()
+    S = 0
+
+    for created_at, event_type, payload_raw in rows:
+        d_key = _occurred_at_utc(created_at).date().isoformat()
+        payload: dict = {}
+        try:
+            payload = json.loads(payload_raw or "{}")
+        except json.JSONDecodeError:
+            logger.debug("gai_skip_bad_payload tenant=%s", tenant_id)
+            continue
+
+        if event_type == WORKSPACE_SESSION_STARTED:
+            S += 1
+            active_days.add(d_key)
+            continue
+
+        if event_type == WORKSPACE_FEATURE_USED:
+            fn = str(payload.get("feature_name") or "").strip()
+            if fn in GAI_GOVERNANCE_FEATURE_NAMES:
+                F_raw += 1
+                feature_names_hit.add(fn)
+                active_days.add(d_key)
+
+    D = len(active_days)
+    d_sat = 20 if window_days >= 60 else 8
+    f_max = 120 if window_days >= 60 else 45
+    f_sat = 60 if window_days >= 60 else 20
+    e_max = 4.0
+    e_sat = 2.0
+
+    F_eff = min(F_raw, f_max)
+    K = min(len(feature_names_hit), _K_MAX)
+    denom_d = min(window_days, d_sat)
+    s_d = min(1.0, math.sqrt(D / denom_d)) if denom_d > 0 else 0.0
+    s_f = min(1.0, math.sqrt(F_eff / f_sat)) if f_sat > 0 else 0.0
+    s_k = K / float(_K_MAX)
+    e_raw = F_eff / float(max(S, 1))
+    e = min(e_raw, e_max)
+    s_e = min(1.0, math.sqrt(e / e_sat)) if e_sat > 0 else 0.0
+
+    gai_01 = 0.35 * s_d + 0.25 * s_f + 0.30 * s_k + 0.10 * s_e
+    idx = int(round(100.0 * max(0.0, min(1.0, gai_01))))
+
+    components = GovernanceActivityIndexComponents(
+        s_D=round(s_d, 4),
+        s_F=round(s_f, 4),
+        s_K=round(s_k, 4),
+        s_E=round(s_e, 4),
+        D=D,
+        F_eff=F_eff,
+        K=K,
+        S=S,
+    )
+    return GovernanceActivityBlock(
+        index=idx,
+        level=_gai_level(idx),  # type: ignore[arg-type]
+        window_days=window_days,
+        last_computed_at=now,
+        components=components,
+    )

--- a/app/services/governance_maturity_service.py
+++ b/app/services/governance_maturity_service.py
@@ -1,0 +1,134 @@
+"""Aggregiert Readiness, GAI und OAMI für Governance-Maturity-API."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.governance_maturity_models import (
+    GovernanceActivityBlock,
+    GovernanceMaturityResponse,
+    GovernanceReadinessBlock,
+    OperationalAiMonitoringBlock,
+)
+from app.services.governance_activity_index import compute_governance_activity_index
+from app.services.oami_explanation import explain_tenant_oami_de
+from app.services.operational_monitoring_index import compute_tenant_operational_monitoring_index
+from app.services.readiness_score_service import compute_readiness_score
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def _derive_narrative_tag_ids(
+    *,
+    readiness_score: int | None,
+    gai_index: int,
+    oami_has_data: bool,
+) -> list[str]:
+    tags: list[str] = []
+    if readiness_score is not None and readiness_score >= 60 and gai_index < 40:
+        tags.append("structurally_strong_low_usage")
+    if readiness_score is not None and readiness_score < 45:
+        tags.append("readiness_needs_attention")
+    if not oami_has_data:
+        tags.append("operational_monitoring_not_visible")
+    elif gai_index >= 60 and readiness_score is not None and readiness_score >= 60:
+        tags.append("balanced_governance_signals")
+    return tags
+
+
+def build_governance_maturity_response(
+    session: Session,
+    tenant_id: str,
+    *,
+    window_days: int = 90,
+) -> GovernanceMaturityResponse:
+    now = datetime.now(UTC)
+    readiness_block: GovernanceReadinessBlock | None = None
+    readiness_display: int | None = None
+
+    if is_feature_enabled(FeatureFlag.readiness_score, tenant_id, session=session):
+        try:
+            rs = compute_readiness_score(session, tenant_id)
+            readiness_block = GovernanceReadinessBlock(
+                score=rs.score,
+                level=str(rs.level),
+                interpretation=rs.interpretation,
+            )
+            readiness_display = rs.score
+        except Exception:
+            logger.exception("governance_maturity_readiness_failed tenant=%s", tenant_id)
+
+    try:
+        gai = compute_governance_activity_index(
+            session,
+            tenant_id,
+            window_days=window_days,
+            as_of=now,
+        )
+    except Exception:
+        logger.exception("governance_maturity_gai_failed tenant=%s", tenant_id)
+        gai = GovernanceActivityBlock(
+            index=0,
+            level="low",
+            window_days=window_days,
+            last_computed_at=now,
+            components=None,
+        )
+
+    oami_block: OperationalAiMonitoringBlock
+    try:
+        oami = compute_tenant_operational_monitoring_index(
+            session,
+            tenant_id,
+            window_days=window_days,
+            persist_snapshot=False,
+        )
+        expl = explain_tenant_oami_de(oami)
+        if oami.has_any_runtime_data:
+            oami_block = OperationalAiMonitoringBlock(
+                status="active",
+                index=oami.operational_monitoring_index,
+                level=oami.level,
+                window_days=window_days,
+                message_de=expl.summary_de,
+                drivers_de=list(expl.drivers_de),
+            )
+        else:
+            oami_block = OperationalAiMonitoringBlock(
+                status="not_configured",
+                index=None,
+                level=None,
+                window_days=window_days,
+                message_de=expl.summary_de,
+                drivers_de=list(expl.drivers_de),
+            )
+    except Exception:
+        logger.exception("governance_maturity_oami_failed tenant=%s", tenant_id)
+        oami_block = OperationalAiMonitoringBlock(
+            status="not_configured",
+            window_days=window_days,
+            message_de="Operatives Monitoring konnte nicht geladen werden.",
+        )
+
+    tags = _derive_narrative_tag_ids(
+        readiness_score=readiness_display,
+        gai_index=gai.index,
+        oami_has_data=oami_block.status == "active",
+    )
+
+    return GovernanceMaturityResponse(
+        tenant_id=tenant_id,
+        computed_at=now,
+        readiness=readiness_block,
+        governance_activity=gai,
+        operational_ai_monitoring=oami_block,
+        narrative_tag_ids=tags,
+        readiness_display_score=readiness_display,
+        readiness_score_adjustment_note=None,
+    )

--- a/app/services/oami_explanation.py
+++ b/app/services/oami_explanation.py
@@ -1,0 +1,119 @@
+"""Strukturierte OAMI-Kurztexte (ohne LLM), deutsch, für UI und Reportings."""
+
+from __future__ import annotations
+
+from app.operational_monitoring_models import (
+    OamiExplanationOut,
+    SystemMonitoringIndexOut,
+    TenantOperationalMonitoringIndexOut,
+)
+
+
+def explain_system_oami_de(result: SystemMonitoringIndexOut) -> OamiExplanationOut:
+    """Haupttreiber aus Teilscores und Zählern (Tenant-System)."""
+    if not result.has_data:
+        return OamiExplanationOut(
+            summary_de=(
+                "Im gewählten Fenster liegen keine Laufzeit-Monitoring-Events vor. "
+                "Operative Überwachung (z. B. SAP AI Core) ist nicht sichtbar "
+                "oder noch nicht angebunden."
+            ),
+            drivers_de=[
+                "Keine Signale zu Datenaktualität, Vorfällen oder "
+                "Schwellenverletzungen im Fenster.",
+            ],
+            monitoring_gap_de=(
+                "Anbindung von Laufzeit-Events oder Heartbeats empfehlen, um Post-Market-Signale "
+                "zu dokumentieren."
+            ),
+        )
+
+    c = result.components
+    drivers: list[str] = []
+
+    if c.freshness >= 0.7:
+        drivers.append("Aktuelle Laufzeit-Signale (gute Datenaktualität).")
+    elif c.freshness <= 0.35:
+        drivers.append("Stagnierende oder veraltete Monitoring-Signale (Freshness niedrig).")
+
+    if c.activity_days >= 0.5:
+        drivers.append("Über viele Tage verteilte Aktivität im Fenster.")
+    elif c.activity_days <= 0.2:
+        drivers.append("Wenige aktive Tage – mögliche Lücke in der kontinuierlichen Überwachung.")
+
+    if result.high_severity_incident_count > 0:
+        drivers.append(
+            f"{result.high_severity_incident_count} schwerwiegende Vorfälle (high/critical) "
+            f"im Fenster ({result.incident_count} Vorfälle gesamt)."
+        )
+    elif result.incident_count > 0:
+        drivers.append(
+            f"{result.incident_count} Vorfälle ohne hohe Schwere – "
+            "Stabilität wirkt begrenzt belastet."
+        )
+    else:
+        drivers.append("Keine klassifizierten Vorfälle im Fenster.")
+
+    if result.metric_threshold_breach_count > 0:
+        drivers.append(
+            f"{result.metric_threshold_breach_count} Schwellenverletzungen bei Metriken "
+            "(Drift/Leistung)."
+        )
+    else:
+        drivers.append("Keine Metrik-Schwellenverletzungen erfasst.")
+
+    if c.metric_stability >= 0.75:
+        drivers.append("Metrik-Stabilität aus Sicht der Schwellenwerte günstig.")
+
+    level_de = {"low": "niedrig", "medium": "mittel", "high": "hoch"}[result.level]
+    summary_de = (
+        f"Operativer Monitoring-Index: {result.operational_monitoring_index}/100 ({level_de}). "
+        f"Letztes Event: {'bekannt' if result.last_event_at else 'unbekannt'}."
+    )
+
+    gap: str | None = None
+    if c.freshness <= 0.35 or c.activity_days <= 0.2:
+        gap = "Kontinuität der Überwachung verbessern (regelmäßige Heartbeats oder KPI-Snapshots)."
+
+    return OamiExplanationOut(
+        summary_de=summary_de,
+        drivers_de=drivers[:8],
+        monitoring_gap_de=gap,
+    )
+
+
+def explain_tenant_oami_de(result: TenantOperationalMonitoringIndexOut) -> OamiExplanationOut:
+    """Portfolio-/Tenant-Aggregat."""
+    if not result.has_any_runtime_data or result.components is None:
+        return OamiExplanationOut(
+            summary_de=(
+                "Mandantenweit keine Laufzeit-Events im Fenster – operatives KI-Monitoring "
+                "ist nicht sichtbar."
+            ),
+            drivers_de=["Keine Systeme mit Monitoring-Signalen im gewählten Zeitraum."],
+            monitoring_gap_de=(
+                "SAP AI Core / BTP oder andere Quellen anbinden oder Seeds für Pilot nutzen."
+            ),
+        )
+
+    c = result.components
+    drivers: list[str] = [
+        f"{result.systems_scored} KI-System(e) mit Laufzeitdaten im Fenster.",
+    ]
+    if c.incident_stability < 0.5:
+        drivers.append("Erhöhte Vorfälle oder Schwellenbelastung in gewichteten Systemen.")
+    if c.freshness < 0.5:
+        drivers.append("Teils veraltete Signale – Prüfung der Datenpipelines sinnvoll.")
+    if c.metric_stability >= 0.7:
+        drivers.append("Metriken überwiegend stabil (wenige Schwellenverletzungen).")
+
+    level_de = {"low": "niedrig", "medium": "mittel", "high": "hoch"}[result.level]
+    summary_de = (
+        f"Mandanten-OAMI: {result.operational_monitoring_index}/100 ({level_de}), "
+        f"risikogewichtet über {result.systems_scored} System(e)."
+    )
+    return OamiExplanationOut(
+        summary_de=summary_de,
+        drivers_de=drivers[:8],
+        monitoring_gap_de=None,
+    )

--- a/app/services/operational_monitoring_index.py
+++ b/app/services/operational_monitoring_index.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
@@ -15,6 +16,9 @@ from app.operational_monitoring_models import (
 )
 from app.repositories.ai_runtime_events import AiRuntimeEventRepository
 from app.repositories.ai_systems import AISystemRepository
+from app.services.oami_explanation import explain_system_oami_de, explain_tenant_oami_de
+
+logger = logging.getLogger(__name__)
 
 # Kalibrierung gemäß docs/governance-operational-ai-monitoring.md (Abschn. 3.2)
 _OAMI_WEIGHTS = (0.25, 0.25, 0.35, 0.15)  # freshness, coverage, incident, stability
@@ -40,9 +44,11 @@ def _freshness_component(last_occurred_at: datetime | None, now: datetime) -> fl
 
 
 def _coverage_component(distinct_days: int, window_days: int) -> float:
+    """Sättigung nach überschaubarer Aktivität (nicht erst nach 90/90 Tagen)."""
     if window_days <= 0:
         return 0.0
-    return min(1.0, float(distinct_days) / float(window_days))
+    d_sat = min(window_days, 30)
+    return min(1.0, float(distinct_days) / float(max(1, d_sat)))
 
 
 def _incident_component(incident_count: int, incident_high: int) -> float:
@@ -117,7 +123,7 @@ def compute_system_monitoring_index(
     last_at = agg.get("last_occurred_at")
     last_dt = last_at if isinstance(last_at, datetime) else None
 
-    return SystemMonitoringIndexOut(
+    base = SystemMonitoringIndexOut(
         ai_system_id=ai_system_id,
         tenant_id=tenant_id,
         window_days=window_days,
@@ -130,7 +136,9 @@ def compute_system_monitoring_index(
         metric_threshold_breach_count=int(agg.get("breach_count") or 0),
         distinct_active_days=int(agg.get("distinct_days") or 0),
         components=comp,
+        explanation=None,
     )
+    return base.model_copy(update={"explanation": explain_system_oami_de(base)})
 
 
 def _risk_weight(risk_level: str | None) -> float:
@@ -170,9 +178,17 @@ def compute_tenant_operational_monitoring_index(
             systems_scored=0,
             has_any_runtime_data=False,
             components=None,
+            explanation=None,
         )
+        out = out.model_copy(update={"explanation": explain_tenant_oami_de(out)})
         if persist_snapshot:
             _persist_tenant_snapshot(session, tenant_id, window_days, out, now)
+        logger.info(
+            "oami_compute tenant_id=%s window_days=%s systems_scored=0 index=0 persist=%s",
+            tenant_id,
+            window_days,
+            persist_snapshot,
+        )
         return out
 
     weighted_index = 0.0
@@ -209,9 +225,19 @@ def compute_tenant_operational_monitoring_index(
         systems_scored=len(system_ids),
         has_any_runtime_data=True,
         components=comp_t,
+        explanation=None,
     )
+    out = out.model_copy(update={"explanation": explain_tenant_oami_de(out)})
     if persist_snapshot:
         _persist_tenant_snapshot(session, tenant_id, window_days, out, now)
+    logger.info(
+        "oami_compute tenant_id=%s window_days=%s systems_scored=%s index=%s persist=%s",
+        tenant_id,
+        window_days,
+        len(system_ids),
+        idx,
+        persist_snapshot,
+    )
     return out
 
 

--- a/app/services/readiness_score_explain.py
+++ b/app/services/readiness_score_explain.py
@@ -34,7 +34,37 @@ def explain_readiness_score(
         msg = "LLM features are disabled for this tenant (COMPLIANCEHUB_FEATURE_LLM_ENABLED)."
         raise PermissionError(msg)
 
-    facts = json.dumps(snapshot.model_dump(mode="json"), ensure_ascii=False)
+    oami_context: dict[str, object] | None = None
+    try:
+        from app.services.oami_explanation import explain_tenant_oami_de
+        from app.services.operational_monitoring_index import (
+            compute_tenant_operational_monitoring_index,
+        )
+
+        oami = compute_tenant_operational_monitoring_index(
+            session,
+            tenant_id,
+            window_days=90,
+            persist_snapshot=False,
+        )
+        expl = explain_tenant_oami_de(oami)
+        oami_context = {
+            "window_days": 90,
+            "operational_monitoring_index": oami.operational_monitoring_index,
+            "level": oami.level,
+            "has_any_runtime_data": oami.has_any_runtime_data,
+            "systems_scored": oami.systems_scored,
+            "summary_de": expl.summary_de,
+            "drivers_de": expl.drivers_de[:6],
+        }
+    except Exception:
+        logger.exception("readiness_explain_oami_context_failed tenant=%s", tenant_id)
+
+    envelope: dict[str, object] = {
+        "readiness": snapshot.model_dump(mode="json"),
+        "operational_ai_monitoring": oami_context,
+    }
+    facts = json.dumps(envelope, ensure_ascii=False)
     prompt = _SYSTEM + "\n\nJSON-Fakten:\n" + facts
 
     router = LLMRouter(session=session)

--- a/app/services/runtime_events_demo_guard.py
+++ b/app/services/runtime_events_demo_guard.py
@@ -1,0 +1,22 @@
+"""Demo-Mandanten: keine Laufzeit-Events per API (nur Seeds/Intern)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import HTTPException, status
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+
+def ensure_runtime_events_api_ingest_allowed(session: Session, tenant_id: str) -> None:
+    """403 wenn registrierter Mandant als Demo markiert (externe Connectoren)."""
+    from app.repositories.tenant_registry import TenantRegistryRepository
+
+    row = TenantRegistryRepository(session).get_by_id(tenant_id)
+    if row is not None and row.is_demo:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Runtime event ingest is not available for demo tenants",
+        )

--- a/app/services/runtime_events_ingest.py
+++ b/app/services/runtime_events_ingest.py
@@ -2,16 +2,31 @@
 
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.orm import Session
 
 from app.models_db import AiRuntimeEventTable
-from app.operational_monitoring_models import RuntimeEventIn, RuntimeEventsIngestResult
+from app.operational_monitoring_models import (
+    RuntimeEventIn,
+    RuntimeEventRejection,
+    RuntimeEventsIngestResult,
+)
 from app.repositories.ai_kpis import AiKpiRepository
 from app.repositories.ai_runtime_events import AiRuntimeEventRepository
+from app.runtime_event_catalog import (
+    ValidatedRuntimeFields,
+    rejection_message_en,
+    validate_runtime_event_fields,
+)
 from app.services.runtime_event_sanitize import sanitize_runtime_event_extra
+
+logger = logging.getLogger(__name__)
+
+_RUNTIME_EVENTS_INGEST_LOG = "runtime_events_ingest"
+_OAMI_COMPUTE_LOG = "oami_compute"
 
 
 def _day_bounds_utc(dt: datetime) -> tuple[datetime, datetime]:
@@ -26,14 +41,15 @@ def _maybe_upsert_kpi_from_event(
     *,
     tenant_id: str,
     ai_system_id: str,
+    vf: ValidatedRuntimeFields,
     ev: RuntimeEventIn,
 ) -> bool:
-    if ev.value is None or ev.metric_key is None:
+    if ev.value is None or vf.metric_key is None:
         return False
-    if str(ev.event_type) not in ("metric_snapshot", "metric_threshold_breach"):
+    if vf.event_type not in ("metric_snapshot", "metric_threshold_breach"):
         return False
     repo = AiKpiRepository(session)
-    definition = repo.get_definition_by_key(ev.metric_key.strip())
+    definition = repo.get_definition_by_key(vf.metric_key)
     if definition is None:
         return False
     start, end = _day_bounds_utc(ev.occurred_at)
@@ -61,40 +77,59 @@ def ingest_runtime_events(
     refresh_incident_summary: bool = True,
 ) -> RuntimeEventsIngestResult:
     """
-    Validiert und persistiert Events. Idempotenz über (tenant_id, source_event_id).
+    Validiert und persistiert Events. Idempotenz über (tenant_id, source, source_event_id).
 
-    Optional: KPI-Zeitreihe bei bekanntem metric_key + metric_snapshot/-breach.
+    Ungültige Einträge werden übersprungen; gültige werden bei gemischten Batches trotzdem
+    geschrieben (best effort).
     """
     repo = AiRuntimeEventRepository(session)
     inserted = 0
     skipped = 0
     kpi_updates = 0
+    rejected = 0
+    rejections: list[RuntimeEventRejection] = []
     now = datetime.now(UTC)
     window_start = now - timedelta(days=90)
     window_end = now
-    batch_seen: set[str] = set()
+    batch_seen: set[tuple[str, str]] = set()
 
     try:
-        for ev in events:
+        for idx, ev in enumerate(events):
             sid = ev.source_event_id.strip()
-            if sid in batch_seen:
+            vf, err = validate_runtime_event_fields(ev)
+            if err is not None or vf is None:
+                rejected += 1
+                if len(rejections) < 50:
+                    rejections.append(
+                        RuntimeEventRejection(
+                            index=idx,
+                            source_event_id=sid[:128],
+                            code=err or "validation_error",
+                            message=rejection_message_en(err or "validation_error"),
+                        ),
+                    )
+                continue
+
+            dedupe_key = (vf.source, sid[:128])
+            if dedupe_key in batch_seen:
                 skipped += 1
                 continue
-            if repo.exists_by_source_event_id(tenant_id, sid):
+            if repo.exists_by_tenant_source_event_id(tenant_id, vf.source, sid):
                 skipped += 1
                 continue
-            batch_seen.add(sid)
+            batch_seen.add(dedupe_key)
+
             extra = sanitize_runtime_event_extra(ev.extra if isinstance(ev.extra, dict) else {})
             row = AiRuntimeEventTable(
                 id=str(uuid.uuid4()),
                 tenant_id=tenant_id,
                 ai_system_id=ai_system_id,
-                source=str(ev.source)[:64],
+                source=vf.source,
                 source_event_id=sid[:128],
-                event_type=str(ev.event_type)[:64],
-                severity=(ev.severity[:32] if ev.severity else None),
-                metric_key=(ev.metric_key[:128] if ev.metric_key else None),
-                incident_code=(ev.incident_code[:128] if ev.incident_code else None),
+                event_type=vf.event_type,
+                severity=vf.severity,
+                metric_key=vf.metric_key,
+                incident_code=vf.incident_code,
                 value=ev.value,
                 delta=ev.delta,
                 threshold_breached=ev.threshold_breached,
@@ -112,6 +147,7 @@ def ingest_runtime_events(
                 session,
                 tenant_id=tenant_id,
                 ai_system_id=ai_system_id,
+                vf=vf,
                 ev=ev,
             ):
                 kpi_updates += 1
@@ -128,10 +164,24 @@ def ingest_runtime_events(
                 )
             session.commit()
 
+        logger.info(
+            "%s tenant_id=%s ai_system_id=%s inserted=%d skipped_duplicate=%d "
+            "rejected_invalid=%d kpi_updates=%d",
+            _RUNTIME_EVENTS_INGEST_LOG,
+            tenant_id,
+            ai_system_id,
+            inserted,
+            skipped,
+            rejected,
+            kpi_updates,
+        )
+
         return RuntimeEventsIngestResult(
             inserted=inserted,
             skipped_duplicate=skipped,
             kpi_updates=kpi_updates,
+            rejected_invalid=rejected,
+            rejections=rejections,
         )
     except Exception:
         session.rollback()

--- a/db/migrations/20250325_ai_runtime_events_oami.sql
+++ b/db/migrations/20250325_ai_runtime_events_oami.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS ai_runtime_events (
     extra JSON NOT NULL DEFAULT ('{}'),
     CONSTRAINT fk_ai_runtime_events_ai_system
         FOREIGN KEY (ai_system_id) REFERENCES ai_systems (id) ON DELETE CASCADE,
-    CONSTRAINT uq_ai_runtime_events_idempotent UNIQUE (tenant_id, source_event_id)
+    CONSTRAINT uq_ai_runtime_events_tenant_source_event UNIQUE (tenant_id, source, source_event_id)
 );
 
 CREATE INDEX IF NOT EXISTS ix_ai_runtime_events_tenant_id ON ai_runtime_events (tenant_id);

--- a/db/migrations/20250326_ai_runtime_events_unique_source.sql
+++ b/db/migrations/20250326_ai_runtime_events_unique_source.sql
@@ -1,0 +1,3 @@
+-- Idempotenz: (tenant_id, source, source_event_id) statt nur (tenant_id, source_event_id).
+-- SQLite erlaubt UNIQUE-Änderung nicht in-place: bei bestehenden DBs Tabelle neu aufbauen
+-- oder frische Migration aus 20250325_ai_runtime_events_oami.sql verwenden.

--- a/docs/governance-operational-ai-monitoring.md
+++ b/docs/governance-operational-ai-monitoring.md
@@ -16,7 +16,8 @@
 
 - [`governance-maturity-lens.md`](./governance-maturity-lens.md) – OAMI als dritte Säule neben Readiness und GAI.  
 - [`governance-telemetry.md`](./governance-telemetry.md) – Workspace-Telemetrie (getrennt von Laufzeit-KI-Events).  
-- [`governance-activity-index.md`](./governance-activity-index.md) – GAI.
+- [`governance-activity-index.md`](./governance-activity-index.md) – GAI.  
+- [`runtime-events-oami-operations-runbook.md`](./runtime-events-oami-operations-runbook.md) – Betrieb: ENV, Logs, synthetisches Seeding.
 
 ---
 
@@ -28,7 +29,7 @@ Alle eingespielten Laufzeit-Events werden in **eine** kanonische Form normalisie
 
 | Feld | Typ | Pflicht | Beschreibung |
 |------|-----|---------|--------------|
-| `event_id` | string (UUID) | ja | Idempotenz-Schlüssel (von Quelle oder von ComplianceHub generiert). |
+| `source_event_id` | string | ja | Idempotenz-Schlüssel **pro** `source` (von Quelle oder von ComplianceHub generiert). |
 | `tenant_id` | string | ja | ComplianceHub-Mandant (RLS). |
 | `ai_system_id` | string | ja | FK zu `ai_systems.id` (Register); Mapping aus SAP-Deployment/Resource-ID über Konfigurationstabelle. |
 | `source` | string (enum) | ja | Ursprung, z. B. `sap_ai_core`, `sap_btp_event_mesh`, `manual_import`, `other_provider`. |
@@ -85,7 +86,7 @@ Runtime-Events werden **nicht** als neue „Pflichten“ im Graph gespeichert, s
 | `id` | uuid, PK | PK | Intern. |
 | `tenant_id` | text, NOT NULL | ja (composite) | RLS. |
 | `ai_system_id` | text, NOT NULL, FK → `ai_systems.id` | ja | Register. |
-| `event_id` | text, NOT NULL | UNIQUE (tenant_id, event_id) | Idempotenz. |
+| `source_event_id` | text, NOT NULL | UNIQUE (tenant_id, source, source_event_id) | Idempotenz je Quelle (gleiche externe ID bei anderem `source` ist erlaubt). |
 | `source` | text, NOT NULL | | |
 | `event_type` | text, NOT NULL | ja | |
 | `severity` | text | | |
@@ -276,14 +277,50 @@ Kombination mit bestehenden Tags (z. B. `structurally_strong_low_usage`) für **
 
 ---
 
-## 7. Verwandte Code-Pfade (Ist-Zustand)
+## 7. Betrieb, Observability, Demo-Daten & regulatorische Einordnung
+
+### 7.1 Ingest- und Aggregationsfrequenz (Empfehlung)
+
+| Prozess | Typische Frequenz | Hinweis |
+|---------|-------------------|---------|
+| **API-Ingest** (`POST` Batch) | Ereignisgetrieben oder 1–5 Min. Batches | Idempotent über `(tenant_id, source, source_event_id)`; gemischte Batches: gültige Events werden geschrieben, ungültige werden abgelehnt und in der Antwort aufgelistet (Cap auf Ablehnungsdetails). |
+| **Incident-Summaries / KPI aus Events** | On-ingest oder periodischer Job (z. B. 15–60 Min.) | Abgestimmt mit Board-/Advisor-Aktualisierung und Last auf der DB. |
+| **OAMI-Berechnung** | On-read (API) und/oder bei Snapshot-Persistenz nach Ingest | Standard-Fenster **30 / 90 Tage** (`window_days`); Coverage-Sättigung nutzt ein internes Cap (z. B. min(Fenster, 30 Tage)), damit sehr lange Fenster den Score nicht „aufweichen“. |
+
+### 7.2 Logging & Metriken (NIS2 / ISO 42001 – Nachvollziehbarkeit)
+
+Mindestumfang (ohne Payload-Inhalte, DSGVO-minimiert):
+
+| Schlüssel / Kontext | Zweck |
+|---------------------|--------|
+| `runtime_events_ingest` | Strukturiertes Log pro Ingest: `tenant_id`, `inserted`, `skipped_duplicate`, `rejected_invalid`, Dauer; unterstützt **Incident-Response** und Kapazitätsplanung (NIS2: Erkennung/Logging). |
+| `oami_compute` | Berechnung OAMI (System/Tenant): Fenster, Ergebnisindex, ggf. Fehlerpfad – Nachweis **Überwachungsprozesse** (ISO 42001 Monitoring & Measurement). |
+
+**EU AI Act Art. 72 (Post-Market-Monitoring):** Laufzeit-Events und OAMI liefern **technische Evidenz** für Überwachung nach Inverkehrbringen (Vorfälle, Schwellenverletzungen, Änderungen). ComplianceHub **qualifiziert nicht** automatisch Meldepflichten oder „schwere Vorfälle“; Auswertung und rechtliche Einordnung bleiben beim Verantwortlichen.
+
+**ISO/IEC 42001:** OAMI und strukturierte Erklärungen (Treiber, Lücken) unterstützen **Messung, Überwachung und Verbesserung** des AI-Managementsystems; sie ersetzen keine Management-Review-Protokolle.
+
+### 7.3 Demo- und Pilot-Mandanten
+
+- **Synthetische Daten:** Skripte (z. B. unter `scripts/`) sind klar als **synthetic / demo** gekennzeichnet und nutzen stabile `source_event_id`-Werte für **wiederholbares Seeding**.  
+- **Kein produktiver Ingest:** Für Mandanten mit `is_demo` (und konsistent mit Playground-Read-Only) ist **API-Ingest von Laufzeit-Events gesperrt** (HTTP 403); Daten kommen ausschließlich aus kontrolliertem Seeding – **keine** Anbindung externer SAP-Instanzen in Demo.  
+- **Pilot:** Produktive Piloten nutzen echte Ingest-Keys und Mapping; Demo-Trennung verhindert Vermischung von Test- und Echtdaten.
+
+---
+
+## 8. Verwandte Code-Pfade (Ist-Zustand)
 
 | Bereich | Datei / Tabelle |
 |---------|-----------------|
 | AI-Systeme | `app/models_db.py` → `AISystemTable` |
 | KPI-Werte | `AiKpiDefinitionDB`, `ai_system_kpi_values` |
+| Laufzeit-Events & Katalog | `app/runtime_event_catalog.py`, `app/services/runtime_events_ingest.py`, `ai_runtime_events` |
+| OAMI & Erklärungen | `app/services/operational_monitoring_index.py`, `app/services/oami_explanation.py` |
+| Governance Maturity | `app/services/governance_maturity_service.py`, `GET .../governance-maturity` |
+| Board / Advisor | `app/main.py` (Board-Report), `app/services/board_report_markdown.py`, `app/services/advisor_client_governance_snapshot.py` |
+| Demo-Sperre Ingest | `app/services/runtime_events_demo_guard.py` |
 | Workspace-Telemetrie (getrennt) | `app/services/workspace_telemetry.py` |
 
 ---
 
-*Version: 1.0 – Spezifikation für SAP AI Core Post-Market-Signale und OAMI; Implementierung nur nach Security/DPO-Freigabe für konkrete SAP-Payloads.*
+*Version: 1.1 – Spezifikation für SAP AI Core Post-Market-Signale und OAMI; Implementierung nur nach Security/DPO-Freigabe für konkrete SAP-Payloads.*

--- a/docs/runtime-events-oami-operations-runbook.md
+++ b/docs/runtime-events-oami-operations-runbook.md
@@ -1,0 +1,88 @@
+# Runbook: AI-Runtime-Events, Ingest & OAMI (Betrieb)
+
+Kurzanleitung für Betrieb und Piloten. Detaillierte Fachspezifikation: [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md).
+
+## 1. Feature-Flags (ENV)
+
+| Variable | Default (Code) | Wirkung |
+|----------|----------------|---------|
+| `COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY` | `true` | Schaltet `GET .../governance-maturity` (Readiness + GAI + OAMI-Block). Bei `false`: HTTP 403. |
+
+Weitere Flags (Board, Advisor-Snapshot, Readiness) bleiben wie in `app/feature_flags.py` dokumentiert; für OAMI im Board ist u. a. der Board-Report-Flag relevant.
+
+## 2. Wichtige API-Pfade
+
+| Methode | Pfad | Zweck |
+|---------|------|--------|
+| `POST` | `/api/v1/ai-systems/{ai_system_id}/runtime-events` | Batch-Ingest (Header `X-Tenant-Id` o. ä. wie in eurer Auth). |
+| `POST` | `/api/v1/tenants/{tenant_id}/ai-systems/{ai_system_id}/runtime-events` | Alias mit explizitem Mandanten im Pfad. |
+| `GET` | `/api/v1/ai-systems/{ai_system_id}/monitoring-index` | OAMI pro System (`window_days` Query, typisch 30/90). |
+| `GET` | `/api/v1/tenants/{tenant_id}/operational-monitoring-index` | Tenant-OAMI. |
+| `GET` | `/api/v1/tenants/{tenant_id}/governance-maturity` | Readiness + GAI + `operational_ai_monitoring`. |
+
+**Idempotenz Ingest:** eindeutig über `(tenant_id, source, source_event_id)` in der Datenbank; Duplikate im Batch werden ebenfalls übersprungen.
+
+**Demo-Mandanten (`tenants.is_demo`):** API-Ingest für Runtime-Events ist **gesperrt** (HTTP 403). Daten nur über kontrolliertes Seeding (siehe unten).
+
+## 3. Logging (grep / Log-Aggregator)
+
+Alle Meldungen über den Standard-Logger; Präfix im Log-Text zur einfachen Filterung:
+
+### `runtime_events_ingest`
+
+Pro abgeschlossenem Ingest (nach Commit oder bei leerem Insert ohne Commit):
+
+```
+runtime_events_ingest tenant_id=<id> ai_system_id=<id> inserted=<n> skipped_duplicate=<n> rejected_invalid=<n> kpi_updates=<n>
+```
+
+- Keine Roh-Payloads; nur Zähler und IDs.
+- Hohe `rejected_invalid` bei stabilem Volumen: Integrations- oder Mapping-Fehler prüfen (Katalog `app/runtime_event_catalog.py`).
+
+### `oami_compute`
+
+Nach Tenant-OAMI-Berechnung:
+
+- Ohne Events im Fenster:  
+  `oami_compute tenant_id=<id> window_days=<n> systems_scored=0 index=0 persist=<true|false>`
+- Mit Daten:  
+  `oami_compute tenant_id=<id> window_days=<n> systems_scored=<n> index=<0-100> persist=<true|false>`
+
+`persist=true` schreibt/aktualisiert den Tenant-Snapshot (Warm-Cache für Reports).
+
+## 4. Synthetische Demo-Daten (idempotent)
+
+**Nur** für Demos/Piloten mit klarem Mandat; nicht für Produktions-Echtdaten.
+
+```bash
+# Aus Projektroot, virtuelle Umgebung aktivieren
+python scripts/seed_synthetic_ai_runtime_events.py --tenant-id <TENANT_ID> --system-id <AI_SYSTEM_ID>
+```
+
+- `--dry-run`: keine DB-Änderung, nur Ausgabe „would insert …“.
+- Quelle in der DB: `synthetic_demo_seed`; stabile `source_event_id`-Muster → **erneutes Ausführen überspringt** vorhandene Zeilen.
+- Nach Commit: optionaler Aufruf `compute_tenant_operational_monitoring_index` mit `persist_snapshot=True` (siehe Skript-Ende).
+
+Voraussetzung: `ai_systems`-Zeile existiert und gehört zum angegebenen `tenant_id`.
+
+## 5. Schnell-Checkliste bei Incidents
+
+1. Letzte `runtime_events_ingest`-Zeile für betroffenen `tenant_id` / `ai_system_id`: `inserted` vs. `rejected_invalid`.
+2. Integrations-Client: `event_type`, `severity`, `source`, `metric_key` / `incident_code` gegen Katalog.
+3. OAMI „0 / low“ mit `systems_scored=0`: erwartbar ohne Events im Fenster; Erklärungsobjekt in API prüfen.
+4. Demo-Mandant: kein API-Ingest erwarten; Seeding-Pfad nutzen.
+
+## 6. Verwandte Dateien
+
+| Thema | Pfad |
+|-------|------|
+| Validierung & Enums | `app/runtime_event_catalog.py` |
+| Ingest & Incident-Refresh | `app/services/runtime_events_ingest.py` |
+| JSON-Minimierung `extra` | `app/services/runtime_event_sanitize.py` |
+| Demo-Ingest-Sperre | `app/services/runtime_events_demo_guard.py` |
+| OAMI + Snapshots | `app/services/operational_monitoring_index.py` |
+| Deutsche Kurzerklärung (ohne LLM) | `app/services/oami_explanation.py` |
+
+---
+
+*Letzte Ausrichtung: OAMI-Pipeline, Governance Maturity, Board/Advisor; bei Abweichungen Code als Quelle der Wahrheit nutzen.*

--- a/scripts/seed_synthetic_ai_runtime_events.py
+++ b/scripts/seed_synthetic_ai_runtime_events.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""
+SYNTHETISCHE Demo-/Pilot-Daten für ai_runtime_events (nicht für Produktion).
+
+- Quelle: synthetic_demo_seed (von Runtime-Katalog erlaubt).
+- Idempotente source_event_ids: synthetic-seed-{tenant_short}-{system_short}-{n}.
+- Umgeht API-Ingest (Demo-Mandanten blocken API) – direkte Session.
+
+Usage:
+  python scripts/seed_synthetic_ai_runtime_events.py --tenant-id TENANT --system-id SYS1
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import uuid
+from datetime import UTC, datetime, timedelta
+
+_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from sqlalchemy.orm import Session  # noqa: E402
+
+from app.db import engine  # noqa: E402
+from app.models_db import AiRuntimeEventTable, AISystemTable  # noqa: E402
+from app.repositories.ai_runtime_events import AiRuntimeEventRepository  # noqa: E402
+from app.services.operational_monitoring_index import (  # noqa: E402
+    compute_tenant_operational_monitoring_index,
+)
+
+
+def _slug(s: str, n: int = 8) -> str:
+    x = "".join(c if c.isalnum() else "-" for c in s.lower())
+    return x[:n]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Seed synthetic AI runtime events (labeled).")
+    p.add_argument("--tenant-id", required=True)
+    p.add_argument("--system-id", required=True)
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    tid = args.tenant_id.strip()
+    sid = args.system_id.strip()
+
+    with Session(engine) as session:
+        sys_row = session.get(AISystemTable, sid)
+        if sys_row is None or str(sys_row.tenant_id) != tid:
+            print("error: ai_system not found for tenant", file=sys.stderr)
+            sys.exit(1)
+
+        repo = AiRuntimeEventRepository(session)
+        now = datetime.now(UTC)
+        ts = _slug(tid, 6)
+        ss = _slug(sid, 6)
+        events: list[dict] = [
+            {
+                "source_event_id": f"synthetic-seed-{ts}-{ss}-hb",
+                "event_type": "heartbeat",
+                "occurred_at": now - timedelta(days=1),
+            },
+            {
+                "source_event_id": f"synthetic-seed-{ts}-{ss}-snap",
+                "event_type": "metric_snapshot",
+                "metric_key": "drift_score",
+                "value": 0.08,
+                "occurred_at": now - timedelta(days=2),
+            },
+            {
+                "source_event_id": f"synthetic-seed-{ts}-{ss}-inc1",
+                "event_type": "incident",
+                "severity": "medium",
+                "incident_code": "SYNTH_DEPLOYMENT_DELAY",
+                "occurred_at": now - timedelta(days=5),
+            },
+            {
+                "source_event_id": f"synthetic-seed-{ts}-{ss}-breach",
+                "event_type": "metric_threshold_breach",
+                "metric_key": "error_rate",
+                "value": 0.12,
+                "threshold_breached": True,
+                "occurred_at": now - timedelta(days=7),
+            },
+        ]
+
+        inserted = 0
+        for spec in events:
+            seid = spec["source_event_id"]
+            if repo.exists_by_tenant_source_event_id(tid, "synthetic_demo_seed", seid):
+                continue
+            row = AiRuntimeEventTable(
+                id=str(uuid.uuid4()),
+                tenant_id=tid,
+                ai_system_id=sid,
+                source="synthetic_demo_seed",
+                source_event_id=seid,
+                event_type=spec["event_type"],
+                severity=spec.get("severity"),
+                metric_key=spec.get("metric_key"),
+                incident_code=spec.get("incident_code"),
+                value=spec.get("value"),
+                delta=None,
+                threshold_breached=spec.get("threshold_breached"),
+                environment="prod",
+                model_version="synthetic-v1",
+                occurred_at=spec["occurred_at"].astimezone(UTC),
+                received_at=now,
+                extra={"region": "eu-de"},
+            )
+            session.add(row)
+            inserted += 1
+
+        if args.dry_run:
+            session.rollback()
+            print(f"dry-run: would insert {inserted} events")
+            return
+
+        session.commit()
+        print(f"inserted {inserted} synthetic runtime events")
+
+        oami = compute_tenant_operational_monitoring_index(
+            session,
+            tid,
+            window_days=90,
+            persist_snapshot=True,
+        )
+        print(
+            f"tenant OAMI snapshot (90d): index={oami.operational_monitoring_index} "
+            f"level={oami.level} systems={oami.systems_scored}",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ai_board_governance_report.py
+++ b/tests/test_ai_board_governance_report.py
@@ -53,6 +53,7 @@ def test_board_report_happy_path():
     assert "total_systems_with_suppliers" in data["supplier_risk_overview"]
     assert "alerts" in data
     assert isinstance(data["alerts"], list)
+    assert "operational_monitoring" in data
 
 
 def test_board_report_tenant_isolation():

--- a/tests/test_governance_maturity_api.py
+++ b/tests/test_governance_maturity_api.py
@@ -1,0 +1,91 @@
+"""Governance Maturity API (Readiness + GAI + OAMI)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.ai_system_models import (
+    AIActCategory,
+    AISystemCriticality,
+    AISystemRiskLevel,
+    DataSensitivity,
+)
+from app.main import app
+
+
+@pytest.fixture
+def client() -> TestClient:
+    with TestClient(app) as c:
+        yield c
+
+
+def _headers(tenant_id: str) -> dict[str, str]:
+    return {"x-api-key": "test-api-key", "x-tenant-id": tenant_id}
+
+
+def _create_system(client: TestClient, tenant_id: str, system_id: str) -> None:
+    payload = {
+        "id": system_id,
+        "name": "GM Test",
+        "description": "Test",
+        "business_unit": "BU",
+        "risk_level": AISystemRiskLevel.high.value,
+        "ai_act_category": AIActCategory.high_risk.value,
+        "gdpr_dpia_required": True,
+        "criticality": AISystemCriticality.high.value,
+        "data_sensitivity": DataSensitivity.internal.value,
+        "has_incident_runbook": True,
+        "has_supplier_risk_register": True,
+        "has_backup_runbook": True,
+    }
+    r = client.post("/api/v1/ai-systems", json=payload, headers=_headers(tenant_id))
+    assert r.status_code == 200, r.text
+
+
+def test_governance_maturity_200_shape(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_READINESS_SCORE", "true")
+    tid = f"gm-{uuid.uuid4().hex[:12]}"
+    h = _headers(tid)
+    _create_system(client, tid, "gm-sys-1")
+    client.post(
+        "/api/v1/ai-systems/gm-sys-1/runtime-events",
+        headers=h,
+        json={
+            "events": [
+                {
+                    "source_event_id": "gm-hb",
+                    "source": "sap_ai_core",
+                    "event_type": "heartbeat",
+                    "occurred_at": "2026-01-15T12:00:00+00:00",
+                },
+            ],
+        },
+    )
+    r = client.get(f"/api/v1/tenants/{tid}/governance-maturity", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant_id"] == tid
+    assert "governance_activity" in body
+    assert 0 <= body["governance_activity"]["index"] <= 100
+    assert body["governance_activity"]["level"] in ("low", "medium", "high")
+    oam = body["operational_ai_monitoring"]
+    assert oam["status"] in ("active", "not_configured")
+    if oam["status"] == "active":
+        assert oam["index"] is not None
+
+
+def test_governance_maturity_forbidden_when_flag_off(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "false")
+    tid = f"gm-{uuid.uuid4().hex[:12]}"
+    r = client.get(f"/api/v1/tenants/{tid}/governance-maturity", headers=_headers(tid))
+    assert r.status_code == 403

--- a/tests/test_runtime_events_oami.py
+++ b/tests/test_runtime_events_oami.py
@@ -70,7 +70,11 @@ def test_runtime_events_ingest_idempotent_and_oami_apis(client: TestClient) -> N
     }
     r1 = client.post(f"/api/v1/ai-systems/{sid}/runtime-events", json=batch, headers=h)
     assert r1.status_code == 200, r1.text
-    assert r1.json() == {"inserted": 1, "skipped_duplicate": 0, "kpi_updates": 0}
+    j1 = r1.json()
+    assert j1["inserted"] == 1
+    assert j1["skipped_duplicate"] == 0
+    assert j1["kpi_updates"] == 0
+    assert j1.get("rejected_invalid", 0) == 0
 
     r1b = client.post(f"/api/v1/ai-systems/{sid}/runtime-events", json=batch, headers=h)
     assert r1b.status_code == 200
@@ -93,6 +97,8 @@ def test_runtime_events_ingest_idempotent_and_oami_apis(client: TestClient) -> N
     assert 0 <= body["operational_monitoring_index"] <= 100
     assert body["level"] in ("low", "medium", "high")
     assert "freshness" in body["components"]
+    assert body.get("explanation") is not None
+    assert "summary_de" in body["explanation"]
 
     r_t = client.get(f"/api/v1/tenants/{tid}/operational-monitoring-index", headers=h)
     assert r_t.status_code == 200
@@ -257,3 +263,114 @@ def test_incidents_lower_oami(client: TestClient) -> None:
         headers=quiet_h,
     ).json()["operational_monitoring_index"]
     assert noisy < quiet
+
+
+def test_runtime_events_mixed_batch_valid_invalid_duplicate(client: TestClient) -> None:
+    tid = f"oami-{uuid.uuid4().hex[:12]}"
+    h = _headers(tid)
+    sid = "oami-mix-sys"
+    _create_system(client, tid, sid)
+    now = datetime.now(UTC)
+    r = client.post(
+        f"/api/v1/ai-systems/{sid}/runtime-events",
+        headers=h,
+        json={
+            "events": [
+                {
+                    "source_event_id": "good-1",
+                    "source": "sap_ai_core",
+                    "event_type": "heartbeat",
+                    "occurred_at": now.isoformat(),
+                },
+                {
+                    "source_event_id": "bad-type",
+                    "source": "sap_ai_core",
+                    "event_type": "not_a_real_type",
+                    "occurred_at": now.isoformat(),
+                },
+                {
+                    "source_event_id": "good-1",
+                    "source": "sap_ai_core",
+                    "event_type": "heartbeat",
+                    "occurred_at": now.isoformat(),
+                },
+                {
+                    "source_event_id": "good-2",
+                    "source": "sap_ai_core",
+                    "event_type": "heartbeat",
+                    "occurred_at": now.isoformat(),
+                },
+            ],
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["inserted"] == 2
+    assert body["skipped_duplicate"] == 1
+    assert body["rejected_invalid"] == 1
+    assert len(body["rejections"]) >= 1
+
+
+def test_runtime_events_idempotency_per_source(client: TestClient) -> None:
+    tid = f"oami-{uuid.uuid4().hex[:12]}"
+    h = _headers(tid)
+    sid = "oami-dedupe-src"
+    _create_system(client, tid, sid)
+    now = datetime.now(UTC)
+    base = {
+        "source_event_id": "shared-ext-id",
+        "event_type": "heartbeat",
+        "occurred_at": now.isoformat(),
+    }
+    r1 = client.post(
+        f"/api/v1/ai-systems/{sid}/runtime-events",
+        headers=h,
+        json={"events": [{**base, "source": "sap_ai_core"}]},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["inserted"] == 1
+    r2 = client.post(
+        f"/api/v1/ai-systems/{sid}/runtime-events",
+        headers=h,
+        json={"events": [{**base, "source": "manual_import"}]},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["inserted"] == 1
+
+
+def test_demo_tenant_blocks_runtime_event_api_ingest(client: TestClient) -> None:
+    from app.models_db import TenantDB
+
+    tid = f"oami-dpg-{uuid.uuid4().hex[:10]}"
+    with SessionLocal() as s:
+        s.add(
+            TenantDB(
+                id=tid,
+                display_name="Demo PG",
+                industry="IT",
+                country="DE",
+                is_demo=True,
+                demo_playground=True,
+            ),
+        )
+        s.commit()
+    h = _headers(tid)
+    _create_system(client, tid, "sys-demo-pg")
+    r = client.post(
+        "/api/v1/ai-systems/sys-demo-pg/runtime-events",
+        headers=h,
+        json={
+            "events": [
+                {
+                    "source_event_id": "x1",
+                    "source": "sap_ai_core",
+                    "event_type": "heartbeat",
+                    "occurred_at": datetime.now(UTC).isoformat(),
+                },
+            ],
+        },
+    )
+    assert r.status_code == 403
+    det = r.json().get("detail", "")
+    assert isinstance(det, str)
+    assert "runtime" in det.lower()


### PR DESCRIPTION
Add runtime event catalog validation and idempotency on (tenant_id, source, source_event_id). Extend ingest logging, OAMI explanations, tenant scoring and snapshots. Wire OAMI into governance-maturity API, board reports, advisor snapshots, and readiness explain context. Block API ingest for demo tenants; add synthetic seed script. Register COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY in feature flag env map. Document operations in runtime-events-oami-operations-runbook.md and extend governance-operational-ai-monitoring.md.

Made-with: Cursor