### PR TITLE
test(docs): golden advisor brief scenarios A–D and Markdown regressions

### DIFF
--- a/docs/advisor-governance-maturity-brief.md
+++ b/docs/advisor-governance-maturity-brief.md
@@ -1,5 +1,22 @@
 # Advisor Governance-Maturity-Brief
 
+## Kanonische Berater-Szenarien (A–D)
+
+Für Regression und Qualitätssicherung sind **vier Profile** definiert (siehe `tests/fixtures/advisor-governance-maturity-brief/README.md`):
+
+| ID | Readiness / GAI / OAMI | Konservatives Gesamt | Nutzen für den Berater |
+|----|-------------------------|----------------------|-------------------------|
+| **A** | basic / low / low | low | Grundlagen: Register, Steuerungsnutzung, Monitoring aufbauen |
+| **B** | managed / high / low | low | Monitoring und Laufzeit-Signale nachziehen |
+| **C** | embedded / medium / medium | medium | Nutzung verbreitern, Monitoring harmonisieren |
+| **D** | embedded / high / high | high | Feintuning, Skalierung, kontinuierliche Überwachung |
+
+- **JSON (Fake-LLM):** `tests/fixtures/advisor-governance-maturity-brief/scenario_{a,b,c,d}_llm.json`
+- **Markdown-Goldens (Brief-Abschnitt):** `tests/fixtures/advisor-tenant-report-markdown/scenario_{a,b,c,d}_brief_section.md`
+- **Snapshots (Readiness/GAI/OAMI-Zahlen):** `tests/advisor_brief_scenario_snapshots.py`
+
+Die Auswertung entspricht dem **Board-Kern**: gleiche API-Enums (`basic`/`managed`/`embedded`, `low`/`medium`/`high`), konservatives Gesamtlevel als Minimum der Säulen. Der Berater-Brief ergänzt **Fokuslisten** und **Mandantentext**, ohne neue messbare Fakten neben dem Snapshot zu erfinden.
+
 ## Beziehung zum Board-`GovernanceMaturitySummary`
 
 | Artefakt | Rolle |
@@ -20,6 +37,38 @@ Die UI und Integrationen sollen **strukturierte Felder** (Enums, Listen) nutzen,
 - **Einbindung:** Advisor-Portfolio (`governance_maturity_advisor_brief`), Mandanten-Snapshot-API, Markdown-Steckbrief (`render_tenant_report_markdown`), KI-Snapshot-Markdown (Präfix-Abschnitt vor LLM-Fließtext).
 
 Hinweis: Ist `COMPLIANCEHUB_FEATURE_LLM_ENABLED` aktiv, kann pro Mandant im Portfolio **ein zusätzlicher LLM-Aufruf** für den Brief entstehen (Triaging). Ohne LLM nutzt das System den deterministischen Fallback.
+
+## Beispiel JSON – Szenario A (Grundlagen, Auszug)
+
+Vollständige Datei: `tests/fixtures/advisor-governance-maturity-brief/scenario_a_llm.json`. Kurzfassung:
+
+```json
+{
+  "recommended_focus_areas": [
+    "Readiness: KI-Register und Rollen konsistent führen; offene Nachweise zu High-Risk-Systemen schließen.",
+    "GAI: Steuerungsprozesse in der Plattform verankern (Reviews, Freigaben, dokumentierte Nutzung).",
+    "OAMI: Mindestens für High-Risk-Systeme Monitoring und Incident-Runbooks vorbereiten."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage",
+  "client_ready_paragraph_de": "Für die kommenden drei Monate empfehlen wir, die Grundlagen der KI-Governance zu schließen …"
+}
+```
+
+Der Block `governance_maturity_summary` in derselben Datei wird beim Parsen an den Snapshot angeglichen; Enums und Zahlen im Export folgen der API, nicht dem rohen LLM-JSON.
+
+## Beispiel JSON – Szenario B (Monitoring nachziehen, Auszug)
+
+Datei: `scenario_b_llm.json`. Typische Fokuszeile:
+
+```json
+{
+  "recommended_focus_areas": [
+    "OAMI priorisieren: KPI-Zeitreihen, Incidents und Runbooks für High-Risk-Systeme ausbauen.",
+    "Readiness-Lücken bei High-Risk parallel schließen, damit Monitoring auf saubere Stammdaten aufsetzt."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage"
+}
+```
 
 ## Beispiel JSON (Mandant mit niedrigem OAMI)
 
@@ -59,7 +108,30 @@ Hinweis: Ist `COMPLIANCEHUB_FEATURE_LLM_ENABLED` aktiv, kann pro Mandant im Port
 
 ## Beispiel Markdown-Abschnitt (Steckbrief / Export)
 
-Der Block wird von `render_advisor_governance_maturity_brief_markdown_section` erzeugt und in den Mandanten-Steckbrief sowie optional vor den KI-Snapshot-Markdown gesetzt:
+Der Block wird von `render_advisor_governance_maturity_brief_markdown_section` erzeugt und in den Mandanten-Steckbrief sowie optional vor den KI-Snapshot-Markdown gesetzt.
+
+**Referenz-Goldens pro Szenario:** `tests/fixtures/advisor-tenant-report-markdown/scenario_{a,b,c,d}_brief_section.md`
+
+Beispiel (Szenario B, gekürzt — Monitoring-Schwerpunkt):
+
+```markdown
+## Governance-Reife – Kurzüberblick
+
+**Gesamtbild (konservativ):** low
+
+Struktur und Steuerungsnutzung sind gestärkt; das konservative Gesamtbild wird jedoch durch begrenztes Laufzeit-Monitoring nach unten gezogen. …
+
+**Empfohlene Fokusbereiche**
+
+- OAMI priorisieren: KPI-Zeitreihen, Incidents und Runbooks für High-Risk-Systeme ausbauen.
+- Readiness-Lücken bei High-Risk parallel schließen, damit Monitoring auf saubere Stammdaten aufsetzt.
+
+**Vorgeschlagener Zeithorizont:** nächste 90 Tage
+
+Ihre organisatorische und prozessuale Steuerung ist auf einem guten Weg; sinnvoll ist jetzt, operatives Monitoring …
+```
+
+Älteres Beispiel (generischer Low-OAMI-Fall) zur Einordnung:
 
 ```markdown
 ## Governance-Reife – Kurzüberblick
@@ -81,5 +153,6 @@ Aus Sicht der KI-Governance empfehlen wir, operatives Monitoring und die offenen
 ## Tests
 
 - `tests/test_advisor_governance_maturity_brief_parse.py` — Parse, Align, Fallback, Markdown, Prompt-Marker.
+- `tests/test_advisor_brief_golden_scenarios.py` — Szenarien A–D: Fake-LLM-JSON, konservatives Level, Markdown-Goldens, Einbettung im Mandanten-Steckbrief.
 - `tests/test_governance_maturity_contract.py::test_advisor_brief_json_schema_instructions_shape` — Contract-String.
-- Fixture: `tests/fixtures/advisor_governance_maturity_brief_golden/response_ok.json`.
+- Legacy-Fixture: `tests/fixtures/advisor_governance_maturity_brief_golden/response_ok.json`.

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
@@ -218,5 +218,8 @@ describe("AdvisorGovernanceSnapshotView", () => {
     expect(screen.getByText(/Governance-Maturity-Brief/i)).toBeTruthy();
     expect(screen.getByText(/Konservatives Gesamtbild/i)).toBeTruthy();
     expect(screen.getByText(/nächste 90 Tage/i)).toBeTruthy();
+    const focusList = screen.getByTestId("snap-gm-advisor-brief").querySelector("ul");
+    expect(focusList?.textContent).toContain("OAMI niedrig");
+    expect(screen.getByText(/Nächste Schritte \(Horizont\)/i)).toBeTruthy();
   });
 });

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
@@ -102,6 +102,16 @@ describe("AdvisorPortfolioTable", () => {
     expect(cell.textContent).toContain("OAMI");
   });
 
+  it("includes focus areas and next-steps window in Reife-Brief tooltip title", () => {
+    portfolioFeatureFlags.governanceMaturity = true;
+    render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
+    const span = screen.getByTestId("advisor-gm-brief-t-demo-1").querySelector("span[title]");
+    const title = span?.getAttribute("title") ?? "";
+    expect(title).toContain("OAMI niedrig");
+    expect(title).toContain("Zeithorizont:");
+    expect(title).toContain("nächste 90 Tage");
+  });
+
   it("shows Mandanten-Steckbrief download links when advisorId is set", () => {
     portfolioFeatureFlags.snapshot = true;
     portfolioFeatureFlags.readiness = true;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "setuptools.build_meta"
 pythonpath = [
   ".",
   "app",
+  "tests",
 ]
 addopts = "-q"
 

--- a/tests/advisor_brief_scenario_snapshots.py
+++ b/tests/advisor_brief_scenario_snapshots.py
@@ -1,0 +1,134 @@
+"""Shared GovernanceMaturityResponse fixtures for advisor brief golden scenarios (A–D)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.governance_maturity_models import (
+    GovernanceActivityBlock,
+    GovernanceMaturityResponse,
+    GovernanceReadinessBlock,
+    OperationalAiMonitoringBlock,
+)
+
+_FIXED_NOW = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+
+
+def governance_maturity_snapshot_scenario_a() -> GovernanceMaturityResponse:
+    """A: basic / low / low — Grundlagen aufbauen."""
+    return GovernanceMaturityResponse(
+        tenant_id="golden-advisor-scenario-a",
+        computed_at=_FIXED_NOW,
+        readiness=GovernanceReadinessBlock(
+            score=35,
+            level="basic",
+            interpretation="Struktureller Aufbau steht am Anfang.",
+        ),
+        governance_activity=GovernanceActivityBlock(
+            index=32,
+            level="low",
+            window_days=90,
+            last_computed_at=_FIXED_NOW,
+            components=None,
+        ),
+        operational_ai_monitoring=OperationalAiMonitoringBlock(
+            status="active",
+            index=30,
+            level="low",
+            window_days=90,
+            message_de="Wenige belastbare Laufzeit-Signale im Fenster.",
+            drivers_de=[],
+        ),
+    )
+
+
+def governance_maturity_snapshot_scenario_b() -> GovernanceMaturityResponse:
+    """B: managed / high / low — Monitoring nachziehen."""
+    return GovernanceMaturityResponse(
+        tenant_id="golden-advisor-scenario-b",
+        computed_at=_FIXED_NOW,
+        readiness=GovernanceReadinessBlock(
+            score=58,
+            level="managed",
+            interpretation="Solide strukturelle Basis mit verbleibenden Lücken.",
+        ),
+        governance_activity=GovernanceActivityBlock(
+            index=78,
+            level="high",
+            window_days=90,
+            last_computed_at=_FIXED_NOW,
+            components=None,
+        ),
+        operational_ai_monitoring=OperationalAiMonitoringBlock(
+            status="active",
+            index=34,
+            level="low",
+            window_days=90,
+            message_de="Laufzeit-Signale noch dünn; Monitoring ausbaufähig.",
+            drivers_de=[],
+        ),
+    )
+
+
+def governance_maturity_snapshot_scenario_c() -> GovernanceMaturityResponse:
+    """C: embedded / medium / medium — Nutzung verbreitern."""
+    return GovernanceMaturityResponse(
+        tenant_id="golden-advisor-scenario-c",
+        computed_at=_FIXED_NOW,
+        readiness=GovernanceReadinessBlock(
+            score=82,
+            level="embedded",
+            interpretation="Strukturell weit fortgeschritten.",
+        ),
+        governance_activity=GovernanceActivityBlock(
+            index=55,
+            level="medium",
+            window_days=90,
+            last_computed_at=_FIXED_NOW,
+            components=None,
+        ),
+        operational_ai_monitoring=OperationalAiMonitoringBlock(
+            status="active",
+            index=52,
+            level="medium",
+            window_days=90,
+            message_de="Monitoring etabliert; Abdeckung ausbaufähig.",
+            drivers_de=[],
+        ),
+    )
+
+
+def governance_maturity_snapshot_scenario_d() -> GovernanceMaturityResponse:
+    """D: embedded / high / high — Feintuning & Skalierung."""
+    return GovernanceMaturityResponse(
+        tenant_id="golden-advisor-scenario-d",
+        computed_at=_FIXED_NOW,
+        readiness=GovernanceReadinessBlock(
+            score=90,
+            level="embedded",
+            interpretation="Integrierte KI-Governance.",
+        ),
+        governance_activity=GovernanceActivityBlock(
+            index=82,
+            level="high",
+            window_days=90,
+            last_computed_at=_FIXED_NOW,
+            components=None,
+        ),
+        operational_ai_monitoring=OperationalAiMonitoringBlock(
+            status="active",
+            index=76,
+            level="high",
+            window_days=90,
+            message_de="Belastbare Laufzeit-Signale und Trends verfügbar.",
+            drivers_de=[],
+        ),
+    )
+
+
+SCENARIO_SNAPSHOTS: dict[str, GovernanceMaturityResponse] = {
+    "a": governance_maturity_snapshot_scenario_a(),
+    "b": governance_maturity_snapshot_scenario_b(),
+    "c": governance_maturity_snapshot_scenario_c(),
+    "d": governance_maturity_snapshot_scenario_d(),
+}

--- a/tests/fixtures/advisor-governance-maturity-brief/README.md
+++ b/tests/fixtures/advisor-governance-maturity-brief/README.md
@@ -1,0 +1,40 @@
+# Advisor Governance-Maturity-Brief – kanonische Szenarien (Golden)
+
+Die JSON-Dateien `scenario_*_llm.json` simulieren **rohe LLM-Antworten** (ein JSON-Objekt). Beim Parsen werden `score` / `index` / `level` im Block `governance_maturity_summary` an den jeweiligen **Mandanten-Snapshot** angeglichen (`align_governance_maturity_summary_to_snapshot`); Fokuslisten, Zeithorizont und `client_ready_paragraph_de` werden aus dem JSON übernommen.
+
+| ID | Profil (Readiness / GAI / OAMI) | Konservatives Gesamt-Level | Berater-Fokus (Kurz) |
+|----|----------------------------------|----------------------------|----------------------|
+| **A** | basic / low / low | low | Grundlagen: Register, Nutzung der Steuerung, Monitoring aufbauen |
+| **B** | managed / high / low | low | Struktur und Nutzung stärker; **operatives Monitoring nachziehen** |
+| **C** | embedded / medium / medium | medium | Reife insgesamt solide; **Nutzung vertiefen**, Monitoring weiter ausbauen |
+| **D** | embedded / high / high | high | Hohe Reife; **Feintuning, Skalierung**, kontinuierliche Überwachung |
+
+## Metriken (repräsentativ, je Szenario)
+
+### A – „Grundlagen aufbauen“
+- Readiness-Score **35**, Level **basic**
+- GAI-Index **32**, Level **low**
+- OAMI-Index **30**, Level **low** (aktiv, 90-Tage-Fenster)
+
+### B – „Monitoring nachziehen“
+- Readiness **58**, **managed**
+- GAI **78**, **high**
+- OAMI **34**, **low**
+
+### C – „Nutzung verbreitern“
+- Readiness **82**, **embedded**
+- GAI **55**, **medium**
+- OAMI **52**, **medium**
+
+### D – „Feintuning & Skalierung“
+- Readiness **90**, **embedded**
+- GAI **82**, **high**
+- OAMI **76**, **high**
+
+## Markdown-Goldens
+
+Die zugehörigen erwarteten Export-Fragmente (nur Abschnitt „Governance-Reife – Kurzüberblick“) liegen unter:
+
+`tests/fixtures/advisor-tenant-report-markdown/scenario_*_brief_section.md`
+
+Sie werden gegen die Ausgabe von `render_advisor_governance_maturity_brief_markdown_section` nach Parse + Align verglichen (Tests normalisieren Zeilenenden und trailing whitespace).

--- a/tests/fixtures/advisor-governance-maturity-brief/scenario_a_llm.json
+++ b/tests/fixtures/advisor-governance-maturity-brief/scenario_a_llm.json
@@ -1,0 +1,32 @@
+{
+  "governance_maturity_summary": {
+    "readiness": {
+      "score": 0,
+      "level": "embedded",
+      "short_reason": "Strukturell sind Register und Rollen noch nicht durchgängig; der fachliche Aufbau der KI-Governance steht im Vordergrund."
+    },
+    "activity": {
+      "index": 0,
+      "level": "high",
+      "short_reason": "Die dokumentierte Nutzung von Steuerungsartefakten ist noch gering; wiederkehrende Governance-Rituale werden selten abgebildet."
+    },
+    "operational_monitoring": {
+      "index": 0,
+      "level": "high",
+      "short_reason": "Operative Laufzeit-Signale und Alarmierungen sind nur ansatzweise vorhanden; Transparenz im Betrieb bleibt begrenzt."
+    },
+    "overall_assessment": {
+      "level": "high",
+      "short_summary": "Aus Beratersicht liegt der Schwerpunkt auf dem Aufbau belastbarer Grundlagen: Register, Verantwortlichkeiten und erste Monitoring-Fähigkeiten sollten in den nächsten Wochen priorisiert werden.",
+      "key_risks": ["Lücken im KI-Register", "Fehlende Laufzeit-Transparenz"],
+      "key_strengths": []
+    }
+  },
+  "recommended_focus_areas": [
+    "Readiness: KI-Register und Rollen konsistent führen; offene Nachweise zu High-Risk-Systemen schließen.",
+    "GAI: Steuerungsprozesse in der Plattform verankern (Reviews, Freigaben, dokumentierte Nutzung).",
+    "OAMI: Mindestens für High-Risk-Systeme Monitoring und Incident-Runbooks vorbereiten."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage",
+  "client_ready_paragraph_de": "Für die kommenden drei Monate empfehlen wir, die Grundlagen der KI-Governance zu schließen: vollständiges Register, klare Rollen und erste belastbare Monitoring-Signale. Wir begleiten Sie gern bei der Priorisierung."
+}

--- a/tests/fixtures/advisor-governance-maturity-brief/scenario_b_llm.json
+++ b/tests/fixtures/advisor-governance-maturity-brief/scenario_b_llm.json
@@ -1,0 +1,31 @@
+{
+  "governance_maturity_summary": {
+    "readiness": {
+      "score": 0,
+      "level": "basic",
+      "short_reason": "Readiness ist auf einem soliden mittleren Niveau; wesentliche Register- und Rollenstrukturen sind angelegt, Einzellücken bei High-Risk bleiben."
+    },
+    "activity": {
+      "index": 0,
+      "level": "low",
+      "short_reason": "Governance-Aktivität ist hoch: Policies, Actions und Nachweise werden in der Plattform aktiv genutzt und nachverfolgt."
+    },
+    "operational_monitoring": {
+      "index": 0,
+      "level": "high",
+      "short_reason": "Operatives Monitoring liefert noch wenig belastbare Signale; Alarmierung und Trendauswertung sind ausbaufähig."
+    },
+    "overall_assessment": {
+      "level": "medium",
+      "short_summary": "Struktur und Steuerungsnutzung sind gestärkt; das konservative Gesamtbild wird jedoch durch begrenztes Laufzeit-Monitoring nach unten gezogen. Hier sollte der Beratungsschwerpunkt in den nächsten 90 Tagen liegen.",
+      "key_risks": ["Laufzeit-Blindstellen bei produktiven KI-Systemen"],
+      "key_strengths": ["Hohe Governance-Aktivität in der Plattform"]
+    }
+  },
+  "recommended_focus_areas": [
+    "OAMI priorisieren: KPI-Zeitreihen, Incidents und Runbooks für High-Risk-Systeme ausbauen.",
+    "Readiness-Lücken bei High-Risk parallel schließen, damit Monitoring auf saubere Stammdaten aufsetzt."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage",
+  "client_ready_paragraph_de": "Ihre organisatorische und prozessuale Steuerung ist auf einem guten Weg; sinnvoll ist jetzt, operatives Monitoring und Laufzeit-Transparenz nachzuziehen. Gemeinsam können wir ein belastbares 90-Tage-Fahrplanpaket definieren."
+}

--- a/tests/fixtures/advisor-governance-maturity-brief/scenario_c_llm.json
+++ b/tests/fixtures/advisor-governance-maturity-brief/scenario_c_llm.json
@@ -1,0 +1,31 @@
+{
+  "governance_maturity_summary": {
+    "readiness": {
+      "score": 0,
+      "level": "basic",
+      "short_reason": "Readiness ist auf hohem Niveau etabliert; strukturelle Voraussetzungen für EU AI Act und interne Vorgaben sind weitgehend erfüllt."
+    },
+    "activity": {
+      "index": 0,
+      "level": "low",
+      "short_reason": "Die Nutzung der Plattform für Steuerung ist solide; es gibt noch Potenzial, Artefakte breiter in Fachbereiche zu tragen."
+    },
+    "operational_monitoring": {
+      "index": 0,
+      "level": "low",
+      "short_reason": "Operatives Monitoring ist vorhanden; Tiefe und Abdeckung aller relevanten Systeme können noch wachsen."
+    },
+    "overall_assessment": {
+      "level": "low",
+      "short_summary": "In Summe ein ausgewogenes mittleres Reifebild: Grundlagen stehen, Nutzung und Monitoring sind weiterzuentwickeln, ohne dass akute Grundsatzrisiken im Vordergrund stehen. Fokus auf Breite und Vertiefung.",
+      "key_risks": ["Uneinheitliche Tiefe bei Monitoring je Geschäftsbereich"],
+      "key_strengths": ["Hohe strukturelle Readiness", "Stabile Steuerungsnutzung"]
+    }
+  },
+  "recommended_focus_areas": [
+    "Nutzung verbreitern: weitere Fachbereiche an Reviews und Evidenzen anbinden.",
+    "Monitoring vereinheitlichen: Kennzahlen und Schwellen über das High-Risk-Portfolio harmonisieren."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage",
+  "client_ready_paragraph_de": "Ihre KI-Governance ist insgesamt auf einem guten mittleren Niveau. Für die nächsten Monate empfiehlt sich, Nutzung und Monitoring über das Portfolio hinweg zu vereinheitlichen; wir unterstützen bei Workshops und Priorisierung."
+}

--- a/tests/fixtures/advisor-governance-maturity-brief/scenario_d_llm.json
+++ b/tests/fixtures/advisor-governance-maturity-brief/scenario_d_llm.json
@@ -1,0 +1,31 @@
+{
+  "governance_maturity_summary": {
+    "readiness": {
+      "score": 0,
+      "level": "basic",
+      "short_reason": "Readiness ist auf integriertem Niveau: Register, Risikoklassifikation und Nachweise sind weitgehend konsistent gepflegt."
+    },
+    "activity": {
+      "index": 0,
+      "level": "low",
+      "short_reason": "Governance-Aktivität ist hoch; die Plattform wird für laufende Steuerung, Reporting und Nachweise regelmäßig genutzt."
+    },
+    "operational_monitoring": {
+      "index": 0,
+      "level": "low",
+      "short_reason": "Laufzeit-Signale und Trendauswertungen sind für die wesentlichen Systeme verfügbar und werden ausgewertet."
+    },
+    "overall_assessment": {
+      "level": "low",
+      "short_summary": "Das Gesamtbild ist konservativ hoch eingestuft: Struktur, Nutzung und Monitoring greifen zusammen. Der Beratungsschwerpunkt verschiebt sich auf Feintuning, Skalierung bei wachsendem Portfolio und kontinuierliche Post-Market-Überwachung.",
+      "key_risks": ["Komplexitätszuwachs bei Portfolio-Erweiterung"],
+      "key_strengths": ["Integrierte Steuerung", "Belastbares Monitoring"]
+    }
+  },
+  "recommended_focus_areas": [
+    "Feintuning: Schwellen und Eskalationspfade mit Fachbereichen abstimmen.",
+    "Skalierung: Onboarding neuer Systeme an etablierte Governance-Patterns koppeln."
+  ],
+  "suggested_next_steps_window": "nächste 90 Tage",
+  "client_ready_paragraph_de": "Ihre KI-Governance ist auf einem hohen Niveau angekommen. Sinnvoll ist jetzt die Feinjustierung bei wachsender Systemlandschaft und die Sicherstellung, dass neue Use Cases die gleichen Standards erfüllen. Wir beraten gern zu Skalierung und kontinuierlicher Überwachung."
+}

--- a/tests/fixtures/advisor-tenant-report-markdown/README.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/README.md
@@ -1,0 +1,25 @@
+# Advisor Tenant Report – Markdown-Goldens (Brief-Abschnitt)
+
+Diese Dateien enthalten **nur** den Abschnitt **„Governance-Reife – Kurzüberblick“**, wie er von `render_advisor_governance_maturity_brief_markdown_section` erzeugt wird.
+
+- **Quelle:** `tests/fixtures/advisor-governance-maturity-brief/scenario_*_llm.json` (Fake-LLM-JSON) + passender Snapshot aus `tests/advisor_brief_scenario_snapshots.py`, danach `parse_advisor_governance_maturity_brief` → `render_…`.
+- **Regeneration** (bei bewusster Anpassung von Parse/Render):
+
+```bash
+cd /path/to/Compliance-Hub
+PYTHONPATH=app:tests:. python -c "
+from pathlib import Path
+from advisor_brief_scenario_snapshots import SCENARIO_SNAPSHOTS
+from app.services.advisor_governance_maturity_brief_parse import parse_advisor_governance_maturity_brief
+from app.services.advisor_governance_maturity_brief_markdown import render_advisor_governance_maturity_brief_markdown_section
+ROOT = Path('tests/fixtures')
+for sid in 'abcd':
+    snap = SCENARIO_SNAPSHOTS[sid]
+    raw = (ROOT / 'advisor-governance-maturity-brief' / f'scenario_{sid}_llm.json').read_text(encoding='utf-8')
+    out = parse_advisor_governance_maturity_brief(raw, snap)
+    md = render_advisor_governance_maturity_brief_markdown_section(out.brief)
+    (ROOT / 'advisor-tenant-report-markdown' / f'scenario_{sid}_brief_section.md').write_text(md, encoding='utf-8')
+"
+```
+
+Tests vergleichen normalisierte Zeilenenden (trailing whitespace entfernt).

--- a/tests/fixtures/advisor-tenant-report-markdown/scenario_a_brief_section.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/scenario_a_brief_section.md
@@ -1,0 +1,15 @@
+## Governance-Reife – Kurzüberblick
+
+**Gesamtbild (konservativ):** low
+
+Aus Beratersicht liegt der Schwerpunkt auf dem Aufbau belastbarer Grundlagen: Register, Verantwortlichkeiten und erste Monitoring-Fähigkeiten sollten in den nächsten Wochen priorisiert werden.
+
+**Empfohlene Fokusbereiche**
+
+- Readiness: KI-Register und Rollen konsistent führen; offene Nachweise zu High-Risk-Systemen schließen.
+- GAI: Steuerungsprozesse in der Plattform verankern (Reviews, Freigaben, dokumentierte Nutzung).
+- OAMI: Mindestens für High-Risk-Systeme Monitoring und Incident-Runbooks vorbereiten.
+
+**Vorgeschlagener Zeithorizont:** nächste 90 Tage
+
+Für die kommenden drei Monate empfehlen wir, die Grundlagen der KI-Governance zu schließen: vollständiges Register, klare Rollen und erste belastbare Monitoring-Signale. Wir begleiten Sie gern bei der Priorisierung.

--- a/tests/fixtures/advisor-tenant-report-markdown/scenario_b_brief_section.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/scenario_b_brief_section.md
@@ -1,0 +1,14 @@
+## Governance-Reife – Kurzüberblick
+
+**Gesamtbild (konservativ):** low
+
+Struktur und Steuerungsnutzung sind gestärkt; das konservative Gesamtbild wird jedoch durch begrenztes Laufzeit-Monitoring nach unten gezogen. Hier sollte der Beratungsschwerpunkt in den nächsten 90 Tagen liegen.
+
+**Empfohlene Fokusbereiche**
+
+- OAMI priorisieren: KPI-Zeitreihen, Incidents und Runbooks für High-Risk-Systeme ausbauen.
+- Readiness-Lücken bei High-Risk parallel schließen, damit Monitoring auf saubere Stammdaten aufsetzt.
+
+**Vorgeschlagener Zeithorizont:** nächste 90 Tage
+
+Ihre organisatorische und prozessuale Steuerung ist auf einem guten Weg; sinnvoll ist jetzt, operatives Monitoring und Laufzeit-Transparenz nachzuziehen. Gemeinsam können wir ein belastbares 90-Tage-Fahrplanpaket definieren.

--- a/tests/fixtures/advisor-tenant-report-markdown/scenario_c_brief_section.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/scenario_c_brief_section.md
@@ -1,0 +1,14 @@
+## Governance-Reife – Kurzüberblick
+
+**Gesamtbild (konservativ):** medium
+
+In Summe ein ausgewogenes mittleres Reifebild: Grundlagen stehen, Nutzung und Monitoring sind weiterzuentwickeln, ohne dass akute Grundsatzrisiken im Vordergrund stehen. Fokus auf Breite und Vertiefung.
+
+**Empfohlene Fokusbereiche**
+
+- Nutzung verbreitern: weitere Fachbereiche an Reviews und Evidenzen anbinden.
+- Monitoring vereinheitlichen: Kennzahlen und Schwellen über das High-Risk-Portfolio harmonisieren.
+
+**Vorgeschlagener Zeithorizont:** nächste 90 Tage
+
+Ihre KI-Governance ist insgesamt auf einem guten mittleren Niveau. Für die nächsten Monate empfiehlt sich, Nutzung und Monitoring über das Portfolio hinweg zu vereinheitlichen; wir unterstützen bei Workshops und Priorisierung.

--- a/tests/fixtures/advisor-tenant-report-markdown/scenario_d_brief_section.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/scenario_d_brief_section.md
@@ -1,0 +1,14 @@
+## Governance-Reife – Kurzüberblick
+
+**Gesamtbild (konservativ):** high
+
+Das Gesamtbild ist konservativ hoch eingestuft: Struktur, Nutzung und Monitoring greifen zusammen. Der Beratungsschwerpunkt verschiebt sich auf Feintuning, Skalierung bei wachsendem Portfolio und kontinuierliche Post-Market-Überwachung.
+
+**Empfohlene Fokusbereiche**
+
+- Feintuning: Schwellen und Eskalationspfade mit Fachbereichen abstimmen.
+- Skalierung: Onboarding neuer Systeme an etablierte Governance-Patterns koppeln.
+
+**Vorgeschlagener Zeithorizont:** nächste 90 Tage
+
+Ihre KI-Governance ist auf einem hohen Niveau angekommen. Sinnvoll ist jetzt die Feinjustierung bei wachsender Systemlandschaft und die Sicherstellung, dass neue Use Cases die gleichen Standards erfüllen. Wir beraten gern zu Skalierung und kontinuierlicher Überwachung.

--- a/tests/test_advisor_brief_golden_scenarios.py
+++ b/tests/test_advisor_brief_golden_scenarios.py
@@ -1,0 +1,102 @@
+"""Golden regression: fake LLM JSON → parse/align → Markdown + tenant report embed."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from advisor_brief_scenario_snapshots import SCENARIO_SNAPSHOTS
+
+from app.advisor_models import AdvisorTenantReport, TenantReportCriticalRequirementItem
+from app.services.advisor_governance_maturity_brief_markdown import (
+    render_advisor_governance_maturity_brief_markdown_section,
+)
+from app.services.advisor_governance_maturity_brief_parse import (
+    parse_advisor_governance_maturity_brief,
+)
+from app.services.advisor_tenant_report_markdown import render_tenant_report_markdown
+
+_JSON_DIR = Path(__file__).resolve().parent / "fixtures" / "advisor-governance-maturity-brief"
+_MD_DIR = Path(__file__).resolve().parent / "fixtures" / "advisor-tenant-report-markdown"
+
+
+def _normalize_markdown(text: str) -> str:
+    """Stabile Vergleichsbasis: keine trailing spaces, konsistentes Datei-Ende."""
+    lines = [line.rstrip() for line in text.strip().splitlines()]
+    return "\n".join(lines).strip() + "\n"
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "expected_overall"),
+    [
+        ("a", "low"),
+        ("b", "low"),
+        ("c", "medium"),
+        ("d", "high"),
+    ],
+)
+def test_parse_fake_llm_json_aligns_conservative_overall_level(
+    scenario_id: str,
+    expected_overall: str,
+) -> None:
+    snap = SCENARIO_SNAPSHOTS[scenario_id]
+    raw = (_JSON_DIR / f"scenario_{scenario_id}_llm.json").read_text(encoding="utf-8")
+    out = parse_advisor_governance_maturity_brief(raw, snap)
+    assert out.parse_ok is True
+    assert out.used_llm_client_paragraph is True
+    assert out.brief.governance_maturity_summary.overall_assessment.level == expected_overall
+
+
+@pytest.mark.parametrize("scenario_id", ["a", "b", "c", "d"])
+def test_advisor_brief_markdown_matches_golden_file(scenario_id: str) -> None:
+    snap = SCENARIO_SNAPSHOTS[scenario_id]
+    raw = (_JSON_DIR / f"scenario_{scenario_id}_llm.json").read_text(encoding="utf-8")
+    out = parse_advisor_governance_maturity_brief(raw, snap)
+    generated = render_advisor_governance_maturity_brief_markdown_section(out.brief)
+    expected_path = _MD_DIR / f"scenario_{scenario_id}_brief_section.md"
+    expected = expected_path.read_text(encoding="utf-8")
+    assert _normalize_markdown(generated) == _normalize_markdown(expected)
+
+
+def test_tenant_report_markdown_embeds_normalized_brief_section() -> None:
+    """Vollständiger Steckbrief enthält denselben Brief-Block wie die Golden-Datei."""
+    snap = SCENARIO_SNAPSHOTS["a"]
+    raw = (_JSON_DIR / "scenario_a_llm.json").read_text(encoding="utf-8")
+    brief = parse_advisor_governance_maturity_brief(raw, snap).brief
+    fixed_ts = datetime(2025, 6, 15, 10, 30, 0, tzinfo=UTC)
+    report = AdvisorTenantReport(
+        tenant_id="golden-tenant-a",
+        tenant_name="Golden Mandant A",
+        industry="IT",
+        country="DE",
+        generated_at_utc=fixed_ts,
+        ai_systems_total=5,
+        high_risk_systems_count=1,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.45,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=400,
+        nis2_incident_readiness_percent=60.0,
+        nis2_supplier_risk_coverage_percent=55.0,
+        nis2_ot_it_segregation_mean_percent=None,
+        nis2_critical_focus_systems_count=0,
+        governance_open_actions_count=2,
+        governance_overdue_actions_count=0,
+        top_critical_requirements=[
+            TenantReportCriticalRequirementItem(
+                code="HR-01",
+                name="Dokumentation",
+                affected_systems_count=1,
+            ),
+        ],
+        setup_completed_steps=4,
+        setup_total_steps=7,
+        setup_open_step_labels=["Evidenzen"],
+        governance_maturity_advisor_brief=brief,
+    )
+    full_md = render_tenant_report_markdown(report)
+    frag = render_advisor_governance_maturity_brief_markdown_section(brief)
+    assert "## Governance-Reife – Kurzüberblick" in full_md
+    assert _normalize_markdown(frag) in _normalize_markdown(full_md)
+    assert "nächste 90 Tage" in full_md


### PR DESCRIPTION
Add scenario LLM JSON fixtures, aligned markdown goldens, shared snapshots, and pytest coverage for parse/align, conservative overall level, and tenant report embedding. Document scenarios in advisor-governance-maturity-brief.md. Extend frontend tests for Reife-Brief tooltip and snapshot section. Add tests/ to pytest pythonpath for shared snapshot module.

Made-with: Cursor