### PR TITLE
docs(demo): board walkthrough, UX copy, OAMI in advisor snapshot

### DIFF
--- a/docs/demo-board-ready-walkthrough.md
+++ b/docs/demo-board-ready-walkthrough.md
@@ -1,0 +1,113 @@
+# Internes Demo-Skript: Board- & Berater-Walkthrough (ComplianceHub)
+
+Zielgruppe: **Sales**, **Customer Success**, **Berater-Partner** – reproduzierbare Führung für **CISO/Board** (ein Mandant) und **Advisor** (Portfolio + Deep Dive).  
+Technische Provisionierung: [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md).
+
+**Kernbotschaft in drei Säulen**
+
+| Säule | Produktname | Was Sie sagen (Kurz) |
+|-------|-------------|----------------------|
+| **Struktur** | AI & Compliance **Readiness** | „Wo stehen wir mit EU AI Act, ISO 42001/27001 und Nachweisen – unabhängig vom Tagesgeschäft?“ |
+| **Nutzung** | **GAI** (Governance Activity Index) | „Nutzen wir ComplianceHub wirklich für Steuerung – Playbook, Cross-Reg, Board?“ |
+| **Betrieb** | **OAMI** (Operational AI Monitoring) | „Sehen wir Laufzeit-Signale und Vorfälle – Anknüpfung an NIS2-Incident-Themen und Post-Market-Monitoring?“ |
+
+Alle **Demodaten sind synthetisch** (keine echten Betriebs- oder Personendaten). Runtime-Events und Telemetrie sind **realistisch**, aber **nicht** aus Produktiv-SAP.
+
+---
+
+## Vorbereitung (ca. 5 Minuten vor Termin)
+
+1. **Backend** mit Demo-ENV: `COMPLIANCEHUB_DEMO_SEED_API_KEYS`, `COMPLIANCEHUB_DEMO_SEED_TENANT_IDS`, Feature **demo_seeding** aktiv.  
+2. **Mandant anlegen** (Allowlist + Key):
+   ```http
+   POST /api/v1/demo/tenants/seed
+   x-api-key: <demo-seed-key>
+   {"template_key": "industrial_sme", "tenant_id": "demo-mittelstand-ag"}
+   ```
+   (oder Preset `python scripts/seed_demo_tenant.py --preset mittelstand-ag`.)  
+3. **Frontend**: Workspace mit `x-tenant-id` / Login auf genau diesen Mandanten; bei **Advisor-Demo** `NEXT_PUBLIC_ADVISOR_ID` und Mandanten-Link gesetzt.  
+4. **Flags**: Readiness, Board-Report, Advisor-Snapshot nach Bedarf **an** (wie Pilot).
+
+**Checkliste vor Live-Demo:** Mandant öffnet sich, Board-Report-Liste nicht leer, Readiness-Karte lädt, bei Advisor: Portfolio zeigt Zeilen.
+
+---
+
+## A) CISO / Board – Ein Mandant, Deep Dive (~10 oder ~15 Min.)
+
+### Screen-Folge (empfohlen)
+
+| # | Screen / Bereich | Dauer (10′ / 15′) | Was Sie zeigen |
+|---|------------------|-------------------|----------------|
+| 1 | **Workspace-Banner** | 1′ / 1′ | Demo read-only: keine produktiven Änderungen; Daten gekennzeichnet. |
+| 2 | **KI-Register** (`/tenant/ai-systems`) | 2′ / 3′ | Hochrisiko-Systeme (Anhang III), Kurzbezug **EU AI Act**; NIS2-Relevanz über Kritikalität. |
+| 3 | **Cross-Regulation** (`/tenant/cross-regulation-dashboard`) | 2′ / 4′ | Coverage vs. Gaps (**Art. 9, 11, 12** etc.), ISO-42001/27001-Kontext. |
+| 4 | **Board-KPIs / NIS2** (`/board/nis2-kritis`, `/board/kpis`) | 1′ / 2′ | Incident-Readiness, Supplier – **NIS2**-Narrativ ohne Rechtsberatung. |
+| 5 | **AI Compliance Board-Report** (`/board/ai-compliance-report`) | 2′ / 3′ | **Readiness-Karte** (strukturell); vorgefertigter **Demo-Board-Report**; OAMI-Auszug im Report wo vorhanden. |
+| 6 | **Optional 15′** | +3′ | EU-AI-Act-Readiness-Seite, Playbook-Phase, oder **Governance-Maturity** per API/Docs erwähnen (Readiness + GAI + OAMI in einem JSON). |
+
+### Talking Points (Auszug)
+
+- „Der **Readiness Score** bündelt Setup, Coverage, KPIs, Gaps und Reporting – das ist unsere **Board-taugliche** Einordnung zur **EU AI Act**-Reife, nicht die juristische Klassifikation.“  
+- „**GAI** messen wir aus der **Nutzung** von Playbook, Cross-Reg und Board – das unterscheidet **Papier-Compliance** von aktiver Governance.“  
+- „**OAMI** steht für **operative Signale** (Vorfälle, Drift, Deployments) – das stützt **Post-Market-Monitoring** und das Gespräch mit **NIS2**-Incident-Prozessen, ohne dass wir hier Meldepflichten automatisch qualifizieren.“
+
+### Typische Board-/CISO-Fragen (diese Demo adressiert)
+
+- „**Wie sehen wir unseren EU-AI-Act-Reifegrad** über eine Zahl hinaus?“ → Readiness-Dimensionen + Cross-Reg-Gaps.  
+- „**Wie koppeln wir NIS2-Incidents an KI-Governance?**“ → NIS2-KPIs + Runtime-/OAMI-Narrativ + Actions im Register.  
+- „**Was fehlt uns noch vor 2026?**“ → Offene Actions, rote/amber Gaps, Board-Report-Empfehlungen (Demo-Text).
+
+---
+
+## B) Advisor – Portfolio + ein Mandant (~10 oder ~15 Min.)
+
+### Screen-Folge
+
+| # | Screen | Dauer (10′ / 15′) | Was Sie zeigen |
+|---|--------|-------------------|----------------|
+| 1 | **Advisor-Portfolio** (`/advisor`) | 2′ / 3′ | Vergleich Mandanten: EU-AI-Act-Readiness, **Readiness-Badge** (strukturell), Cross-Reg-Ø, High-Risk-Anzahl. |
+| 2 | **Spalten-Tooltips** | 0.5′ | Kurz: Readiness = fünf Dimensionen; Cross-Reg = Framework-Coverage. |
+| 3 | **Governance-Snapshot** (Mandant wählen) | 4′ / 6′ | Mandantenstammdaten, **Readiness**, Setup, AI-Systeme, KPIs, Cross-Reg-Tabelle, **OAMI** (Index, Level, Kurznarrativ), Reports. |
+| 4 | **Board im Workspace** (CTA aus Snapshot) | 2′ / 3′ | Gleicher Mandant: **Demo-Board-Report anzeigen**, Readiness-Karte erneut – roter Faden. |
+| 5 | **Optional 15′** | +3′ | Zweiter Mandant im Portfolio kurz vergleichen (z. B. Industrie vs. Kanzlei-Template). |
+
+### Talking Points
+
+- „Im Portfolio sehen Sie **schnell**, wo Mandanten in **Readiness** und **Cross-Reg** auseinanderlaufen – ideal für **Priorisierung**.“  
+- „Der **Snapshot** ist Ihr **einziges Blatt** vor dem Mandantentermin: Register, KPIs, Lücken, **operative KI-Überwachung** (OAMI).“  
+- „Alles, was wie **Live-Betrieb** aussieht, ist in der Demo **synthetisch** – für Vertrauen in die **Story**, nicht für echte SLAs.“
+
+### Typische Berater-Fragen
+
+- „**Wie priorisiere ich zehn Mandanten?**“ → Portfolio-Health + Readiness-Badge + Cross-Reg-Ø.  
+- „**Was nehme ich in das Geschäftsführungsgespräch?**“ → Snapshot + Board-Report-PDF/MD-Export (wenn erlaubt).
+
+---
+
+## Zeitvarianten
+
+| Variant | CISO-Pfad | Advisor-Pfad |
+|---------|-----------|--------------|
+| **10 Min.** | Schritte 1–5 ohne EU-AI-Act-Extra | Schritte 1–4, ein Mandant |
+| **15 Min.** | + EU-AI-Act/Playbook oder Governance-Maturity API | + zweiter Mandant Kurzvergleich |
+
+---
+
+## Nach dem Termin
+
+- Fragen notieren, die **außerhalb** des Produktumfangs lagen (Rechtsberatung, individuelle SAP-Architektur).  
+- Bei Bedarf **erneut seeden** (idempotent) oder zweiten Demo-Mandanten anlegen (siehe `demo-governance-maturity-flow.md`).
+
+---
+
+## Automatisierter Smoke-Check (CI / Pre-Demo)
+
+Siehe **`tests/test_demo_walkthrough_smoke.py`**: seeded Demo-Mandant, dann GET auf Readiness, Governance Maturity, Board-Reports, High-Risk-Count. Vor Live-Terminal optional:
+
+```bash
+pytest tests/test_demo_walkthrough_smoke.py -q
+```
+
+---
+
+*Version: 1.0 – intern; keine Kunden-PDF ohne Durchsicht Legal/Compliance.*

--- a/docs/demo-governance-maturity-flow.md
+++ b/docs/demo-governance-maturity-flow.md
@@ -4,6 +4,7 @@ Ziel: In **10–15 Minuten** CISO-, Board- oder Advisor-Demo die **drei Säulen*
 
 Verwandte Runbooks:
 
+- [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – **Internes Skript** (10/15 Min., CISO/Board vs. Advisor, Talking Points).  
 - [`runtime-events-oami-operations-runbook.md`](./runtime-events-oami-operations-runbook.md) – Logs, ENV, Einzelskript Runtime-Events.  
 - [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – OAMI-Fachspezifikation.  
 - [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel.

--- a/docs/governance-maturity-lens.md
+++ b/docs/governance-maturity-lens.md
@@ -9,7 +9,8 @@
 - [`governance-telemetry.md`](./governance-telemetry.md) – Event-Modell, keine PII.  
 - [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel, Gewichte, Datenmodell-Skizze.  
 - [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – SAP AI Core Events, OAMI, Persistenz, BTP-Integrationsmuster.  
-- [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md) – Demo/Pilot: Seeding, Szenarien, 10–15-Minuten-Ablauf.
+- [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md) – Demo/Pilot: Seeding, Szenarien, 10–15-Minuten-Ablauf.  
+- [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – Internes Skript (CISO/Board vs. Advisor, Talking Points).
 
 ---
 

--- a/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
+++ b/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
@@ -196,8 +196,10 @@ export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }
           className="mb-6 rounded-lg border border-amber-200 bg-amber-50/90 px-3 py-2 text-sm text-amber-950"
           role="status"
         >
-          <strong className="font-semibold">Demo (read-only):</strong> Vorhandene Reports ansehen und
-          exportieren. Neue KI-Generierung ist deaktiviert.
+          <strong className="font-semibold">Demomandant (read-only):</strong> Keine produktiven
+          Änderungen; Runtime-Telemetrie und Reports sind <strong>synthetisch</strong>, aber für EU AI
+          Act / NIS2 / ISO-Gespräche anschlussfähig. Vorhandene Reports ansehen und exportieren – neue
+          KI-Generierung ist deaktiviert.
         </div>
       ) : null}
 
@@ -216,7 +218,7 @@ export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }
                 className={`${CH_BTN_SECONDARY} mt-3 text-xs`}
                 onClick={() => setSelectedId(last.id)}
               >
-                {mutationsBlocked ? "Demo-Report ansehen" : "Anzeigen"}
+                {mutationsBlocked ? "Demo-Board-Report anzeigen" : "Anzeigen"}
               </button>
             </>
           ) : (

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
@@ -56,6 +56,14 @@ const { fetchSnap, postMd } = vi.hoisted(() => {
       last_report_audience: null,
       last_report_title: null,
     },
+    operational_ai_monitoring: {
+      index_90d: 58,
+      level: "medium",
+      has_runtime_data: true,
+      systems_scored: 2,
+      narrative_de: "Operatives Monitoring: mittlere Reife (Demo).",
+      drivers_de: ["Letzte Laufzeitereignisse", "KPI-Trends"],
+    },
   };
   const fetchSnap = vi.fn().mockResolvedValue(minimalSnapshot);
   const postMd = vi.fn().mockResolvedValue({
@@ -98,6 +106,8 @@ describe("AdvisorGovernanceSnapshotView", () => {
     });
     expect(await screen.findByText("Mandant X")).toBeTruthy();
     expect(screen.getByTestId("snap-client-info")).toBeTruthy();
+    expect(screen.getByTestId("snap-oami")).toBeTruthy();
+    expect(screen.getByText(/Operatives Monitoring: mittlere Reife/i)).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("snap-gen-md"));
     await waitFor(() => {

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
@@ -156,6 +156,12 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
           Mandanten-Governance-Snapshot
         </h1>
         <p className="mt-2 font-mono text-sm text-slate-600">{clientTenantId}</p>
+        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-slate-600">
+          Überblick für Beratungsgespräche: <strong className="font-medium text-slate-800">Readiness</strong>{" "}
+          (strukturelle EU-AI-Act-/ISO-Reife), KPIs/Cross-Reg, Reports und optional{" "}
+          <strong className="font-medium text-slate-800">OAMI</strong> (operative Laufzeit-Signale –
+          Post-Market-/NIS2-Anschluss ohne automatische Rechtsqualifikation).
+        </p>
         <div className="mt-4 flex flex-wrap gap-2">
           <Link href="/advisor" className={`${CH_BTN_SECONDARY} text-xs no-underline`}>
             Zurück zum Portfolio
@@ -224,6 +230,11 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
           {featureReadinessScore() && readiness ? (
             <section className={CH_CARD} data-testid="snap-readiness">
               <p className={CH_SECTION_LABEL}>AI &amp; Compliance Readiness</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Struktureller Reifegrad (Setup, Framework-Coverage, KPIs, Gaps, Reporting) – ergänzt
+                durch Nutzung der Plattform (GAI) und Laufzeit (OAMI), nicht identisch mit dem
+                EU-AI-Act-Readiness-Badge im Portfolio.
+              </p>
               <p className="mt-2 text-sm text-slate-700">{readiness.interpretation}</p>
               <p className="mt-3 text-3xl font-bold tabular-nums text-slate-900">
                 <span className={readiness.score < 40 ? "text-rose-700" : readiness.score < 70 ? "text-amber-800" : "text-emerald-800"}>
@@ -247,6 +258,53 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
                   <li key={i}>{line}</li>
                 ))}
               </ul>
+            </section>
+          ) : null}
+
+          {snap.operational_ai_monitoring &&
+          (snap.operational_ai_monitoring.systems_scored > 0 ||
+            (snap.operational_ai_monitoring.narrative_de &&
+              snap.operational_ai_monitoring.narrative_de.length > 0) ||
+            snap.operational_ai_monitoring.index_90d != null) ? (
+            <section className={CH_CARD} data-testid="snap-oami">
+              <p className={CH_SECTION_LABEL}>Operatives KI-Monitoring (OAMI, 90 Tage)</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Technische Signale aus dem KI-Betrieb (Vorfälle, Drift, Deployments). Unterstützt
+                Gespräche zu <strong className="font-medium text-slate-700">EU AI Act</strong>{" "}
+                Post-Market-Monitoring und <strong className="font-medium text-slate-700">NIS2</strong>{" "}
+                Incident-Management – ohne Roh-Inhalte und ohne automatische Melde-Entscheidung. In
+                Demos häufig <strong className="font-medium text-slate-700">synthetisch</strong>.
+              </p>
+              <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
+                <div>
+                  <dt className="text-xs font-semibold text-slate-500">Index / Level</dt>
+                  <dd className="font-medium text-slate-900">
+                    {snap.operational_ai_monitoring.index_90d ?? "–"}{" "}
+                    <span className="text-slate-500">
+                      / 100 · {snap.operational_ai_monitoring.level ?? "–"}
+                    </span>
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-semibold text-slate-500">Systeme mit Daten</dt>
+                  <dd className="tabular-nums text-slate-800">
+                    {snap.operational_ai_monitoring.systems_scored}
+                  </dd>
+                </div>
+              </dl>
+              {snap.operational_ai_monitoring.narrative_de ? (
+                <p className="mt-3 text-sm text-slate-700">{snap.operational_ai_monitoring.narrative_de}</p>
+              ) : null}
+              {snap.operational_ai_monitoring.drivers_de?.length ? (
+                <div className="mt-3">
+                  <p className={CH_SECTION_LABEL}>Treiber</p>
+                  <ul className="mt-1 list-inside list-disc text-sm text-slate-700">
+                    {snap.operational_ai_monitoring.drivers_de.map((line, i) => (
+                      <li key={i}>{line}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
             </section>
           ) : null}
 
@@ -326,7 +384,7 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
                   openWorkspaceTenantAndGo(clientTenantId, "/board/ai-compliance-report")
                 }
               >
-                Board-Report-Ansicht öffnen (Mandanten-Workspace)
+                Demo-Board-Report / Workspace öffnen
               </button>
             ) : null}
           </section>

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -79,7 +79,12 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                   <th>Cross-Reg Ø</th>
                 </>
               ) : null}
-              <th>EU AI Act Readiness</th>
+              <th
+                title="Heuristischer Register-/Klassifikationsüberblick – nicht identisch mit dem strukturellen AI & Compliance Readiness Score (fünf Dimensionen)."
+                className="max-w-[7rem]"
+              >
+                EU AI Act Readiness
+              </th>
               <th>NIS2 Ø / Coverage</th>
               <th>High-Risk</th>
               <th>Setup</th>
@@ -87,7 +92,7 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
               <th>Status</th>
               {readinessUi ? (
                 <th
-                  title="Berechnet aus Setup, Framework-Coverage, KPIs, regulatorischen Gaps und Board-Reports."
+                  title="AI & Compliance Readiness (0–100): Setup, EU-AI-Act-/ISO-Coverage, KPI-Register, regulatorische Gaps, Board-Reporting. Ergänzt GAI (Nutzung) und OAMI (Laufzeit) im Snapshot."
                   className="max-w-[6rem]"
                 >
                   Readiness

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -24,12 +24,23 @@ function levelLabelDe(level: string): string {
   return level;
 }
 
-function DimBar({ testId, label, value }: { testId: string; label: string; value: number }) {
+function DimBar({
+  testId,
+  label,
+  value,
+  hint,
+}: {
+  testId: string;
+  label: string;
+  value: number;
+  /** Kurz-Tooltip (Board-tauglich, EU AI Act / ISO / NIS2-Kontext). */
+  hint?: string;
+}) {
   const v = Math.max(0, Math.min(100, value));
   return (
     <div className="mt-2" data-testid={testId}>
       <div className="flex justify-between text-[0.65rem] font-medium text-slate-600">
-        <span>{label}</span>
+        <span title={hint}>{label}</span>
         <span className="tabular-nums text-slate-800">{v}</span>
       </div>
       <div className="mt-0.5 h-1.5 overflow-hidden rounded-full bg-slate-100">
@@ -100,8 +111,10 @@ export function BoardReadinessCard({
       <p className={CH_SECTION_LABEL}>AI &amp; Compliance Readiness</p>
       {isDemoTenant ? (
         <p className="mt-1 text-xs leading-snug text-slate-500">
-          Demo: Score aus synthetischen Mandantendaten. Nutzung (GAI) und Laufzeitüberwachung (OAMI)
-          siehe Governance-Maturity-API bzw. Board-Report.
+          <strong className="font-semibold text-slate-600">Demomandant</strong> – keine echten
+          Betriebsdaten. Score = strukturelle Reife (EU AI Act, ISO 42001/27001, Nachweise). Nutzung
+          der Plattform (GAI) und Laufzeit-Signale (OAMI) ergänzen das Bild im Board-Report bzw. in
+          der Governance-Maturity-Auswertung.
         </p>
       ) : null}
       {busy && !data ? <p className="mt-2 text-sm text-slate-600">Lade Score…</p> : null}
@@ -135,14 +148,38 @@ export function BoardReadinessCard({
           <p className="mt-3 text-sm leading-relaxed text-slate-700">{data.interpretation}</p>
           {d ? (
             <div className="mt-4 max-w-md border-t border-slate-100 pt-3">
-              <DimBar testId="readiness-dim-setup" label="Setup" value={d.setup.score_0_100} />
-              <DimBar testId="readiness-dim-coverage" label="Coverage" value={d.coverage.score_0_100} />
-              <DimBar testId="readiness-dim-kpi" label="KPIs" value={d.kpi.score_0_100} />
-              <DimBar testId="readiness-dim-gaps" label="Gaps" value={d.gaps.score_0_100} />
+              <p className="mb-1 text-[0.65rem] font-medium text-slate-500">
+                Fünf Dimensionen (ohne einzelne KI-Laufzeit – die liefert OAMI separat)
+              </p>
+              <DimBar
+                testId="readiness-dim-setup"
+                label="Setup"
+                value={d.setup.score_0_100}
+                hint="AI-Governance-Wizard, Rollen, Framework-Scopes (u. a. ISO 42001-Anschluss)."
+              />
+              <DimBar
+                testId="readiness-dim-coverage"
+                label="Coverage"
+                value={d.coverage.score_0_100}
+                hint="Abdeckung EU AI Act, NIS2, ISO 27001/42001 im Compliance-Graphen."
+              />
+              <DimBar
+                testId="readiness-dim-kpi"
+                label="KPIs"
+                value={d.kpi.score_0_100}
+                hint="KPI-/KRI-Zeitreihen im KI-Register (Drift, Incidents, …)."
+              />
+              <DimBar
+                testId="readiness-dim-gaps"
+                label="Gaps"
+                value={d.gaps.score_0_100}
+                hint="Regulatorische Lücken – z. B. fehlende Controls zu EU-AI-Act-Pflichten."
+              />
               <DimBar
                 testId="readiness-dim-reporting"
                 label="Reporting"
                 value={d.reporting.score_0_100}
+                hint="Board- und Management-Reports – Transparenz für Aufsichtsrat / GF."
               />
             </div>
           ) : null}

--- a/frontend/src/components/demo/DemoTenantSetupPanel.tsx
+++ b/frontend/src/components/demo/DemoTenantSetupPanel.tsx
@@ -129,8 +129,11 @@ export function DemoTenantSetupPanel({
             <li>{result.policy_rows_count} Policy-Zeilen</li>
           </ul>
           <p className="mt-2 text-xs text-emerald-800">
-            Alerts und Readiness sind aktiv. Öffnen Sie den Mandanten im Workspace für die
-            Compliance-Übersicht.
+            Alerts und Readiness sind aktiv. Governance-Telemetrie (GAI) und Laufzeit-Demo (OAMI)
+            werden mitgeseedet. Öffnen Sie den Mandanten im Workspace für die Compliance-Übersicht.
+            Internes 10–15-Minuten-Skript:{" "}
+            <code className="rounded bg-white/80 px-1">docs/demo-board-ready-walkthrough.md</code> im
+            Repository.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
             <button

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -27,6 +27,12 @@ async function tenantApiFetch(path: string, tenantId: string, init?: RequestInit
   });
 
   if (!res.ok) {
+    if (res.status === 403) {
+      throw new Error(
+        "Zugriff verweigert (HTTP 403). Häufig bei Demomandanten: schreibende Aktionen sind " +
+          "deaktiviert (read-only). Lesende Aufrufe und vorgefüllte Reports bleiben nutzbar.",
+      );
+    }
     throw new Error(`API ${path} failed with ${res.status}`);
   }
 
@@ -1492,6 +1498,15 @@ export interface AdvisorClientGovernanceSnapshotDto {
     last_report_title: string | null;
   };
   readiness?: ReadinessScoreResponseDto | null;
+  /** OAMI (90 Tage), synthetisch in Demo – Post-Market / NIS2-Gespräch ohne PII. */
+  operational_ai_monitoring?: {
+    index_90d: number | null;
+    level: string | null;
+    has_runtime_data: boolean;
+    systems_scored: number;
+    narrative_de: string;
+    drivers_de: string[];
+  } | null;
 }
 
 export async function fetchAdvisorClientGovernanceSnapshot(
@@ -1509,6 +1524,11 @@ export async function fetchAdvisorClientGovernanceSnapshot(
     cache: "no-store",
   });
   if (!res.ok) {
+    if (res.status === 403) {
+      throw new Error(
+        "Governance-Snapshot nicht verfügbar (HTTP 403). Prüfen Sie API-Key, Advisor-Zuordnung oder Demo-Schreibrechte.",
+      );
+    }
     throw new Error(`Governance snapshot failed: ${res.status}`);
   }
   return res.json() as Promise<AdvisorClientGovernanceSnapshotDto>;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ _TEST_API_KEYS = (
 )
 _DEMO_SEED_TENANTS = (
     "demo-seed-tenant-1,demo-seed-tenant-2,demo-isolation-a,demo-isolation-b,demo-direct-only,"
-    "demo-domain-kpi-tenant,demo-domain-br-tenant"
+    "demo-domain-kpi-tenant,demo-domain-br-tenant,demo-smoke-e2e"
 )
 
 

--- a/tests/test_demo_walkthrough_smoke.py
+++ b/tests/test_demo_walkthrough_smoke.py
@@ -1,0 +1,82 @@
+"""
+Smoke-Test: Demo-Seed + zentrale GETs für Board-/Advisor-Walkthrough (CI / Pre-Demo).
+
+Prüft nicht jedes UI-Feld, sondern: Seed ok, Readiness, Governance Maturity (GAI+OAMI),
+Board-Reports, Hochrisiko-Systeme vorhanden.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.security import get_settings
+
+TENANT = "demo-smoke-e2e"
+DEMO_KEY = "demo-seed-key"
+TENANT_KEY = "board-kpi-key"
+
+
+@pytest.fixture
+def client() -> TestClient:
+    with TestClient(app) as c:
+        yield c
+
+
+def _seed(client: TestClient) -> None:
+    r = client.post(
+        "/api/v1/demo/tenants/seed",
+        headers={"x-api-key": DEMO_KEY},
+        json={"template_key": "industrial_sme", "tenant_id": TENANT},
+    )
+    assert r.status_code in (200, 409), r.text
+
+
+def _th() -> dict[str, str]:
+    return {"x-api-key": TENANT_KEY, "x-tenant-id": TENANT}
+
+
+def test_demo_walkthrough_smoke_seed_and_core_apis(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_READINESS_SCORE", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_AI_COMPLIANCE_BOARD_REPORT", "true")
+    get_settings.cache_clear()
+
+    _seed(client)
+
+    r_rs = client.get(f"/api/v1/tenants/{TENANT}/readiness-score", headers=_th())
+    assert r_rs.status_code == 200, r_rs.text
+    rs = r_rs.json()
+    assert 0 <= int(rs.get("score", -1)) <= 100
+    assert rs.get("level") in ("basic", "managed", "embedded")
+
+    r_gm = client.get(f"/api/v1/tenants/{TENANT}/governance-maturity", headers=_th())
+    assert r_gm.status_code == 200, r_gm.text
+    gm = r_gm.json()
+    assert gm["tenant_id"] == TENANT
+    gai = gm["governance_activity"]
+    assert 0 <= int(gai["index"]) <= 100
+    assert gai["level"] in ("low", "medium", "high")
+    oam = gm["operational_ai_monitoring"]
+    assert oam["status"] in ("active", "not_configured")
+    if oam["status"] == "active":
+        assert oam["index"] is not None
+        assert 0 <= int(oam["index"]) <= 100
+
+    r_br = client.get(f"/api/v1/tenants/{TENANT}/board/ai-compliance-reports", headers=_th())
+    assert r_br.status_code == 200, r_br.text
+    reports = r_br.json()
+    assert isinstance(reports, list)
+    assert len(reports) >= 1
+
+    r_ai = client.get("/api/v1/ai-systems", headers=_th())
+    assert r_ai.status_code == 200, r_ai.text
+    systems = r_ai.json()
+    assert isinstance(systems, list)
+    assert len(systems) >= 1
+    high = [s for s in systems if str(s.get("risk_level", "")).lower() == "high"]
+    assert len(high) >= 1


### PR DESCRIPTION
Add docs/demo-board-ready-walkthrough.md (CISO/Board vs advisor scripts, 10/15 min). Polish German copy and tooltips on Board readiness, board report demo banner, advisor portfolio headers. Show OAMI block in advisor governance snapshot; extend API DTO and 403 hints for tenant/advisor fetches. Demo setup panel notes GAI/OAMI seed and walkthrough path. Add pytest smoke test (demo-smoke-e2e) and conftest allowlist entry. Link new doc from governance maturity docs.

Made-with: Cursor