### PR TITLE
feat(governance-maturity): typed copy helpers, portfolio GAI/OAMI, tests

### DIFF
--- a/app/advisor_portfolio_models.py
+++ b/app/advisor_portfolio_models.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from app.advisor_client_snapshot_models import AdvisorTenantGovernanceBrief
 from app.readiness_score_models import ReadinessScoreSummary
+
+GaiOamiLevel = Literal["low", "medium", "high"]
+
+
+class GovernanceActivityPortfolioSummary(BaseModel):
+    """Kurzform GAI für Berater-Portfolio (0–100 + Level)."""
+
+    index: int = Field(ge=0, le=100)
+    level: GaiOamiLevel
+
+
+class OperationalMonitoringPortfolioSummary(BaseModel):
+    """Kurzform OAMI für Berater-Portfolio."""
+
+    index: int | None = Field(default=None, ge=0, le=100)
+    level: GaiOamiLevel | None = None
 
 
 class AdvisorPortfolioTenantEntry(BaseModel):
@@ -34,6 +51,14 @@ class AdvisorPortfolioTenantEntry(BaseModel):
     readiness_summary: ReadinessScoreSummary | None = Field(
         default=None,
         description="Optional: Readiness Score (FEATURE_READINESS_SCORE).",
+    )
+    governance_activity_summary: GovernanceActivityPortfolioSummary | None = Field(
+        default=None,
+        description="Optional: GAI (FEATURE_GOVERNANCE_MATURITY).",
+    )
+    operational_monitoring_summary: OperationalMonitoringPortfolioSummary | None = Field(
+        default=None,
+        description="Optional: OAMI (FEATURE_GOVERNANCE_MATURITY).",
     )
 
 

--- a/app/services/advisor_portfolio.py
+++ b/app/services/advisor_portfolio.py
@@ -8,7 +8,12 @@ from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
-from app.advisor_portfolio_models import AdvisorPortfolioResponse, AdvisorPortfolioTenantEntry
+from app.advisor_portfolio_models import (
+    AdvisorPortfolioResponse,
+    AdvisorPortfolioTenantEntry,
+    GovernanceActivityPortfolioSummary,
+    OperationalMonitoringPortfolioSummary,
+)
 from app.feature_flags import FeatureFlag, is_feature_enabled
 from app.readiness_score_models import ReadinessScoreSummary
 from app.repositories.advisor_tenants import AdvisorTenantRepository
@@ -23,6 +28,7 @@ from app.repositories.violations import ViolationRepository
 from app.services.advisor_client_governance_snapshot import build_governance_brief_for_tenant
 from app.services.ai_governance_kpis import compute_ai_governance_kpis
 from app.services.compliance_dashboard import compute_ai_compliance_overview
+from app.services.governance_maturity_service import build_governance_maturity_response
 from app.services.readiness_score_service import compute_readiness_score
 from app.services.setup_status import compute_tenant_setup_status
 
@@ -85,6 +91,27 @@ def build_advisor_portfolio(
                 logger.exception("advisor_portfolio_readiness_failed tenant=%s", tid)
                 readiness_summary = None
 
+        gai_summary: GovernanceActivityPortfolioSummary | None = None
+        oami_summary: OperationalMonitoringPortfolioSummary | None = None
+        if is_feature_enabled(FeatureFlag.governance_maturity):
+            try:
+                gm = build_governance_maturity_response(session, tid, window_days=90)
+                ga = gm.governance_activity
+                gai_summary = GovernanceActivityPortfolioSummary(
+                    index=ga.index,
+                    level=ga.level,
+                )
+                ob = gm.operational_ai_monitoring
+                if ob.status == "active" and ob.level is not None:
+                    oami_summary = OperationalMonitoringPortfolioSummary(
+                        index=ob.index,
+                        level=ob.level,
+                    )
+            except Exception:
+                logger.exception("advisor_portfolio_governance_maturity_failed tenant=%s", tid)
+                gai_summary = None
+                oami_summary = None
+
         tenants_out.append(
             AdvisorPortfolioTenantEntry(
                 tenant_id=tid,
@@ -104,6 +131,8 @@ def build_advisor_portfolio(
                 setup_progress_ratio=setup_ratio,
                 governance_brief=brief,
                 readiness_summary=readiness_summary,
+                governance_activity_summary=gai_summary,
+                operational_monitoring_summary=oami_summary,
             ),
         )
 
@@ -131,6 +160,10 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
         "setup_progress_ratio",
         "readiness_score",
         "readiness_level",
+        "gai_index",
+        "gai_level",
+        "oami_index",
+        "oami_level",
     ]
     w = csv.DictWriter(buf, fieldnames=fieldnames)
     w.writeheader()
@@ -139,6 +172,12 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
         rs = row.get("readiness_summary")
         row["readiness_score"] = rs["score"] if rs else ""
         row["readiness_level"] = rs["level"] if rs else ""
+        ga = row.get("governance_activity_summary")
+        om = row.get("operational_monitoring_summary")
+        row["gai_index"] = ga["index"] if ga else ""
+        row["gai_level"] = ga["level"] if ga else ""
+        row["oami_index"] = om["index"] if om and om.get("index") is not None else ""
+        row["oami_level"] = om["level"] if om and om.get("level") is not None else ""
         w.writerow({k: row.get(k) for k in fieldnames})
     return buf.getvalue()
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,5 +1,9 @@
 This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
 
+## Governance-Maturity-Copy (Readiness, GAI, OAMI)
+
+Board- und Berater-Texte zu **AI & Compliance Readiness**, **Governance-Aktivitätsindex (GAI)** und **Operativem KI-Monitoring (OAMI)** liegen zentral in [`src/lib/governanceMaturityDeCopy.ts`](src/lib/governanceMaturityDeCopy.ts) (Level-Typen: [`src/lib/governanceMaturityTypes.ts`](src/lib/governanceMaturityTypes.ts)). Neue oder geänderte UI-Strings dort pflegen, nicht in Komponenten duplizieren. Abgleich mit dem gesprochenen Demo-Flow: [`../docs/demo-board-ready-walkthrough.md`](../docs/demo-board-ready-walkthrough.md).
+
 ## Getting Started
 
 First, run the development server:

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
@@ -1,11 +1,30 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AdvisorClientGovernanceSnapshotDto } from "@/lib/api";
+import {
+  GAI_FULL_NAME,
+  GAI_TOOLTIP_C_LEVEL,
+  OAMI_DEMO_SIGNALS_NOTE,
+  OAMI_FULL_NAME,
+  OAMI_SECTION_TITLE,
+  OAMI_TOOLTIP_C_LEVEL,
+  READINESS_PRODUCT_TITLE,
+  READINESS_TAGLINE,
+} from "@/lib/governanceMaturityDeCopy";
 
 import { AdvisorGovernanceSnapshotView } from "./AdvisorGovernanceSnapshotView";
 
-const { fetchSnap, postMd } = vi.hoisted(() => {
+const snapshotViewFlags = vi.hoisted(() => ({ readinessScore: false }));
+
+const { fetchSnap, postMd, fetchAdvisorReadiness } = vi.hoisted(() => {
   const minimalSnapshot: AdvisorClientGovernanceSnapshotDto = {
     advisor_id: "adv@x",
     client_tenant_id: "t-1",
@@ -71,7 +90,20 @@ const { fetchSnap, postMd } = vi.hoisted(() => {
     provider: "anthropic",
     model_id: "claude",
   });
-  return { fetchSnap, postMd };
+  const fetchAdvisorReadiness = vi.fn().mockResolvedValue({
+    tenant_id: "t-1",
+    score: 71,
+    level: "managed",
+    interpretation: "Readiness OK.",
+    dimensions: {
+      setup: { normalized: 0.7, score_0_100: 70 },
+      coverage: { normalized: 0.7, score_0_100: 70 },
+      kpi: { normalized: 0.7, score_0_100: 70 },
+      gaps: { normalized: 0.7, score_0_100: 70 },
+      reporting: { normalized: 0.7, score_0_100: 70 },
+    },
+  });
+  return { fetchSnap, postMd, fetchAdvisorReadiness };
 });
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -81,6 +113,7 @@ vi.mock("@/lib/api", async (importOriginal) => {
     ADVISOR_ID_FROM_ENV: "adv@test",
     fetchAdvisorClientGovernanceSnapshot: fetchSnap,
     postAdvisorGovernanceSnapshotMarkdown: postMd,
+    fetchAdvisorTenantReadinessScore: fetchAdvisorReadiness,
   };
 });
 
@@ -93,8 +126,13 @@ vi.mock("@/lib/config", async (importOriginal) => {
   return {
     ...actual,
     featureAiComplianceBoardReport: () => false,
-    featureReadinessScore: () => false,
+    featureReadinessScore: () => snapshotViewFlags.readinessScore,
   };
+});
+
+afterEach(() => {
+  snapshotViewFlags.readinessScore = false;
+  cleanup();
 });
 
 describe("AdvisorGovernanceSnapshotView", () => {
@@ -116,5 +154,33 @@ describe("AdvisorGovernanceSnapshotView", () => {
     });
     expect(await screen.findByTestId("snap-md-preview")).toBeTruthy();
     expect(screen.getByText("Punkt")).toBeTruthy();
+  });
+
+  it("renders Readiness, GAI and OAMI tiles using centralized copy strings", async () => {
+    snapshotViewFlags.readinessScore = true;
+    render(<AdvisorGovernanceSnapshotView clientTenantId="t-1" />);
+
+    await waitFor(() => {
+      expect(fetchAdvisorReadiness).toHaveBeenCalledWith("adv@test", "t-1");
+    });
+
+    const intro = screen.getByTestId("advisor-governance-snapshot-view");
+    expect(intro.textContent).toContain(READINESS_PRODUCT_TITLE);
+    expect(intro.textContent).toContain(READINESS_TAGLINE.slice(0, 40));
+    expect(intro.textContent).toContain(GAI_FULL_NAME);
+    expect(intro.textContent).toContain(GAI_TOOLTIP_C_LEVEL.slice(0, 40));
+    expect(intro.textContent).toContain(OAMI_FULL_NAME);
+
+    const readinessSection = await screen.findByTestId("snap-readiness");
+    expect(within(readinessSection).getByText(READINESS_PRODUCT_TITLE)).toBeTruthy();
+
+    const gaiTile = screen.getByTestId("snap-gai-note");
+    expect(within(gaiTile).getByText(GAI_FULL_NAME)).toBeTruthy();
+    expect(gaiTile.textContent).toContain(GAI_TOOLTIP_C_LEVEL.slice(0, 50));
+
+    const oamiTile = screen.getByTestId("snap-oami");
+    expect(within(oamiTile).getByText(OAMI_SECTION_TITLE)).toBeTruthy();
+    expect(oamiTile.textContent).toContain(OAMI_TOOLTIP_C_LEVEL.slice(0, 50));
+    expect(within(oamiTile).getByText(OAMI_DEMO_SIGNALS_NOTE)).toBeTruthy();
   });
 });

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
@@ -26,11 +26,14 @@ import {
   GAI_FULL_NAME,
   GAI_REG_HINT_SHORT,
   GAI_TOOLTIP_C_LEVEL,
+  getReadinessCopy,
   OAMI_ADVISOR_DETAIL_EXTRA,
+  OAMI_DEMO_SIGNALS_NOTE,
   OAMI_FULL_NAME,
   OAMI_REG_HINT_SHORT,
   OAMI_SECTION_TITLE,
   OAMI_TOOLTIP_C_LEVEL,
+  parseReadinessLevel,
   READINESS_ADVISOR_DETAIL_EXTRA,
   READINESS_PRODUCT_TITLE,
   READINESS_REG_HINT_SHORT,
@@ -142,6 +145,8 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
   useEffect(() => {
     void syncReadiness(snap);
   }, [snap, syncReadiness]);
+
+  const readinessLevelParsed = readiness ? parseReadinessLevel(readiness.level) : null;
 
   const genMd = async () => {
     if (!advisorId) return;
@@ -270,7 +275,11 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
                 <span className="text-lg font-semibold text-slate-500">/100</span>
                 <span
                   className="ml-2 text-base font-medium text-slate-600"
-                  title={READINESS_REG_HINT_SHORT}
+                  title={
+                    readinessLevelParsed
+                      ? getReadinessCopy(readinessLevelParsed).levelWithRegTooltip
+                      : READINESS_REG_HINT_SHORT
+                  }
                 >
                   ({readinessLevelLabelDe(readiness.level)})
                 </span>
@@ -317,9 +326,7 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
               <p className="mt-1 text-xs text-slate-600">{OAMI_TOOLTIP_C_LEVEL}</p>
               <p className="mt-1 text-xs text-slate-600">{OAMI_ADVISOR_DETAIL_EXTRA}</p>
               <p className="mt-1 text-[0.65rem] text-slate-500">{OAMI_REG_HINT_SHORT}</p>
-              <p className="mt-1 text-xs text-slate-500">
-                In Demos typischerweise synthetische Signale – keine Anbindung an Produktiv-SAP.
-              </p>
+              <p className="mt-1 text-xs text-slate-500">{OAMI_DEMO_SIGNALS_NOTE}</p>
               <dl className="mt-3 grid gap-2 text-sm sm:grid-cols-2">
                 <div>
                   <dt className="text-xs font-semibold text-slate-500">Index / Level</dt>

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
@@ -2,10 +2,21 @@ import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AdvisorPortfolioTenantEntry } from "@/lib/api";
+import {
+  PORTFOLIO_COL_GAI_SHORT,
+  PORTFOLIO_COL_OAMI_SHORT,
+  PORTFOLIO_COL_READINESS,
+  getActivityCopy,
+  getMonitoringCopy,
+} from "@/lib/governanceMaturityDeCopy";
 
 import { AdvisorPortfolioTable } from "./AdvisorPortfolioTable";
 
-const portfolioFeatureFlags = vi.hoisted(() => ({ snapshot: true, readiness: true }));
+const portfolioFeatureFlags = vi.hoisted(() => ({
+  snapshot: true,
+  readiness: true,
+  governanceMaturity: true,
+}));
 
 vi.mock("@/lib/workspaceTenantClient", () => ({
   openWorkspaceTenantAndGoComplianceOverview: vi.fn(),
@@ -19,12 +30,14 @@ vi.mock("@/lib/config", async (importOriginal) => {
     featurePilotRunbook: () => true,
     featureAdvisorClientSnapshot: () => portfolioFeatureFlags.snapshot,
     featureReadinessScore: () => portfolioFeatureFlags.readiness,
+    featureGovernanceMaturity: () => portfolioFeatureFlags.governanceMaturity,
   };
 });
 
 afterEach(() => {
   portfolioFeatureFlags.snapshot = true;
   portfolioFeatureFlags.readiness = true;
+  portfolioFeatureFlags.governanceMaturity = true;
   cleanup();
 });
 
@@ -51,6 +64,8 @@ const sampleRows: AdvisorPortfolioTenantEntry[] = [
       nis2_critical_ai_count: 1,
     },
     readiness_summary: { score: 58, level: "managed" },
+    governance_activity_summary: { index: 42, level: "medium" },
+    operational_monitoring_summary: { index: 55, level: "high" },
   },
 ];
 
@@ -110,6 +125,36 @@ describe("AdvisorPortfolioTable", () => {
     portfolioFeatureFlags.snapshot = true;
     render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
     expect(screen.queryByTestId("advisor-readiness-badge-t-demo-1")).toBeNull();
-    expect(screen.queryByText("Readiness")).toBeNull();
+    expect(screen.queryByText(PORTFOLIO_COL_READINESS)).toBeNull();
+  });
+
+  it("uses governanceMaturityDeCopy column headers and index level labels for GAI/OAMI", () => {
+    portfolioFeatureFlags.governanceMaturity = true;
+    render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
+
+    expect(
+      screen.getByRole("columnheader", { name: PORTFOLIO_COL_READINESS }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: PORTFOLIO_COL_GAI_SHORT }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: PORTFOLIO_COL_OAMI_SHORT }),
+    ).toBeTruthy();
+
+    const gaiCell = screen.getByTestId("advisor-gai-cell-t-demo-1");
+    expect(gaiCell.textContent).toContain("42");
+    expect(gaiCell.textContent).toContain(getActivityCopy("medium").levelLabelDe);
+
+    const oamiCell = screen.getByTestId("advisor-oami-cell-t-demo-1");
+    expect(oamiCell.textContent).toContain("55");
+    expect(oamiCell.textContent).toContain(getMonitoringCopy("high").levelLabelDe);
+  });
+
+  it("hides GAI/OAMI columns when featureGovernanceMaturity is off", () => {
+    portfolioFeatureFlags.governanceMaturity = false;
+    render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
+    expect(screen.queryByRole("columnheader", { name: PORTFOLIO_COL_GAI_SHORT })).toBeNull();
+    expect(screen.queryByTestId("advisor-gai-cell-t-demo-1")).toBeNull();
   });
 });

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -7,12 +7,16 @@ import { portfolioHealth, type PortfolioHealth } from "@/lib/advisorPortfolioHea
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD } from "@/lib/boardLayout";
 import * as chConfig from "@/lib/config";
 import {
+  indexLevelLabelDe,
   PORTFOLIO_COL_EU_AI_ACT,
   PORTFOLIO_COL_EU_AI_ACT_TOOLTIP,
+  PORTFOLIO_COL_GAI_SHORT,
+  PORTFOLIO_COL_GAI_TOOLTIP,
+  PORTFOLIO_COL_OAMI_SHORT,
+  PORTFOLIO_COL_OAMI_TOOLTIP,
   PORTFOLIO_COL_READINESS,
   PORTFOLIO_COL_READINESS_TOOLTIP,
-  READINESS_REG_HINT_SHORT,
-  readinessLevelLabelDe,
+  readinessPortfolioBadgeTooltip,
 } from "@/lib/governanceMaturityDeCopy";
 import {
   openWorkspaceTenantAndGo,
@@ -63,6 +67,7 @@ function readinessBadgeClasses(score: number): string {
 export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTableProps) {
   const snapUi = chConfig.featureAdvisorClientSnapshot();
   const readinessUi = chConfig.featureReadinessScore();
+  const governanceMaturityUi = chConfig.featureGovernanceMaturity();
 
   if (rows.length === 0) {
     return (
@@ -99,6 +104,16 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                 <th title={PORTFOLIO_COL_READINESS_TOOLTIP} className="max-w-[6rem]">
                   {PORTFOLIO_COL_READINESS}
                 </th>
+              ) : null}
+              {governanceMaturityUi ? (
+                <>
+                  <th title={PORTFOLIO_COL_GAI_TOOLTIP} className="max-w-[7rem]">
+                    {PORTFOLIO_COL_GAI_SHORT}
+                  </th>
+                  <th title={PORTFOLIO_COL_OAMI_TOOLTIP} className="max-w-[7rem]">
+                    {PORTFOLIO_COL_OAMI_SHORT}
+                  </th>
+                </>
               ) : null}
               {snapUi ? <th>Snapshot</th> : null}
               <th>Mandanten-Steckbrief</th>
@@ -201,7 +216,7 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                       {t.readiness_summary ? (
                         <span
                           className={`inline-flex min-w-[2.25rem] justify-center rounded-full px-2 py-0.5 text-xs font-bold tabular-nums ${readinessBadgeClasses(t.readiness_summary.score)}`}
-                          title={`Reifegrad ${readinessLevelLabelDe(t.readiness_summary.level)} (0–100). ${READINESS_REG_HINT_SHORT}`}
+                          title={readinessPortfolioBadgeTooltip(t.readiness_summary.level)}
                           data-testid={`advisor-readiness-badge-${t.tenant_id}`}
                         >
                           {t.readiness_summary.score}
@@ -210,6 +225,42 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                         <span className="text-xs text-[var(--sbs-text-muted)]">–</span>
                       )}
                     </td>
+                  ) : null}
+                  {governanceMaturityUi ? (
+                    <>
+                      <td
+                        className="text-center align-middle text-xs tabular-nums text-[var(--sbs-text-secondary)]"
+                        data-testid={`advisor-gai-cell-${t.tenant_id}`}
+                      >
+                        {t.governance_activity_summary ? (
+                          <span title={PORTFOLIO_COL_GAI_TOOLTIP}>
+                            {t.governance_activity_summary.index}
+                            <span className="text-[var(--sbs-text-muted)]">
+                              {" "}
+                              · {indexLevelLabelDe(t.governance_activity_summary.level)}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-[var(--sbs-text-muted)]">–</span>
+                        )}
+                      </td>
+                      <td
+                        className="text-center align-middle text-xs tabular-nums text-[var(--sbs-text-secondary)]"
+                        data-testid={`advisor-oami-cell-${t.tenant_id}`}
+                      >
+                        {t.operational_monitoring_summary?.level != null ? (
+                          <span title={PORTFOLIO_COL_OAMI_TOOLTIP}>
+                            {t.operational_monitoring_summary.index ?? "–"}
+                            <span className="text-[var(--sbs-text-muted)]">
+                              {" "}
+                              · {indexLevelLabelDe(t.operational_monitoring_summary.level)}
+                            </span>
+                          </span>
+                        ) : (
+                          <span className="text-[var(--sbs-text-muted)]">–</span>
+                        )}
+                      </td>
+                    </>
                   ) : null}
                   {snapUi ? (
                     <td className="align-top">

--- a/frontend/src/components/board/BoardReadinessCard.test.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 const { fetchReadiness } = vi.hoisted(() => ({
   fetchReadiness: vi.fn(),
@@ -28,7 +28,17 @@ vi.mock("@/lib/workspaceTenantClient", () => ({
   openWorkspaceTenantAndGo: vi.fn(),
 }));
 
+import {
+  DEMO_HINT_READINESS_CARD,
+  getReadinessCopy,
+  READINESS_PRODUCT_TITLE,
+} from "@/lib/governanceMaturityDeCopy";
+
 import { BoardReadinessCard } from "./BoardReadinessCard";
+
+afterEach(() => {
+  cleanup();
+});
 
 describe("BoardReadinessCard", () => {
   it("renders score and dimension bars", async () => {
@@ -53,5 +63,59 @@ describe("BoardReadinessCard", () => {
     });
     expect(screen.getByTestId("readiness-dim-setup")).toBeTruthy();
     expect(screen.getByTestId("readiness-dim-coverage")).toBeTruthy();
+  });
+
+  it.each([
+    ["basic", "Basis"],
+    ["managed", "Etabliert"],
+    ["embedded", "Integriert"],
+  ] as const)("renders readiness level %s as %s (static)", async (level, deLabel) => {
+    fetchReadiness.mockResolvedValue({
+      tenant_id: "t-x",
+      score: 50,
+      level,
+      interpretation: "Test.",
+      dimensions: {
+        setup: { normalized: 0.5, score_0_100: 50 },
+        coverage: { normalized: 0.5, score_0_100: 50 },
+        kpi: { normalized: 0.5, score_0_100: 50 },
+        gaps: { normalized: 0.5, score_0_100: 50 },
+        reporting: { normalized: 0.5, score_0_100: 50 },
+      },
+    });
+
+    render(<BoardReadinessCard tenantId="t-x" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("board-readiness-level-label").textContent).toBe(deLabel);
+    });
+    const el = screen.getByTestId("board-readiness-level-label");
+    expect(el.getAttribute("title")).toBe(getReadinessCopy(level).levelWithRegTooltip);
+  });
+
+  it("shows demo banner copy for demo tenants (static readiness)", () => {
+    render(
+      <BoardReadinessCard
+        tenantId="t-demo"
+        isDemoTenant
+        staticReadiness={{
+          tenant_id: "t-demo",
+          score: 40,
+          level: "basic",
+          interpretation: "Demo.",
+          dimensions: {
+            setup: { normalized: 0.4, score_0_100: 40 },
+            coverage: { normalized: 0.4, score_0_100: 40 },
+            kpi: { normalized: 0.4, score_0_100: 40 },
+            gaps: { normalized: 0.4, score_0_100: 40 },
+            reporting: { normalized: 0.4, score_0_100: 40 },
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(DEMO_HINT_READINESS_CARD)).toBeTruthy();
+    const card = screen.getByTestId("board-readiness-card");
+    expect(card.textContent).toContain(READINESS_PRODUCT_TITLE);
   });
 });

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -11,6 +11,8 @@ import { CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
 import { featureLlmEnabled, featureLlmExplain, featureReadinessScore } from "@/lib/config";
 import {
   DEMO_HINT_READINESS_CARD,
+  getReadinessCopy,
+  parseReadinessLevel,
   READINESS_DIM_COVERAGE,
   READINESS_DIM_COVERAGE_HINT,
   READINESS_DIM_GAPS,
@@ -22,6 +24,7 @@ import {
   READINESS_DIM_SETUP,
   READINESS_DIM_SETUP_HINT,
   READINESS_FIVE_DIMS_CAPTION,
+  READINESS_LEVEL_ROW_LABEL,
   READINESS_PRODUCT_TITLE,
   READINESS_REG_HINT_SHORT,
   READINESS_TAGLINE,
@@ -68,14 +71,20 @@ function DimBar({
 export function BoardReadinessCard({
   tenantId,
   isDemoTenant = false,
+  /** Wenn gesetzt: kein initialer API-Fetch (z. B. Vitest). „Aktualisieren“ ruft weiterhin die API auf. */
+  staticReadiness,
 }: {
   tenantId: string;
   /** Pilot/Seed-Mandant: kurzer Hinweis, dass der Score aus Demo-Daten stammt. */
   isDemoTenant?: boolean;
+  staticReadiness?: ReadinessScoreResponseDto;
 }) {
-  const [data, setData] = useState<ReadinessScoreResponseDto | null>(null);
+  const staticMode = staticReadiness !== undefined;
+  const [data, setData] = useState<ReadinessScoreResponseDto | null>(() =>
+    staticMode ? staticReadiness : null,
+  );
   const [err, setErr] = useState<string | null>(null);
-  const [busy, setBusy] = useState(true);
+  const [busy, setBusy] = useState(() => !staticMode);
   const [explainBusy, setExplainBusy] = useState(false);
   const [explain, setExplain] = useState<string | null>(null);
   const [explainErr, setExplainErr] = useState<string | null>(null);
@@ -95,8 +104,14 @@ export function BoardReadinessCard({
   }, [tenantId]);
 
   useEffect(() => {
+    if (staticMode) {
+      setData(staticReadiness);
+      setBusy(false);
+      setErr(null);
+      return;
+    }
     void load();
-  }, [load]);
+  }, [load, staticMode, staticReadiness]);
 
   if (!featureReadinessScore()) {
     return null;
@@ -117,6 +132,7 @@ export function BoardReadinessCard({
   };
 
   const d = data?.dimensions;
+  const readinessLevelParsed = data ? parseReadinessLevel(data.level) : null;
 
   return (
     <article className={CH_CARD} data-testid="board-readiness-card">
@@ -144,8 +160,16 @@ export function BoardReadinessCard({
                 <span className="text-lg font-semibold text-slate-500">/100</span>
               </p>
               <p className="mt-1 text-sm font-medium text-slate-700">
-                Reifegrad:{" "}
-                <span className="text-slate-900" title={READINESS_REG_HINT_SHORT}>
+                {READINESS_LEVEL_ROW_LABEL}{" "}
+                <span
+                  className="text-slate-900"
+                  title={
+                    readinessLevelParsed
+                      ? getReadinessCopy(readinessLevelParsed).levelWithRegTooltip
+                      : READINESS_REG_HINT_SHORT
+                  }
+                  data-testid="board-readiness-level-label"
+                >
                   {readinessLevelLabelDe(data.level)}
                 </span>
               </p>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1398,6 +1398,11 @@ export interface AdvisorPortfolioTenantEntry {
   setup_progress_ratio: number;
   governance_brief?: AdvisorTenantGovernanceBriefDto | null;
   readiness_summary?: ReadinessScoreSummaryDto | null;
+  governance_activity_summary?: { index: number; level: string } | null;
+  operational_monitoring_summary?: {
+    index: number | null;
+    level: string | null;
+  } | null;
 }
 
 export interface AdvisorPortfolioResponse {

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -30,6 +30,11 @@ export function featureReadinessScore(): boolean {
   return envBool(process.env.NEXT_PUBLIC_FEATURE_READINESS_SCORE, true);
 }
 
+/** Governance Maturity Lens: GAI + OAMI im Portfolio u. a. (Backend COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY). */
+export function featureGovernanceMaturity(): boolean {
+  return envBool(process.env.NEXT_PUBLIC_FEATURE_GOVERNANCE_MATURITY, true);
+}
+
 export function featureDemoSeeding(): boolean {
   return envBool(process.env.NEXT_PUBLIC_FEATURE_DEMO_SEEDING, true);
 }

--- a/frontend/src/lib/governanceMaturityDeCopy.test.ts
+++ b/frontend/src/lib/governanceMaturityDeCopy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getActivityCopy,
+  getMonitoringCopy,
+  getReadinessCopy,
+  indexLevelLabelDe,
+  parseIndexLevel,
+  parseReadinessLevel,
+  readinessLevelLabelDe,
+  readinessPortfolioBadgeTooltip,
+} from "./governanceMaturityDeCopy";
+
+describe("governanceMaturityDeCopy helpers", () => {
+  it("parses readiness API levels", () => {
+    expect(parseReadinessLevel("basic")).toBe("basic");
+    expect(parseReadinessLevel("MANAGED")).toBe("managed");
+    expect(parseReadinessLevel("unknown")).toBeNull();
+  });
+
+  it("getReadinessCopy returns German labels", () => {
+    expect(getReadinessCopy("basic").levelLabelDe).toBe("Basis");
+    expect(getReadinessCopy("managed").levelLabelDe).toBe("Etabliert");
+    expect(getReadinessCopy("embedded").levelLabelDe).toBe("Integriert");
+  });
+
+  it("readinessLevelLabelDe falls back for unknown", () => {
+    expect(readinessLevelLabelDe("custom")).toBe("custom");
+  });
+
+  it("parses index levels for GAI/OAMI", () => {
+    expect(parseIndexLevel("low")).toBe("low");
+    expect(parseIndexLevel("HIGH")).toBe("high");
+    expect(parseIndexLevel(null)).toBeNull();
+  });
+
+  it("getActivityCopy and getMonitoringCopy share index labels", () => {
+    expect(getActivityCopy("medium").levelLabelDe).toBe("Mittel");
+    expect(getMonitoringCopy("medium").levelLabelDe).toBe("Mittel");
+    expect(getMonitoringCopy("high").fullName).toContain("OAMI");
+  });
+
+  it("indexLevelLabelDe handles empty and unknown", () => {
+    expect(indexLevelLabelDe(null)).toBe("–");
+    expect(indexLevelLabelDe("weird")).toBe("weird");
+  });
+
+  it("readinessPortfolioBadgeTooltip uses copy reg hint", () => {
+    const t = readinessPortfolioBadgeTooltip("managed");
+    expect(t).toContain("Etabliert");
+    expect(t).toContain("0–100");
+  });
+});

--- a/frontend/src/lib/governanceMaturityDeCopy.ts
+++ b/frontend/src/lib/governanceMaturityDeCopy.ts
@@ -1,12 +1,26 @@
 /**
- * Board-taugliche deutsche Texte: Governance-Maturity (Readiness, GAI, OAMI).
- * Einheitliche Begriffe für Board, CISO, Aufsichtsrat und Berater (DACH).
+ * Zentrale deutschsprachige Texte für Governance Maturity (Readiness, GAI, OAMI).
  *
- * Referenz für Redaktion: docs/governance-maturity-copy-de.md
+ * **Konvention:** Alle sichtbaren Board-/Berater-Strings zu diesen Themen kommen aus diesem Modul
+ * (keine parallelen Inline-Literals in Komponenten). Anpassungen nur hier vornehmen.
+ *
+ * Inhaltliche Abstimmung mit dem Demo-Script: `docs/demo-board-ready-walkthrough.md`
+ * Begriffstabelle: `docs/governance-maturity-copy-de.md`
+ *
+ * Level-Typen: `governanceMaturityTypes.ts` — Parser/Helper unten für konsistente Labels.
  */
+
+import type { ActivityLevel, IndexLevel, MonitoringLevel, ReadinessLevel } from "@/lib/governanceMaturityTypes";
+import {
+  INDEX_LEVEL_API_VALUES,
+  READINESS_LEVEL_API_VALUES,
+} from "@/lib/governanceMaturityTypes";
 
 /** Produktbezeichnung in der UI (nicht übersetzen: etabliertes Marken-Element). */
 export const READINESS_PRODUCT_TITLE = "AI & Compliance Readiness";
+
+/** Zeile unter dem Score: „Reifegrad: …“. */
+export const READINESS_LEVEL_ROW_LABEL = "Reifegrad:";
 
 /** Kurz erklärt, was der Score misst (Unterzeile / Fließtext). */
 export const READINESS_TAGLINE =
@@ -49,6 +63,10 @@ export const OAMI_REG_HINT_SHORT =
 /** Abschnittstitel Snapshot / Board (90-Tage-Fenster). */
 export const OAMI_SECTION_TITLE = "Operativer KI-Monitoring-Index (OAMI, 90 Tage)";
 
+/** Hinweis unter OAMI in Demos (Snapshot). */
+export const OAMI_DEMO_SIGNALS_NOTE =
+  "In Demos typischerweise synthetische Signale – keine Anbindung an Produktiv-SAP.";
+
 /** Demomandant: Board-Report-Banner (ein Absatz). */
 export const DEMO_BANNER_BOARD_REPORT =
   "Demomandant (read-only): keine produktiven Änderungen. Alle Werte sind Beispieldaten ohne echten Betrieb. Sie dienen EU-AI-Act-, NIS2- und ISO-Gesprächen; vorgefüllte Reports ansehen und exportieren – neue KI-Generierung ist deaktiviert.";
@@ -63,12 +81,22 @@ export const DEMO_SEED_SUCCESS_GOVERNANCE_NOTE =
 
 /** Portfolio: Hinweis unter Überschrift / vor Tabelle. */
 export const PORTFOLIO_GOVERNANCE_MATURITY_NOTE =
-  "Hinweis: In der Spalte „Readiness“ sehen Sie den strukturellen AI- & Compliance-Readiness-Score (0–100). Governance-Aktivität (GAI) und operativer KI-Monitoring-Index (OAMI) je Mandant finden Sie im Governance-Snapshot.";
+  "Hinweis: In der Spalte „Readiness“ sehen Sie den strukturellen AI- & Compliance-Readiness-Score (0–100). Spalten Governance-Aktivität und Operatives Monitoring zeigen GAI- und OAMI-Level; Details im Governance-Snapshot.";
 
 /** Spalten-Header (kurz). */
 export const PORTFOLIO_COL_READINESS = "Readiness";
 
 export const PORTFOLIO_COL_READINESS_TOOLTIP = `${READINESS_TOOLTIP_C_LEVEL} ${READINESS_REG_HINT_SHORT}`;
+
+/** Portfolio: GAI-Spalte (Kurzform). */
+export const PORTFOLIO_COL_GAI_SHORT = "Governance-Aktivität";
+
+export const PORTFOLIO_COL_GAI_TOOLTIP = `${GAI_TOOLTIP_C_LEVEL} ${GAI_REG_HINT_SHORT}`;
+
+/** Portfolio: OAMI-Spalte (Kurzform). */
+export const PORTFOLIO_COL_OAMI_SHORT = "Operatives Monitoring";
+
+export const PORTFOLIO_COL_OAMI_TOOLTIP = `${OAMI_TOOLTIP_C_LEVEL} ${OAMI_REG_HINT_SHORT}`;
 
 export const PORTFOLIO_COL_EU_AI_ACT = "EU AI Act (Register)";
 
@@ -99,31 +127,91 @@ export const READINESS_DIM_REPORTING = "Board-Reporting";
 export const READINESS_DIM_REPORTING_HINT =
   "Berichte für Vorstand, Aufsichtsrat und Prüfer – Transparenz der Governance.";
 
+const READINESS_LEVEL_LABEL_DE: Record<ReadinessLevel, string> = {
+  basic: "Basis",
+  managed: "Etabliert",
+  embedded: "Integriert",
+};
+
+const INDEX_LEVEL_LABEL_DE: Record<IndexLevel, string> = {
+  low: "Niedrig",
+  medium: "Mittel",
+  high: "Hoch",
+};
+
+export function parseReadinessLevel(raw: string | null | undefined): ReadinessLevel | null {
+  if (raw == null || raw === "") return null;
+  const v = String(raw).toLowerCase().trim();
+  return (READINESS_LEVEL_API_VALUES as readonly string[]).includes(v)
+    ? (v as ReadinessLevel)
+    : null;
+}
+
+export function parseIndexLevel(raw: string | null | undefined): IndexLevel | null {
+  if (raw == null || raw === "") return null;
+  const v = String(raw).toLowerCase().trim();
+  return (INDEX_LEVEL_API_VALUES as readonly string[]).includes(v) ? (v as IndexLevel) : null;
+}
+
+/** Tooltip-Text für Readiness-Badge in der Portfolio-Tabelle (ohne numerischen Score). */
+export function readinessPortfolioBadgeTooltip(levelApi: string): string {
+  const p = parseReadinessLevel(levelApi);
+  const label = p ? getReadinessCopy(p).levelLabelDe : levelApi;
+  return `Reifegrad ${label} (0–100). ${READINESS_REG_HINT_SHORT}`;
+}
+
+export function getReadinessCopy(level: ReadinessLevel) {
+  return {
+    levelLabelDe: READINESS_LEVEL_LABEL_DE[level],
+    productTitle: READINESS_PRODUCT_TITLE,
+    tagline: READINESS_TAGLINE,
+    cLevelTooltip: READINESS_TOOLTIP_C_LEVEL,
+    regHintShort: READINESS_REG_HINT_SHORT,
+    /** Kurz-Tooltip nur für das Level-Badge (Readiness-Karte / Snapshot). */
+    levelWithRegTooltip: `${READINESS_LEVEL_LABEL_DE[level]} — ${READINESS_REG_HINT_SHORT}`,
+  };
+}
+
+export function getActivityCopy(level: ActivityLevel) {
+  return {
+    levelLabelDe: INDEX_LEVEL_LABEL_DE[level],
+    fullName: GAI_FULL_NAME,
+    cLevelTooltip: GAI_TOOLTIP_C_LEVEL,
+    advisorExtra: GAI_ADVISOR_DETAIL_EXTRA,
+    regHintShort: GAI_REG_HINT_SHORT,
+    columnHeaderShort: PORTFOLIO_COL_GAI_SHORT,
+    columnTooltip: PORTFOLIO_COL_GAI_TOOLTIP,
+  };
+}
+
+export function getMonitoringCopy(level: MonitoringLevel) {
+  return {
+    levelLabelDe: INDEX_LEVEL_LABEL_DE[level],
+    fullName: OAMI_FULL_NAME,
+    sectionTitle: OAMI_SECTION_TITLE,
+    cLevelTooltip: OAMI_TOOLTIP_C_LEVEL,
+    advisorExtra: OAMI_ADVISOR_DETAIL_EXTRA,
+    regHintShort: OAMI_REG_HINT_SHORT,
+    columnHeaderShort: PORTFOLIO_COL_OAMI_SHORT,
+    columnTooltip: PORTFOLIO_COL_OAMI_TOOLTIP,
+  };
+}
+
 /** Readiness-Level (API: basic | managed | embedded). */
 export function readinessLevelLabelDe(level: string): string {
-  switch (level) {
-    case "basic":
-      return "Basis";
-    case "managed":
-      return "Etabliert";
-    case "embedded":
-      return "Integriert";
-    default:
-      return level;
-  }
+  const p = parseReadinessLevel(level);
+  return p ? getReadinessCopy(p).levelLabelDe : level;
 }
 
 /** GAI / OAMI Level (API: low | medium | high). */
 export function indexLevelLabelDe(level: string | null | undefined): string {
-  if (!level) return "–";
-  switch (String(level).toLowerCase()) {
-    case "low":
-      return "Niedrig";
-    case "medium":
-      return "Mittel";
-    case "high":
-      return "Hoch";
-    default:
-      return level;
-  }
+  if (level == null || level === "") return "–";
+  const p = parseIndexLevel(level);
+  return p ? INDEX_LEVEL_LABEL_DE[p] : String(level);
 }
+
+export type { ActivityLevel, IndexLevel, MonitoringLevel, ReadinessLevel } from "@/lib/governanceMaturityTypes";
+export {
+  INDEX_LEVEL_API_VALUES,
+  READINESS_LEVEL_API_VALUES,
+} from "@/lib/governanceMaturityTypes";

--- a/frontend/src/lib/governanceMaturityTypes.ts
+++ b/frontend/src/lib/governanceMaturityTypes.ts
@@ -1,0 +1,16 @@
+/**
+ * API- und UI-gleiche Level-Werte für Governance Maturity (Readiness, GAI, OAMI).
+ * Backend: readiness basic|managed|embedded; GAI/OAMI low|medium|high.
+ */
+
+export const READINESS_LEVEL_API_VALUES = ["basic", "managed", "embedded"] as const;
+export type ReadinessLevel = (typeof READINESS_LEVEL_API_VALUES)[number];
+
+export const INDEX_LEVEL_API_VALUES = ["low", "medium", "high"] as const;
+export type IndexLevel = (typeof INDEX_LEVEL_API_VALUES)[number];
+
+/** Governance-Aktivitätsindex (GAI) – gleiche Skala wie OAMI. */
+export type ActivityLevel = IndexLevel;
+
+/** Operativer KI-Monitoring-Index (OAMI) – gleiche Skala wie GAI. */
+export type MonitoringLevel = IndexLevel;


### PR DESCRIPTION
- Add governanceMaturityTypes + getReadinessCopy/getActivityCopy/getMonitoringCopy, parsers, portfolio column copy\n- BoardReadinessCard: READINESS_LEVEL_ROW_LABEL, level tooltip via helpers, optional staticReadiness\n- Advisor portfolio: GAI/OAMI columns behind featureGovernanceMaturity; API types\n- Backend: governance_activity_summary + operational_monitoring_summary on advisor portfolio; CSV fields\n- Vitest for copy, BoardReadinessCard, portfolio, snapshot; frontend README note

Made-with: Cursor