### PR TITLE
feat(ux): standardize DE governance-maturity copy (Readiness, GAI, OAMI)

### DIFF
--- a/docs/demo-board-ready-walkthrough.md
+++ b/docs/demo-board-ready-walkthrough.md
@@ -3,13 +3,15 @@
 Zielgruppe: **Sales**, **Customer Success**, **Berater-Partner** – reproduzierbare Führung für **CISO/Board** (ein Mandant) und **Advisor** (Portfolio + Deep Dive).  
 Technische Provisionierung: [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md).
 
-**Kernbotschaft in drei Säulen**
+**Kernbotschaft in drei Säulen** (Begriffe wie in der UI, siehe [`governance-maturity-copy-de.md`](./governance-maturity-copy-de.md))
 
-| Säule | Produktname | Was Sie sagen (Kurz) |
-|-------|-------------|----------------------|
-| **Struktur** | AI & Compliance **Readiness** | „Wo stehen wir mit EU AI Act, ISO 42001/27001 und Nachweisen – unabhängig vom Tagesgeschäft?“ |
-| **Nutzung** | **GAI** (Governance Activity Index) | „Nutzen wir ComplianceHub wirklich für Steuerung – Playbook, Cross-Reg, Board?“ |
-| **Betrieb** | **OAMI** (Operational AI Monitoring) | „Sehen wir Laufzeit-Signale und Vorfälle – Anknüpfung an NIS2-Incident-Themen und Post-Market-Monitoring?“ |
+| Säule | Produktname (deutsch) | Was Sie sagen (1 Satz) |
+|-------|------------------------|-------------------------|
+| **Struktur** | **AI & Compliance Readiness** | „Wo stehen Aufbau, Framework-Abdeckung, KPI-Register, Lücken und Board-Reporting – also die strukturelle KI-Compliance-Reife zu EU AI Act, ISO/IEC 42001 und 27001?“ |
+| **Nutzung** | **Governance-Aktivitätsindex (GAI)** | „Nutzen wir Playbook, Cross-Regulation und Board-Reports wirklich – oder nur auf dem Papier?“ |
+| **Betrieb** | **Operativer KI-Monitoring-Index (OAMI)** | „Welche technischen Laufzeit-Signale sehen wir – zur Einordnung von Post-Market-Monitoring und NIS2-Incident-Themen, ohne automatische Melde-Entscheidung?“ |
+
+**Reifegrade Readiness:** Basis · Etabliert · Integriert. **Stufen GAI/OAMI:** Niedrig · Mittel · Hoch.
 
 Alle **Demodaten sind synthetisch** (keine echten Betriebs- oder Personendaten). Runtime-Events und Telemetrie sind **realistisch**, aber **nicht** aus Produktiv-SAP.
 
@@ -42,14 +44,14 @@ Alle **Demodaten sind synthetisch** (keine echten Betriebs- oder Personendaten).
 | 2 | **KI-Register** (`/tenant/ai-systems`) | 2′ / 3′ | Hochrisiko-Systeme (Anhang III), Kurzbezug **EU AI Act**; NIS2-Relevanz über Kritikalität. |
 | 3 | **Cross-Regulation** (`/tenant/cross-regulation-dashboard`) | 2′ / 4′ | Coverage vs. Gaps (**Art. 9, 11, 12** etc.), ISO-42001/27001-Kontext. |
 | 4 | **Board-KPIs / NIS2** (`/board/nis2-kritis`, `/board/kpis`) | 1′ / 2′ | Incident-Readiness, Supplier – **NIS2**-Narrativ ohne Rechtsberatung. |
-| 5 | **AI Compliance Board-Report** (`/board/ai-compliance-report`) | 2′ / 3′ | **Readiness-Karte** (strukturell); vorgefertigter **Demo-Board-Report**; OAMI-Auszug im Report wo vorhanden. |
-| 6 | **Optional 15′** | +3′ | EU-AI-Act-Readiness-Seite, Playbook-Phase, oder **Governance-Maturity** per API/Docs erwähnen (Readiness + GAI + OAMI in einem JSON). |
+| 5 | **AI Compliance Board-Report** (`/board/ai-compliance-report`) | 2′ / 3′ | **AI & Compliance Readiness**-Karte; **Demomandant**-Banner; vorgefüllter **Demo-Board-Report**; OAMI im Report wo vorhanden. |
+| 6 | **Optional 15′** | +3′ | EU-AI-Act-Readiness-Seite, Playbook, oder API **Governance Maturity** (Readiness + **governance_activity** + **operational_ai_monitoring**). |
 
-### Talking Points (Auszug)
+### Talking Points (Auszug) – gleiche Wortwahl wie in der Oberfläche
 
-- „Der **Readiness Score** bündelt Setup, Coverage, KPIs, Gaps und Reporting – das ist unsere **Board-taugliche** Einordnung zur **EU AI Act**-Reife, nicht die juristische Klassifikation.“  
-- „**GAI** messen wir aus der **Nutzung** von Playbook, Cross-Reg und Board – das unterscheidet **Papier-Compliance** von aktiver Governance.“  
-- „**OAMI** steht für **operative Signale** (Vorfälle, Drift, Deployments) – das stützt **Post-Market-Monitoring** und das Gespräch mit **NIS2**-Incident-Prozessen, ohne dass wir hier Meldepflichten automatisch qualifizieren.“
+- „**AI & Compliance Readiness** bündelt die fünf Dimensionen struktureller Reife – das ist unsere **board-taugliche** Einordnung, **nicht** die juristische Hochrisiko-Klassifikation und **nicht** dasselbe wie die Spalte **EU AI Act (Register)** im Berater-Portfolio.“  
+- „Der **Governance-Aktivitätsindex** zeigt, ob die Governance-Funktionen **tatsächlich genutzt** werden – Unterscheidung von Papier-Compliance.“  
+- „Der **operative KI-Monitoring-Index** fasst Laufzeit-Signale zusammen – Gespräch zu **EU AI Act** Post-Market-Monitoring und **NIS2**-Incidents, **ohne** automatische Qualifikation von Meldepflichten.“
 
 ### Typische Board-/CISO-Fragen (diese Demo adressiert)
 
@@ -65,17 +67,17 @@ Alle **Demodaten sind synthetisch** (keine echten Betriebs- oder Personendaten).
 
 | # | Screen | Dauer (10′ / 15′) | Was Sie zeigen |
 |---|--------|-------------------|----------------|
-| 1 | **Advisor-Portfolio** (`/advisor`) | 2′ / 3′ | Vergleich Mandanten: EU-AI-Act-Readiness, **Readiness-Badge** (strukturell), Cross-Reg-Ø, High-Risk-Anzahl. |
-| 2 | **Spalten-Tooltips** | 0.5′ | Kurz: Readiness = fünf Dimensionen; Cross-Reg = Framework-Coverage. |
-| 3 | **Governance-Snapshot** (Mandant wählen) | 4′ / 6′ | Mandantenstammdaten, **Readiness**, Setup, AI-Systeme, KPIs, Cross-Reg-Tabelle, **OAMI** (Index, Level, Kurznarrativ), Reports. |
-| 4 | **Board im Workspace** (CTA aus Snapshot) | 2′ / 3′ | Gleicher Mandant: **Demo-Board-Report anzeigen**, Readiness-Karte erneut – roter Faden. |
+| 1 | **Advisor-Portfolio** (`/advisor`) | 2′ / 3′ | Vergleich Mandanten: Spalte **EU AI Act (Register)**, **Readiness** (struktureller Score), Cross-Reg-Ø, High-Risk. Hinweiszeile zu **GAI** und **OAMI** im Snapshot. |
+| 2 | **Spalten-Tooltips** | 0.5′ | **Readiness** = AI & Compliance Readiness (fünf Dimensionen); **EU AI Act (Register)** = Register-Heuristik. |
+| 3 | **Governance-Snapshot** (Mandant wählen) | 4′ / 6′ | Einleitung (drei Säulen), **AI & Compliance Readiness**, Kachel **GAI** (Verweis API), **OAMI** (Index, Stufe Niedrig/Mittel/Hoch, Narrativ), Setup, KPIs, Cross-Reg, Reports. |
+| 4 | **Board im Workspace** (CTA aus Snapshot) | 2′ / 3′ | **Demo-Board-Report anzeigen**, Readiness-Karte – gleiche Begriffe wie oben. |
 | 5 | **Optional 15′** | +3′ | Zweiter Mandant im Portfolio kurz vergleichen (z. B. Industrie vs. Kanzlei-Template). |
 
 ### Talking Points
 
-- „Im Portfolio sehen Sie **schnell**, wo Mandanten in **Readiness** und **Cross-Reg** auseinanderlaufen – ideal für **Priorisierung**.“  
-- „Der **Snapshot** ist Ihr **einziges Blatt** vor dem Mandantentermin: Register, KPIs, Lücken, **operative KI-Überwachung** (OAMI).“  
-- „Alles, was wie **Live-Betrieb** aussieht, ist in der Demo **synthetisch** – für Vertrauen in die **Story**, nicht für echte SLAs.“
+- „Im Portfolio sehen Sie **schnell** Unterschiede zwischen **EU AI Act (Register)** und strukturellem **Readiness** sowie Cross-Reg – ideal zur **Priorisierung**.“  
+- „Der **Snapshot** bündelt **Readiness**, den erklärten **GAI** und **OAMI**, KPIs und Lücken – ein Blatt fürs Mandantengespräch.“  
+- „Laufzeit-Daten in der Demo sind **synthetisch** – glaubwürdige Story, keine Produktiv-SLA.“
 
 ### Typische Berater-Fragen
 

--- a/docs/demo-governance-maturity-flow.md
+++ b/docs/demo-governance-maturity-flow.md
@@ -5,6 +5,7 @@ Ziel: In **10–15 Minuten** CISO-, Board- oder Advisor-Demo die **drei Säulen*
 Verwandte Runbooks:
 
 - [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – **Internes Skript** (10/15 Min., CISO/Board vs. Advisor, Talking Points).  
+- [`governance-maturity-copy-de.md`](./governance-maturity-copy-de.md) – **Einheitliche deutsche Begriffe** (Readiness, GAI, OAMI).  
 - [`runtime-events-oami-operations-runbook.md`](./runtime-events-oami-operations-runbook.md) – Logs, ENV, Einzelskript Runtime-Events.  
 - [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – OAMI-Fachspezifikation.  
 - [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel.

--- a/docs/governance-maturity-copy-de.md
+++ b/docs/governance-maturity-copy-de.md
@@ -1,0 +1,50 @@
+# Governance-Maturity: deutsche Produktterminologie (ComplianceHub)
+
+**Zielgruppe:** CISO, Vorstand, Aufsichtsrat, GRC-/ISMS-Berater (DACH).  
+**Implementierung:** zentrale Konstanten in `frontend/src/lib/governanceMaturityDeCopy.ts` – diese Datei ist die **inhaltliche Referenz**; bei Abweichungen zuerst dort anpassen, dann UI prüfen.
+
+---
+
+## 1. Festgelegte Begriffe
+
+| Begriff | Offizielle UI-/Produktbezeichnung | Kurz erklärt |
+|---------|-------------------------------------|--------------|
+| Strukturelle Reife | **AI & Compliance Readiness** | Aufbau, Framework-Abdeckung, KPI-Register, Lücken, Board-Reporting – EU AI Act (u. a. Art. 9–15), ISO/IEC 42001, ISO/IEC 27001, NIS2-Anschluss. |
+| Nutzung der Plattform | **Governance-Aktivitätsindex (GAI)** | Ob Playbook, Cross-Regulation, Board und Register **tatsächlich genutzt** werden. |
+| Operative Signale | **Operativer KI-Monitoring-Index (OAMI)** | Technische Laufzeit-Signale (Vorfälle, Schwellen, Deployments) – Post-Market-Monitoring, NIS2-Incident-Bezug; keine automatische Melde-Entscheidung. |
+
+**Reifegrade (Readiness, API `basic` / `managed` / `embedded`):** **Basis** · **Etabliert** · **Integriert**  
+**Stufen bei Indexwerten GAI/OAMI (`low` / `medium` / `high`):** **Niedrig** · **Mittel** · **Hoch**
+
+**Portfolio-Spalte „EU AI Act (Register)“:** heuristischer Registerüberblick – **nicht** identisch mit dem strukturellen Readiness-Score.
+
+---
+
+## 2. Tooltips und Regulierungs-Footer (Auszug)
+
+| Kennzahl | C-Level-Tooltip (ein Satz) | Regulierungs-Footer (kurz) |
+|----------|----------------------------|----------------------------|
+| Readiness | Siehe `READINESS_TOOLTIP_C_LEVEL` in TS. | EU AI Act Art. 9–15, ISO/IEC 42001, ISO/IEC 27001; NIS2 über Governance/Incident. |
+| GAI | Siehe `GAI_TOOLTIP_C_LEVEL`. | Nachweisbare Steuerungsaktivität; kein Ersatz für Prüfung. |
+| OAMI | Siehe `OAMI_TOOLTIP_C_LEVEL`. | EU AI Act Post-Market (Art. 72), NIS2 Incident. |
+
+Ausführliche Sätze für Berater-Detail: `READINESS_ADVISOR_DETAIL_EXTRA`, `GAI_ADVISOR_DETAIL_EXTRA`, `OAMI_ADVISOR_DETAIL_EXTRA` im TS.
+
+---
+
+## 3. Banner und Demohinweise
+
+- **Board-Report (read-only):** `DEMO_BANNER_BOARD_REPORT`
+- **Readiness-Karte (Demo):** `DEMO_HINT_READINESS_CARD`
+- **Portfolio-Hinweis:** `PORTFOLIO_GOVERNANCE_MATURITY_NOTE`
+- **Nach Demo-Seed:** `DEMO_SEED_SUCCESS_GOVERNANCE_NOTE`
+
+---
+
+## 4. Walkthrough-Skript
+
+Begriffe im gesprochenen Text: [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – an diese Tabelle anbinden.
+
+---
+
+*Version 1.0 – Redaktion/Produkt; keine Rechtsberatung.*

--- a/docs/governance-maturity-lens.md
+++ b/docs/governance-maturity-lens.md
@@ -10,7 +10,8 @@
 - [`governance-activity-index.md`](./governance-activity-index.md) – GAI-Formel, Gewichte, Datenmodell-Skizze.  
 - [`governance-operational-ai-monitoring.md`](./governance-operational-ai-monitoring.md) – SAP AI Core Events, OAMI, Persistenz, BTP-Integrationsmuster.  
 - [`demo-governance-maturity-flow.md`](./demo-governance-maturity-flow.md) – Demo/Pilot: Seeding, Szenarien, 10–15-Minuten-Ablauf.  
-- [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – Internes Skript (CISO/Board vs. Advisor, Talking Points).
+- [`demo-board-ready-walkthrough.md`](./demo-board-ready-walkthrough.md) – Internes Skript (CISO/Board vs. Advisor, Talking Points).  
+- [`governance-maturity-copy-de.md`](./governance-maturity-copy-de.md) – **Terminologie und Tooltips** (Board-taugliches Deutsch).
 
 ---
 

--- a/frontend/src/app/advisor/page.tsx
+++ b/frontend/src/app/advisor/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/api";
 import { portfolioHealth } from "@/lib/advisorPortfolioHealth";
 import { CH_CARD, CH_SECTION_LABEL, CH_SHELL } from "@/lib/boardLayout";
+import { PORTFOLIO_GOVERNANCE_MATURITY_NOTE } from "@/lib/governanceMaturityDeCopy";
 import {
   featureAdvisorWorkspace,
   featureAiComplianceBoardReport,
@@ -235,6 +236,10 @@ export default function AdvisorPortfolioPage() {
               tenantIds={[...new Set(processed.map((t) => t.tenant_id))]}
             />
           ) : null}
+
+          <p className="mb-3 max-w-4xl text-xs leading-relaxed text-slate-600">
+            {PORTFOLIO_GOVERNANCE_MATURITY_NOTE}
+          </p>
 
           <AdvisorPortfolioTable rows={processed} advisorId={advisorId} />
         </>

--- a/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
+++ b/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.tsx
@@ -22,6 +22,7 @@ import { BoardReadinessCard } from "@/components/board/BoardReadinessCard";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import { GovernanceViewFeatureTelemetry } from "@/components/workspace/GovernanceViewFeatureTelemetry";
 import { useWorkspaceMode } from "@/hooks/useWorkspaceMode";
+import { DEMO_BANNER_BOARD_REPORT } from "@/lib/governanceMaturityDeCopy";
 
 const ALL_FRAMEWORKS: { key: string; label: string }[] = [
   { key: "eu_ai_act", label: "EU AI Act" },
@@ -196,10 +197,7 @@ export function AiComplianceBoardReportClient({ tenantId }: { tenantId: string }
           className="mb-6 rounded-lg border border-amber-200 bg-amber-50/90 px-3 py-2 text-sm text-amber-950"
           role="status"
         >
-          <strong className="font-semibold">Demomandant (read-only):</strong> Keine produktiven
-          Änderungen; Runtime-Telemetrie und Reports sind <strong>synthetisch</strong>, aber für EU AI
-          Act / NIS2 / ISO-Gespräche anschlussfähig. Vorhandene Reports ansehen und exportieren – neue
-          KI-Generierung ist deaktiviert.
+          {DEMO_BANNER_BOARD_REPORT}
         </div>
       ) : null}
 

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
@@ -106,6 +106,7 @@ describe("AdvisorGovernanceSnapshotView", () => {
     });
     expect(await screen.findByText("Mandant X")).toBeTruthy();
     expect(screen.getByTestId("snap-client-info")).toBeTruthy();
+    expect(screen.getByTestId("snap-gai-note")).toBeTruthy();
     expect(screen.getByTestId("snap-oami")).toBeTruthy();
     expect(screen.getByText(/Operatives Monitoring: mittlere Reife/i)).toBeTruthy();
 

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
@@ -21,6 +21,24 @@ import {
   CH_SHELL,
 } from "@/lib/boardLayout";
 import { featureAiComplianceBoardReport, featureReadinessScore } from "@/lib/config";
+import {
+  GAI_ADVISOR_DETAIL_EXTRA,
+  GAI_FULL_NAME,
+  GAI_REG_HINT_SHORT,
+  GAI_TOOLTIP_C_LEVEL,
+  OAMI_ADVISOR_DETAIL_EXTRA,
+  OAMI_FULL_NAME,
+  OAMI_REG_HINT_SHORT,
+  OAMI_SECTION_TITLE,
+  OAMI_TOOLTIP_C_LEVEL,
+  READINESS_ADVISOR_DETAIL_EXTRA,
+  READINESS_PRODUCT_TITLE,
+  READINESS_REG_HINT_SHORT,
+  READINESS_TAGLINE,
+  READINESS_TOOLTIP_C_LEVEL,
+  indexLevelLabelDe,
+  readinessLevelLabelDe,
+} from "@/lib/governanceMaturityDeCopy";
 import { openWorkspaceTenantAndGo } from "@/lib/workspaceTenantClient";
 
 const mdComponents = {
@@ -156,12 +174,22 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
           Mandanten-Governance-Snapshot
         </h1>
         <p className="mt-2 font-mono text-sm text-slate-600">{clientTenantId}</p>
-        <p className="mt-3 max-w-3xl text-sm leading-relaxed text-slate-600">
-          Überblick für Beratungsgespräche: <strong className="font-medium text-slate-800">Readiness</strong>{" "}
-          (strukturelle EU-AI-Act-/ISO-Reife), KPIs/Cross-Reg, Reports und optional{" "}
-          <strong className="font-medium text-slate-800">OAMI</strong> (operative Laufzeit-Signale –
-          Post-Market-/NIS2-Anschluss ohne automatische Rechtsqualifikation).
-        </p>
+        <div className="mt-3 max-w-3xl space-y-2 text-sm leading-relaxed text-slate-600">
+          <p title={READINESS_TOOLTIP_C_LEVEL}>
+            <span className="font-semibold text-slate-800">{READINESS_PRODUCT_TITLE}:</span>{" "}
+            {READINESS_TAGLINE}
+          </p>
+          <p title={GAI_TOOLTIP_C_LEVEL}>
+            <span className="font-semibold text-slate-800">{GAI_FULL_NAME}:</span>{" "}
+            {GAI_TOOLTIP_C_LEVEL} {GAI_ADVISOR_DETAIL_EXTRA}
+          </p>
+          <p className="text-xs text-slate-500">{GAI_REG_HINT_SHORT}</p>
+          <p title={OAMI_TOOLTIP_C_LEVEL}>
+            <span className="font-semibold text-slate-800">{OAMI_FULL_NAME}:</span>{" "}
+            {OAMI_TOOLTIP_C_LEVEL} {OAMI_ADVISOR_DETAIL_EXTRA}
+          </p>
+          <p className="text-xs text-slate-500">{OAMI_REG_HINT_SHORT}</p>
+        </div>
         <div className="mt-4 flex flex-wrap gap-2">
           <Link href="/advisor" className={`${CH_BTN_SECONDARY} text-xs no-underline`}>
             Zurück zum Portfolio
@@ -229,20 +257,22 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
 
           {featureReadinessScore() && readiness ? (
             <section className={CH_CARD} data-testid="snap-readiness">
-              <p className={CH_SECTION_LABEL}>AI &amp; Compliance Readiness</p>
-              <p className="mt-1 text-xs text-slate-500">
-                Struktureller Reifegrad (Setup, Framework-Coverage, KPIs, Gaps, Reporting) – ergänzt
-                durch Nutzung der Plattform (GAI) und Laufzeit (OAMI), nicht identisch mit dem
-                EU-AI-Act-Readiness-Badge im Portfolio.
+              <p className={CH_SECTION_LABEL} title={READINESS_TOOLTIP_C_LEVEL}>
+                {READINESS_PRODUCT_TITLE}
               </p>
+              <p className="mt-1 text-xs text-slate-500">{READINESS_ADVISOR_DETAIL_EXTRA}</p>
+              <p className="mt-1 text-[0.65rem] text-slate-500">{READINESS_REG_HINT_SHORT}</p>
               <p className="mt-2 text-sm text-slate-700">{readiness.interpretation}</p>
               <p className="mt-3 text-3xl font-bold tabular-nums text-slate-900">
                 <span className={readiness.score < 40 ? "text-rose-700" : readiness.score < 70 ? "text-amber-800" : "text-emerald-800"}>
                   {readiness.score}
                 </span>
                 <span className="text-lg font-semibold text-slate-500">/100</span>
-                <span className="ml-2 text-base font-medium text-slate-600">
-                  ({readiness.level === "basic" ? "Basic" : readiness.level === "managed" ? "Managed" : "Embedded"})
+                <span
+                  className="ml-2 text-base font-medium text-slate-600"
+                  title={READINESS_REG_HINT_SHORT}
+                >
+                  ({readinessLevelLabelDe(readiness.level)})
                 </span>
               </p>
               <ul className="mt-3 grid gap-1 text-xs text-slate-600 sm:grid-cols-2">
@@ -261,19 +291,34 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
             </section>
           ) : null}
 
+          <section className={CH_CARD} data-testid="snap-gai-note">
+            <p className={CH_SECTION_LABEL} title={GAI_TOOLTIP_C_LEVEL}>
+              {GAI_FULL_NAME}
+            </p>
+            <p className="mt-1 text-sm text-slate-700">{GAI_TOOLTIP_C_LEVEL}</p>
+            <p className="mt-1 text-xs text-slate-600">{GAI_ADVISOR_DETAIL_EXTRA}</p>
+            <p className="mt-2 text-[0.65rem] text-slate-500">{GAI_REG_HINT_SHORT}</p>
+            <p className="mt-2 text-xs text-slate-600">
+              Kennzahl und Verlauf (0–100, z. B. 90 Tage) siehe API{" "}
+              <span className="font-mono text-[0.7rem]">GET …/governance-maturity</span> – Feld{" "}
+              <span className="font-mono text-[0.7rem]">governance_activity</span>.
+            </p>
+          </section>
+
           {snap.operational_ai_monitoring &&
           (snap.operational_ai_monitoring.systems_scored > 0 ||
             (snap.operational_ai_monitoring.narrative_de &&
               snap.operational_ai_monitoring.narrative_de.length > 0) ||
             snap.operational_ai_monitoring.index_90d != null) ? (
             <section className={CH_CARD} data-testid="snap-oami">
-              <p className={CH_SECTION_LABEL}>Operatives KI-Monitoring (OAMI, 90 Tage)</p>
+              <p className={CH_SECTION_LABEL} title={OAMI_TOOLTIP_C_LEVEL}>
+                {OAMI_SECTION_TITLE}
+              </p>
+              <p className="mt-1 text-xs text-slate-600">{OAMI_TOOLTIP_C_LEVEL}</p>
+              <p className="mt-1 text-xs text-slate-600">{OAMI_ADVISOR_DETAIL_EXTRA}</p>
+              <p className="mt-1 text-[0.65rem] text-slate-500">{OAMI_REG_HINT_SHORT}</p>
               <p className="mt-1 text-xs text-slate-500">
-                Technische Signale aus dem KI-Betrieb (Vorfälle, Drift, Deployments). Unterstützt
-                Gespräche zu <strong className="font-medium text-slate-700">EU AI Act</strong>{" "}
-                Post-Market-Monitoring und <strong className="font-medium text-slate-700">NIS2</strong>{" "}
-                Incident-Management – ohne Roh-Inhalte und ohne automatische Melde-Entscheidung. In
-                Demos häufig <strong className="font-medium text-slate-700">synthetisch</strong>.
+                In Demos typischerweise synthetische Signale – keine Anbindung an Produktiv-SAP.
               </p>
               <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
                 <div>
@@ -281,7 +326,7 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
                   <dd className="font-medium text-slate-900">
                     {snap.operational_ai_monitoring.index_90d ?? "–"}{" "}
                     <span className="text-slate-500">
-                      / 100 · {snap.operational_ai_monitoring.level ?? "–"}
+                      / 100 · {indexLevelLabelDe(snap.operational_ai_monitoring.level)}
                     </span>
                   </dd>
                 </div>

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -7,6 +7,14 @@ import { portfolioHealth, type PortfolioHealth } from "@/lib/advisorPortfolioHea
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD } from "@/lib/boardLayout";
 import * as chConfig from "@/lib/config";
 import {
+  PORTFOLIO_COL_EU_AI_ACT,
+  PORTFOLIO_COL_EU_AI_ACT_TOOLTIP,
+  PORTFOLIO_COL_READINESS,
+  PORTFOLIO_COL_READINESS_TOOLTIP,
+  READINESS_REG_HINT_SHORT,
+  readinessLevelLabelDe,
+} from "@/lib/governanceMaturityDeCopy";
+import {
   openWorkspaceTenantAndGo,
   openWorkspaceTenantAndGoComplianceOverview,
 } from "@/lib/workspaceTenantClient";
@@ -79,11 +87,8 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                   <th>Cross-Reg Ø</th>
                 </>
               ) : null}
-              <th
-                title="Heuristischer Register-/Klassifikationsüberblick – nicht identisch mit dem strukturellen AI & Compliance Readiness Score (fünf Dimensionen)."
-                className="max-w-[7rem]"
-              >
-                EU AI Act Readiness
+              <th title={PORTFOLIO_COL_EU_AI_ACT_TOOLTIP} className="max-w-[7rem]">
+                {PORTFOLIO_COL_EU_AI_ACT}
               </th>
               <th>NIS2 Ø / Coverage</th>
               <th>High-Risk</th>
@@ -91,11 +96,8 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
               <th>Offene Actions</th>
               <th>Status</th>
               {readinessUi ? (
-                <th
-                  title="AI & Compliance Readiness (0–100): Setup, EU-AI-Act-/ISO-Coverage, KPI-Register, regulatorische Gaps, Board-Reporting. Ergänzt GAI (Nutzung) und OAMI (Laufzeit) im Snapshot."
-                  className="max-w-[6rem]"
-                >
-                  Readiness
+                <th title={PORTFOLIO_COL_READINESS_TOOLTIP} className="max-w-[6rem]">
+                  {PORTFOLIO_COL_READINESS}
                 </th>
               ) : null}
               {snapUi ? <th>Snapshot</th> : null}
@@ -199,7 +201,7 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                       {t.readiness_summary ? (
                         <span
                           className={`inline-flex min-w-[2.25rem] justify-center rounded-full px-2 py-0.5 text-xs font-bold tabular-nums ${readinessBadgeClasses(t.readiness_summary.score)}`}
-                          title={`Level ${t.readiness_summary.level}; aus Setup, Coverage, KPIs, Gaps, Reports.`}
+                          title={`Reifegrad ${readinessLevelLabelDe(t.readiness_summary.level)} (0–100). ${READINESS_REG_HINT_SHORT}`}
                           data-testid={`advisor-readiness-badge-${t.tenant_id}`}
                         >
                           {t.readiness_summary.score}

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -9,19 +9,31 @@ import {
 } from "@/lib/api";
 import { CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
 import { featureLlmEnabled, featureLlmExplain, featureReadinessScore } from "@/lib/config";
+import {
+  DEMO_HINT_READINESS_CARD,
+  READINESS_DIM_COVERAGE,
+  READINESS_DIM_COVERAGE_HINT,
+  READINESS_DIM_GAPS,
+  READINESS_DIM_GAPS_HINT,
+  READINESS_DIM_KPIS,
+  READINESS_DIM_KPIS_HINT,
+  READINESS_DIM_REPORTING,
+  READINESS_DIM_REPORTING_HINT,
+  READINESS_DIM_SETUP,
+  READINESS_DIM_SETUP_HINT,
+  READINESS_FIVE_DIMS_CAPTION,
+  READINESS_PRODUCT_TITLE,
+  READINESS_REG_HINT_SHORT,
+  READINESS_TAGLINE,
+  READINESS_TOOLTIP_C_LEVEL,
+  readinessLevelLabelDe,
+} from "@/lib/governanceMaturityDeCopy";
 import { openWorkspaceTenantAndGo } from "@/lib/workspaceTenantClient";
 
 function scoreAccent(score: number): string {
   if (score < 40) return "text-rose-700";
   if (score < 70) return "text-amber-800";
   return "text-emerald-800";
-}
-
-function levelLabelDe(level: string): string {
-  if (level === "basic") return "Basic";
-  if (level === "managed") return "Managed";
-  if (level === "embedded") return "Embedded";
-  return level;
 }
 
 function DimBar({
@@ -108,14 +120,13 @@ export function BoardReadinessCard({
 
   return (
     <article className={CH_CARD} data-testid="board-readiness-card">
-      <p className={CH_SECTION_LABEL}>AI &amp; Compliance Readiness</p>
+      <p className={CH_SECTION_LABEL} title={READINESS_TOOLTIP_C_LEVEL}>
+        {READINESS_PRODUCT_TITLE}
+      </p>
+      <p className="mt-1 text-xs leading-snug text-slate-600">{READINESS_TAGLINE}</p>
+      <p className="mt-1 text-[0.65rem] leading-snug text-slate-500">{READINESS_REG_HINT_SHORT}</p>
       {isDemoTenant ? (
-        <p className="mt-1 text-xs leading-snug text-slate-500">
-          <strong className="font-semibold text-slate-600">Demomandant</strong> – keine echten
-          Betriebsdaten. Score = strukturelle Reife (EU AI Act, ISO 42001/27001, Nachweise). Nutzung
-          der Plattform (GAI) und Laufzeit-Signale (OAMI) ergänzen das Bild im Board-Report bzw. in
-          der Governance-Maturity-Auswertung.
-        </p>
+        <p className="mt-2 text-xs leading-snug text-amber-900/90">{DEMO_HINT_READINESS_CARD}</p>
       ) : null}
       {busy && !data ? <p className="mt-2 text-sm text-slate-600">Lade Score…</p> : null}
       {err ? (
@@ -133,7 +144,10 @@ export function BoardReadinessCard({
                 <span className="text-lg font-semibold text-slate-500">/100</span>
               </p>
               <p className="mt-1 text-sm font-medium text-slate-700">
-                Level: <span className="text-slate-900">{levelLabelDe(data.level)}</span>
+                Reifegrad:{" "}
+                <span className="text-slate-900" title={READINESS_REG_HINT_SHORT}>
+                  {readinessLevelLabelDe(data.level)}
+                </span>
               </p>
             </div>
             <button
@@ -149,37 +163,37 @@ export function BoardReadinessCard({
           {d ? (
             <div className="mt-4 max-w-md border-t border-slate-100 pt-3">
               <p className="mb-1 text-[0.65rem] font-medium text-slate-500">
-                Fünf Dimensionen (ohne einzelne KI-Laufzeit – die liefert OAMI separat)
+                {READINESS_FIVE_DIMS_CAPTION}
               </p>
               <DimBar
                 testId="readiness-dim-setup"
-                label="Setup"
+                label={READINESS_DIM_SETUP}
                 value={d.setup.score_0_100}
-                hint="AI-Governance-Wizard, Rollen, Framework-Scopes (u. a. ISO 42001-Anschluss)."
+                hint={READINESS_DIM_SETUP_HINT}
               />
               <DimBar
                 testId="readiness-dim-coverage"
-                label="Coverage"
+                label={READINESS_DIM_COVERAGE}
                 value={d.coverage.score_0_100}
-                hint="Abdeckung EU AI Act, NIS2, ISO 27001/42001 im Compliance-Graphen."
+                hint={READINESS_DIM_COVERAGE_HINT}
               />
               <DimBar
                 testId="readiness-dim-kpi"
-                label="KPIs"
+                label={READINESS_DIM_KPIS}
                 value={d.kpi.score_0_100}
-                hint="KPI-/KRI-Zeitreihen im KI-Register (Drift, Incidents, …)."
+                hint={READINESS_DIM_KPIS_HINT}
               />
               <DimBar
                 testId="readiness-dim-gaps"
-                label="Gaps"
+                label={READINESS_DIM_GAPS}
                 value={d.gaps.score_0_100}
-                hint="Regulatorische Lücken – z. B. fehlende Controls zu EU-AI-Act-Pflichten."
+                hint={READINESS_DIM_GAPS_HINT}
               />
               <DimBar
                 testId="readiness-dim-reporting"
-                label="Reporting"
+                label={READINESS_DIM_REPORTING}
                 value={d.reporting.score_0_100}
-                hint="Board- und Management-Reports – Transparenz für Aufsichtsrat / GF."
+                hint={READINESS_DIM_REPORTING_HINT}
               />
             </div>
           ) : null}

--- a/frontend/src/components/demo/DemoTenantSetupPanel.tsx
+++ b/frontend/src/components/demo/DemoTenantSetupPanel.tsx
@@ -9,6 +9,7 @@ import {
   type DemoTenantTemplateDto,
 } from "@/lib/api";
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+import { DEMO_SEED_SUCCESS_GOVERNANCE_NOTE } from "@/lib/governanceMaturityDeCopy";
 import { openWorkspaceTenantAndGoComplianceOverview } from "@/lib/workspaceTenantClient";
 
 export interface DemoTenantSetupPanelProps {
@@ -129,11 +130,8 @@ export function DemoTenantSetupPanel({
             <li>{result.policy_rows_count} Policy-Zeilen</li>
           </ul>
           <p className="mt-2 text-xs text-emerald-800">
-            Alerts und Readiness sind aktiv. Governance-Telemetrie (GAI) und Laufzeit-Demo (OAMI)
-            werden mitgeseedet. Öffnen Sie den Mandanten im Workspace für die Compliance-Übersicht.
-            Internes 10–15-Minuten-Skript:{" "}
-            <code className="rounded bg-white/80 px-1">docs/demo-board-ready-walkthrough.md</code> im
-            Repository.
+            Alerts und struktureller Readiness sind aktiv. {DEMO_SEED_SUCCESS_GOVERNANCE_NOTE} Öffnen
+            Sie den Mandanten im Workspace für die Compliance-Übersicht.
           </p>
           <div className="mt-3 flex flex-wrap gap-2">
             <button

--- a/frontend/src/lib/governanceMaturityDeCopy.ts
+++ b/frontend/src/lib/governanceMaturityDeCopy.ts
@@ -1,0 +1,129 @@
+/**
+ * Board-taugliche deutsche Texte: Governance-Maturity (Readiness, GAI, OAMI).
+ * Einheitliche Begriffe für Board, CISO, Aufsichtsrat und Berater (DACH).
+ *
+ * Referenz für Redaktion: docs/governance-maturity-copy-de.md
+ */
+
+/** Produktbezeichnung in der UI (nicht übersetzen: etabliertes Marken-Element). */
+export const READINESS_PRODUCT_TITLE = "AI & Compliance Readiness";
+
+/** Kurz erklärt, was der Score misst (Unterzeile / Fließtext). */
+export const READINESS_TAGLINE =
+  "Strukturelle Reife von Aufbau, Framework-Abdeckung, KPI-Register, Lücken und Board-Reporting – unabhängig von der Tagesnutzung der Plattform.";
+
+/** Ein Satz für Tooltip / Hover (C-Level). */
+export const READINESS_TOOLTIP_C_LEVEL =
+  "Misst, wie gut KI-Governance dokumentiert und abgesichert ist: EU AI Act (u. a. Risiko, Nachweise, Art. 9–15), ISO/IEC 42001 (KI-Managementsystem) und ISMS (ISO/IEC 27001), mit Anknüpfung an NIS2 über Nachweise und Steuerung.";
+
+/** Optional zweiter Satz (Berater-Detail, Snapshot). */
+export const READINESS_ADVISOR_DETAIL_EXTRA =
+  "Nicht identisch mit dem EU-AI-Act-Readiness-Badge in der Portfolio-Spalte (dort: heuristischer Registerüberblick).";
+
+/** Kurzer Regulierungs-Footer für Tooltips. */
+export const READINESS_REG_HINT_SHORT =
+  "Regulatorik: EU AI Act Art. 9–15, ISO/IEC 42001, ISO/IEC 27001; NIS2-Anschluss über Governance und Incident-Prozesse.";
+
+export const GAI_FULL_NAME = "Governance-Aktivitätsindex (GAI)";
+
+export const GAI_TOOLTIP_C_LEVEL =
+  "Zeigt, ob Playbook, Cross-Regulation, Board-Reports und Register in ComplianceHub tatsächlich genutzt werden – Unterscheidung von reiner Papier-Compliance.";
+
+export const GAI_ADVISOR_DETAIL_EXTRA =
+  "Hilft bei Audit- und Board-Vorbereitung: nachvollziehbare Aktivität statt nur dokumentierter Prozesse.";
+
+export const GAI_REG_HINT_SHORT =
+  "Steht für nachweisbare Steuerungsaktivität; unterstützt Aufsichts- und Prüfungsgespräche, ersetzt keine Prüfung.";
+
+export const OAMI_FULL_NAME = "Operativer KI-Monitoring-Index (OAMI)";
+
+export const OAMI_TOOLTIP_C_LEVEL =
+  "Bündelt technische Laufzeit-Signale (Vorfälle, Schwellen, Deployments) aus dem KI-Betrieb – ohne Rohdaten aus Modellen oder personenbezogene Inhalte.";
+
+export const OAMI_ADVISOR_DETAIL_EXTRA =
+  "Unterstützt Gespräche zu Post-Market-Monitoring und NIS2-relevantem Incident-Management; keine automatische Qualifikation von Meldepflichten.";
+
+export const OAMI_REG_HINT_SHORT =
+  "Bezug: EU AI Act Post-Market-Monitoring (Art. 72), NIS2 zu Erkennung und Steuerung von Vorfällen.";
+
+/** Abschnittstitel Snapshot / Board (90-Tage-Fenster). */
+export const OAMI_SECTION_TITLE = "Operativer KI-Monitoring-Index (OAMI, 90 Tage)";
+
+/** Demomandant: Board-Report-Banner (ein Absatz). */
+export const DEMO_BANNER_BOARD_REPORT =
+  "Demomandant (read-only): keine produktiven Änderungen. Alle Werte sind Beispieldaten ohne echten Betrieb. Sie dienen EU-AI-Act-, NIS2- und ISO-Gesprächen; vorgefüllte Reports ansehen und exportieren – neue KI-Generierung ist deaktiviert.";
+
+/** Demomandant: Readiness-Karte. */
+export const DEMO_HINT_READINESS_CARD =
+  "Demomandant – Beispielwerte, keine echten Betriebsdaten. Dieser Score beschreibt die strukturelle KI-Compliance-Reife (EU AI Act, ISO/IEC 42001 und 27001, Nachweise). Governance-Aktivität (GAI) und Laufzeit-Signale (OAMI) zeigen Board-Report und Governance-Snapshot.";
+
+/** Nach erfolgreichem Demo-Seed (Setup-Panel). */
+export const DEMO_SEED_SUCCESS_GOVERNANCE_NOTE =
+  "Zusätzlich werden synthetische Daten für den Governance-Aktivitätsindex (GAI) und den operativen KI-Monitoring-Index (OAMI) erzeugt. Internes Walkthrough: docs/demo-board-ready-walkthrough.md.";
+
+/** Portfolio: Hinweis unter Überschrift / vor Tabelle. */
+export const PORTFOLIO_GOVERNANCE_MATURITY_NOTE =
+  "Hinweis: In der Spalte „Readiness“ sehen Sie den strukturellen AI- & Compliance-Readiness-Score (0–100). Governance-Aktivität (GAI) und operativer KI-Monitoring-Index (OAMI) je Mandant finden Sie im Governance-Snapshot.";
+
+/** Spalten-Header (kurz). */
+export const PORTFOLIO_COL_READINESS = "Readiness";
+
+export const PORTFOLIO_COL_READINESS_TOOLTIP = `${READINESS_TOOLTIP_C_LEVEL} ${READINESS_REG_HINT_SHORT}`;
+
+export const PORTFOLIO_COL_EU_AI_ACT = "EU AI Act (Register)";
+
+export const PORTFOLIO_COL_EU_AI_ACT_TOOLTIP =
+  "Heuristischer Überblick aus KI-Register und Klassifikation – nicht identisch mit dem strukturellen Readiness-Score (fünf Dimensionen).";
+
+/** Fünf Dimensionen – Überschrift über Balken. */
+export const READINESS_FIVE_DIMS_CAPTION =
+  "Fünf Dimensionen der strukturellen Reife (operative KI-Laufzeit = OAMI)";
+
+export const READINESS_DIM_SETUP = "Aufbau & Rollen";
+export const READINESS_DIM_SETUP_HINT =
+  "Wizard, Rollen, Framework-Scopes – u. a. ISO/IEC 42001 (KI-MS) und NIS2-Bezug im Setup.";
+
+export const READINESS_DIM_COVERAGE = "Framework-Abdeckung";
+export const READINESS_DIM_COVERAGE_HINT =
+  "Abdeckung EU AI Act, NIS2, ISO/IEC 27001/42001 im Compliance-Graphen.";
+
+export const READINESS_DIM_KPIS = "KPI-Register";
+export const READINESS_DIM_KPIS_HINT =
+  "Zeitreihen zu Drift, Incidents u. a. – Anschluss an Hochrisiko-Systeme.";
+
+export const READINESS_DIM_GAPS = "Regulatorische Lücken";
+export const READINESS_DIM_GAPS_HINT =
+  "Sichtbare Lücken zu Pflichten des EU AI Act und weiterer Frameworks.";
+
+export const READINESS_DIM_REPORTING = "Board-Reporting";
+export const READINESS_DIM_REPORTING_HINT =
+  "Berichte für Vorstand, Aufsichtsrat und Prüfer – Transparenz der Governance.";
+
+/** Readiness-Level (API: basic | managed | embedded). */
+export function readinessLevelLabelDe(level: string): string {
+  switch (level) {
+    case "basic":
+      return "Basis";
+    case "managed":
+      return "Etabliert";
+    case "embedded":
+      return "Integriert";
+    default:
+      return level;
+  }
+}
+
+/** GAI / OAMI Level (API: low | medium | high). */
+export function indexLevelLabelDe(level: string | null | undefined): string {
+  if (!level) return "–";
+  switch (String(level).toLowerCase()) {
+    case "low":
+      return "Niedrig";
+    case "medium":
+      return "Mittel";
+    case "high":
+      return "Hoch";
+    default:
+      return level;
+  }
+}


### PR DESCRIPTION
Add frontend/src/lib/governanceMaturityDeCopy.ts with Board-ready German strings, level labels (Basis/Etabliert/Integriert; Niedrig/Mittel/Hoch), tooltips and demo banners. Wire Board readiness card, board report banner, advisor portfolio headers/note, advisor snapshot (GAI tile, OAMI labels), demo setup panel. Add docs/governance-maturity-copy-de.md; align demo walkthrough and lens links.

Made-with: Cursor