### PR TITLE
feat(llm): align readiness explain with governance-maturity copy cont…

### DIFF
--- a/app/governance_maturity_contract.py
+++ b/app/governance_maturity_contract.py
@@ -1,0 +1,134 @@
+"""
+Language-agnostic API contract for governance maturity levels (aligned with frontend).
+
+Frontend mirror: frontend/src/lib/governanceMaturityTypes.ts
+German presentation (UI only): frontend/src/lib/governanceMaturityDeCopy.ts
+
+All LLM prompts and structured JSON must use **API level strings** only
+(basic | managed | embedded) and (low | medium | high), never ad-hoc synonyms.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Literal
+
+# --- API values (identical to TypeScript READINESS_LEVEL_API_VALUES / INDEX_LEVEL_API_VALUES)
+
+
+class ReadinessLevelApi(StrEnum):
+    BASIC = "basic"
+    MANAGED = "managed"
+    EMBEDDED = "embedded"
+
+
+class GovernanceActivityLevelApi(StrEnum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class OperationalMonitoringLevelApi(StrEnum):
+    """Same scale as GAI; distinct type for documentation/clarity."""
+
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+ReadinessLevelLiteral = Literal["basic", "managed", "embedded"]
+IndexLevelLiteral = Literal["low", "medium", "high"]
+
+READINESS_API_LEVELS: tuple[str, ...] = tuple(m.value for m in ReadinessLevelApi)
+INDEX_API_LEVELS: tuple[str, ...] = tuple(m.value for m in GovernanceActivityLevelApi)
+
+# German labels (Board copy); must stay in sync with governanceMaturityDeCopy.ts
+READINESS_LEVEL_DE: dict[str, str] = {
+    ReadinessLevelApi.BASIC.value: "Basis",
+    ReadinessLevelApi.MANAGED.value: "Etabliert",
+    ReadinessLevelApi.EMBEDDED.value: "Integriert",
+}
+
+INDEX_LEVEL_DE: dict[str, str] = {
+    GovernanceActivityLevelApi.LOW.value: "Niedrig",
+    GovernanceActivityLevelApi.MEDIUM.value: "Mittel",
+    GovernanceActivityLevelApi.HIGH.value: "Hoch",
+}
+
+
+def readiness_level_de(api: str) -> str:
+    """German label for prompts; falls back to API string if unknown."""
+    return READINESS_LEVEL_DE.get(str(api).strip().lower(), str(api))
+
+
+def index_level_de(api: str | None) -> str:
+    if api is None or str(api).strip() == "":
+        return "–"
+    k = str(api).strip().lower()
+    return INDEX_LEVEL_DE.get(k, str(api))
+
+
+def normalize_readiness_level(raw: object) -> ReadinessLevelLiteral | None:
+    if raw is None:
+        return None
+    v = str(raw).strip().lower()
+    if v in READINESS_API_LEVELS:
+        return v  # type: ignore[return-value]
+    return None
+
+
+def normalize_index_level(raw: object) -> IndexLevelLiteral | None:
+    if raw is None:
+        return None
+    v = str(raw).strip().lower()
+    if v in INDEX_API_LEVELS:
+        return v  # type: ignore[return-value]
+    return None
+
+
+def terminology_contract_for_llm_prompt() -> str:
+    """
+    Instruct the model: fixed German *display* names for reference in narrative,
+    but JSON `level` fields must use API enums only.
+    """
+    return (
+        "Terminologie (verbindlich, keine alternativen Stufenbezeichnungen erfinden):\n"
+        "- AI & Compliance Readiness: API-Level basic | managed | embedded entsprechen "
+        "den UI-Bezeichnungen Basis | Etabliert | Integriert.\n"
+        "- Governance-Aktivitätsindex (GAI) und Operativer KI-Monitoring-Index (OAMI): "
+        "API-Level low | medium | high entsprechen Niedrig | Mittel | Hoch.\n"
+        "Im JSON sind ausschließlich die englischen API-Werte (basic, managed, embedded, "
+        "low, medium, high) in den Feldern `level` erlaubt.\n"
+        "Regulatorischer Rahmen (kurz, konsistent): EU AI Act, NIS2, ISO/IEC 42001, "
+        "ISO/IEC 27001 — ohne Paragraphenzitate, ohne neue Akronyme für die Indizes.\n"
+        "In Fließtext-Feldern: keine eigenen Synonyme für diese Stufen (z. B. nicht "
+        "„fortgeschritten“ statt Etabliert/integriert); Ursachen und Maßnahmen sachlich "
+        "beschreiben.\n"
+    )
+
+
+def readiness_explain_json_schema_instructions() -> str:
+    """Exact JSON shape expected from the readiness explain LLM (single object, no markdown)."""
+    return (
+        "Antworte ausschließlich mit **einem** JSON-Objekt "
+        "(kein Markdown, keine Codefences). Schema:\n"
+        "{\n"
+        '  "readiness_explanation": {\n'
+        '    "score": <integer 0-100>,\n'
+        '    "level": "basic" | "managed" | "embedded",\n'
+        '    "short_reason": "<1-3 Sätze Deutsch, ohne alternative Stufenlabels>",\n'
+        '    "drivers_positive": ["<kurz>", "..."],\n'
+        '    "drivers_negative": ["<kurz>", "..."],\n'
+        '    "regulatory_focus": "<1 Satz: Bezug EU AI Act / NIS2 / ISO 42001/27001>"\n'
+        "  },\n"
+        '  "operational_monitoring_explanation": null | {\n'
+        '    "index": <integer 0-100 oder null>,\n'
+        '    "level": "low" | "medium" | "high" | null,\n'
+        '    "recent_incidents_summary": "<kurz Deutsch oder leer>",\n'
+        '    "monitoring_gaps": ["<kurz>", "..."],\n'
+        '    "improvement_suggestions": ["<kurz>", "..."]\n'
+        "  }\n"
+        "}\n"
+        "Wenn keine OAMI-Daten im Kontext: setze operational_monitoring_explanation auf null.\n"
+        "listen: höchstens je 5 Einträge, je Eintrag höchstens 200 Zeichen.\n"
+    )

--- a/app/readiness_score_models.py
+++ b/app/readiness_score_models.py
@@ -9,7 +9,10 @@ from pydantic import BaseModel, Field
 ReadinessLevel = Literal["basic", "managed", "embedded"]
 
 __all__ = [
+    "OperationalMonitoringExplanationStructured",
+    "OamiExplainLevel",
     "ReadinessDimensionOut",
+    "ReadinessExplanationStructured",
     "ReadinessLevel",
     "ReadinessScoreDimensions",
     "ReadinessScoreExplainResponse",
@@ -51,7 +54,35 @@ class ReadinessScoreSummary(BaseModel):
     level: ReadinessLevel
 
 
+OamiExplainLevel = Literal["low", "medium", "high"]
+
+
+class ReadinessExplanationStructured(BaseModel):
+    """Structured LLM output; `level` uses API enum (UI maps to Basis/Etabliert/Integriert)."""
+
+    score: int = Field(ge=0, le=100)
+    level: ReadinessLevel
+    short_reason: str = Field(default="", max_length=4000)
+    drivers_positive: list[str] = Field(default_factory=list, max_length=8)
+    drivers_negative: list[str] = Field(default_factory=list, max_length=8)
+    regulatory_focus: str = Field(default="", max_length=2000)
+
+
+class OperationalMonitoringExplanationStructured(BaseModel):
+    """OAMI narrative from LLM; `level` uses API enum (UI maps to Niedrig/Mittel/Hoch)."""
+
+    index: int | None = Field(default=None, ge=0, le=100)
+    level: OamiExplainLevel | None = None
+    recent_incidents_summary: str = Field(default="", max_length=2000)
+    monitoring_gaps: list[str] = Field(default_factory=list, max_length=8)
+    improvement_suggestions: list[str] = Field(default_factory=list, max_length=8)
+
+
 class ReadinessScoreExplainResponse(BaseModel):
+    """`explanation` für Legacy-Clients; optional strukturiert für Board-UI + Copy-Modul."""
+
     explanation: str
     provider: str = ""
     model_id: str = ""
+    readiness_explanation: ReadinessExplanationStructured | None = None
+    operational_monitoring_explanation: OperationalMonitoringExplanationStructured | None = None

--- a/app/services/readiness_explain_structured.py
+++ b/app/services/readiness_explain_structured.py
@@ -1,0 +1,202 @@
+"""Parse and validate structured JSON from readiness-score LLM; compose legacy explanation text."""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from app.governance_maturity_contract import (
+    normalize_index_level,
+    normalize_readiness_level,
+)
+from app.readiness_score_models import (
+    OperationalMonitoringExplanationStructured,
+    ReadinessExplanationStructured,
+    ReadinessScoreExplainResponse,
+    ReadinessScoreResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_json_fence(raw: str) -> str:
+    t = raw.strip()
+    if t.startswith("```"):
+        t = re.sub(r"^```(?:json)?\s*", "", t, flags=re.IGNORECASE)
+        t = re.sub(r"\s*```\s*$", "", t)
+    return t.strip()
+
+
+def extract_json_object(raw: str) -> dict[str, Any] | None:
+    """Best-effort: fenced JSON, or first {...} block."""
+    t = _strip_json_fence(raw)
+    try:
+        data = json.loads(t)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        pass
+    start = t.find("{")
+    end = t.rfind("}")
+    if start >= 0 and end > start:
+        try:
+            data = json.loads(t[start : end + 1])
+            return data if isinstance(data, dict) else None
+        except json.JSONDecodeError:
+            return None
+    return None
+
+
+def _clamp_str_list(xs: Any, *, max_items: int, max_len: int) -> list[str]:
+    if not isinstance(xs, list):
+        return []
+    out: list[str] = []
+    for item in xs[:max_items]:
+        s = str(item).strip()[:max_len]
+        if s:
+            out.append(s)
+    return out
+
+
+def _coerce_readiness_struct(
+    data: dict[str, Any],
+    snapshot: ReadinessScoreResponse,
+) -> ReadinessExplanationStructured | None:
+    block = data.get("readiness_explanation")
+    if not isinstance(block, dict):
+        return None
+    level_raw = block.get("level")
+    level = normalize_readiness_level(level_raw) or snapshot.level
+    score_raw = block.get("score", snapshot.score)
+    try:
+        score = int(score_raw)
+    except (TypeError, ValueError):
+        score = snapshot.score
+    score = max(0, min(100, score))
+    return ReadinessExplanationStructured(
+        score=score,
+        level=level,
+        short_reason=str(block.get("short_reason") or "")[:4000],
+        drivers_positive=_clamp_str_list(block.get("drivers_positive"), max_items=8, max_len=500),
+        drivers_negative=_clamp_str_list(block.get("drivers_negative"), max_items=8, max_len=500),
+        regulatory_focus=str(block.get("regulatory_focus") or "")[:2000],
+    )
+
+
+def _coerce_oami_struct(
+    data: dict[str, Any],
+    *,
+    default_index: int | None,
+    default_level: str | None,
+) -> OperationalMonitoringExplanationStructured | None:
+    block = data.get("operational_monitoring_explanation")
+    if block is None:
+        return None
+    if not isinstance(block, dict):
+        return None
+    idx_raw = block.get("index", default_index)
+    index: int | None
+    try:
+        if idx_raw is None:
+            index = default_index
+        else:
+            index = max(0, min(100, int(idx_raw)))
+    except (TypeError, ValueError):
+        index = default_index
+
+    lvl = normalize_index_level(block.get("level", default_level))
+    if lvl is None and default_level:
+        lvl = normalize_index_level(default_level)
+
+    return OperationalMonitoringExplanationStructured(
+        index=index,
+        level=lvl,
+        recent_incidents_summary=str(block.get("recent_incidents_summary") or "")[:2000],
+        monitoring_gaps=_clamp_str_list(block.get("monitoring_gaps"), max_items=8, max_len=500),
+        improvement_suggestions=_clamp_str_list(
+            block.get("improvement_suggestions"),
+            max_items=8,
+            max_len=500,
+        ),
+    )
+
+
+def compose_legacy_explanation_text(
+    readiness: ReadinessExplanationStructured,
+    oami: OperationalMonitoringExplanationStructured | None,
+) -> str:
+    """Single block for clients that only render `explanation` (no structured UI)."""
+    parts: list[str] = []
+    if readiness.short_reason.strip():
+        parts.append(readiness.short_reason.strip())
+    if readiness.drivers_negative:
+        block = ["Priorisierte Maßnahmen (Auszug):"] + [
+            f"{i}. {d}" for i, d in enumerate(readiness.drivers_negative[:3], start=1)
+        ]
+        parts.append("\n".join(block))
+    if oami and (oami.improvement_suggestions or oami.monitoring_gaps):
+        xs = oami.improvement_suggestions or oami.monitoring_gaps
+        block = ["Operatives Monitoring (OAMI):"] + [f"- {s}" for s in xs[:3]]
+        parts.append("\n".join(block))
+    return "\n\n".join(parts).strip()
+
+
+def build_readiness_explain_response_from_llm_text(
+    llm_text: str,
+    *,
+    snapshot: ReadinessScoreResponse,
+    oami_index: int | None,
+    oami_level: str | None,
+    has_oami_context: bool,
+    provider: str,
+    model_id: str,
+) -> ReadinessScoreExplainResponse:
+    data = extract_json_object(llm_text)
+    if not data:
+        logger.info("readiness_explain_json_parse_failed; using raw text")
+        return ReadinessScoreExplainResponse(
+            explanation=(llm_text or "").strip(),
+            provider=provider,
+            model_id=model_id,
+            readiness_explanation=None,
+            operational_monitoring_explanation=None,
+        )
+
+    r_struct = _coerce_readiness_struct(data, snapshot)
+    o_struct: OperationalMonitoringExplanationStructured | None = None
+    if has_oami_context:
+        o_struct = _coerce_oami_struct(
+            data,
+            default_index=oami_index,
+            default_level=oami_level,
+        )
+        if o_struct is not None and o_struct.level is None and oami_level:
+            o_struct = o_struct.model_copy(
+                update={"level": normalize_index_level(oami_level)},
+            )
+
+    if r_struct is None:
+        return ReadinessScoreExplainResponse(
+            explanation=(llm_text or "").strip(),
+            provider=provider,
+            model_id=model_id,
+            readiness_explanation=None,
+            operational_monitoring_explanation=o_struct,
+        )
+
+    # Align score/level with server truth if model drifted
+    r_aligned = r_struct.model_copy(
+        update={"score": snapshot.score, "level": snapshot.level},
+    )
+    narrative = compose_legacy_explanation_text(r_aligned, o_struct)
+    if not narrative:
+        narrative = (snapshot.interpretation or "").strip() or (llm_text or "").strip()
+
+    return ReadinessScoreExplainResponse(
+        explanation=narrative,
+        provider=provider,
+        model_id=model_id,
+        readiness_explanation=r_aligned,
+        operational_monitoring_explanation=o_struct,
+    )

--- a/app/services/readiness_score_explain.py
+++ b/app/services/readiness_score_explain.py
@@ -1,28 +1,45 @@
-"""LLM: kurze Erklärung zum Readiness Score (aggregierte Kennzahlen, keine PII)."""
+"""LLM: strukturierte Erklärung zum Readiness Score (API-Enums, deutsch, kein PII)."""
 
 from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.governance_maturity_contract import (
+    readiness_explain_json_schema_instructions,
+    terminology_contract_for_llm_prompt,
+)
 from app.llm_models import LLMTaskType
 from app.readiness_score_models import ReadinessScoreExplainResponse, ReadinessScoreResponse
 from app.services.llm_router import LLMRouter
+from app.services.readiness_explain_structured import (
+    build_readiness_explain_response_from_llm_text,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
 
-_SYSTEM = (
-    "Du erklärst CxOs und CISOs in DACH in 3–5 Sätzen, wie ein AI & Compliance Readiness Score "
-    "zustande kommt und welche Top-3-Maßnahmen sinnvoll sind. Nutze klare Sprache, keine "
-    "Normzitate. Nutze ausschließlich die JSON-Fakten; erfinde keine Zahlen.\n\n"
-    "Struktur: (1) Kurz einordnen, warum Level und Score plausibel sind. "
-    "(2) Genau drei nummerierte, priorisierte Maßnahmen."
+_SYSTEM_PREFIX = (
+    "Du bist ein Compliance-Assistenzmodell für deutschsprachige Board- und CISO-Audienz "
+    "(DACH). Antworte nur mit gültigem JSON gemäß Schema — kein Markdown, keine Einleitung.\n\n"
 )
+
+
+def _build_system_prompt() -> str:
+    return (
+        _SYSTEM_PREFIX
+        + terminology_contract_for_llm_prompt()
+        + "\n"
+        + readiness_explain_json_schema_instructions()
+        + "\n"
+        "Nutze ausschließlich die nachfolgenden JSON-Fakten; erfinde keine Zahlen, Mandanten "
+        "oder KI-Systeme.\n"
+    )
 
 
 def explain_readiness_score(
@@ -35,6 +52,9 @@ def explain_readiness_score(
         raise PermissionError(msg)
 
     oami_context: dict[str, object] | None = None
+    oami_index: int | None = None
+    oami_level: str | None = None
+    has_oami_context = False
     try:
         from app.services.oami_explanation import explain_tenant_oami_de
         from app.services.operational_monitoring_index import (
@@ -48,6 +68,9 @@ def explain_readiness_score(
             persist_snapshot=False,
         )
         expl = explain_tenant_oami_de(oami)
+        oami_index = oami.operational_monitoring_index
+        oami_level = oami.level
+        has_oami_context = bool(oami.has_any_runtime_data)
         oami_context = {
             "window_days": 90,
             "operational_monitoring_index": oami.operational_monitoring_index,
@@ -60,21 +83,46 @@ def explain_readiness_score(
     except Exception:
         logger.exception("readiness_explain_oami_context_failed tenant=%s", tenant_id)
 
+    gai_context: dict[str, object] | None = None
+    if is_feature_enabled(FeatureFlag.governance_maturity):
+        try:
+            from app.services.governance_activity_index import compute_governance_activity_index
+
+            gai = compute_governance_activity_index(
+                session,
+                tenant_id,
+                window_days=90,
+                as_of=datetime.now(UTC),
+            )
+            gai_context = {
+                "governance_activity_index": gai.index,
+                "level": gai.level,
+                "window_days": gai.window_days,
+            }
+        except Exception:
+            logger.exception("readiness_explain_gai_context_failed tenant=%s", tenant_id)
+
     envelope: dict[str, object] = {
         "readiness": snapshot.model_dump(mode="json"),
         "operational_ai_monitoring": oami_context,
+        "governance_activity": gai_context,
     }
     facts = json.dumps(envelope, ensure_ascii=False)
-    prompt = _SYSTEM + "\n\nJSON-Fakten:\n" + facts
+    prompt = _build_system_prompt() + "\nJSON-Fakten:\n" + facts
 
     router = LLMRouter(session=session)
     resp = router.route_and_call(
         LLMTaskType.READINESS_SCORE_EXPLAIN,
         prompt,
         tenant_id,
+        response_format="json_object",
     )
-    return ReadinessScoreExplainResponse(
-        explanation=(resp.text or "").strip(),
+    return build_readiness_explain_response_from_llm_text(
+        resp.text or "",
+        snapshot=snapshot,
+        oami_index=oami_index,
+        oami_level=oami_level,
+        has_oami_context=has_oami_context,
         provider=str(resp.provider.value),
         model_id=resp.model_id,
     )

--- a/docs/governance-maturity-copy-contract.md
+++ b/docs/governance-maturity-copy-contract.md
@@ -1,0 +1,45 @@
+# Governance-Maturity: Copy- und API-Vertrag (Backend ↔ Frontend)
+
+Ziel: **gleiche Fachbegriffe** und **stabile API-Enums** für Readiness, GAI und OAMI; **deutsche Labels** kommen primär aus dem Frontend-Copy-Modul, das Backend liefert **strukturierte Inhalte** (Gründe, Maßnahmen) und **API-Level-Strings**.
+
+## 1. API-Level (sprachneutral)
+
+| Konzept | API-Werte (`level`) | Deutsche UI-Labels (nur Frontend) |
+|--------|----------------------|-------------------------------------|
+| AI & Compliance Readiness | `basic`, `managed`, `embedded` | Basis, Etabliert, Integriert |
+| Governance-Aktivität (GAI) | `low`, `medium`, `high` | Niedrig, Mittel, Hoch |
+| Operatives KI-Monitoring (OAMI) | `low`, `medium`, `high` | Niedrig, Mittel, Hoch |
+
+**Backend (Python):** `app/governance_maturity_contract.py` — `ReadinessLevelApi`, `GovernanceActivityLevelApi`, `OperationalMonitoringLevelApi`, Normalisierer `normalize_readiness_level` / `normalize_index_level`.
+
+**Frontend (TypeScript):** `frontend/src/lib/governanceMaturityTypes.ts` — dieselben String-Unions.
+
+**Deutsche Texte / Tooltips:** ausschließlich `frontend/src/lib/governanceMaturityDeCopy.ts` (siehe auch `docs/governance-maturity-copy-de.md`).
+
+## 2. LLM Readiness-Explain (`POST .../readiness-score/explain`)
+
+- **Prompt:** `terminology_contract_for_llm_prompt()` + `readiness_explain_json_schema_instructions()` in `app/governance_maturity_contract.py`; Implementierung in `app/services/readiness_score_explain.py`.
+- **Erwartetes Modell-Output:** ein JSON-Objekt (ohne Markdown) mit:
+  - `readiness_explanation`: `score`, `level` (API!), `short_reason`, `drivers_positive`, `drivers_negative`, `regulatory_focus`
+  - `operational_monitoring_explanation`: optional / `null` — `index`, `level` (API!), `recent_incidents_summary`, `monitoring_gaps`, `improvement_suggestions`
+- **Validierung:** `app/services/readiness_explain_structured.py` parst JSON, clamped Listen, **erzwingt `readiness.score`/`readiness.level` aus dem Server-Snapshot** (kein Drift).
+- **Antwort:** `ReadinessScoreExplainResponse` (`app/readiness_score_models.py`):
+  - `explanation` — zusammengesetzter Fließtext für Legacy-UI
+  - `readiness_explanation` / `operational_monitoring_explanation` — optional strukturiert für Board-UI
+
+`response_format=json_object` wird an OpenAI durchgereicht; andere Provider liefern ggf. Text — Parser toleriert Codefences und extrahiert `{...}`.
+
+## 3. Frontend-Konsum
+
+- **Labels:** immer `governanceMaturityDeCopy` + `getReadinessCopy` / `getActivityCopy` / `getMonitoringCopy` anhand der **API-Levels** aus dem Score/Snapshot/API.
+- **KI-Text:** `short_reason`, `drivers_*`, `regulatory_focus`, OAMI-Felder aus der API anzeigen; **keine** parallelen Level-Strings im UI erfinden, wenn strukturierte `level`-Felder gesetzt sind.
+- **Typen:** `frontend/src/lib/api.ts` — DTOs zu `ReadinessScoreExplainResponse` (strukturierte Felder optional).
+
+Demo-Script: `docs/demo-board-ready-walkthrough.md`.
+
+## 4. Tests / Guardrails
+
+- `tests/test_governance_maturity_contract.py` — Terminologie-Strings und Enum-Mengen.
+- `tests/test_readiness_explain_structured.py` — JSON-Parsing, Level-Normalisierung, Ausrichtung an Snapshot.
+
+Bei neuen Stufen: **Frontend-Typen, `governanceMaturityDeCopy`, `governance_maturity_contract` und Pydantic-Models** gemeinsam erweitern; LLM-Schema-String in `readiness_explain_json_schema_instructions()` anpassen.

--- a/docs/readiness-score.md
+++ b/docs/readiness-score.md
@@ -25,7 +25,7 @@ Der **Readiness Score** (0–100) fasst Mandantensignale aus dem bestehenden Com
 ## API
 
 - Mandant: `GET /api/v1/tenants/{tenant_id}/readiness-score` (Tenant-Header muss passen)  
-- Optional KI-Erklärung: `POST /api/v1/tenants/{tenant_id}/readiness-score/explain` (benötigt `COMPLIANCEHUB_FEATURE_LLM_ENABLED` und `COMPLIANCEHUB_FEATURE_LLM_EXPLAIN`)  
+- Optional KI-Erklärung: `POST /api/v1/tenants/{tenant_id}/readiness-score/explain` (benötigt `COMPLIANCEHUB_FEATURE_LLM_ENABLED` und `COMPLIANCEHUB_FEATURE_LLM_EXPLAIN`). Antwort: Fließtext `explanation` plus optional `readiness_explanation` / `operational_monitoring_explanation` (JSON-Enums wie Score-API; UI-Labels im Frontend aus `governanceMaturityDeCopy`). Vertrag: `docs/governance-maturity-copy-contract.md`.  
 - Berater-Proxy: `GET /api/v1/advisors/{advisor_id}/tenants/{tenant_id}/readiness-score` (nur verknüpfte Mandanten)  
 
 Feature-Flag: `COMPLIANCEHUB_FEATURE_READINESS_SCORE` / `NEXT_PUBLIC_FEATURE_READINESS_SCORE`.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Governance-Maturity-Copy (Readiness, GAI, OAMI)
 
-Board- und Berater-Texte zu **AI & Compliance Readiness**, **Governance-Aktivitätsindex (GAI)** und **Operativem KI-Monitoring (OAMI)** liegen zentral in [`src/lib/governanceMaturityDeCopy.ts`](src/lib/governanceMaturityDeCopy.ts) (Level-Typen: [`src/lib/governanceMaturityTypes.ts`](src/lib/governanceMaturityTypes.ts)). Neue oder geänderte UI-Strings dort pflegen, nicht in Komponenten duplizieren. Abgleich mit dem gesprochenen Demo-Flow: [`../docs/demo-board-ready-walkthrough.md`](../docs/demo-board-ready-walkthrough.md).
+Board- und Berater-Texte zu **AI & Compliance Readiness**, **Governance-Aktivitätsindex (GAI)** und **Operativem KI-Monitoring (OAMI)** liegen zentral in [`src/lib/governanceMaturityDeCopy.ts`](src/lib/governanceMaturityDeCopy.ts) (Level-Typen: [`src/lib/governanceMaturityTypes.ts`](src/lib/governanceMaturityTypes.ts)). Neue oder geänderte UI-Strings dort pflegen, nicht in Komponenten duplizieren. Abgleich mit dem gesprochenen Demo-Flow: [`../docs/demo-board-ready-walkthrough.md`](../docs/demo-board-ready-walkthrough.md). Backend-Enums und KI-Erklärungen: [`../docs/governance-maturity-copy-contract.md`](../docs/governance-maturity-copy-contract.md).
 
 ## Getting Started
 

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -5,12 +5,14 @@ import React, { useCallback, useEffect, useState } from "react";
 import {
   fetchTenantReadinessScore,
   postTenantReadinessScoreExplain,
+  type ReadinessScoreExplainResponseDto,
   type ReadinessScoreResponseDto,
 } from "@/lib/api";
 import { CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
 import { featureLlmEnabled, featureLlmExplain, featureReadinessScore } from "@/lib/config";
 import {
   DEMO_HINT_READINESS_CARD,
+  OAMI_FULL_NAME,
   getReadinessCopy,
   parseReadinessLevel,
   READINESS_DIM_COVERAGE,
@@ -86,7 +88,7 @@ export function BoardReadinessCard({
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(() => !staticMode);
   const [explainBusy, setExplainBusy] = useState(false);
-  const [explain, setExplain] = useState<string | null>(null);
+  const [explainResult, setExplainResult] = useState<ReadinessScoreExplainResponseDto | null>(null);
   const [explainErr, setExplainErr] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -120,10 +122,10 @@ export function BoardReadinessCard({
   const runExplain = async () => {
     setExplainBusy(true);
     setExplainErr(null);
-    setExplain(null);
+    setExplainResult(null);
     try {
       const r = await postTenantReadinessScoreExplain(tenantId);
-      setExplain(r.explanation);
+      setExplainResult(r);
     } catch (e) {
       setExplainErr(e instanceof Error ? e.message : "KI-Erklärung fehlgeschlagen");
     } finally {
@@ -258,10 +260,49 @@ export function BoardReadinessCard({
                 {explainBusy ? "KI formuliert…" : "Score per KI erklären (Top-3-Maßnahmen)"}
               </button>
               {explainErr ? <p className="mt-2 text-sm text-rose-800">{explainErr}</p> : null}
-              {explain ? (
-                <p className="mt-3 whitespace-pre-wrap text-sm text-slate-700" data-testid="board-readiness-explain-text">
-                  {explain}
-                </p>
+              {explainResult ? (
+                <div className="mt-3 space-y-2" data-testid="board-readiness-explain-block">
+                  <p
+                    className="whitespace-pre-wrap text-sm text-slate-700"
+                    data-testid="board-readiness-explain-text"
+                  >
+                    {explainResult.explanation}
+                  </p>
+                  {explainResult.readiness_explanation?.regulatory_focus ? (
+                    <p className="text-xs leading-snug text-slate-500">
+                      {explainResult.readiness_explanation.regulatory_focus}
+                    </p>
+                  ) : null}
+                  {explainResult.readiness_explanation &&
+                  explainResult.readiness_explanation.drivers_positive.length > 0 ? (
+                    <div>
+                      <p className="text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500">
+                        Stärken
+                      </p>
+                      <ul className="mt-1 list-inside list-disc text-xs text-slate-600">
+                        {explainResult.readiness_explanation.drivers_positive.map((line, i) => (
+                          <li key={i}>{line}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                  {explainResult.operational_monitoring_explanation &&
+                  (explainResult.operational_monitoring_explanation.improvement_suggestions.length > 0 ||
+                    explainResult.operational_monitoring_explanation.monitoring_gaps.length > 0) ? (
+                    <div className="border-t border-slate-100 pt-2">
+                      <p className="text-[0.65rem] font-semibold text-slate-600">{OAMI_FULL_NAME}</p>
+                      <ul className="mt-1 list-inside list-disc text-xs text-slate-600">
+                        {(
+                          explainResult.operational_monitoring_explanation.improvement_suggestions.length
+                            ? explainResult.operational_monitoring_explanation.improvement_suggestions
+                            : explainResult.operational_monitoring_explanation.monitoring_gaps
+                        ).map((line, i) => (
+                          <li key={i}>{line}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  ) : null}
+                </div>
               ) : null}
             </div>
           ) : null}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1374,6 +1374,32 @@ export interface ReadinessScoreSummaryDto {
   level: "basic" | "managed" | "embedded";
 }
 
+/** Strukturierte KI-Erklärung; Level = API-Enums (UI-Labels via governanceMaturityDeCopy). */
+export interface ReadinessExplanationStructuredDto {
+  score: number;
+  level: "basic" | "managed" | "embedded";
+  short_reason: string;
+  drivers_positive: string[];
+  drivers_negative: string[];
+  regulatory_focus: string;
+}
+
+export interface OperationalMonitoringExplanationStructuredDto {
+  index: number | null;
+  level: "low" | "medium" | "high" | null;
+  recent_incidents_summary: string;
+  monitoring_gaps: string[];
+  improvement_suggestions: string[];
+}
+
+export interface ReadinessScoreExplainResponseDto {
+  explanation: string;
+  provider: string;
+  model_id: string;
+  readiness_explanation?: ReadinessExplanationStructuredDto | null;
+  operational_monitoring_explanation?: OperationalMonitoringExplanationStructuredDto | null;
+}
+
 export interface AdvisorTenantGovernanceBriefDto {
   wizard_progress_count: number;
   wizard_steps_total: number;
@@ -2125,7 +2151,7 @@ export async function fetchTenantReadinessScore(tenantId: string): Promise<Readi
 
 export async function postTenantReadinessScoreExplain(
   tenantId: string,
-): Promise<{ explanation: string; provider: string; model_id: string }> {
+): Promise<ReadinessScoreExplainResponseDto> {
   const tid = encodeURIComponent(tenantId);
   return tenantApiFetch(`/api/v1/tenants/${tid}/readiness-score/explain`, tenantId, {
     method: "POST",

--- a/frontend/src/lib/governanceMaturityDeCopy.ts
+++ b/frontend/src/lib/governanceMaturityDeCopy.ts
@@ -6,6 +6,7 @@
  *
  * Inhaltliche Abstimmung mit dem Demo-Script: `docs/demo-board-ready-walkthrough.md`
  * Begriffstabelle: `docs/governance-maturity-copy-de.md`
+ * Backend/API-Enums & LLM-Vertrag: `docs/governance-maturity-copy-contract.md`
  *
  * Level-Typen: `governanceMaturityTypes.ts` — Parser/Helper unten für konsistente Labels.
  */

--- a/tests/test_governance_maturity_contract.py
+++ b/tests/test_governance_maturity_contract.py
@@ -1,0 +1,50 @@
+"""Guardrails: governance maturity API contract and LLM terminology strings."""
+
+from __future__ import annotations
+
+from app.governance_maturity_contract import (
+    INDEX_API_LEVELS,
+    INDEX_LEVEL_DE,
+    READINESS_API_LEVELS,
+    READINESS_LEVEL_DE,
+    normalize_index_level,
+    normalize_readiness_level,
+    readiness_explain_json_schema_instructions,
+    terminology_contract_for_llm_prompt,
+)
+
+
+def test_readiness_api_levels_match_frontend_cardinality() -> None:
+    assert READINESS_API_LEVELS == ("basic", "managed", "embedded")
+
+
+def test_index_api_levels_match_frontend_cardinality() -> None:
+    assert INDEX_API_LEVELS == ("low", "medium", "high")
+
+
+def test_german_labels_complete_for_all_api_levels() -> None:
+    for k in READINESS_API_LEVELS:
+        assert k in READINESS_LEVEL_DE and READINESS_LEVEL_DE[k]
+    for k in INDEX_API_LEVELS:
+        assert k in INDEX_LEVEL_DE and INDEX_LEVEL_DE[k]
+
+
+def test_normalizers_accept_case_insensitive() -> None:
+    assert normalize_readiness_level("MANAGED") == "managed"
+    assert normalize_index_level("HIGH") == "high"
+    assert normalize_readiness_level("nope") is None
+    assert normalize_index_level("") is None
+
+
+def test_llm_prompt_contains_fixed_german_stage_names() -> None:
+    block = terminology_contract_for_llm_prompt()
+    for word in ("Basis", "Etabliert", "Integriert", "Niedrig", "Mittel", "Hoch"):
+        assert word in block
+    for api in ("basic", "managed", "embedded", "low", "medium", "high"):
+        assert api in block
+
+
+def test_json_schema_instructions_list_allowed_level_tokens() -> None:
+    instr = readiness_explain_json_schema_instructions()
+    assert '"basic" | "managed" | "embedded"' in instr or "basic" in instr
+    assert "operational_monitoring_explanation" in instr

--- a/tests/test_readiness_explain_structured.py
+++ b/tests/test_readiness_explain_structured.py
@@ -1,0 +1,100 @@
+"""Structured readiness explain: JSON extract, coercion, snapshot alignment."""
+
+from __future__ import annotations
+
+from app.readiness_score_models import (
+    ReadinessDimensionOut,
+    ReadinessScoreDimensions,
+    ReadinessScoreResponse,
+)
+from app.services.readiness_explain_structured import (
+    build_readiness_explain_response_from_llm_text,
+    extract_json_object,
+)
+
+
+def _snapshot(*, score: int = 55, level: str = "managed") -> ReadinessScoreResponse:
+    dim = ReadinessDimensionOut
+    d = ReadinessScoreDimensions(
+        setup=dim(normalized=0.5, score_0_100=50),
+        coverage=dim(normalized=0.5, score_0_100=50),
+        kpi=dim(normalized=0.5, score_0_100=50),
+        gaps=dim(normalized=0.5, score_0_100=50),
+        reporting=dim(normalized=0.5, score_0_100=50),
+    )
+    return ReadinessScoreResponse(
+        tenant_id="t1",
+        score=score,
+        level=level,  # type: ignore[arg-type]
+        interpretation="Statisch.",
+        dimensions=d,
+    )
+
+
+def test_extract_json_object_strips_fence() -> None:
+    raw = '```json\n{"a": 1}\n```'
+    assert extract_json_object(raw) == {"a": 1}
+
+
+def test_build_response_aligns_readiness_to_snapshot() -> None:
+    snap = _snapshot(score=60, level="embedded")
+    llm = """
+    {
+      "readiness_explanation": {
+        "score": 20,
+        "level": "basic",
+        "short_reason": "Kurz.",
+        "drivers_positive": ["a"],
+        "drivers_negative": ["b", "c"],
+        "regulatory_focus": "EU AI Act"
+      },
+      "operational_monitoring_explanation": null
+    }
+    """
+    out = build_readiness_explain_response_from_llm_text(
+        llm,
+        snapshot=snap,
+        oami_index=None,
+        oami_level=None,
+        has_oami_context=False,
+        provider="openai",
+        model_id="gpt-4o",
+    )
+    assert out.readiness_explanation is not None
+    assert out.readiness_explanation.score == 60
+    assert out.readiness_explanation.level == "embedded"
+    assert "Kurz." in out.explanation
+
+
+def test_oami_struct_coerced_when_context_present() -> None:
+    snap = _snapshot()
+    llm = """
+    {
+      "readiness_explanation": {
+        "score": 55,
+        "level": "managed",
+        "short_reason": "R",
+        "drivers_positive": [],
+        "drivers_negative": [],
+        "regulatory_focus": ""
+      },
+      "operational_monitoring_explanation": {
+        "index": 40,
+        "level": "medium",
+        "recent_incidents_summary": "",
+        "monitoring_gaps": ["g1"],
+        "improvement_suggestions": ["s1"]
+      }
+    }
+    """
+    out = build_readiness_explain_response_from_llm_text(
+        llm,
+        snapshot=snap,
+        oami_index=40,
+        oami_level="medium",
+        has_oami_context=True,
+        provider="x",
+        model_id="y",
+    )
+    assert out.operational_monitoring_explanation is not None
+    assert out.operational_monitoring_explanation.level == "medium"


### PR DESCRIPTION
…ract

- Add governance_maturity_contract (API enums, DE labels, LLM terminology + JSON schema text)\n- Structured explain parse/validate; snapshot-aligned readiness level/score; optional OAMI block\n- Extend ReadinessScoreExplainResponse; GAI context in explain envelope when flag on\n- Docs: governance-maturity-copy-contract.md; readiness-score + README + copy header links\n- Frontend: explain DTOs; BoardReadinessCard renders structured regulatory/strengths/OAMI\n- Tests: contract guardrails + readiness_explain_structured

Made-with: Cursor