### PR TITLE
test(governance): OAMI explain goldens and mapping snapshot

### DIFF
--- a/app/governance_maturity_contract.py
+++ b/app/governance_maturity_contract.py
@@ -5,6 +5,8 @@ Language-agnostic API contract for governance maturity levels (aligned with fron
 - API enums used in JSON (LLM + REST)
 - German labels injected into LLM prompts (mirrors UI copy; canonical UI strings live in TS)
 - Explain-schema version string for prompts and change tracking
+- Readiness- und OAMI-Index-Bänder für Regression (`contract_full_mapping_snapshot`,
+  `contract_full_oami_mapping_snapshot`)
 
 Frontend mirror: frontend/src/lib/governanceMaturityTypes.ts
 German presentation (UI): frontend/src/lib/governanceMaturityDeCopy.ts
@@ -95,6 +97,22 @@ def derive_readiness_level_from_score(score: int) -> ReadinessLevelLiteral:
     return "embedded"
 
 
+def derive_oami_level_from_index(index: int) -> IndexLevelLiteral:
+    """
+    OAMI-Index (0–100) → API-Level; gleiche Bänder wie
+    ``operational_monitoring_index._level_from_index``.
+
+    Kalibrierung: ``docs/governance-operational-ai-monitoring.md``.
+    Für Tests und Mapping-Snapshots; serverseitiges OAMI-Level bleibt im Explain-Flow autoritativ.
+    """
+    s = max(0, min(100, int(index)))
+    if s < 40:
+        return "low"
+    if s < 70:
+        return "medium"
+    return "high"
+
+
 def normalize_readiness_level(raw: object) -> ReadinessLevelLiteral | None:
     if raw is None:
         return None
@@ -153,6 +171,41 @@ def contract_full_mapping_snapshot() -> dict[str, object]:
         },
     ]
     return {**base, "readiness_score_bands": bands}
+
+
+def contract_full_oami_mapping_snapshot() -> dict[str, object]:
+    """
+    OAMI-Index-Bänder → API-Level → DE-Label (Regression).
+
+    Checked against ``tests/fixtures/governance_maturity_oami_mapping_snapshot.json`` — update that
+    file intentionally when bands or labels change.
+    """
+    return {
+        "contract_version": GOVERNANCE_MATURITY_CONTRACT_VERSION,
+        "source": "app.services.operational_monitoring_index._level_from_index",
+        "index_api_levels": list(INDEX_API_LEVELS),
+        "index_level_de": {k: INDEX_LEVEL_DE[k] for k in INDEX_API_LEVELS},
+        "oami_index_bands": [
+            {
+                "index_min": 0,
+                "index_max_exclusive": 40,
+                "level": GovernanceActivityLevelApi.LOW.value,
+                "label_de": INDEX_LEVEL_DE[GovernanceActivityLevelApi.LOW.value],
+            },
+            {
+                "index_min": 40,
+                "index_max_exclusive": 70,
+                "level": GovernanceActivityLevelApi.MEDIUM.value,
+                "label_de": INDEX_LEVEL_DE[GovernanceActivityLevelApi.MEDIUM.value],
+            },
+            {
+                "index_min": 70,
+                "index_max_exclusive": 101,
+                "level": GovernanceActivityLevelApi.HIGH.value,
+                "label_de": INDEX_LEVEL_DE[GovernanceActivityLevelApi.HIGH.value],
+            },
+        ],
+    }
 
 
 def regulatory_context_standard() -> str:

--- a/docs/governance-maturity-copy-contract.md
+++ b/docs/governance-maturity-copy-contract.md
@@ -60,7 +60,17 @@ Hilfsfunktion (Tests/Docs): `derive_readiness_level_from_score(score)` im Contra
 
 ### 3.2 GAI / OAMI (0–100 Index)
 
-Es gibt **keinen** zweiten „numerischen Level-Typ“ im Contract: der Index (0–100) und das API-Level (`low`/`medium`/`high`) werden in den **jeweiligen Services** aus der Datenlage abgeleitet. Das Contract-Modul definiert nur **Enums und Labels** sowie Parser `normalize_index_level`.
+Der Index (0–100) und das API-Level (`low` / `medium` / `high`) werden in den **jeweiligen Services** aus der Datenlage abgeleitet. Das Contract-Modul definiert **Enums, Labels**, Parser `normalize_index_level` sowie **Dokumentations-Bänder** für OAMI (Regression).
+
+**OAMI-Index → API-Level** (wie `operational_monitoring_index._level_from_index`; Snapshot: `contract_full_oami_mapping_snapshot()`):
+
+| Index (ganzzahlig 0–100) | Typischer API-Level |
+|--------------------------|---------------------|
+| &lt; 40 | `low` |
+| 40–69 | `medium` |
+| ≥ 70 | `high` |
+
+Hilfsfunktion (Tests/Docs): `derive_oami_level_from_index(index)` — **nicht** zur Überschreibung des serverseitigen OAMI-Levels im Explain-Flow verwenden.
 
 ### 3.3 DE-Labels
 
@@ -142,6 +152,20 @@ Die Dateien sind **canonical fixtures** für `tests/test_readiness_explain_golde
 }
 ```
 
+### 4.4 Golden Samples: OAMI-Block (`operational_monitoring_explanation`)
+
+Unter `tests/fixtures/oami-explain/` liegen **drei** vollständige Beispiele mit **Readiness- und OAMI-Block** (ohne Markdown). Sie spiegeln Niedrig/Mittel/Hoch beim operativen Monitoring und die erlaubten Index-Level-Enums.
+
+| Datei | Szenario (kurz) | OAMI-Index (Beispiel) | `level` (API) | DE-Label (UI) |
+|-------|-----------------|------------------------|---------------|---------------|
+| `response_low.json` | Kaum Daten, ungeklärte Vorfälle | ~28 | `low` | Niedrig |
+| `response_medium.json` | Monitoring sichtbar, einige Incidents | ~55 | `medium` | Mittel |
+| `response_high.json` | Kontinuierliche Beobachtung, wenige Incidents | ~85 | `high` | Hoch |
+
+**Regression der Index-Bänder:** `tests/fixtures/governance_maturity_oami_mapping_snapshot.json` muss `contract_full_oami_mapping_snapshot()` entsprechen (siehe Abschn. 9).
+
+**Tests:** `tests/test_oami_explain_golden_regression.py` (inkl. kombinierter Readiness+OAMI-Strukturtest und Fallback bei ungültigem OAMI-`level`).
+
 ---
 
 ## 5. Regeln für LLM-Output
@@ -158,7 +182,7 @@ Die Dateien sind **canonical fixtures** für `tests/test_readiness_explain_golde
 
 | Baustein | Datei / Funktion |
 |----------|------------------|
-| Enums, Labels, Limits, Version, `contract_full_mapping_snapshot()` | `app/governance_maturity_contract.py` |
+| Enums, Labels, Limits, Version, `contract_full_mapping_snapshot()`, `contract_full_oami_mapping_snapshot()`, `derive_oami_level_from_index` | `app/governance_maturity_contract.py` |
 | Prompt-Zusammenbau (nur Contract + Fakten) | `app/services/readiness_explain_prompt.py` → `build_readiness_explain_prompt` |
 | LLM-Aufruf | `app/services/readiness_score_explain.py` → `explain_readiness_score` |
 | Parse / Validierung / Fallback | `app/services/readiness_explain_structured.py` → `parse_readiness_explain_llm_json`, `parse_and_validate_readiness_explain_response` |
@@ -182,16 +206,17 @@ Die Dateien sind **canonical fixtures** für `tests/test_readiness_explain_golde
 3. **Dieses Dokument** + `docs/governance-maturity-copy-de.md` + ggf. `readiness-score.md` aktualisieren.
 4. **Frontend:** `governanceMaturityTypes.ts`, `governanceMaturityDeCopy.ts`, `api.ts` DTOs.
 5. **Pydantic:** `readiness_score_models.py` (Listenlängen, Literals).
-6. **Tests:** `tests/test_governance_maturity_contract.py`, `tests/test_readiness_explain_structured.py`, `tests/test_readiness_explain_prompt.py`, `tests/test_readiness_explain_golden_regression.py` anpassen.
-7. **Fixtures:** `tests/fixtures/governance_maturity_mapping_snapshot.json` und `tests/fixtures/readiness_explain_golden/*.json` bei Band- oder Golden-Änderungen aktualisieren.
+6. **Tests:** `tests/test_governance_maturity_contract.py`, `tests/test_readiness_explain_structured.py`, `tests/test_readiness_explain_prompt.py`, `tests/test_readiness_explain_golden_regression.py`, `tests/test_oami_explain_golden_regression.py` anpassen.
+7. **Fixtures:** `tests/fixtures/governance_maturity_mapping_snapshot.json`, `tests/fixtures/governance_maturity_oami_mapping_snapshot.json`, `tests/fixtures/readiness_explain_golden/*.json` und `tests/fixtures/oami-explain/*.json` bei Band- oder Golden-Änderungen aktualisieren.
 
 ---
 
 ## 9. Tests (Referenz)
 
-- **Mapping-Datei:** `tests/fixtures/governance_maturity_mapping_snapshot.json` muss exakt `contract_full_mapping_snapshot()` aus `governance_maturity_contract.py` entsprechen (CI bricht bei Drift).
-- **Golden-Regression:** `tests/test_readiness_explain_golden_regression.py` — Parser, Snapshot-Ausrichtung, erlaubte Keys, Whitespace-Toleranz, Prompt-Struktur (Version + Mandantenfakten).
-- **Contract:** `contract_mapping_for_tests()` / Score-Bänder vs. `derive_readiness_level_from_score`.
+- **Mapping-Dateien:** `governance_maturity_mapping_snapshot.json` ≡ `contract_full_mapping_snapshot()`; `governance_maturity_oami_mapping_snapshot.json` ≡ `contract_full_oami_mapping_snapshot()` (CI bricht bei Drift).
+- **Golden-Regression Readiness:** `tests/test_readiness_explain_golden_regression.py` — Parser, Snapshot-Ausrichtung, erlaubte Keys, Whitespace-Toleranz, Prompt-Struktur (Version + Mandantenfakten).
+- **Golden-Regression OAMI:** `tests/test_oami_explain_golden_regression.py` — OAMI-Block, DE-Label-Konsistenz, ungültiges `level` → Server-Fallback, kombinierter Readiness+OAMI-Check.
+- **Contract:** `contract_mapping_for_tests()` / Readiness-Bänder vs. `derive_readiness_level_from_score`; OAMI-Bänder vs. `derive_oami_level_from_index` und Abgleich mit `operational_monitoring_index._level_from_index`.
 - **Prompt:** alle API-Werte und DE-Labels aus den Maps; keine parallele Hardcode-Liste.
 - **Parser:** ungültige `level`-Strings, fehlende Blöcke (`test_readiness_explain_structured.py`).
 

--- a/tests/fixtures/governance_maturity_oami_mapping_snapshot.json
+++ b/tests/fixtures/governance_maturity_oami_mapping_snapshot.json
@@ -1,0 +1,30 @@
+{
+  "contract_version": "2",
+  "source": "app.services.operational_monitoring_index._level_from_index",
+  "index_api_levels": ["low", "medium", "high"],
+  "index_level_de": {
+    "low": "Niedrig",
+    "medium": "Mittel",
+    "high": "Hoch"
+  },
+  "oami_index_bands": [
+    {
+      "index_min": 0,
+      "index_max_exclusive": 40,
+      "level": "low",
+      "label_de": "Niedrig"
+    },
+    {
+      "index_min": 40,
+      "index_max_exclusive": 70,
+      "level": "medium",
+      "label_de": "Mittel"
+    },
+    {
+      "index_min": 70,
+      "index_max_exclusive": 101,
+      "level": "high",
+      "label_de": "Hoch"
+    }
+  ]
+}

--- a/tests/fixtures/oami-explain/README.md
+++ b/tests/fixtures/oami-explain/README.md
@@ -1,0 +1,22 @@
+# Golden fixtures: `operational_monitoring_explanation` (OAMI)
+
+Vollständige Modell-JSON-Beispiele für den **Governance-Maturity-Explain**-Pfad, wenn OAMI-Kontext aktiv ist (`has_oami_context=True`). Zusammen mit `readiness_explanation` spiegeln sie die erwartete Struktur, erlaubten API-Enums (`low` \| `medium` \| `high`) und den deutschsprachigen Ton.
+
+## Zweck
+
+- **Regression:** Parser (`parse_and_validate_readiness_explain_response`) und Contract-Enums bleiben stabil.
+- **Review:** Inhaltlich realistische Kurztexte für GRC-/Produkt-Reviews; bei Schema- oder Band-Änderungen Fixtures und Tests **gemeinsam** anpassen.
+
+## Dateien
+
+| Datei | Szenario | OAMI-Index (Beispiel) | API-`level` | DE-Label (UI) |
+|-------|----------|------------------------|-------------|---------------|
+| `response_low.json` | Kaum Monitoring-Signale, mehrere ungeklärte Vorfälle | ~28 | `low` | Niedrig |
+| `response_medium.json` | Monitoring vorhanden, einige Incidents, größtenteils bearbeitet | ~55 | `medium` | Mittel |
+| `response_high.json` | Kontinuierliche Beobachtung, wenige Incidents, schnelle Reaktion | ~85 | `high` | Hoch |
+
+Die **Readiness**-Blöcke sind an die bestehenden Golden-Samples (`readiness_explain_golden`) angelehnt (Basis / Etabliert / Integriert), damit kombinierte End-to-End-Reviews ein konsistentes Bild erhalten.
+
+**Mapping-Referenz (Index → Level):** `tests/fixtures/governance_maturity_oami_mapping_snapshot.json` bzw. `contract_full_oami_mapping_snapshot()` in `app/governance_maturity_contract.py`.
+
+**Tests:** `tests/test_oami_explain_golden_regression.py`

--- a/tests/fixtures/oami-explain/response_high.json
+++ b/tests/fixtures/oami-explain/response_high.json
@@ -1,0 +1,25 @@
+{
+  "readiness_explanation": {
+    "score": 88,
+    "level": "embedded",
+    "short_reason": "Hohe strukturelle Reife über alle Dimensionen: Setup, Coverage, KPI-Register, Gap-Transparenz und Board-Reporting sind weitgehend etabliert; Optimierungen sind fein.",
+    "drivers_positive": [
+      "Konsistente Dokumentation und Reporting-Historie.",
+      "Geringe kritische regulatorische Gap-Last im aktiven Scope."
+    ],
+    "drivers_negative": ["Feintuning: Trend-Qualität der KPIs und Peer-Benchmarks prüfen."],
+    "regulatory_focus": "EU AI Act Post-Market-Monitoring und NIS2-Incident-Steuerung bleiben im Blick; ISO 42001/27001 kontinuierlich evidenzbasiert halten."
+  },
+  "operational_monitoring_explanation": {
+    "index": 85,
+    "level": "high",
+    "recent_incidents_summary": "Kontinuierliche Laufzeitbeobachtung; nur vereinzelte Incidents, die zügig bearbeitet und nachvollziehbar abgeschlossen wurden.",
+    "monitoring_gaps": [
+      "Randfälle bei seltenen Deployment-Pfaden noch ohne vollständige Telemetrie."
+    ],
+    "improvement_suggestions": [
+      "Trend-Alarme mit Board-relevanten Schwellen feinjustieren.",
+      "Quartalsweise Review der Monitoring-Abdeckung gegen Systemänderungen."
+    ]
+  }
+}

--- a/tests/fixtures/oami-explain/response_low.json
+++ b/tests/fixtures/oami-explain/response_low.json
@@ -1,0 +1,27 @@
+{
+  "readiness_explanation": {
+    "score": 44,
+    "level": "basic",
+    "short_reason": "Der Score liegt unter der Schwelle für etablierte Strukturen: Setup und Framework-Abdeckung sind noch ausbaufähig; KPI-Register und Board-Reports sind nur teilweise gefüllt.",
+    "drivers_positive": ["Erste Schritte im AI-Governance-Setup sind dokumentiert."],
+    "drivers_negative": [
+      "Cross-Regulation-Coverage und kritische Gaps priorisieren.",
+      "Mindestens zwei KPI-Zeitreihen pro High-Risk-System anlegen.",
+      "Regelmäßige Board- oder Advisor-Reports etablieren."
+    ],
+    "regulatory_focus": "Fokus EU AI Act Nachweise und ISO/IEC 42001/27001-Abdeckung im Tool; NIS2 über Steuerungs- und Incident-Prozesse adressieren."
+  },
+  "operational_monitoring_explanation": {
+    "index": 28,
+    "level": "low",
+    "recent_incidents_summary": "Kaum belastbare Laufzeitdaten; mehrere Vorfälle sind noch ohne klaren Abschluss oder dokumentierte Root-Cause.",
+    "monitoring_gaps": [
+      "Kontinuierliche Erfassung von Runtime-Signalen fehlt weitgehend.",
+      "Incident-Status und Eskalationspfade sind heterogen oder unvollständig."
+    ],
+    "improvement_suggestions": [
+      "Wöchentliche Monitoring-Snapshots für High-Risk-Systeme etablieren.",
+      "Offene Vorfälle triagieren und SLA für Erstreaktion festlegen."
+    ]
+  }
+}

--- a/tests/fixtures/oami-explain/response_medium.json
+++ b/tests/fixtures/oami-explain/response_medium.json
@@ -1,0 +1,28 @@
+{
+  "readiness_explanation": {
+    "score": 68,
+    "level": "managed",
+    "short_reason": "Solide strukturelle Basis: Wizard und Coverage sind überwiegend vorhanden; verbleibende Lücken betreffen vor allem KPI-Tiefen und konsistente Reporting-Historie.",
+    "drivers_positive": [
+      "Framework-Scopes sind gesetzt; kritische Gaps sind sichtbar und adressierbar."
+    ],
+    "drivers_negative": [
+      "KPI-Zeitreihen für alle relevanten High-Risk-Systeme vervollständigen.",
+      "Board-Reporting-Rhythmus formalisieren."
+    ],
+    "regulatory_focus": "EU AI Act und ISO 42001: Nachweise zur Steuerung; ISO 27001-Bezug über ISMS-Aktivitäten; NIS2-relevante Incident-Prozesse koppeln."
+  },
+  "operational_monitoring_explanation": {
+    "index": 55,
+    "level": "medium",
+    "recent_incidents_summary": "Monitoring-Signale sind sichtbar; in den letzten Wochen einige Incidents, überwiegend mit dokumentierter Bearbeitung und Abschluss.",
+    "monitoring_gaps": [
+      "Einige Systeme liefern noch lückenhafte Ereignis-Historie.",
+      "Nachverfolgung bei mittlerer Schwere ist nicht überall einheitlich."
+    ],
+    "improvement_suggestions": [
+      "Coverage auf alle produktiven KI-Systeme im Scope ausweiten.",
+      "Playbooks für Wiederholungsfälle und Eskalation schärfen."
+    ]
+  }
+}

--- a/tests/test_governance_maturity_contract.py
+++ b/tests/test_governance_maturity_contract.py
@@ -12,7 +12,9 @@ from app.governance_maturity_contract import (
     READINESS_API_LEVELS,
     READINESS_LEVEL_DE,
     contract_full_mapping_snapshot,
+    contract_full_oami_mapping_snapshot,
     contract_mapping_for_tests,
+    derive_oami_level_from_index,
     derive_readiness_level_from_score,
     normalize_index_level,
     normalize_readiness_level,
@@ -22,6 +24,9 @@ from app.governance_maturity_contract import (
 
 _MAPPING_SNAPSHOT_PATH = (
     Path(__file__).resolve().parent / "fixtures" / "governance_maturity_mapping_snapshot.json"
+)
+_OAMI_MAPPING_SNAPSHOT_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "governance_maturity_oami_mapping_snapshot.json"
 )
 
 
@@ -85,6 +90,43 @@ def test_derive_readiness_level_from_score_bands() -> None:
     assert derive_readiness_level_from_score(69) == "managed"
     assert derive_readiness_level_from_score(70) == "embedded"
     assert derive_readiness_level_from_score(100) == "embedded"
+
+
+def test_derive_oami_level_from_index_bands() -> None:
+    assert derive_oami_level_from_index(0) == "low"
+    assert derive_oami_level_from_index(39) == "low"
+    assert derive_oami_level_from_index(40) == "medium"
+    assert derive_oami_level_from_index(69) == "medium"
+    assert derive_oami_level_from_index(70) == "high"
+    assert derive_oami_level_from_index(100) == "high"
+
+
+def test_oami_bands_in_full_snapshot_match_derive() -> None:
+    snap = contract_full_oami_mapping_snapshot()
+    bands = snap["oami_index_bands"]
+    assert isinstance(bands, list) and len(bands) == 3
+    for b in bands:
+        lo = int(b["index_min"])
+        hi_ex = int(b["index_max_exclusive"])
+        for idx in range(lo, min(hi_ex, 101)):
+            assert derive_oami_level_from_index(idx) == b["level"]
+
+
+def test_derive_oami_matches_operational_monitoring_service_bands() -> None:
+    from app.services.operational_monitoring_index import _level_from_index
+
+    for idx in range(0, 101):
+        assert derive_oami_level_from_index(idx) == _level_from_index(idx)
+
+
+def test_governance_maturity_oami_mapping_snapshot_file_matches_contract() -> None:
+    """
+    Intentional gate: if OAMI bands or labels change, update
+    tests/fixtures/governance_maturity_oami_mapping_snapshot.json in the same PR.
+    """
+    from_file = json.loads(_OAMI_MAPPING_SNAPSHOT_PATH.read_text(encoding="utf-8"))
+    live = contract_full_oami_mapping_snapshot()
+    assert from_file == live
 
 
 def test_governance_maturity_mapping_snapshot_file_matches_contract() -> None:

--- a/tests/test_oami_explain_golden_regression.py
+++ b/tests/test_oami_explain_golden_regression.py
@@ -1,0 +1,204 @@
+"""
+Golden LLM JSON with OAMI block: parser regression (no live LLM).
+
+Updating ``tests/fixtures/oami-explain/*.json`` or the OAMI mapping snapshot
+must be an intentional review when contract or bands change.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.governance_maturity_contract import INDEX_API_LEVELS, INDEX_LEVEL_DE
+from app.readiness_score_models import (
+    ReadinessDimensionOut,
+    ReadinessScoreDimensions,
+    ReadinessScoreResponse,
+)
+from app.services.readiness_explain_structured import (
+    parse_and_validate_readiness_explain_response,
+    parse_readiness_explain_llm_json,
+)
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "oami-explain"
+
+_OAMI_BLOCK_KEYS = frozenset(
+    {
+        "index",
+        "level",
+        "recent_incidents_summary",
+        "monitoring_gaps",
+        "improvement_suggestions",
+    },
+)
+_TOP_KEYS = frozenset({"readiness_explanation", "operational_monitoring_explanation"})
+
+
+def _snapshot(
+    *,
+    tenant_id: str,
+    score: int,
+    level: str,
+    interpretation: str = "Statischer Referenztext.",
+) -> ReadinessScoreResponse:
+    dim = ReadinessDimensionOut
+    d = ReadinessScoreDimensions(
+        setup=dim(normalized=0.5, score_0_100=50),
+        coverage=dim(normalized=0.5, score_0_100=50),
+        kpi=dim(normalized=0.5, score_0_100=50),
+        gaps=dim(normalized=0.5, score_0_100=50),
+        reporting=dim(normalized=0.5, score_0_100=50),
+    )
+    return ReadinessScoreResponse(
+        tenant_id=tenant_id,
+        score=score,
+        level=level,  # type: ignore[arg-type]
+        interpretation=interpretation,
+        dimensions=d,
+    )
+
+
+def _load_golden(name: str) -> str:
+    return (_FIXTURES / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    (
+        "filename",
+        "tenant_id",
+        "readiness_score",
+        "readiness_level",
+        "oami_index",
+        "oami_level",
+        "oami_summary_substr",
+        "readiness_reason_substr",
+    ),
+    [
+        (
+            "response_low.json",
+            "golden-oami-low",
+            44,
+            "basic",
+            28,
+            "low",
+            "Kaum belastbare",
+            "Schwelle",
+        ),
+        (
+            "response_medium.json",
+            "golden-oami-medium",
+            68,
+            "managed",
+            55,
+            "medium",
+            "Monitoring-Signale",
+            "Solide strukturelle",
+        ),
+        (
+            "response_high.json",
+            "golden-oami-high",
+            88,
+            "embedded",
+            85,
+            "high",
+            "Kontinuierliche",
+            "Hohe strukturelle",
+        ),
+    ],
+)
+def test_oami_golden_llm_json_parses_and_aligns(
+    filename: str,
+    tenant_id: str,
+    readiness_score: int,
+    readiness_level: str,
+    oami_index: int,
+    oami_level: str,
+    oami_summary_substr: str,
+    readiness_reason_substr: str,
+) -> None:
+    raw = _load_golden(filename)
+    snap = _snapshot(tenant_id=tenant_id, score=readiness_score, level=readiness_level)
+    data = parse_readiness_explain_llm_json(raw)
+    assert data is not None
+    assert set(data.keys()) == _TOP_KEYS
+    oami_block = data["operational_monitoring_explanation"]
+    assert isinstance(oami_block, dict)
+    assert set(oami_block.keys()) <= _OAMI_BLOCK_KEYS
+    assert oami_block.get("level") in INDEX_API_LEVELS
+
+    out = parse_and_validate_readiness_explain_response(
+        raw,
+        snapshot=snap,
+        oami_index=oami_index,
+        oami_level=oami_level,
+        has_oami_context=True,
+        provider="golden_stub",
+        model_id="fixture",
+    )
+    assert out.readiness_explanation is not None
+    assert out.readiness_explanation.score == readiness_score
+    assert out.readiness_explanation.level == readiness_level
+    assert out.operational_monitoring_explanation is not None
+    o = out.operational_monitoring_explanation
+    assert o.index == oami_index
+    assert o.level == oami_level
+    assert INDEX_LEVEL_DE[oami_level] in ("Niedrig", "Mittel", "Hoch")
+    assert oami_summary_substr in o.recent_incidents_summary
+    assert readiness_reason_substr in out.explanation
+
+
+def test_oami_golden_json_whitespace_variants_parse_identically() -> None:
+    raw_pretty = _load_golden("response_low.json")
+    one_line = json.dumps(json.loads(raw_pretty), ensure_ascii=False, separators=(",", ":"))
+    a = parse_readiness_explain_llm_json(raw_pretty)
+    b = parse_readiness_explain_llm_json(one_line)
+    assert a == b
+
+
+def test_invalid_oami_level_falls_back_to_server_level() -> None:
+    raw = _load_golden("response_medium.json")
+    payload = json.loads(raw)
+    assert isinstance(payload["operational_monitoring_explanation"], dict)
+    payload["operational_monitoring_explanation"]["level"] = "bogus_not_an_api_level"
+    raw_bad = json.dumps(payload, ensure_ascii=False)
+
+    snap = _snapshot(tenant_id="golden-oami-invalid", score=68, level="managed")
+    out = parse_and_validate_readiness_explain_response(
+        raw_bad,
+        snapshot=snap,
+        oami_index=55,
+        oami_level="medium",
+        has_oami_context=True,
+        provider="golden_stub",
+        model_id="fixture",
+    )
+    assert out.operational_monitoring_explanation is not None
+    assert out.operational_monitoring_explanation.level == "medium"
+
+
+def test_combined_readiness_and_oami_golden_structure_and_de_labels() -> None:
+    """End-to-end: same payload carries both blocks; interplay must survive pipeline refactors."""
+    raw = _load_golden("response_medium.json")
+    snap = _snapshot(tenant_id="golden-combined", score=68, level="managed")
+    out = parse_and_validate_readiness_explain_response(
+        raw,
+        snapshot=snap,
+        oami_index=55,
+        oami_level="medium",
+        has_oami_context=True,
+        provider="golden_stub",
+        model_id="fixture",
+    )
+    assert out.readiness_explanation is not None
+    re = out.readiness_explanation
+    assert re.level == "managed"
+    assert "Solide strukturelle" in re.short_reason
+    assert out.operational_monitoring_explanation is not None
+    oe = out.operational_monitoring_explanation
+    assert oe.level == "medium"
+    assert INDEX_LEVEL_DE[oe.level] == "Mittel"
+    assert isinstance(oe.monitoring_gaps, list) and oe.monitoring_gaps
+    assert isinstance(oe.improvement_suggestions, list) and oe.improvement_suggestions


### PR DESCRIPTION
Add derive_oami_level_from_index and contract_full_oami_mapping_snapshot() mirroring operational_monitoring_index bands. Store governance_maturity_oami_mapping_snapshot.json with drift test. Add tests/fixtures/oami-explain golden JSON, README, and test_oami_explain_golden_regression.py (invalid level fallback, combined readiness+OAMI). Document OAMI bands and fixtures in governance-maturity-copy-contract.md.

Made-with: Cursor