### PR TITLE
feat(demo): governance maturity seed (GAI + OAMI) and runbook

### DIFF
--- a/app/demo_models.py
+++ b/app/demo_models.py
@@ -30,6 +30,30 @@ class DemoSeedResponse(BaseModel):
     board_reports_count: int = 0
     ai_kpi_value_rows_count: int = 0
     cross_reg_control_rows_count: int = 0
+    demo_governance_telemetry_events_inserted: int = Field(
+        default=0,
+        description="usage_events für GAI (Governance Activity Index), idempotent.",
+    )
+    demo_governance_runtime_events_inserted: int = Field(
+        default=0,
+        description="Neue ai_runtime_events (synthetisch) für OAMI-Demo.",
+    )
+    demo_oami_snapshot_refreshed: bool = Field(
+        default=False,
+        description="Tenant-OAMI-Snapshot nach Seed neu persistiert.",
+    )
+
+
+class DemoGovernanceMaturityLayerRequest(BaseModel):
+    tenant_id: str = Field(..., min_length=1, max_length=255)
+
+
+class DemoGovernanceMaturityLayerResponse(BaseModel):
+    tenant_id: str
+    telemetry_events_inserted: int
+    runtime_events_inserted: int
+    oami_snapshot_persisted: bool
+    skipped_already_seeded: bool
 
 
 class TenantWorkspaceMetaResponse(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -123,7 +123,13 @@ from app.cross_regulation_models import (
     RequirementControlsDetailResponse,
 )
 from app.db import engine, get_session
-from app.demo_models import DemoSeedRequest, DemoSeedResponse, TenantWorkspaceMetaResponse
+from app.demo_models import (
+    DemoGovernanceMaturityLayerRequest,
+    DemoGovernanceMaturityLayerResponse,
+    DemoSeedRequest,
+    DemoSeedResponse,
+    TenantWorkspaceMetaResponse,
+)
 from app.demo_templates import DemoTenantTemplate, get_demo_template, list_demo_tenant_templates
 from app.demo_tenant_guard import (
     compute_workspace_mode_ui,
@@ -279,6 +285,7 @@ from app.services.cross_regulation_llm_gap_assistant import (
     generate_cross_regulation_llm_gap_suggestions,
 )
 from app.services.cross_regulation_seed import ensure_cross_regulation_catalog_seeded
+from app.services.demo_governance_maturity_seed import seed_demo_governance_maturity_layer
 from app.services.demo_tenant_seeder import seed_demo_tenant
 from app.services.eu_ai_act_readiness import compute_eu_ai_act_readiness_overview
 from app.services.evidence_service import (
@@ -3098,6 +3105,7 @@ def post_demo_tenant_seed(
             action_repo=action_repo,
             evidence_repo=evidence_repo,
         )
+        layer = seed_demo_governance_maturity_layer(session, body.tenant_id)
         usage_event_logger.log_usage_event(
             session,
             body.tenant_id,
@@ -3105,9 +3113,17 @@ def post_demo_tenant_seed(
             {
                 "template_key": body.template_key,
                 "advisor_linked": result.advisor_linked,
+                "demo_governance_telemetry_events_inserted": layer.telemetry_events_inserted,
+                "demo_governance_runtime_events_inserted": layer.runtime_events_inserted,
             },
         )
-        return result
+        return result.model_copy(
+            update={
+                "demo_governance_telemetry_events_inserted": layer.telemetry_events_inserted,
+                "demo_governance_runtime_events_inserted": layer.runtime_events_inserted,
+                "demo_oami_snapshot_refreshed": layer.oami_snapshot_persisted,
+            },
+        )
     except ValueError as exc:
         msg = str(exc)
         if "already has AI systems" in msg:
@@ -3119,6 +3135,38 @@ def post_demo_tenant_seed(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=msg,
         ) from exc
+
+
+@app.post(
+    "/api/v1/demo/tenants/governance-maturity-layer",
+    response_model=DemoGovernanceMaturityLayerResponse,
+    tags=["demo"],
+)
+def post_demo_governance_maturity_layer(
+    body: DemoGovernanceMaturityLayerRequest,
+    _ff_demos: Annotated[None, Depends(create_feature_guard(FeatureFlag.demo_seeding))],
+    session: Annotated[Session, Depends(get_session)],
+    _api_key: Annotated[str, Depends(require_demo_seed_api_key)],
+) -> DemoGovernanceMaturityLayerResponse:
+    """
+    Demo/Pilot: GAI-Telemetrie (usage_events), synthetische Runtime-Events (OAMI),
+    Snapshot-Refresh. Für Mandanten mit Kern-Demo-Daten (z. B. nach 409 auf vollen Seed).
+    """
+    ensure_demo_tenant_seed_allowed(body.tenant_id)
+    try:
+        layer = seed_demo_governance_maturity_layer(session, body.tenant_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    return DemoGovernanceMaturityLayerResponse(
+        tenant_id=body.tenant_id.strip(),
+        telemetry_events_inserted=layer.telemetry_events_inserted,
+        runtime_events_inserted=layer.runtime_events_inserted,
+        oami_snapshot_persisted=layer.oami_snapshot_persisted,
+        skipped_already_seeded=layer.skipped_already_seeded,
+    )
 
 
 @app.get("/api/v1/tenant/compliance-overview", response_model=TenantComplianceOverview)

--- a/app/services/demo_governance_maturity_seed.py
+++ b/app/services/demo_governance_maturity_seed.py
@@ -1,0 +1,195 @@
+"""Demo/Pilot: Governance-Telemetrie (GAI), synthetische Laufzeit-Events (OAMI), Snapshot-Refresh.
+
+Idempotent pro Mandant (Anker-Usage-Event + stabile source_event_ids).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from uuid import NAMESPACE_DNS, uuid5
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.models_db import AISystemTable, UsageEventTable
+from app.repositories.ai_runtime_events import AiRuntimeEventRepository
+from app.services.demo_synthetic_runtime_events import ensure_synthetic_runtime_events_for_system
+from app.services.operational_monitoring_index import compute_tenant_operational_monitoring_index
+from app.services.usage_event_logger import WORKSPACE_FEATURE_USED, WORKSPACE_SESSION_STARTED
+
+logger = logging.getLogger(__name__)
+
+_DEMO_SEED_PAYLOAD_MARKER = "governance_maturity_v1"
+
+# GAI: mittlerer bis mittel-hoher Index (~60–75) bei 90-Tage-Fenster
+_GAI_FEATURE_ROTATION: tuple[str, ...] = (
+    "playbook_overview",
+    "ai_governance_playbook",
+    "cross_regulation_summary",
+    "cross_regulation_dashboard",
+    "board_reports_overview",
+)
+
+
+@dataclass(frozen=True)
+class DemoGovernanceMaturitySeedResult:
+    telemetry_events_inserted: int
+    runtime_events_inserted: int
+    oami_snapshot_persisted: bool
+    skipped_already_seeded: bool
+
+
+def _anchor_usage_event_id(tenant_id: str) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"compliancehub:demo:gov_maturity:anchor:{tenant_id}"))
+
+
+def _usage_event_id(tenant_id: str, seq: int) -> str:
+    return str(uuid5(NAMESPACE_DNS, f"compliancehub:demo:gov_maturity:evt:{tenant_id}:{seq}"))
+
+
+def _list_high_risk_system_ids(session: Session, tenant_id: str, *, limit: int = 2) -> list[str]:
+    stmt = (
+        select(AISystemTable.id)
+        .where(
+            AISystemTable.tenant_id == tenant_id,
+            AISystemTable.risk_level == "high",
+        )
+        .order_by(AISystemTable.created_at_utc.asc())
+        .limit(limit)
+    )
+    return [str(x) for x in session.execute(stmt).scalars().all()]
+
+
+def _insert_governance_telemetry(session: Session, tenant_id: str, *, now: datetime) -> int:
+    """Sessions + feature_used über 8 Kalendertage; 4 unterschiedliche Governance-Features."""
+    anchor = _anchor_usage_event_id(tenant_id)
+    if session.get(UsageEventTable, anchor) is not None:
+        return 0
+
+    rows: list[UsageEventTable] = []
+    base_payload = {"_demo_seed": _DEMO_SEED_PAYLOAD_MARKER}
+
+    rows.append(
+        UsageEventTable(
+            id=anchor,
+            tenant_id=tenant_id,
+            event_type=WORKSPACE_SESSION_STARTED,
+            payload_json=json.dumps({**base_payload, "phase": "anchor"}),
+            created_at_utc=now - timedelta(days=8, hours=2),
+        ),
+    )
+
+    seq = 0
+    for day in range(8):
+        day_ts = now - timedelta(days=7 - day, hours=10)
+        seq += 1
+        rows.append(
+            UsageEventTable(
+                id=_usage_event_id(tenant_id, seq),
+                tenant_id=tenant_id,
+                event_type=WORKSPACE_SESSION_STARTED,
+                payload_json=json.dumps({**base_payload, "day": day}),
+                created_at_utc=day_ts,
+            ),
+        )
+        # 1–2 Feature-Events pro Tag, rotierend durch 4 Features (K=4)
+        for j in range(2 if day % 2 == 0 else 1):
+            fn = _GAI_FEATURE_ROTATION[(day + j) % len(_GAI_FEATURE_ROTATION)]
+            seq += 1
+            rows.append(
+                UsageEventTable(
+                    id=_usage_event_id(tenant_id, seq),
+                    tenant_id=tenant_id,
+                    event_type=WORKSPACE_FEATURE_USED,
+                    payload_json=json.dumps({**base_payload, "feature_name": fn}),
+                    created_at_utc=day_ts + timedelta(minutes=15 + j * 20),
+                ),
+            )
+
+    for row in rows:
+        session.add(row)
+    return len(rows)
+
+
+def seed_demo_governance_maturity_layer(
+    session: Session,
+    tenant_id: str,
+    *,
+    runtime_tag: str = "govmat",
+) -> DemoGovernanceMaturitySeedResult:
+    """
+    Ergänzt einen bereits (Kern-)geseedeten Mandanten um GAI- und OAMI-Story.
+
+    - Leerer Mandant ohne AI-Systeme: ValueError.
+    - Bereits ausgeführter Telemetrie-Seed: überspringt Usage-Inserts, Runtime bleibt idempotent,
+      OAMI-Snapshot wird trotzdem neu geschrieben (persist).
+    """
+    tid = tenant_id.strip()
+    if not tid:
+        raise ValueError("tenant_id required")
+
+    stmt_count = select(AISystemTable.id).where(AISystemTable.tenant_id == tid).limit(1)
+    if session.execute(stmt_count).scalar_one_or_none() is None:
+        raise ValueError("Tenant has no AI systems; run core demo seed first.")
+
+    now = datetime.now(UTC)
+    skipped_anchor = session.get(UsageEventTable, _anchor_usage_event_id(tid)) is not None
+
+    tel_n = _insert_governance_telemetry(session, tid, now=now)
+    if tel_n:
+        logger.info("demo_gov_maturity_telemetry tenant_id=%s rows=%d", tid, tel_n)
+
+    high_risk = _list_high_risk_system_ids(session, tid, limit=2)
+    rt_n = 0
+    for sid in high_risk:
+        rt_n += ensure_synthetic_runtime_events_for_system(
+            session,
+            tid,
+            sid,
+            tag=runtime_tag,
+        )
+
+    if tel_n or rt_n:
+        session.flush()
+
+    ev_repo = AiRuntimeEventRepository(session)
+    win_end = now
+    win_start = now - timedelta(days=90)
+    for sid in high_risk:
+        ev_repo.refresh_incident_summary(
+            tenant_id=tid,
+            ai_system_id=sid,
+            window_start=win_start,
+            window_end=win_end,
+            summary_id=str(uuid.uuid4()),
+        )
+
+    session.flush()
+    session.commit()
+
+    oami = compute_tenant_operational_monitoring_index(
+        session,
+        tid,
+        window_days=90,
+        persist_snapshot=True,
+    )
+    session.commit()
+
+    logger.info(
+        "demo_gov_maturity_done tenant_id=%s telemetry=%s runtime_inserted=%d oami_index=%s",
+        tid,
+        tel_n,
+        rt_n,
+        oami.operational_monitoring_index,
+    )
+
+    return DemoGovernanceMaturitySeedResult(
+        telemetry_events_inserted=tel_n,
+        runtime_events_inserted=rt_n,
+        oami_snapshot_persisted=True,
+        skipped_already_seeded=skipped_anchor and tel_n == 0 and rt_n == 0,
+    )

--- a/app/services/demo_synthetic_runtime_events.py
+++ b/app/services/demo_synthetic_runtime_events.py
@@ -1,0 +1,202 @@
+"""Deterministische synthetische ai_runtime_events für Demo/Pilot (keine PII, Katalog-konform)."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import NAMESPACE_DNS, uuid5
+
+from app.models_db import AiRuntimeEventTable
+from app.repositories.ai_runtime_events import AiRuntimeEventRepository
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+SYNTHETIC_RUNTIME_SOURCE = "synthetic_demo_seed"
+
+
+def _occurred_at_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
+def _per_system_event_prefix(*, tag: str, ai_system_id: str) -> str:
+    """Kurz-Präfix pro System: UNIQUE (tenant_id, source, source_event_id) ist global je Quelle."""
+    t = "".join(c if c.isalnum() else "" for c in tag.lower())[:8] or "gov"
+    h = str(uuid5(NAMESPACE_DNS, f"ch:synthetic_rt:{ai_system_id}"))[:10]
+    return f"synthetic-{t}-{h}"
+
+
+def synthetic_governance_demo_runtime_specs(
+    *,
+    now: datetime,
+    tag: str,
+    ai_system_id: str,
+) -> list[dict[str, object]]:
+    """
+    16 Events über ~90 Tage: Heartbeats, Snapshots, Incidents (mittel, zeitlich zurückliegend),
+    Deployment-Änderungen, ein Drift-Breach – für glaubwürdiges OAMI „Medium“.
+    """
+    prefix = _per_system_event_prefix(tag=tag, ai_system_id=ai_system_id)
+
+    def oid(suffix: str) -> str:
+        return f"{prefix}-{suffix}"[:128]
+
+    return [
+        {
+            "source_event_id": oid("hb-recent"),
+            "event_type": "heartbeat",
+            "occurred_at": now - timedelta(days=1),
+        },
+        {
+            "source_event_id": oid("hb-3d"),
+            "event_type": "heartbeat",
+            "occurred_at": now - timedelta(days=3),
+        },
+        {
+            "source_event_id": oid("snap-drift"),
+            "event_type": "metric_snapshot",
+            "metric_key": "drift_score",
+            "value": 0.07,
+            "occurred_at": now - timedelta(days=4),
+        },
+        {
+            "source_event_id": oid("snap-err"),
+            "event_type": "metric_snapshot",
+            "metric_key": "error_rate",
+            "value": 0.04,
+            "occurred_at": now - timedelta(days=6),
+        },
+        {
+            "source_event_id": oid("inc-med"),
+            "event_type": "incident",
+            "severity": "medium",
+            "incident_code": "DEMO_LATENCY_SPIKE",
+            "occurred_at": now - timedelta(days=8),
+        },
+        {
+            "source_event_id": oid("deploy-1"),
+            "event_type": "deployment_change",
+            "occurred_at": now - timedelta(days=10),
+        },
+        {
+            "source_event_id": oid("breach-drift"),
+            "event_type": "metric_threshold_breach",
+            "metric_key": "drift_score",
+            "value": 0.19,
+            "threshold_breached": True,
+            "occurred_at": now - timedelta(days=14),
+        },
+        {
+            "source_event_id": oid("inc-low"),
+            "event_type": "incident",
+            "severity": "low",
+            "incident_code": "DEMO_FALSE_POSITIVE",
+            "occurred_at": now - timedelta(days=18),
+        },
+        {
+            "source_event_id": oid("snap-drift-2"),
+            "event_type": "metric_snapshot",
+            "metric_key": "drift_score",
+            "value": 0.11,
+            "occurred_at": now - timedelta(days=22),
+        },
+        {
+            "source_event_id": oid("hb-25d"),
+            "event_type": "heartbeat",
+            "occurred_at": now - timedelta(days=25),
+        },
+        {
+            "source_event_id": oid("deploy-2"),
+            "event_type": "deployment_change",
+            "occurred_at": now - timedelta(days=30),
+        },
+        {
+            "source_event_id": oid("inc-med-old"),
+            "event_type": "incident",
+            "severity": "medium",
+            "incident_code": "DEMO_API_TIMEOUT",
+            "occurred_at": now - timedelta(days=40),
+        },
+        {
+            "source_event_id": oid("snap-safety"),
+            "event_type": "metric_snapshot",
+            "metric_key": "safety_violation_count",
+            "value": 0.0,
+            "occurred_at": now - timedelta(days=48),
+        },
+        {
+            "source_event_id": oid("hb-55d"),
+            "event_type": "heartbeat",
+            "occurred_at": now - timedelta(days=55),
+        },
+        {
+            "source_event_id": oid("breach-err"),
+            "event_type": "metric_threshold_breach",
+            "metric_key": "error_rate",
+            "value": 0.11,
+            "threshold_breached": True,
+            "occurred_at": now - timedelta(days=62),
+        },
+        {
+            "source_event_id": oid("deploy-3"),
+            "event_type": "deployment_change",
+            "occurred_at": now - timedelta(days=78),
+        },
+    ]
+
+
+def ensure_synthetic_runtime_events_for_system(
+    session: Session,
+    tenant_id: str,
+    ai_system_id: str,
+    *,
+    tag: str = "govmat",
+) -> int:
+    """Fügt fehlende synthetische Events hinzu. Idempotent pro (tenant, source, source_event_id)."""
+    repo = AiRuntimeEventRepository(session)
+    now = datetime.now(UTC)
+    specs = synthetic_governance_demo_runtime_specs(
+        now=now,
+        tag=tag,
+        ai_system_id=ai_system_id,
+    )
+    inserted = 0
+    for spec in specs:
+        seid = str(spec["source_event_id"])
+        if repo.exists_by_tenant_source_event_id(tenant_id, SYNTHETIC_RUNTIME_SOURCE, seid):
+            continue
+        row = AiRuntimeEventTable(
+            id=str(uuid.uuid4()),
+            tenant_id=tenant_id,
+            ai_system_id=ai_system_id,
+            source=SYNTHETIC_RUNTIME_SOURCE,
+            source_event_id=seid,
+            event_type=str(spec["event_type"]),
+            severity=spec.get("severity"),  # type: ignore[arg-type]
+            metric_key=spec.get("metric_key"),  # type: ignore[arg-type]
+            incident_code=spec.get("incident_code"),  # type: ignore[arg-type]
+            value=spec.get("value"),  # type: ignore[arg-type]
+            delta=None,
+            threshold_breached=spec.get("threshold_breached"),  # type: ignore[arg-type]
+            environment="prod",
+            model_version="demo-synthetic",
+            occurred_at=_occurred_at_utc(spec["occurred_at"]),
+            received_at=now,
+            extra={"region": "eu-de", "demo_synthetic": True},
+        )
+        repo.add(row)
+        inserted += 1
+    if inserted:
+        logger.info(
+            "demo_synthetic_runtime_events tenant_id=%s ai_system_id=%s inserted=%d",
+            tenant_id,
+            ai_system_id,
+            inserted,
+        )
+    return inserted

--- a/docs/demo-governance-maturity-flow.md
+++ b/docs/demo-governance-maturity-flow.md
@@ -1,0 +1,124 @@
+# Demo/Pilot: Governance Maturity Lens (Readiness + GAI + OAMI)
+
+Ziel: In **10–15 Minuten** CISO-, Board- oder Advisor-Demo die **drei Säulen** zeigen: strukturelle **Readiness**, Nutzung der Plattform (**GAI**), und **operative KI-Überwachung** (**OAMI**). Alle Daten sind **synthetisch**, ohne echte Kundendaten.
+
+Verwandte Runbooks:
+
+- [`runtime-events-oami-operations-runbook.md`](./runtime-events-oami-operations-runbook.md) – Logs, ENV, Einzelskript Runtime-Events.  
+- [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – OAMI-Fachspezifikation.  
+- [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel.
+
+---
+
+## 1. Kanonische Demo-Szenarien (Narrativ)
+
+### Szenario A – Industrie-SME („Predictive Maintenance + Vision“)
+
+| Aspekt | Inhalt |
+|--------|--------|
+| **Kontext** | Fertigung mit **SAP S/4HANA** und **SAP AI Core** (Demo-Erzählung); Fokus Hochrisiko **Qualitätskontrolle Vision** und **Arbeitssicherheit**. |
+| **AI-Systeme** | Mind. zwei **high** (Anhang III), dazu **limited** / **low** (RAG, PM) – aus Template `industrial_sme`. |
+| **NIS2** | Hochrisiko-Systeme mit Incident-/Lieferketten-KPIs; Actions zu **Art. 21** verknüpft. |
+| **Cross-Reg** | EU AI Act **Art. 9, 11, 12** über Demo-Controls; ISO **42001** im Setup-Payload; Wizard-Schritte gesetzt. |
+| **KPIs** | `incident_rate_ai`, `drift_indicator` Zeitreihen; Board-KPIs aus Register. |
+| **Ziel-Signal** | **Readiness** eher **Managed** (Lücken sichtbar). **GAI** **mittel bis mittel-hoch** (8 Tage Telemetrie). **OAMI** **mittel** (Heartbeats, Snapshots, einige Incidents/Breaches, alles idempotent). |
+
+**API-Template-Key:** `industrial_sme`  
+**CLI-Preset:** `mittelstand-ag` → `demo-mittelstand-ag`
+
+### Szenario B – Advisor / Kanzlei-Portfolio
+
+| Aspekt | Inhalt |
+|--------|--------|
+| **Kontext** | Steuerberatung / GRC-Beratung mit **mehreren** Demo-Mandanten unterschiedlicher Branche. |
+| **Umsetzung** | Zwei Mandanten seeden, z. B. `demo-mittelstand-ag` (`industrial_sme`) und `demo-grc-consulting` (`tax_advisor`); Advisor-Link optional mit `advisor_id` beim Seed. |
+| **Story** | Im **Advisor-Portfolio** unterschiedliche Readiness- und Setup-Fortschritte vergleichen; pro Mandant **Governance Maturity** (API) und **Snapshot** mit OAMI-Block. |
+
+**API-Template-Keys:** `tax_advisor`, `industrial_sme`  
+**CLI-Preset:** `grc-consulting` → `demo-grc-consulting`
+
+---
+
+## 2. Provisionierung (Reihenfolge)
+
+### Voraussetzungen
+
+- `COMPLIANCEHUB_DEMO_SEED_TENANT_IDS` enthält die Ziel-`tenant_id`.  
+- `COMPLIANCEHUB_DEMO_SEED_API_KEYS` gesetzt; Feature **demo_seeding** an.  
+- Optional: KPI-Definitionen und Cross-Reg-Katalog (CLI/API-Seed ruft `ensure_*` auf).
+
+### Schritt A – Kern-Demo-Daten
+
+**API** (wie bisher):
+
+```http
+POST /api/v1/demo/tenants/seed
+x-api-key: <demo-seed-key>
+{"template_key": "industrial_sme", "tenant_id": "demo-mittelstand-ag"}
+```
+
+**CLI:**
+
+```bash
+python scripts/seed_demo_tenant.py --preset mittelstand-ag
+# oder
+python scripts/seed_demo_tenant.py --tenant-id demo-x --template industrial_sme --display-name "Demo AG"
+```
+
+Der Kern-Seed legt u. a. AI-Register, Klassifikationen, NIS2-KPI-Zeilen, Policies, Actions, Evidenzen, Cross-Reg-Controls, KPI-Werte, Board-Reports, Setup-Payload an.
+
+### Schritt B – Governance-Maturity-Layer (GAI + OAMI)
+
+Wird **automatisch** nach erfolgreichem `POST .../demo/tenants/seed` ausgeführt (gleiche Transaktions-Session-Kette wie im Code).
+
+Manuell nachziehen (z. B. Mandant hatte schon AI-Systeme und vollständiger Seed liefert **409**):
+
+```http
+POST /api/v1/demo/tenants/governance-maturity-layer
+x-api-key: <demo-seed-key>
+{"tenant_id": "demo-mittelstand-ag"}
+```
+
+**CLI:** `seed_demo_tenant.py` ruft den Layer **immer** am Ende auf (auch wenn der Kern-Seed übersprungen wurde).
+
+Der Layer:
+
+1. Schreibt **usage_events** (Sessions + `workspace_feature_used` mit Governance-Features) – **idempotent** über einen Anker-Event.  
+2. Schreibt synthetische **ai_runtime_events** für bis zu **zwei** Hochrisiko-Systeme (`synthetic_demo_seed`, stabile IDs).  
+3. Aktualisiert **Incident-Summaries** (90-Tage-Fenster).  
+4. Berechnet **Tenant-OAMI** und **persistiert** den Snapshot.
+
+### Readiness / GAI / OAMI „rechnen“
+
+- **Readiness:** wird bei `GET .../readiness-score` **on-the-fly** aus Mandantendaten berechnet – kein separater Job.  
+- **GAI:** aus `usage_events` im gewählten Fenster (Standard 90 Tage in Governance Maturity).  
+- **OAMI:** on-read und/oder Snapshot nach Layer (siehe oben).
+
+---
+
+## 3. Demo-Ablauf (10–15 Minuten)
+
+1. **Workspace / Mandant wählen** – Banner „Demo (read-only)“; keine produktiven Writes.  
+2. **Board → AI Compliance Board-Report** – Readiness-Karte (**Managed** o. ä.); vorgefertigte **Demo-Reports** ansehen („Demo-Report ansehen“); OAMI-Texte im generierten Report, sofern Report neu erzeugt (in Demo oft nur Lesen).  
+3. **EU AI Act / KI-Register** – Hochrisiko-Systeme, Lücken (Supplier-Register, Logging).  
+4. **Cross-Regulation** – Art. 9/11/12-Coverage, Gaps.  
+5. **Governance Maturity (API)** – `GET /api/v1/tenants/{id}/governance-maturity`: Readiness + GAI + `operational_ai_monitoring` mit Erklärung.  
+6. **Advisor** – Portfolio und Mandanten-Snapshot mit Readiness + OAMI-Kurztext (falls Advisor-Features aktiv).  
+7. **CISO-Takeaway** – Post-Market-Monitoring (EU AI Act), Betriebsüberwachung (ISO 42001), Nachvollziehbarkeit (NIS2) – alles auf **Demo-Daten** bezogen.
+
+---
+
+## 4. Technische Kurzreferenz
+
+| Komponente | Ort / Endpoint |
+|------------|----------------|
+| Kern-Seed | `app/services/demo_tenant_seeder.py`, `POST /api/v1/demo/tenants/seed` |
+| GAI + Runtime + OAMI-Layer | `app/services/demo_governance_maturity_seed.py`, `POST .../governance-maturity-layer` |
+| Synthetische Runtime-Specs | `app/services/demo_synthetic_runtime_events.py` |
+| Einzelsystem-Runtime (CLI) | `scripts/seed_synthetic_ai_runtime_events.py` |
+
+**Demo-Mandanten:** Runtime-**API-Ingest** bleibt **gesperrt** (403); Daten nur über Seed/Skripte.
+
+---
+
+*Version: 1.0 – abgestimmt auf ComplianceHub Demo-Seeding und Governance-Maturity-API.*

--- a/docs/governance-maturity-lens.md
+++ b/docs/governance-maturity-lens.md
@@ -8,7 +8,8 @@
 
 - [`governance-telemetry.md`](./governance-telemetry.md) – Event-Modell, keine PII.  
 - [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel, Gewichte, Datenmodell-Skizze.  
-- [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – SAP AI Core Events, OAMI, Persistenz, BTP-Integrationsmuster.
+- [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – SAP AI Core Events, OAMI, Persistenz, BTP-Integrationsmuster.  
+- [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md) – Demo/Pilot: Seeding, Szenarien, 10–15-Minuten-Ablauf.
 
 ---
 

--- a/docs/runtime-events-oami-operations-runbook.md
+++ b/docs/runtime-events-oami-operations-runbook.md
@@ -1,6 +1,7 @@
 # Runbook: AI-Runtime-Events, Ingest & OAMI (Betrieb)
 
-Kurzanleitung für Betrieb und Piloten. Detaillierte Fachspezifikation: [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md).
+Kurzanleitung für Betrieb und Piloten. Detaillierte Fachspezifikation: [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md).  
+End-to-End-Demo inkl. GAI + OAMI: [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md).
 
 ## 1. Feature-Flags (ENV)
 

--- a/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
+++ b/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
@@ -55,7 +55,7 @@ const mdComponents = {
 };
 
 export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }) {
-  const { mutationsBlocked } = useWorkspaceMode(tenantId);
+  const { mutationsBlocked, isDemoTenant } = useWorkspaceMode(tenantId);
   const [history, setHistory] = useState<AiComplianceBoardReportListItemDto[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detail, setDetail] = useState<AiComplianceBoardReportDetailDto | null>(null);
@@ -182,7 +182,7 @@ export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }
       </p>
 
       <div className="mb-6">
-        <BoardReadinessCard tenantId={tenantId} />
+        <BoardReadinessCard tenantId={tenantId} isDemoTenant={isDemoTenant} />
       </div>
 
       {loadErr ? (
@@ -216,7 +216,7 @@ export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }
                 className={`${CH_BTN_SECONDARY} mt-3 text-xs`}
                 onClick={() => setSelectedId(last.id)}
               >
-                Anzeigen
+                {mutationsBlocked ? "Demo-Report ansehen" : "Anzeigen"}
               </button>
             </>
           ) : (

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -42,7 +42,14 @@ function DimBar({ testId, label, value }: { testId: string; label: string; value
   );
 }
 
-export function BoardReadinessCard({ tenantId }: { tenantId: string }) {
+export function BoardReadinessCard({
+  tenantId,
+  isDemoTenant = false,
+}: {
+  tenantId: string;
+  /** Pilot/Seed-Mandant: kurzer Hinweis, dass der Score aus Demo-Daten stammt. */
+  isDemoTenant?: boolean;
+}) {
   const [data, setData] = useState<ReadinessScoreResponseDto | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(true);
@@ -91,6 +98,12 @@ export function BoardReadinessCard({ tenantId }: { tenantId: string }) {
   return (
     <article className={CH_CARD} data-testid="board-readiness-card">
       <p className={CH_SECTION_LABEL}>AI &amp; Compliance Readiness</p>
+      {isDemoTenant ? (
+        <p className="mt-1 text-xs leading-snug text-slate-500">
+          Demo: Score aus synthetischen Mandantendaten. Nutzung (GAI) und Laufzeitüberwachung (OAMI)
+          siehe Governance-Maturity-API bzw. Board-Report.
+        </p>
+      ) : null}
       {busy && !data ? <p className="mt-2 text-sm text-slate-600">Lade Score…</p> : null}
       {err ? (
         <p className="mt-2 text-sm text-rose-800">{err}</p>

--- a/scripts/seed_demo_tenant.py
+++ b/scripts/seed_demo_tenant.py
@@ -31,6 +31,9 @@ from app.repositories.tenant_feature_overrides import TenantFeatureOverrideRepos
 from app.repositories.tenant_registry import TenantRegistryRepository  # noqa: E402
 from app.services.ai_kpi_seed import ensure_ai_kpi_definitions_seeded  # noqa: E402
 from app.services.cross_regulation_seed import ensure_cross_regulation_catalog_seeded  # noqa: E402
+from app.services.demo_governance_maturity_seed import (
+    seed_demo_governance_maturity_layer,  # noqa: E402
+)
 from app.services.demo_tenant_seeder import seed_demo_tenant  # noqa: E402
 from app.services.tenant_provisioning import PILOT_TENANT_FEATURE_DEFAULTS  # noqa: E402
 
@@ -81,27 +84,34 @@ def _ensure_tenant_and_seed(session, spec: dict[str, str], *, create_api_key: bo
 
     ai = AISystemRepository(session)
     if ai.list_for_tenant(tid):
-        print(f"skip seed: tenant {tid} already has AI systems")
-        return
+        print(f"skip core seed: tenant {tid} already has AI systems")
+    else:
+        result = seed_demo_tenant(
+            session,
+            spec["template_key"],
+            tid,
+            advisor_id=None,
+            ai_repo=ai,
+            cls_repo=ClassificationRepository(session),
+            nis2_repo=Nis2KritisKpiRepository(session),
+            policy_repo=PolicyRepository(session),
+            action_repo=AIGovernanceActionRepository(session),
+            evidence_repo=EvidenceFileRepository(session),
+        )
+        br = result.board_reports_count
+        kr = result.ai_kpi_value_rows_count
+        xr = result.cross_reg_control_rows_count
+        print(
+            f"seed ok: systems={result.ai_systems_count} board_reports={br} "
+            f"kpi_rows={kr} xref_ctrls={xr}",
+        )
 
-    result = seed_demo_tenant(
-        session,
-        spec["template_key"],
-        tid,
-        advisor_id=None,
-        ai_repo=ai,
-        cls_repo=ClassificationRepository(session),
-        nis2_repo=Nis2KritisKpiRepository(session),
-        policy_repo=PolicyRepository(session),
-        action_repo=AIGovernanceActionRepository(session),
-        evidence_repo=EvidenceFileRepository(session),
-    )
-    br = result.board_reports_count
-    kr = result.ai_kpi_value_rows_count
-    xr = result.cross_reg_control_rows_count
+    layer = seed_demo_governance_maturity_layer(session, tid)
     print(
-        f"seed ok: systems={result.ai_systems_count} board_reports={br} "
-        f"kpi_rows={kr} xref_ctrls={xr}",
+        f"governance maturity layer: telemetry_events={layer.telemetry_events_inserted} "
+        f"runtime_events={layer.runtime_events_inserted} "
+        f"oami_snapshot={layer.oami_snapshot_persisted} "
+        f"skipped_already={layer.skipped_already_seeded}",
     )
 
     if create_api_key:

--- a/scripts/seed_synthetic_ai_runtime_events.py
+++ b/scripts/seed_synthetic_ai_runtime_events.py
@@ -2,9 +2,8 @@
 """
 SYNTHETISCHE Demo-/Pilot-Daten für ai_runtime_events (nicht für Produktion).
 
-- Quelle: synthetic_demo_seed (von Runtime-Katalog erlaubt).
-- Idempotente source_event_ids: synthetic-seed-{tenant_short}-{system_short}-{n}.
-- Umgeht API-Ingest (Demo-Mandanten blocken API) – direkte Session.
+- Quelle: synthetic_demo_seed (Runtime-Katalog).
+- Idempotent über stabile source_event_ids (siehe app.services.demo_synthetic_runtime_events).
 
 Usage:
   python scripts/seed_synthetic_ai_runtime_events.py --tenant-id TENANT --system-id SYS1
@@ -15,8 +14,6 @@ from __future__ import annotations
 import argparse
 import os
 import sys
-import uuid
-from datetime import UTC, datetime, timedelta
 
 _ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if _ROOT not in sys.path:
@@ -25,16 +22,13 @@ if _ROOT not in sys.path:
 from sqlalchemy.orm import Session  # noqa: E402
 
 from app.db import engine  # noqa: E402
-from app.models_db import AiRuntimeEventTable, AISystemTable  # noqa: E402
-from app.repositories.ai_runtime_events import AiRuntimeEventRepository  # noqa: E402
+from app.models_db import AISystemTable  # noqa: E402
+from app.services.demo_synthetic_runtime_events import (  # noqa: E402
+    ensure_synthetic_runtime_events_for_system,
+)
 from app.services.operational_monitoring_index import (  # noqa: E402
     compute_tenant_operational_monitoring_index,
 )
-
-
-def _slug(s: str, n: int = 8) -> str:
-    x = "".join(c if c.isalnum() else "-" for c in s.lower())
-    return x[:n]
 
 
 def main() -> None:
@@ -52,74 +46,19 @@ def main() -> None:
             print("error: ai_system not found for tenant", file=sys.stderr)
             sys.exit(1)
 
-        repo = AiRuntimeEventRepository(session)
-        now = datetime.now(UTC)
-        ts = _slug(tid, 6)
-        ss = _slug(sid, 6)
-        events: list[dict] = [
-            {
-                "source_event_id": f"synthetic-seed-{ts}-{ss}-hb",
-                "event_type": "heartbeat",
-                "occurred_at": now - timedelta(days=1),
-            },
-            {
-                "source_event_id": f"synthetic-seed-{ts}-{ss}-snap",
-                "event_type": "metric_snapshot",
-                "metric_key": "drift_score",
-                "value": 0.08,
-                "occurred_at": now - timedelta(days=2),
-            },
-            {
-                "source_event_id": f"synthetic-seed-{ts}-{ss}-inc1",
-                "event_type": "incident",
-                "severity": "medium",
-                "incident_code": "SYNTH_DEPLOYMENT_DELAY",
-                "occurred_at": now - timedelta(days=5),
-            },
-            {
-                "source_event_id": f"synthetic-seed-{ts}-{ss}-breach",
-                "event_type": "metric_threshold_breach",
-                "metric_key": "error_rate",
-                "value": 0.12,
-                "threshold_breached": True,
-                "occurred_at": now - timedelta(days=7),
-            },
-        ]
-
-        inserted = 0
-        for spec in events:
-            seid = spec["source_event_id"]
-            if repo.exists_by_tenant_source_event_id(tid, "synthetic_demo_seed", seid):
-                continue
-            row = AiRuntimeEventTable(
-                id=str(uuid.uuid4()),
-                tenant_id=tid,
-                ai_system_id=sid,
-                source="synthetic_demo_seed",
-                source_event_id=seid,
-                event_type=spec["event_type"],
-                severity=spec.get("severity"),
-                metric_key=spec.get("metric_key"),
-                incident_code=spec.get("incident_code"),
-                value=spec.get("value"),
-                delta=None,
-                threshold_breached=spec.get("threshold_breached"),
-                environment="prod",
-                model_version="synthetic-v1",
-                occurred_at=spec["occurred_at"].astimezone(UTC),
-                received_at=now,
-                extra={"region": "eu-de"},
-            )
-            session.add(row)
-            inserted += 1
-
+        n = ensure_synthetic_runtime_events_for_system(
+            session,
+            tid,
+            sid,
+            tag="cli",
+        )
         if args.dry_run:
             session.rollback()
-            print(f"dry-run: would insert {inserted} events")
+            print(f"dry-run: would insert up to {n} new events (rolled back)")
             return
 
         session.commit()
-        print(f"inserted {inserted} synthetic runtime events")
+        print(f"inserted {n} synthetic runtime events")
 
         oami = compute_tenant_operational_monitoring_index(
             session,
@@ -127,6 +66,7 @@ def main() -> None:
             window_days=90,
             persist_snapshot=True,
         )
+        session.commit()
         print(
             f"tenant OAMI snapshot (90d): index={oami.operational_monitoring_index} "
             f"level={oami.level} systems={oami.systems_scored}",

--- a/tests/test_demo_tenant_seed.py
+++ b/tests/test_demo_tenant_seed.py
@@ -88,6 +88,20 @@ def test_post_demo_seed_creates_expected_entities() -> None:
     assert int(body.get("board_reports_count", 0)) >= 2
     assert int(body.get("ai_kpi_value_rows_count", 0)) >= 4
     assert int(body.get("cross_reg_control_rows_count", 0)) >= 1
+    assert int(body.get("demo_governance_telemetry_events_inserted", 0)) >= 1
+    assert int(body.get("demo_governance_runtime_events_inserted", 0)) >= 1
+    assert body.get("demo_oami_snapshot_refreshed") is True
+
+    r_layer = client.post(
+        "/api/v1/demo/tenants/governance-maturity-layer",
+        headers=_demo_headers(),
+        json={"tenant_id": T1},
+    )
+    assert r_layer.status_code == 200, r_layer.text
+    layer_body = r_layer.json()
+    assert layer_body["telemetry_events_inserted"] == 0
+    assert layer_body["runtime_events_inserted"] == 0
+    assert layer_body["skipped_already_seeded"] is True
 
     meta = client.get(
         "/api/v1/workspace/tenant-meta",


### PR DESCRIPTION
Add seed_demo_governance_maturity_layer with idempotent usage_events and synthetic runtime events per high-risk system (unique source_event_id per tenant+source). Wire into POST /demo/tenants/seed and new POST /demo/tenants/governance-maturity-layer. Extend DemoSeedResponse; refactor synthetic runtime CLI to shared service. Add docs/demo-governance-maturity-flow.md; UI demo hints on board readiness and Demo-Report label.

Made-with: Cursor