### PR TITLE
feat(advisor): NIS2/KRITIS and incident signals in portfolio priority

### DIFF
--- a/app/advisor_portfolio_models.py
+++ b/app/advisor_portfolio_models.py
@@ -12,6 +12,8 @@ from app.readiness_score_models import ReadinessScoreSummary
 GaiOamiLevel = Literal["low", "medium", "high"]
 AdvisorPortfolioPriority = Literal["high", "medium", "low"]
 AdvisorMaturityScenarioHint = Literal["a", "b", "c", "d"]
+Nis2EntityCategory = Literal["none", "important_entity", "essential_entity"]
+IncidentBurdenLevel = Literal["low", "medium", "high"]
 
 
 class GovernanceActivityPortfolioSummary(BaseModel):
@@ -35,6 +37,24 @@ class AdvisorPortfolioTenantEntry(BaseModel):
     tenant_name: str
     industry: str | None = None
     country: str | None = None
+    nis2_entity_category: Nis2EntityCategory = Field(
+        default="none",
+        description=(
+            "Aus Mandantenfeld nis2_scope normalisiert: keine / wichtige / wesentliche Einrichtung."
+        ),
+    )
+    kritis_sector_key: str | None = Field(
+        default=None,
+        description="Optionaler KRITIS-Sektorschlüssel aus Stammdaten (keine weiteren Details).",
+    )
+    recent_incidents_90d: bool = Field(
+        default=False,
+        description="Mind. ein strukturiertes Incident in den letzten 90 Tagen (Ja/Nein).",
+    )
+    incident_burden_level: IncidentBurdenLevel = Field(
+        default="low",
+        description="Incident-Last 90 Tage: low/medium/high (ohne Einzelfallinhalte).",
+    )
     eu_ai_act_readiness: float = Field(ge=0.0, le=1.0)
     nis2_kritis_kpi_mean_percent: float | None = Field(
         default=None,

--- a/app/main.py
+++ b/app/main.py
@@ -2706,6 +2706,7 @@ def get_advisor_portfolio(
         AIGovernanceActionRepository,
         Depends(get_ai_governance_action_repository),
     ],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
 ) -> AdvisorPortfolioResponse:
     """Berater-Portfolio: Kern-KPIs je zugeordnetem Mandant (keine Cross-Tenant-SQL)."""
     out = build_advisor_portfolio(
@@ -2720,6 +2721,7 @@ def get_advisor_portfolio(
         violation_repo,
         audit_repo,
         action_repo,
+        incident_repo,
     )
     for t in out.tenants:
         usage_event_logger.log_usage_event(
@@ -2751,6 +2753,7 @@ def export_advisor_portfolio(
         AIGovernanceActionRepository,
         Depends(get_ai_governance_action_repository),
     ],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
     export_format: Annotated[Literal["json", "csv"], Query(alias="format")] = "json",
 ) -> Response:
     """Portfolio als JSON- oder CSV-Datei (Partnermeeting, interne Steuerung)."""
@@ -2766,6 +2769,7 @@ def export_advisor_portfolio(
         violation_repo,
         audit_repo,
         action_repo,
+        incident_repo,
     )
     for t in portfolio.tenants:
         usage_event_logger.log_usage_event(

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -29,6 +29,7 @@ class TenantDB(Base):
     industry: Mapped[str] = mapped_column(String(128), nullable=False)
     country: Mapped[str] = mapped_column(String(64), nullable=False, default="DE")
     nis2_scope: Mapped[str] = mapped_column(String(64), nullable=False, default="in_scope")
+    kritis_sector: Mapped[str | None] = mapped_column(String(64), nullable=True)
     ai_act_scope: Mapped[str] = mapped_column(String(64), nullable=False, default="in_scope")
     is_demo: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     demo_playground: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/app/provisioning_models.py
+++ b/app/provisioning_models.py
@@ -8,6 +8,11 @@ class ProvisionTenantRequest(BaseModel):
     industry: str = Field(..., min_length=1, max_length=128)
     country: str = Field(default="DE", max_length=64)
     nis2_scope: str = Field(default="in_scope", max_length=64)
+    kritis_sector: str | None = Field(
+        default=None,
+        max_length=64,
+        description="Optional: KRITIS-Sektorschlüssel (z.B. energy, health, transport).",
+    )
     ai_act_scope: str = Field(default="in_scope", max_length=64)
     advisor_id: str | None = Field(default=None, max_length=255)
     enable_demo_seed: bool = False

--- a/app/repositories/incidents.py
+++ b/app/repositories/incidents.py
@@ -18,6 +18,24 @@ class IncidentRepository:
     def __init__(self, session: Session) -> None:
         self._session = session
 
+    def count_created_since_days(self, tenant_id: str, *, days: int = 90) -> int:
+        """Anzahl Incidents seit `days` Tagen (ohne Inhalt/PII, nur Zähler)."""
+        since = datetime.now(UTC) - timedelta(days=days)
+        stmt = select(func.count(IncidentTable.id)).where(
+            IncidentTable.tenant_id == tenant_id,
+            IncidentTable.created_at_utc >= since,
+        )
+        return int(self._session.execute(stmt).scalar_one() or 0)
+
+    def count_high_severity_since_days(self, tenant_id: str, *, days: int = 90) -> int:
+        since = datetime.now(UTC) - timedelta(days=days)
+        stmt = select(func.count(IncidentTable.id)).where(
+            IncidentTable.tenant_id == tenant_id,
+            IncidentTable.created_at_utc >= since,
+            IncidentTable.severity == IncidentSeverity.high.value,
+        )
+        return int(self._session.execute(stmt).scalar_one() or 0)
+
     def list_for_tenant_last_12_months(self, tenant_id: str) -> list[IncidentTable]:
         """Alle Incidents des Tenants der letzten 12 Monate (für Aggregationen)."""
         since = datetime.now(UTC) - timedelta(days=365)

--- a/app/repositories/tenant_registry.py
+++ b/app/repositories/tenant_registry.py
@@ -25,6 +25,7 @@ class TenantRegistryRepository:
         country: str,
         nis2_scope: str,
         ai_act_scope: str,
+        kritis_sector: str | None = None,
         is_demo: bool = False,
         demo_playground: bool = False,
     ) -> TenantDB:
@@ -34,6 +35,7 @@ class TenantRegistryRepository:
             industry=industry,
             country=country,
             nis2_scope=nis2_scope,
+            kritis_sector=kritis_sector,
             ai_act_scope=ai_act_scope,
             is_demo=is_demo,
             demo_playground=demo_playground,

--- a/app/services/advisor_portfolio.py
+++ b/app/services/advisor_portfolio.py
@@ -13,6 +13,8 @@ from app.advisor_portfolio_models import (
     AdvisorPortfolioResponse,
     AdvisorPortfolioTenantEntry,
     GovernanceActivityPortfolioSummary,
+    IncidentBurdenLevel,
+    Nis2EntityCategory,
     OperationalMonitoringPortfolioSummary,
 )
 from app.feature_flags import FeatureFlag, is_feature_enabled
@@ -23,8 +25,10 @@ from app.repositories.ai_systems import AISystemRepository
 from app.repositories.audit import AuditRepository
 from app.repositories.classifications import ClassificationRepository
 from app.repositories.compliance_gap import ComplianceGapRepository
+from app.repositories.incidents import IncidentRepository
 from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
 from app.repositories.policies import PolicyRepository
+from app.repositories.tenant_registry import TenantRegistryRepository
 from app.repositories.violations import ViolationRepository
 from app.services.advisor_client_governance_snapshot import build_governance_brief_for_tenant
 from app.services.advisor_governance_maturity_brief_llm import (
@@ -33,10 +37,13 @@ from app.services.advisor_governance_maturity_brief_llm import (
 from app.services.advisor_portfolio_priority import (
     advisor_portfolio_priority_sort_key,
     advisor_priority_explanation_de,
+    apply_regulatory_priority_adjustment,
     compute_advisor_priority_bucket,
+    compute_incident_burden_level,
     derive_primary_focus_tag_de,
     effective_readiness_level,
     infer_maturity_scenario_hint,
+    normalize_nis2_entity_category,
 )
 from app.services.ai_governance_kpis import compute_ai_governance_kpis
 from app.services.compliance_dashboard import compute_ai_compliance_overview
@@ -54,8 +61,12 @@ def _portfolio_priority_fields(
     gai_summary: GovernanceActivityPortfolioSummary | None,
     oami_summary: OperationalMonitoringPortfolioSummary | None,
     gm_brief: AdvisorGovernanceMaturityBrief | None,
+    nis2_entity_category: Nis2EntityCategory,
+    kritis_sector_key: str | None,
+    recent_incidents_90d: bool,
+    incident_burden_level: IncidentBurdenLevel,
 ) -> dict[str, object]:
-    """Regelbasierte Priorität + Szenario-Hint + Hauptschwerpunkt."""
+    """Priorität, Szenario, Schwerpunkt; optional NIS2/KRITIS/Incident-Aufstock."""
     rd_level = effective_readiness_level(readiness_summary, eu_ai_act_readiness)
     gai_lv = gai_summary.level if gai_summary else None
     oami_lv = oami_summary.level if oami_summary and oami_summary.level is not None else None
@@ -67,13 +78,24 @@ def _portfolio_priority_fields(
             gai_level=None,
             oami_level=None,
         )
+        base_expl = (
+            "Keine GAI/OAMI-Kennzahlen verfügbar; Priorität standardmäßig „mittel“. "
+            "Hauptschwerpunkt aus Kontext geschätzt."
+        )
+        bucket, expl = apply_regulatory_priority_adjustment(
+            "medium",
+            base_expl,
+            readiness_level=rd_level,
+            oami_level=oami_lv,
+            nis2_category=nis2_entity_category,
+            kritis_sector_key=kritis_sector_key,
+            recent_incidents_90d=recent_incidents_90d,
+            incident_burden=incident_burden_level,
+        )
         return {
-            "advisor_priority": "medium",
-            "advisor_priority_sort_key": 1,
-            "advisor_priority_explanation_de": (
-                "Keine GAI/OAMI-Kennzahlen verfügbar; Priorität standardmäßig „mittel“. "
-                "Hauptschwerpunkt aus Kontext geschätzt."
-            ),
+            "advisor_priority": bucket,
+            "advisor_priority_sort_key": advisor_portfolio_priority_sort_key(bucket),
+            "advisor_priority_explanation_de": expl,
             "maturity_scenario_hint": None,
             "primary_focus_tag_de": primary,
         }
@@ -87,10 +109,20 @@ def _portfolio_priority_fields(
         oami_level=oami_lv,
     )
     explanation = advisor_priority_explanation_de(bucket, scenario, primary)
+    bucket2, expl2 = apply_regulatory_priority_adjustment(
+        bucket,
+        explanation,
+        readiness_level=rd_level,
+        oami_level=oami_lv,
+        nis2_category=nis2_entity_category,
+        kritis_sector_key=kritis_sector_key,
+        recent_incidents_90d=recent_incidents_90d,
+        incident_burden=incident_burden_level,
+    )
     return {
-        "advisor_priority": bucket,
-        "advisor_priority_sort_key": advisor_portfolio_priority_sort_key(bucket),
-        "advisor_priority_explanation_de": explanation,
+        "advisor_priority": bucket2,
+        "advisor_priority_sort_key": advisor_portfolio_priority_sort_key(bucket2),
+        "advisor_priority_explanation_de": expl2,
         "maturity_scenario_hint": scenario,
         "primary_focus_tag_de": primary,
     }
@@ -108,13 +140,26 @@ def build_advisor_portfolio(
     violation_repo: ViolationRepository,
     audit_repo: AuditRepository,
     action_repo: AIGovernanceActionRepository,
+    incident_repo: IncidentRepository,
 ) -> AdvisorPortfolioResponse:
     links = advisor_repo.list_for_advisor(advisor_id)
     tenants_out: list[AdvisorPortfolioTenantEntry] = []
     now = datetime.now(UTC)
+    treg = TenantRegistryRepository(session)
 
     for link in links:
         tid = link.tenant_id
+        trow = treg.get_by_id(tid)
+        nis2_cat = normalize_nis2_entity_category(trow.nis2_scope if trow else None)
+        kritis_key = (
+            trow.kritis_sector.strip()
+            if trow and trow.kritis_sector and str(trow.kritis_sector).strip()
+            else None
+        )
+        c90 = incident_repo.count_created_since_days(tid, days=90)
+        h90 = incident_repo.count_high_severity_since_days(tid, days=90)
+        burden: IncidentBurdenLevel = compute_incident_burden_level(c90, h90)
+        recent = c90 > 0
         overview = compute_ai_compliance_overview(
             tenant_id=tid,
             ai_repo=ai_repo,
@@ -191,6 +236,10 @@ def build_advisor_portfolio(
             gai_summary=gai_summary,
             oami_summary=oami_summary,
             gm_brief=gm_brief,
+            nis2_entity_category=nis2_cat,
+            kritis_sector_key=kritis_key,
+            recent_incidents_90d=recent,
+            incident_burden_level=burden,
         )
 
         tenants_out.append(
@@ -199,6 +248,10 @@ def build_advisor_portfolio(
                 tenant_name=(link.tenant_display_name or tid).strip() or tid,
                 industry=link.industry,
                 country=link.country,
+                nis2_entity_category=nis2_cat,
+                kritis_sector_key=kritis_key,
+                recent_incidents_90d=recent,
+                incident_burden_level=burden,
                 eu_ai_act_readiness=eu_rd,
                 nis2_kritis_kpi_mean_percent=overview.nis2_kritis_kpi_mean_percent,
                 nis2_kritis_systems_full_coverage_ratio=round(
@@ -239,6 +292,10 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
         "tenant_name",
         "industry",
         "country",
+        "nis2_entity_category",
+        "kritis_sector_key",
+        "recent_incidents_90d",
+        "incident_burden_level",
         "eu_ai_act_readiness",
         "nis2_kritis_kpi_mean_percent",
         "nis2_kritis_systems_full_coverage_ratio",
@@ -247,6 +304,11 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
         "setup_completed_steps",
         "setup_total_steps",
         "setup_progress_ratio",
+        "advisor_priority",
+        "advisor_priority_sort_key",
+        "advisor_priority_explanation_de",
+        "maturity_scenario_hint",
+        "primary_focus_tag_de",
         "readiness_score",
         "readiness_level",
         "gai_index",
@@ -260,17 +322,42 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
     w = csv.DictWriter(buf, fieldnames=fieldnames)
     w.writeheader()
     for t in portfolio.tenants:
-        row = t.model_dump()
-        rs = row.get("readiness_summary")
+        row: dict[str, object] = {}
+        d = t.model_dump(mode="python")
+        for k in (
+            "tenant_id",
+            "tenant_name",
+            "industry",
+            "country",
+            "nis2_entity_category",
+            "kritis_sector_key",
+            "recent_incidents_90d",
+            "incident_burden_level",
+            "eu_ai_act_readiness",
+            "nis2_kritis_kpi_mean_percent",
+            "nis2_kritis_systems_full_coverage_ratio",
+            "high_risk_systems_count",
+            "open_governance_actions_count",
+            "setup_completed_steps",
+            "setup_total_steps",
+            "setup_progress_ratio",
+            "advisor_priority",
+            "advisor_priority_sort_key",
+            "advisor_priority_explanation_de",
+            "maturity_scenario_hint",
+            "primary_focus_tag_de",
+        ):
+            row[k] = d.get(k, "")
+        rs = d.get("readiness_summary")
         row["readiness_score"] = rs["score"] if rs else ""
         row["readiness_level"] = rs["level"] if rs else ""
-        ga = row.get("governance_activity_summary")
-        om = row.get("operational_monitoring_summary")
+        ga = d.get("governance_activity_summary")
+        om = d.get("operational_monitoring_summary")
         row["gai_index"] = ga["index"] if ga else ""
         row["gai_level"] = ga["level"] if ga else ""
         row["oami_index"] = om["index"] if om and om.get("index") is not None else ""
         row["oami_level"] = om["level"] if om and om.get("level") is not None else ""
-        gmb = row.get("governance_maturity_advisor_brief")
+        gmb = d.get("governance_maturity_advisor_brief")
         if gmb:
             gms = gmb.get("governance_maturity_summary") or {}
             oa = gms.get("overall_assessment") or {}
@@ -282,11 +369,7 @@ def advisor_portfolio_to_csv(portfolio: AdvisorPortfolioResponse) -> str:
             row["governance_maturity_overall_level"] = ""
             row["governance_maturity_focus_1"] = ""
             row["governance_maturity_next_window"] = ""
-        row["advisor_priority"] = row.get("advisor_priority", "")
-        row["advisor_priority_sort_key"] = row.get("advisor_priority_sort_key", "")
-        row["maturity_scenario_hint"] = row.get("maturity_scenario_hint") or ""
-        row["primary_focus_tag_de"] = row.get("primary_focus_tag_de", "")
-        w.writerow({k: row.get(k) for k in fieldnames})
+        w.writerow({k: row.get(k, "") for k in fieldnames})
     return buf.getvalue()
 
 

--- a/app/services/advisor_portfolio_priority.py
+++ b/app/services/advisor_portfolio_priority.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Literal
 
 from app.advisor_governance_maturity_brief_models import AdvisorGovernanceMaturityBrief
+from app.advisor_portfolio_models import IncidentBurdenLevel, Nis2EntityCategory
 from app.readiness_score_models import ReadinessScoreSummary
 
 AdvisorPriorityBucket = Literal["high", "medium", "low"]
@@ -172,3 +173,147 @@ def advisor_priority_explanation_de(
 def advisor_portfolio_priority_sort_key(bucket: AdvisorPriorityBucket) -> int:
     """Sortierung: niedrigere Zahl = zuerst anzeigen (hohe Priorität oben)."""
     return _PRIORITY_SORT[bucket]
+
+
+def normalize_nis2_entity_category(raw_db_scope: str | None) -> Nis2EntityCategory:
+    """
+    Mappt Mandantenfeld `tenants.nis2_scope` auf drei Berater-Kategorien.
+
+    Explizite Strings (Provisioning/Admin): important_entity, essential_entity, none, …
+    Legacy `in_scope` zählt als wichtige Einrichtung (generische NIS2-Relevanz).
+    """
+    if raw_db_scope is None or not str(raw_db_scope).strip():
+        return "none"
+    s = str(raw_db_scope).strip().lower()
+    if s in ("none", "not_applicable", "na", "out_of_scope", "exempt", "no"):
+        return "none"
+    if s in ("essential_entity", "essential", "kritis_operator", "operator_kritis"):
+        return "essential_entity"
+    if s in (
+        "important_entity",
+        "important",
+        "in_scope",
+        "in-scope",
+        "relevant",
+        "yes",
+    ):
+        return "important_entity"
+    return "important_entity"
+
+
+def compute_incident_burden_level(count_90d: int, high_severity_90d: int) -> IncidentBurdenLevel:
+    """
+    Grobe Laststufe aus Zählern (90 Tage), ohne Inhalte oder Personenbezug.
+
+    high: viele Vorfälle oder wiederholt schwere Einträge.
+    medium: mindestens ein Vorfall im Fenster.
+    low: kein Vorfall.
+    """
+    if count_90d <= 0:
+        return "low"
+    if high_severity_90d >= 2 or count_90d >= 5:
+        return "high"
+    return "medium"
+
+
+def _maturity_stress_for_regulatory(readiness_level: str, oami_level: str | None) -> bool:
+    """True, wenn Readiness oder operatives Monitoring aus NIS2-Sicht nachziehen sollte."""
+    r = _ord_readiness_level(readiness_level)
+    o = _ord_index_level(oami_level) if oami_level is not None else 0
+    weak_r = r is not None and r <= 1
+    weak_o = o < 2
+    return weak_r or weak_o
+
+
+def regulatory_priority_bump_applies(
+    *,
+    nis2_category: Nis2EntityCategory,
+    kritis_sector_key: str | None,
+    recent_incidents_90d: bool,
+    incident_burden: IncidentBurdenLevel,
+    readiness_level: str,
+    oami_level: str | None,
+) -> bool:
+    """
+    Max. eine Stufe anheben, nur bei klarer Kombination (transparente Regeln):
+
+    - Zuerst: Reife-Stress (Readiness nicht „embedded“ oder OAMI nicht „high“).
+    - Dann mindestens eines:
+        - wesentliche Einrichtung (NIS2), oder
+        - KRITIS-Sektor in Stammdaten gepflegt, oder
+        - Vorfälle in 90 Tagen mit mittlerer oder hoher Last.
+    """
+    if not _maturity_stress_for_regulatory(readiness_level, oami_level):
+        return False
+    if nis2_category == "essential_entity":
+        return True
+    if kritis_sector_key:
+        return True
+    if recent_incidents_90d and incident_burden in ("medium", "high"):
+        return True
+    return False
+
+
+def bump_advisor_priority_bucket(bucket: AdvisorPriorityBucket) -> AdvisorPriorityBucket:
+    """Eine Stufe in Richtung „dringlicher“; „high“ bleibt oben."""
+    if bucket == "low":
+        return "medium"
+    if bucket == "medium":
+        return "high"
+    return bucket
+
+
+def regulatory_bump_suffix_de(
+    *,
+    nis2_category: Nis2EntityCategory,
+    kritis_sector_key: str | None,
+    recent_incidents_90d: bool,
+    incident_burden: IncidentBurdenLevel,
+) -> str:
+    """Kurzer Zusatz für Tooltips (ohne Incident-Inhalte)."""
+    parts: list[str] = []
+    if nis2_category == "essential_entity":
+        parts.append("wesentliche Einrichtung (NIS2)")
+    elif nis2_category == "important_entity":
+        parts.append("wichtige Einrichtung (NIS2)")
+    if kritis_sector_key:
+        parts.append("KRITIS-Sektor")
+    if recent_incidents_90d:
+        parts.append(f"Incident-Last 90 Tage: {incident_burden}")
+    core = ", ".join(parts) if parts else "Regulatorisches Signal"
+    return (
+        f" Regulatorischer Aufstock ({core}); bei begrenzter Readiness/Monitoring-Reife "
+        "Priorität eine Stufe erhöht."
+    )[:280]
+
+
+def apply_regulatory_priority_adjustment(
+    base_bucket: AdvisorPriorityBucket,
+    base_explanation_de: str,
+    *,
+    readiness_level: str,
+    oami_level: str | None,
+    nis2_category: Nis2EntityCategory,
+    kritis_sector_key: str | None,
+    recent_incidents_90d: bool,
+    incident_burden: IncidentBurdenLevel,
+) -> tuple[AdvisorPriorityBucket, str]:
+    """Wendet höchstens eine Prioritätsstufe an und hängt einen erklärenden Satz an."""
+    if not regulatory_priority_bump_applies(
+        nis2_category=nis2_category,
+        kritis_sector_key=kritis_sector_key,
+        recent_incidents_90d=recent_incidents_90d,
+        incident_burden=incident_burden,
+        readiness_level=readiness_level,
+        oami_level=oami_level,
+    ):
+        return base_bucket, base_explanation_de
+    new_b = bump_advisor_priority_bucket(base_bucket)
+    suffix = regulatory_bump_suffix_de(
+        nis2_category=nis2_category,
+        kritis_sector_key=kritis_sector_key,
+        recent_incidents_90d=recent_incidents_90d,
+        incident_burden=incident_burden,
+    )
+    merged = f"{base_explanation_de.rstrip()}{suffix}"[:500]
+    return new_b, merged

--- a/app/services/tenant_provisioning.py
+++ b/app/services/tenant_provisioning.py
@@ -59,6 +59,9 @@ def provision_tenant(session: Session, body: ProvisionTenantRequest) -> Provisio
     flags_repo = TenantFeatureOverrideRepository(session)
     keys_repo = TenantApiKeyRepository(session)
 
+    ks: str | None = None
+    if body.kritis_sector is not None and str(body.kritis_sector).strip():
+        ks = str(body.kritis_sector).strip()[:64]
     reg.create(
         tenant_id=tenant_id,
         display_name=body.tenant_name.strip(),
@@ -66,6 +69,7 @@ def provision_tenant(session: Session, body: ProvisionTenantRequest) -> Provisio
         country=body.country.strip() or "DE",
         nis2_scope=body.nis2_scope.strip() or "in_scope",
         ai_act_scope=body.ai_act_scope.strip() or "in_scope",
+        kritis_sector=ks,
     )
 
     flags_repo.set_many(tenant_id, dict(PILOT_TENANT_FEATURE_DEFAULTS))

--- a/docs/advisor-governance-maturity-brief.md
+++ b/docs/advisor-governance-maturity-brief.md
@@ -160,3 +160,4 @@ Aus Sicht der KI-Governance empfehlen wir, operatives Monitoring und die offenen
 ## Siehe auch
 
 - Portfolio-Priorität, Sortierung, Filter und Deep-Link in den Snapshot: [`advisor-portfolio-prioritization.md`](./advisor-portfolio-prioritization.md).
+- NIS2/KRITIS/Incident-Aufstock der Priorität: [`advisor-priority-nis2-kritis.md`](./advisor-priority-nis2-kritis.md).

--- a/docs/advisor-portfolio-prioritization.md
+++ b/docs/advisor-portfolio-prioritization.md
@@ -38,18 +38,19 @@ Link **Snapshot anzeigen** enthält `?highlight=governance-maturity`, damit im G
 - **Standard-Sortierung:** höchste Berater-Priorität zuerst (`advisor_priority_sort_key`), danach **Mandantenname** aufsteigend.
 - **Schnellfilter „Aufbau / Monitoring“:** hohe Priorität oder Szenario A/B.
 - **Schnellfilter „Optimierung“:** niedrige Priorität oder Szenario D.
+- **Regulatorik:** NIS2-relevant · KRITIS-Sektor gepflegt · Vorfälle in 90 Tagen (siehe [advisor-priority-nis2-kritis.md](./advisor-priority-nis2-kritis.md)).
 - **Säulen-Fokus:** Readiness · Governance-Aktivität (GAI) · Monitoring (OAMI) – filtert nach Heuristik/Schwerpunkt und Levels.
 - **Szenario:** Dropdown A–D.
 - **Nur hohe Priorität:** schmale Liste für das nächste Beratungsfenster.
 
 ## Pseudo-Tabelle (Beispiel-Portfolio)
 
-| Mandant | Priorität | Schwerpunkt | GAI | OAMI | Kurzlogik für den Berater |
-|---------|-----------|-------------|-----|------|---------------------------|
-| Alpha GmbH | Hoch · Sz. A | Readiness | Niedrig | Niedrig | Grundlagen zuerst |
-| Beta AG | Hoch · Sz. B | Monitoring | Hoch | Niedrig | Monitoring nachziehen |
-| Gamma SE | Mittel | Nutzung | Mittel | Mittel | Einzelhebel gezielt |
-| Delta KG | Niedrig · Sz. D | Governance | Hoch | Hoch | Pflege / Optimierung |
+| Mandant | Regulatorik | Priorität | Schwerpunkt | GAI | OAMI | Kurzlogik für den Berater |
+|---------|-------------|-----------|-------------|-----|------|---------------------------|
+| Alpha GmbH | NIS2 wesentl. | Hoch · Sz. A | Readiness | Niedrig | Niedrig | Grundlagen zuerst |
+| Beta AG | KRITIS, Vorfälle | Hoch · Sz. B | Monitoring | Hoch | Niedrig | Monitoring + Meldewege |
+| Gamma SE | — | Mittel | Nutzung | Mittel | Mittel | Einzelhebel gezielt |
+| Delta KG | — | Niedrig · Sz. D | Governance | Hoch | Hoch | Pflege / Optimierung |
 
 *(Screenshot: in der Produkt-Doku ergänzen, sobald UI final freigegeben ist.)*
 

--- a/docs/advisor-priority-nis2-kritis.md
+++ b/docs/advisor-priority-nis2-kritis.md
@@ -1,0 +1,61 @@
+# Berater-Priorität: NIS2, KRITIS und Incident-Signale
+
+Erweiterung der **regelbasierten** `advisor_priority` im Mandanten-Portfolio. Ziel: bei wesentlichen/wichtigen Einrichtungen, KRITIS-Sektoren und jüngerer Incident-Last **eine Stufe** nachvollziehbar anheben – ohne versteckte Gewichtung oder PII in der API.
+
+## Stammdaten (Quelle)
+
+| Feld (API) | Quelle | Hinweis |
+|------------|--------|---------|
+| `nis2_entity_category` | `tenants.nis2_scope` normalisiert | `none` / `important_entity` / `essential_entity` |
+| `kritis_sector_key` | `tenants.kritis_sector` | Optional; Sektorschlüssel (z. B. `energy`, `health`), keine weiteren Details |
+| `recent_incidents_90d` | Zähler Incidents | `true`, wenn mindestens ein Eintrag in **90 Tagen** |
+| `incident_burden_level` | Zähler 90 Tage | `low` / `medium` / `high` aus Anzahl und Schwere **high** |
+
+### Normalisierung `nis2_scope` → `nis2_entity_category`
+
+- `none`, `out_of_scope`, … → `none`
+- `essential_entity`, `kritis_operator`, … → `essential_entity`
+- `important_entity`, Legacy **`in_scope`** → `important_entity`
+
+Provisioning: optional `kritis_sector` im Body von `POST /api/v1/tenants/provision`.
+
+## Incident-Last (90 Tage)
+
+- **low:** keine Vorfälle im Fenster
+- **medium:** mindestens ein Vorfall
+- **high:** ≥ 5 Vorfälle **oder** ≥ 2 mit Schwere `high`
+
+Es werden **keine** Titel, Akteure oder Freitexte aus Incidents exportiert.
+
+## Regeln für den regulatorischen Aufstock (max. eine Stufe)
+
+Voraussetzung **A** (Reife-Stress):
+
+- Readiness nicht `embedded` **oder**
+- OAMI fehlt / nicht `high` (fehlendes OAMI zählt vorsichtig als „nicht high“).
+
+Dann mindestens eine der Bedingungen **B**:
+
+1. `nis2_entity_category == essential_entity`
+2. `kritis_sector_key` ist gesetzt (Sektor erfasst)
+3. `recent_incidents_90d` und `incident_burden_level` ∈ {`medium`, `high`}
+
+Wenn **A** und **B** zutreffen: Priorität **eine Stufe anheben** (`low`→`medium`, `medium`→`high`; `high` bleibt).
+
+Der Tooltip-Text (`advisor_priority_explanation_de`) erhält einen kurzen Satz **Regulatorischer Aufstock (…)**, der die auslösenden **Kategorien** nennt, keine Inhalte aus Vorfällen.
+
+## Beispiele
+
+1. **Wesentliche Einrichtung, schwaches Monitoring:** `essential_entity`, Readiness `managed`, OAMI `low` → Aufstock um eine Stufe gegenüber reinem Reife-Score.
+2. **KRITIS Energie, mittlere Readiness:** `kritis_sector_key=energy`, OAMI `medium` → Aufstock (Sektor + Stress).
+3. **Wichtige Einrichtung ohne Vorfälle, gute Reife:** `important_entity`, embedded + OAMI high → **kein** Aufstock (nur NIS2-Badge in der UI).
+4. **Kein NIS2/KRITIS, aber Last und Lücken:** `none`, aber 3 Vorfälle in 90 Tagen (`burden` mindestens medium), Readiness `basic` → Aufstock über Incident-Regel.
+
+## CSV / JSON
+
+Export-Spalten u. a.: `nis2_entity_category`, `kritis_sector_key`, `recent_incidents_90d`, `incident_burden_level`, plus bestehende Prioritäts- und Reife-Felder.
+
+## Verwandte Dokumente
+
+- [advisor-portfolio-prioritization.md](./advisor-portfolio-prioritization.md) – Basispriorität und Filter
+- Code: `app/services/advisor_portfolio_priority.py`, `app/services/advisor_portfolio.py`

--- a/frontend/src/app/advisor/page.tsx
+++ b/frontend/src/app/advisor/page.tsx
@@ -17,6 +17,7 @@ import {
   advisorPrioritySortKey,
   applyAdvisorPortfolioFilters,
   type PortfolioPillarFilter,
+  type PortfolioRegulatoryFilter,
   type PortfolioScenarioFilter,
   type PortfolioSegmentFilter,
 } from "@/lib/advisorPortfolioPriority";
@@ -51,6 +52,7 @@ export default function AdvisorPortfolioPage() {
   const [pillarFilter, setPillarFilter] = useState<PortfolioPillarFilter | null>(null);
   const [scenarioFilter, setScenarioFilter] = useState<PortfolioScenarioFilter | null>(null);
   const [segmentFilter, setSegmentFilter] = useState<PortfolioSegmentFilter | null>(null);
+  const [regulatoryFilter, setRegulatoryFilter] = useState<PortfolioRegulatoryFilter | null>(null);
   const [onlyHighPriority, setOnlyHighPriority] = useState(false);
   const [loadAttempt, setLoadAttempt] = useState(0);
   const showBoardReportsTab =
@@ -94,6 +96,7 @@ export default function AdvisorPortfolioPage() {
       pillar: pillarFilter,
       scenario: scenarioFilter,
       segment: segmentFilter,
+      regulatory: regulatoryFilter,
       priorityBucket: onlyHighPriority ? "high" : null,
     });
     if (onlyCriticalFilter) {
@@ -134,6 +137,7 @@ export default function AdvisorPortfolioPage() {
     pillarFilter,
     scenarioFilter,
     segmentFilter,
+    regulatoryFilter,
     onlyHighPriority,
   ]);
 
@@ -143,6 +147,10 @@ export default function AdvisorPortfolioPage() {
 
   function toggleSegment(s: PortfolioSegmentFilter) {
     setSegmentFilter((cur) => (cur === s ? null : s));
+  }
+
+  function toggleRegulatory(r: PortfolioRegulatoryFilter) {
+    setRegulatoryFilter((cur) => (cur === r ? null : r));
   }
 
   return (
@@ -251,6 +259,33 @@ export default function AdvisorPortfolioPage() {
               >
                 Optimierung
               </button>
+            </div>
+            <div
+              className="mt-2 flex flex-wrap gap-2"
+              role="group"
+              aria-label="NIS2, KRITIS und Incident-Signale"
+            >
+              <span className="self-center text-xs font-semibold text-slate-500">Regulatorik:</span>
+              {(
+                [
+                  ["nis2_relevant", "NIS2-relevant"],
+                  ["kritis_sector", "KRITIS-Sektor"],
+                  ["incidents_90d", "Vorfälle 90 Tage"],
+                ] as const
+              ).map(([key, label]) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={`rounded-lg border px-2.5 py-1 text-xs font-medium ${
+                    regulatoryFilter === key
+                      ? "border-violet-400 bg-violet-50 text-violet-950"
+                      : "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+                  }`}
+                  onClick={() => toggleRegulatory(key)}
+                >
+                  {label}
+                </button>
+              ))}
             </div>
             <div className="mt-2 flex flex-wrap gap-2" role="group" aria-label="Säulen-Fokus">
               <span className="self-center text-xs font-semibold text-slate-500">Fokus:</span>

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
@@ -87,6 +87,10 @@ const sampleRows: AdvisorPortfolioTenantEntry[] = [
       "Mittlere Priorität: Readiness etabliert; GAI/OAMI ohne kritische Lücke.",
     maturity_scenario_hint: null,
     primary_focus_tag_de: "Monitoring",
+    nis2_entity_category: "important_entity",
+    kritis_sector_key: "energy",
+    recent_incidents_90d: false,
+    incident_burden_level: "low",
   },
 ];
 
@@ -190,6 +194,15 @@ describe("AdvisorPortfolioTable", () => {
     const oamiCell = screen.getByTestId("advisor-oami-cell-t-demo-1");
     expect(oamiCell.textContent).toContain("55");
     expect(oamiCell.textContent).toContain(getMonitoringCopy("high").levelLabelDe);
+  });
+
+  it("shows NIS2 and KRITIS row badges when regulatory fields are set", () => {
+    portfolioFeatureFlags.governanceMaturity = true;
+    render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
+    const wrap = screen.getByTestId("advisor-regulatory-row-t-demo-1");
+    expect(wrap.textContent).toContain("NIS2");
+    expect(screen.getByTestId("advisor-kritis-badge-t-demo-1").textContent).toContain("KRITIS");
+    expect(screen.queryByTestId("advisor-incident-flag-t-demo-1")).toBeNull();
   });
 
   it("renders advisor priority badge and Schwerpunkt from API fields", () => {

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -187,6 +187,45 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                     <div className="text-xs font-mono text-[var(--sbs-text-muted)]">
                       {t.tenant_id}
                     </div>
+                    <div
+                      className="mt-1 flex flex-wrap items-center gap-1"
+                      data-testid={`advisor-regulatory-row-${t.tenant_id}`}
+                    >
+                      {t.nis2_entity_category === "essential_entity" ? (
+                        <span
+                          className="rounded bg-violet-50 px-1.5 py-0.5 text-[0.6rem] font-bold uppercase tracking-wide text-violet-900 ring-1 ring-violet-200"
+                          title="NIS2: wesentliche Einrichtung"
+                        >
+                          NIS2 wesentl.
+                        </span>
+                      ) : t.nis2_entity_category === "important_entity" ? (
+                        <span
+                          className="rounded bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-semibold text-slate-800 ring-1 ring-slate-200"
+                          title="NIS2: wichtige Einrichtung oder allgemeine NIS2-Relevanz (Stammdaten)"
+                        >
+                          NIS2
+                        </span>
+                      ) : null}
+                      {t.kritis_sector_key ? (
+                        <span
+                          className="rounded bg-amber-50 px-1.5 py-0.5 text-[0.6rem] font-semibold text-amber-950 ring-1 ring-amber-200"
+                          title={`KRITIS-Sektor: ${t.kritis_sector_key}`}
+                          data-testid={`advisor-kritis-badge-${t.tenant_id}`}
+                        >
+                          KRITIS
+                        </span>
+                      ) : null}
+                      {t.recent_incidents_90d ? (
+                        <span
+                          className="inline-flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-rose-50 px-1 text-[0.65rem] font-bold text-rose-800 ring-1 ring-rose-200"
+                          title={`Vorfälle in den letzten 90 Tagen; Laststufe: ${t.incident_burden_level ?? "?"}. Keine Einzelfallinhalte.`}
+                          aria-label="Hinweis: Vorfälle in den letzten 90 Tagen"
+                          data-testid={`advisor-incident-flag-${t.tenant_id}`}
+                        >
+                          !
+                        </span>
+                      ) : null}
+                    </div>
                   </td>
                   <td
                     className="align-middle text-xs"

--- a/frontend/src/lib/advisorPortfolioPriority.test.ts
+++ b/frontend/src/lib/advisorPortfolioPriority.test.ts
@@ -6,6 +6,7 @@ import {
   applyAdvisorPortfolioFilters,
   advisorPrioritySortKey,
   matchesPillarFocus,
+  matchesRegulatoryFilter,
   matchesSegmentFilter,
   priorityLabelDe,
 } from "./advisorPortfolioPriority";
@@ -79,6 +80,7 @@ describe("advisorPortfolioPriority", () => {
         pillar: null,
         scenario: "a",
         segment: null,
+        regulatory: null,
         priorityBucket: null,
       }).map((x) => x.tenant_id),
     ).toEqual(["a"]);
@@ -87,9 +89,32 @@ describe("advisorPortfolioPriority", () => {
         pillar: null,
         scenario: null,
         segment: null,
+        regulatory: null,
         priorityBucket: "low",
       }).map((x) => x.tenant_id),
     ).toEqual(["b"]);
+  });
+
+  it("matchesRegulatoryFilter and applyAdvisorPortfolioFilters regulatory", () => {
+    const a = row({
+      tenant_id: "x",
+      nis2_entity_category: "important_entity",
+      kritis_sector_key: "energy",
+      recent_incidents_90d: true,
+    });
+    expect(matchesRegulatoryFilter(a, "nis2_relevant")).toBe(true);
+    expect(matchesRegulatoryFilter(a, "kritis_sector")).toBe(true);
+    expect(matchesRegulatoryFilter(a, "incidents_90d")).toBe(true);
+    const noneNis2 = row({ tenant_id: "y", nis2_entity_category: "none" });
+    expect(
+      applyAdvisorPortfolioFilters([a, noneNis2], {
+        pillar: null,
+        scenario: null,
+        segment: null,
+        regulatory: "nis2_relevant",
+        priorityBucket: null,
+      }).map((t) => t.tenant_id),
+    ).toEqual(["x"]);
   });
 
   it("matchesSegmentFilter aufbau_monitoring vs optimierung", () => {

--- a/frontend/src/lib/advisorPortfolioPriority.ts
+++ b/frontend/src/lib/advisorPortfolioPriority.ts
@@ -4,6 +4,8 @@ export type PortfolioPillarFilter = "readiness" | "gai" | "monitoring";
 export type PortfolioScenarioFilter = "a" | "b" | "c" | "d";
 /** Schnellfilter: hohe Priorität / Aufbau+Monitoring vs. Optimierung. */
 export type PortfolioSegmentFilter = "aufbau_monitoring" | "optimierung";
+/** NIS2/KRITIS/Incident-Schnellfilter (UND mit anderen Filtern). */
+export type PortfolioRegulatoryFilter = "nis2_relevant" | "kritis_sector" | "incidents_90d";
 
 export function advisorPrioritySortKey(t: AdvisorPortfolioTenantEntry): number {
   const k = t.advisor_priority_sort_key;
@@ -47,6 +49,20 @@ export function matchesPillarFocus(
   );
 }
 
+export function matchesRegulatoryFilter(
+  t: AdvisorPortfolioTenantEntry,
+  regulatory: PortfolioRegulatoryFilter,
+): boolean {
+  const cat = t.nis2_entity_category ?? "none";
+  if (regulatory === "nis2_relevant") {
+    return cat !== "none";
+  }
+  if (regulatory === "kritis_sector") {
+    return Boolean(t.kritis_sector_key?.trim());
+  }
+  return Boolean(t.recent_incidents_90d);
+}
+
 export function matchesSegmentFilter(
   t: AdvisorPortfolioTenantEntry,
   segment: PortfolioSegmentFilter,
@@ -65,6 +81,7 @@ export function applyAdvisorPortfolioFilters(
     pillar: PortfolioPillarFilter | null;
     scenario: PortfolioScenarioFilter | null;
     segment: PortfolioSegmentFilter | null;
+    regulatory: PortfolioRegulatoryFilter | null;
     priorityBucket: "high" | "medium" | "low" | null;
   },
 ): AdvisorPortfolioTenantEntry[] {
@@ -72,6 +89,7 @@ export function applyAdvisorPortfolioFilters(
     if (filters.pillar && !matchesPillarFocus(t, filters.pillar)) return false;
     if (filters.scenario && t.maturity_scenario_hint !== filters.scenario) return false;
     if (filters.segment && !matchesSegmentFilter(t, filters.segment)) return false;
+    if (filters.regulatory && !matchesRegulatoryFilter(t, filters.regulatory)) return false;
     if (filters.priorityBucket && (t.advisor_priority ?? "medium") !== filters.priorityBucket) {
       return false;
     }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1438,6 +1438,14 @@ export interface AdvisorPortfolioTenantEntry {
   tenant_name: string;
   industry?: string | null;
   country?: string | null;
+  /** Aus Mandanten-nis2_scope normalisiert (none | important_entity | essential_entity). */
+  nis2_entity_category?: "none" | "important_entity" | "essential_entity";
+  /** KRITIS-Sektorschlüssel aus Stammdaten, falls gepflegt. */
+  kritis_sector_key?: string | null;
+  /** Mind. ein strukturiertes Incident in den letzten 90 Tagen. */
+  recent_incidents_90d?: boolean;
+  /** Aggregierte Last (low | medium | high), ohne Einzelfallinhalte. */
+  incident_burden_level?: "low" | "medium" | "high";
   eu_ai_act_readiness: number;
   nis2_kritis_kpi_mean_percent?: number | null;
   nis2_kritis_systems_full_coverage_ratio: number;

--- a/tests/test_advisor_portfolio.py
+++ b/tests/test_advisor_portfolio.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import csv
 import io
 import json
+from datetime import UTC, datetime
 
 import pytest
 from fastapi.testclient import TestClient
 
 from app.db import SessionLocal
 from app.main import app
+from app.models_db import TenantDB
 from app.repositories.advisor_tenants import AdvisorTenantRepository
 
 client = TestClient(app)
@@ -36,6 +38,37 @@ def _adv_headers(advisor_id: str) -> dict[str, str]:
         "x-api-key": API_KEY,
         "x-advisor-id": advisor_id,
     }
+
+
+def _ensure_tenant_registry_row(
+    tenant_id: str,
+    *,
+    nis2_scope: str = "in_scope",
+    kritis_sector: str | None = None,
+) -> None:
+    """Stammdaten für Portfolio-NIS2/KRITIS-Felder (Tests)."""
+    s = SessionLocal()
+    try:
+        row = s.get(TenantDB, tenant_id)
+        if row is None:
+            s.add(
+                TenantDB(
+                    id=tenant_id,
+                    display_name=tenant_id,
+                    industry="Energie",
+                    country="DE",
+                    nis2_scope=nis2_scope,
+                    kritis_sector=kritis_sector,
+                    ai_act_scope="in_scope",
+                    created_at_utc=datetime.now(UTC),
+                ),
+            )
+        else:
+            row.nis2_scope = nis2_scope
+            row.kritis_sector = kritis_sector
+        s.commit()
+    finally:
+        s.close()
 
 
 def _seed_links() -> None:
@@ -145,9 +178,31 @@ def test_advisor_not_in_allowlist_forbidden(monkeypatch: pytest.MonkeyPatch) -> 
     assert r.status_code == 403
 
 
-def test_advisor_portfolio_export_json_and_csv(advisor_allowlist: None) -> None:
+def test_advisor_portfolio_includes_nis2_kritis_incident_fields(advisor_allowlist: None) -> None:
+    _ensure_tenant_registry_row(
+        T1,
+        nis2_scope="essential_entity",
+        kritis_sector="energy",
+    )
     _seed_links()
     _post_min_system(T1, "sx", "low")
+
+    res = client.get(
+        f"/api/v1/advisors/{ADV_A}/tenants/portfolio",
+        headers=_adv_headers(ADV_A),
+    )
+    assert res.status_code == 200, res.text
+    alpha = next(t for t in res.json()["tenants"] if t["tenant_id"] == T1)
+    assert alpha["nis2_entity_category"] == "essential_entity"
+    assert alpha["kritis_sector_key"] == "energy"
+    assert alpha["recent_incidents_90d"] is False
+    assert alpha["incident_burden_level"] == "low"
+
+
+def test_advisor_portfolio_export_json_and_csv(advisor_allowlist: None) -> None:
+    _ensure_tenant_registry_row(T1)
+    _seed_links()
+    _post_min_system(T1, "sys-export-csv", "low")
 
     jr = client.get(
         f"/api/v1/advisors/{ADV_A}/tenants/portfolio-export?format=json",
@@ -166,4 +221,14 @@ def test_advisor_portfolio_export_json_and_csv(advisor_allowlist: None) -> None:
     assert cr.status_code == 200
     rows = list(csv.DictReader(io.StringIO(cr.content.decode("utf-8"))))
     assert len(rows) == 2
-    assert set(rows[0].keys()) >= {"tenant_id", "eu_ai_act_readiness", "setup_progress_ratio"}
+    assert set(rows[0].keys()) >= {
+        "tenant_id",
+        "eu_ai_act_readiness",
+        "setup_progress_ratio",
+        "nis2_entity_category",
+        "kritis_sector_key",
+        "recent_incidents_90d",
+        "incident_burden_level",
+        "advisor_priority",
+        "advisor_priority_explanation_de",
+    }

--- a/tests/test_advisor_portfolio_priority.py
+++ b/tests/test_advisor_portfolio_priority.py
@@ -6,10 +6,14 @@ import pytest
 
 from app.services.advisor_portfolio_priority import (
     advisor_portfolio_priority_sort_key,
+    apply_regulatory_priority_adjustment,
     compute_advisor_priority_bucket,
+    compute_incident_burden_level,
     derive_primary_focus_tag_de,
     effective_readiness_level,
     infer_maturity_scenario_hint,
+    normalize_nis2_entity_category,
+    regulatory_priority_bump_applies,
 )
 
 
@@ -94,6 +98,65 @@ def test_high_priority_without_scenario_when_managed_and_low_oami() -> None:
 
 def test_sort_key_order() -> None:
     assert advisor_portfolio_priority_sort_key("high") < advisor_portfolio_priority_sort_key("low")
+
+
+def test_normalize_nis2_entity_category_maps_legacy_in_scope() -> None:
+    assert normalize_nis2_entity_category(None) == "none"
+    assert normalize_nis2_entity_category("out_of_scope") == "none"
+    assert normalize_nis2_entity_category("essential_entity") == "essential_entity"
+    assert normalize_nis2_entity_category("in_scope") == "important_entity"
+
+
+def test_compute_incident_burden_level_buckets() -> None:
+    assert compute_incident_burden_level(0, 0) == "low"
+    assert compute_incident_burden_level(1, 0) == "medium"
+    assert compute_incident_burden_level(5, 0) == "high"
+    assert compute_incident_burden_level(2, 2) == "high"
+
+
+def test_regulatory_bump_requires_maturity_stress() -> None:
+    assert regulatory_priority_bump_applies(
+        nis2_category="essential_entity",
+        kritis_sector_key=None,
+        recent_incidents_90d=False,
+        incident_burden="low",
+        readiness_level="managed",
+        oami_level="low",
+    )
+    assert not regulatory_priority_bump_applies(
+        nis2_category="essential_entity",
+        kritis_sector_key=None,
+        recent_incidents_90d=False,
+        incident_burden="low",
+        readiness_level="embedded",
+        oami_level="high",
+    )
+
+
+def test_regulatory_bump_incidents_medium_burden() -> None:
+    assert regulatory_priority_bump_applies(
+        nis2_category="none",
+        kritis_sector_key=None,
+        recent_incidents_90d=True,
+        incident_burden="medium",
+        readiness_level="basic",
+        oami_level="high",
+    )
+
+
+def test_apply_regulatory_priority_adjustment_appends_suffix() -> None:
+    adj, expl = apply_regulatory_priority_adjustment(
+        "low",
+        "Geringe Dringlichkeit.",
+        readiness_level="managed",
+        oami_level="low",
+        nis2_category="essential_entity",
+        kritis_sector_key=None,
+        recent_incidents_90d=False,
+        incident_burden="low",
+    )
+    assert adj == "medium"
+    assert "Regulatorischer Aufstock" in expl
 
 
 def test_primary_focus_from_brief_text() -> None:


### PR DESCRIPTION
Add tenants.kritis_sector, normalize nis2_scope to entity category, derive 90d incident counts/burden, and bump advisor_priority at most one step with explainable regulatory suffix.

Extend portfolio API/CSV, IncidentRepository counters, provision body field, and advisor UI badges plus regulatory filters. Document rules in docs/advisor-priority-nis2-kritis.md.

Made-with: Cursor