### PR TITLE
feat(advisor): Risiko/Incident-Lage im Mandanten-Report; DB-Migration…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Test
         run: python -m pytest tests/ -q
+        # DB additive migrations: covered by tests/test_db_migrations_kritis_sector.py;
+        # production/pilot: run `python scripts/migrate_all.py` or rely on API lifespan.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ uvicorn app.main:app --reload
 
 Open `http://127.0.0.1:8000` for the landing page.
 
+Bestehende SQLite-/Postgres-Datenbanken: additive Schema-Updates (z. B. neue ORM-Spalten) laufen beim **ersten Start** der API mit; manuell: `python scripts/migrate_all.py`. Details: `docs/db-migrations.md`.
+
 ## API Endpoints
 
 - `GET /api/v1/health`
@@ -59,6 +61,7 @@ Open `http://127.0.0.1:8000` for the landing page.
 ## Architektur-Dokumente
 
 - `docs/architecture.md`
+- `docs/db-migrations.md` (additive Schema-Updates neben `create_all`)
 - `docs/product-strategy.md`
 - `docs/compliance-mapping.md`
 - Governance-Maturity (API-Enums, LLM-Explain-Schema, DE-Label-Mapping): `docs/governance-maturity-copy-contract.md` — implementiert in `app/governance_maturity_contract.py`

--- a/app/advisor_models.py
+++ b/app/advisor_models.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from app.advisor_governance_maturity_brief_models import AdvisorGovernanceMaturityBrief
+
+RisikoNis2EntityCategory = Literal["none", "important_entity", "essential_entity"]
 
 
 class TenantReportCriticalRequirementItem(BaseModel):
@@ -73,4 +76,34 @@ class AdvisorTenantReport(BaseModel):
             "Optional: Berater-Kurzbrief (gleicher Kern wie Board governance_maturity_summary, "
             "plus Fokus und Zeithorizont)."
         ),
+    )
+
+    risiko_nis2_scope_label_de: str = Field(
+        default=(
+            "Es liegt keine Einordnung als wichtige oder wesentliche Einrichtung nach NIS2 vor "
+            "(bzw. außerhalb des relevanten NIS2-Scope in den Stammdaten geführt)."
+        ),
+        description="Fließtext zur NIS2-Stammdaten-Einordnung für den Risiko-Abschnitt.",
+    )
+    risiko_kritis_sector_label_de: str | None = Field(
+        default=None,
+        description="Anzeigename KRITIS-Sektor, falls hinterlegt.",
+    )
+    risiko_incidents_90d_count: int = Field(default=0, ge=0)
+    risiko_incidents_90d_high_severity: int = Field(default=0, ge=0)
+    risiko_incident_burden_level: Literal["low", "medium", "high"] = Field(
+        default="low",
+        description="Aggregierte Last 90 Tage (ohne Einzelfallinhalte).",
+    )
+    risiko_open_incidents_count: int = Field(default=0, ge=0)
+    risiko_regulatory_priority_note_de: str | None = Field(
+        default=None,
+        description=(
+            "Optional: gleicher erklärender Zusatz wie bei Portfolio-Priorität (Aufstock), "
+            "falls die Heuristik greift."
+        ),
+    )
+    risiko_nis2_entity_category: RisikoNis2EntityCategory | None = Field(
+        default=None,
+        description="Normalisierte NIS2-Kategorie für Templates.",
     )

--- a/app/db_migrations.py
+++ b/app/db_migrations.py
@@ -1,0 +1,55 @@
+"""Additive, idempotent schema migrations for existing databases.
+
+`Base.metadata.create_all()` only creates missing tables; it does not ALTER existing
+tables when new ORM columns are added. Migrations here close that gap until Alembic
+(or similar) is adopted.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+
+def _tenants_table_exists(engine: Engine) -> bool:
+    return inspect(engine).has_table("tenants")
+
+
+def _column_exists(engine: Engine, table: str, column: str) -> bool:
+    insp = inspect(engine)
+    if not insp.has_table(table):
+        return False
+    return any(c["name"] == column for c in insp.get_columns(table))
+
+
+def migrate_add_tenants_kritis_sector(engine: Engine) -> bool:
+    """Ensure ``tenants.kritis_sector`` exists (nullable VARCHAR(64)).
+
+    Returns True if an ALTER was executed, False if the column was already present
+    or the ``tenants`` table does not exist yet.
+    """
+    if not _tenants_table_exists(engine):
+        return False
+    if _column_exists(engine, "tenants", "kritis_sector"):
+        return False
+
+    stmt = text("ALTER TABLE tenants ADD COLUMN kritis_sector VARCHAR(64)")
+    with engine.begin() as conn:
+        conn.execute(stmt)
+    logger.info("db_migration applied: add_tenants_kritis_sector")
+    return True
+
+
+def run_all_db_migrations(engine: Engine) -> list[str]:
+    """Run all registered migrations in order; each is idempotent.
+
+    Returns human-readable ids of migrations that executed an ALTER this run.
+    """
+    applied: list[str] = []
+    if migrate_add_tenants_kritis_sector(engine):
+        applied.append("20260326_add_tenants_kritis_sector")
+    return applied

--- a/app/main.py
+++ b/app/main.py
@@ -123,6 +123,7 @@ from app.cross_regulation_models import (
     RequirementControlsDetailResponse,
 )
 from app.db import engine, get_session
+from app.db_migrations import run_all_db_migrations
 from app.demo_models import (
     DemoGovernanceMaturityLayerRequest,
     DemoGovernanceMaturityLayerResponse,
@@ -374,6 +375,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     """
     # Startup phase
     Base.metadata.create_all(bind=engine)
+    run_all_db_migrations(engine)
     with Session(engine) as seed_session:
         ensure_cross_regulation_catalog_seeded(seed_session)
         ensure_ai_kpi_definitions_seeded(seed_session)
@@ -2919,6 +2921,7 @@ def get_advisor_tenant_report(
         AIGovernanceActionRepository,
         Depends(get_ai_governance_action_repository),
     ],
+    incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
     export_format: Annotated[Literal["json", "markdown"], Query(alias="format")] = "json",
 ) -> AdvisorTenantReport | Response:
     """Mandanten-Steckbrief (JSON oder Markdown) nur bei Zuordnung in advisor_tenants."""
@@ -2938,6 +2941,7 @@ def get_advisor_tenant_report(
         nis2_repo=nis2_repo,
         violation_repo=violation_repo,
         action_repo=action_repo,
+        incident_repo=incident_repo,
     )
     report = enrich_advisor_tenant_report_with_governance_maturity_brief(session, tenant_id, report)
     report = maybe_enrich_advisor_report_with_llm_summary(session, tenant_id, report)

--- a/app/services/advisor_report_llm_enrichment.py
+++ b/app/services/advisor_report_llm_enrichment.py
@@ -40,6 +40,12 @@ def _deterministic_facts_payload(report: AdvisorTenantReport) -> dict:
         "setup_completed_steps": report.setup_completed_steps,
         "setup_total_steps": report.setup_total_steps,
         "setup_open_step_labels": list(report.setup_open_step_labels),
+        "risiko_nis2_entity_category": report.risiko_nis2_entity_category,
+        "risiko_kritis_sector_label_de": report.risiko_kritis_sector_label_de,
+        "risiko_incidents_90d_count": report.risiko_incidents_90d_count,
+        "risiko_incident_burden_level": report.risiko_incident_burden_level,
+        "risiko_open_incidents_count": report.risiko_open_incidents_count,
+        "risiko_regulatory_priority_note_de": report.risiko_regulatory_priority_note_de,
     }
 
 

--- a/app/services/advisor_tenant_report.py
+++ b/app/services/advisor_tenant_report.py
@@ -15,8 +15,10 @@ from app.repositories.ai_governance_actions import AIGovernanceActionRepository
 from app.repositories.ai_systems import AISystemRepository
 from app.repositories.classifications import ClassificationRepository
 from app.repositories.compliance_gap import ComplianceGapRepository
+from app.repositories.incidents import IncidentRepository
 from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
 from app.repositories.violations import ViolationRepository
+from app.services.advisor_tenant_report_risiko import build_tenant_report_risiko_fields
 from app.services.ai_governance_kpis import compute_ai_board_kpis
 from app.services.eu_ai_act_readiness import compute_eu_ai_act_readiness_overview
 from app.services.setup_status import compute_tenant_setup_status
@@ -48,6 +50,7 @@ def build_advisor_tenant_report(
     nis2_repo: Nis2KritisKpiRepository,
     violation_repo: ViolationRepository,
     action_repo: AIGovernanceActionRepository,
+    incident_repo: IncidentRepository,
 ) -> AdvisorTenantReport:
     """
     Aggregiert einen Mandanten-Steckbrief ausschließlich über tenant-gefilterte Services/Repos.
@@ -95,6 +98,14 @@ def build_advisor_tenant_report(
 
     display_name = (link.tenant_display_name or "").strip() or tenant_id
 
+    risiko = build_tenant_report_risiko_fields(
+        session,
+        tenant_id,
+        incident_repo,
+        eu_ai_act_readiness_score=round(readiness.overall_readiness, 4),
+        nis2_incident_readiness_percent=round(board.nis2_incident_readiness_ratio * 100.0, 1),
+    )
+
     return AdvisorTenantReport(
         tenant_id=tenant_id,
         tenant_name=display_name,
@@ -117,4 +128,5 @@ def build_advisor_tenant_report(
         setup_completed_steps=setup.completed_steps,
         setup_total_steps=setup.total_steps,
         setup_open_step_labels=_open_setup_labels(setup),
+        **risiko,
     )

--- a/app/services/advisor_tenant_report_markdown.py
+++ b/app/services/advisor_tenant_report_markdown.py
@@ -4,6 +4,77 @@ from app.advisor_models import AdvisorTenantReport
 from app.services.advisor_governance_maturity_brief_markdown import (
     render_advisor_governance_maturity_brief_markdown_section,
 )
+from app.services.advisor_tenant_report_risiko import incident_burden_label_de
+
+
+def render_risiko_incident_lage_markdown_section(report: AdvisorTenantReport) -> str:
+    """
+    Deterministischer Markdown-Block: NIS2/KRITIS-Stammdaten, 90-Tage-Aggregate, Kurzbeobachtungen.
+
+    Keine LLM-Pflicht; optional kann später ein interpretierender Satz ergänzt werden.
+    """
+    kritis_line = (
+        f"**KRITIS-Sektor:** {report.risiko_kritis_sector_label_de}."
+        if report.risiko_kritis_sector_label_de
+        else "**KRITIS-Sektor:** nicht hinterlegt."
+    )
+    burden_de = incident_burden_label_de(report.risiko_incident_burden_level)
+    if report.risiko_open_incidents_count > 0:
+        open_line = (
+            f"**Offene/laufende Vorfälle (Register):** {report.risiko_open_incidents_count}."
+        )
+    else:
+        open_line = "**Offene/laufende Vorfälle (Register):** keine erfasst."
+
+    obs: list[str] = []
+    if report.risiko_open_incidents_count > 0:
+        obs.append(
+            "- Engere Nachverfolgung der offenen Vorfälle ist sinnvoll "
+            "(Nachweise, interne Fristen, ggf. Vorstandsinformation gemäß Policies).",
+        )
+    if report.risiko_incident_burden_level in ("medium", "high"):
+        obs.append(
+            "- Erhöhte Incident-Aktivität: Melde- und Dokumentationspflichten nach NIS2 sowie "
+            "Anforderungen aus dem KRITIS-Dachgesetz im Blick behalten."
+        )
+    if report.risiko_nis2_entity_category == "essential_entity":
+        obs.append(
+            "- Wesentliche Einrichtung: erhöhte Erwartungen an Incident-Response, "
+            "Dokumentation und IKT-Risikomanagement."
+        )
+    if not obs:
+        obs.append(
+            "- Keine zusätzlichen aggregierten Kurzbeobachtungen über die Kennzahlen hinaus.",
+        )
+
+    reg_block = ""
+    if report.risiko_regulatory_priority_note_de:
+        reg_block = (
+            f"\n**Berater-Portfolio (Priorität):** {report.risiko_regulatory_priority_note_de}\n"
+        )
+
+    obs_text = "\n".join(obs)
+    v90 = report.risiko_incidents_90d_count
+    h90 = report.risiko_incidents_90d_high_severity
+    agg_line = (
+        f"**Vorfälle (90 Tage, aggregiert):** {v90} erfasst, davon **{h90}** "
+        f"mit Schweregrad „hoch“; Laststufe **{burden_de}**. "
+        "Keine Inhalte oder Personen aus Einzelfällen."
+    )
+    return f"""## Risiko- und Incident-Lage (NIS2/KRITIS)
+
+**NIS2-Einordnung:** {report.risiko_nis2_scope_label_de}
+
+{kritis_line}
+
+{agg_line}
+
+{open_line}
+
+### Kurzbeobachtungen
+
+{obs_text}
+{reg_block}"""
 
 
 def render_tenant_report_markdown(report: AdvisorTenantReport) -> str:
@@ -58,6 +129,8 @@ def render_tenant_report_markdown(report: AdvisorTenantReport) -> str:
             + "\n"
         )
 
+    risiko_md = render_risiko_incident_lage_markdown_section(report)
+
     return f"""# Compliance Hub Mandanten-Steckbrief – {report.tenant_name}
 
 **Mandanten-ID:** `{report.tenant_id}`  
@@ -69,6 +142,8 @@ def render_tenant_report_markdown(report: AdvisorTenantReport) -> str:
 - KI-Systeme gesamt: **{report.ai_systems_total}**
 - High-Risk-Systeme (Register): **{report.high_risk_systems_count}**
 - High-Risk mit vollständigen Essential-Controls: **{report.high_risk_with_full_controls_count}**
+
+{risiko_md}
 
 ## EU AI Act
 

--- a/app/services/advisor_tenant_report_risiko.py
+++ b/app/services/advisor_tenant_report_risiko.py
@@ -1,0 +1,123 @@
+"""
+NIS2/KRITIS- und Incident-Kontext für den Mandanten-Steckbrief (Markdown/JSON).
+
+Nur Aggregationen und Stammdaten – keine Inhalte aus Einzelvorfällen.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from sqlalchemy.orm import Session
+
+from app.advisor_portfolio_models import IncidentBurdenLevel, Nis2EntityCategory
+from app.repositories.incidents import IncidentRepository
+from app.repositories.tenant_registry import TenantRegistryRepository
+from app.services.advisor_portfolio_priority import (
+    compute_incident_burden_level,
+    effective_readiness_level,
+    normalize_nis2_entity_category,
+    regulatory_bump_suffix_de,
+    regulatory_priority_bump_applies,
+)
+
+IncidentBurdenDe = Literal["niedrig", "mittel", "hoch"]
+
+
+def nis2_entity_category_report_label_de(cat: Nis2EntityCategory) -> str:
+    """Sachliche Einordnung für Berater-Texte."""
+    if cat == "none":
+        return (
+            "Es liegt keine Einordnung als wichtige oder wesentliche Einrichtung nach NIS2 vor "
+            "(bzw. außerhalb des relevanten NIS2-Scope in den Stammdaten geführt)."
+        )
+    if cat == "important_entity":
+        return "Der Mandant ist als wichtige Einrichtung im Sinne von NIS2 eingestuft (Stammdaten)."
+    return "Der Mandant ist als wesentliche Einrichtung im Sinne von NIS2 eingestuft (Stammdaten)."
+
+
+def kritis_sector_label_de(sector_key: str | None) -> str | None:
+    """Anzeigename für bekannte Sektorschlüssel; sonst Rohschlüssel."""
+    if sector_key is None or not str(sector_key).strip():
+        return None
+    raw = str(sector_key).strip().lower()
+    m = {
+        "energy": "Energie",
+        "health": "Gesundheit",
+        "transport": "Transport",
+        "water": "Wasser",
+        "digital": "Digitale Infrastruktur",
+        "financial": "Finanzmarkt",
+        "other": "Sonstiger Sektor",
+    }
+    return m.get(raw, sector_key.strip())
+
+
+def incident_burden_label_de(burden: IncidentBurdenLevel) -> IncidentBurdenDe:
+    return {"low": "niedrig", "medium": "mittel", "high": "hoch"}[burden]
+
+
+def oami_proxy_from_nis2_incident_readiness_pct(pct: float) -> str:
+    """
+    Grober Surrogat-Level für die regulatorische Prioritätslogik, aus NIS2-Incident-Readiness-%.
+
+    Entspricht nicht dem Board-OAMI; dient nur der konsistenten Aufstock-Heuristik im Steckbrief.
+    """
+    if pct < 45.0:
+        return "low"
+    if pct < 80.0:
+        return "medium"
+    return "high"
+
+
+def build_tenant_report_risiko_fields(
+    session: Session,
+    tenant_id: str,
+    incident_repo: IncidentRepository,
+    *,
+    eu_ai_act_readiness_score: float,
+    nis2_incident_readiness_percent: float,
+) -> dict[str, object]:
+    """Felder für AdvisorTenantReport (Risiko-/Incident-Abschnitt)."""
+    treg = TenantRegistryRepository(session)
+    trow = treg.get_by_id(tenant_id)
+    nis2_cat = normalize_nis2_entity_category(trow.nis2_scope if trow else None)
+    kritis_key = (
+        trow.kritis_sector.strip()
+        if trow and trow.kritis_sector and str(trow.kritis_sector).strip()
+        else None
+    )
+    c90 = incident_repo.count_created_since_days(tenant_id, days=90)
+    h90 = incident_repo.count_high_severity_since_days(tenant_id, days=90)
+    burden: IncidentBurdenLevel = compute_incident_burden_level(c90, h90)
+    open_cnt = incident_repo.count_open_for_tenant(tenant_id)
+    rd_level = effective_readiness_level(None, eu_ai_act_readiness_score)
+    oami_proxy = oami_proxy_from_nis2_incident_readiness_pct(nis2_incident_readiness_percent)
+    recent = c90 > 0
+    bump = regulatory_priority_bump_applies(
+        nis2_category=nis2_cat,
+        kritis_sector_key=kritis_key,
+        recent_incidents_90d=recent,
+        incident_burden=burden,
+        readiness_level=rd_level,
+        oami_level=oami_proxy,
+    )
+    note: str | None = None
+    if bump:
+        note = regulatory_bump_suffix_de(
+            nis2_category=nis2_cat,
+            kritis_sector_key=kritis_key,
+            recent_incidents_90d=recent,
+            incident_burden=burden,
+        ).strip()
+
+    return {
+        "risiko_nis2_scope_label_de": nis2_entity_category_report_label_de(nis2_cat),
+        "risiko_kritis_sector_label_de": kritis_sector_label_de(kritis_key),
+        "risiko_incidents_90d_count": c90,
+        "risiko_incidents_90d_high_severity": h90,
+        "risiko_incident_burden_level": burden,
+        "risiko_open_incidents_count": open_cnt,
+        "risiko_regulatory_priority_note_de": note,
+        "risiko_nis2_entity_category": nis2_cat,
+    }

--- a/docs/advisor-governance-maturity-brief.md
+++ b/docs/advisor-governance-maturity-brief.md
@@ -34,7 +34,7 @@ Die UI und Integrationen sollen **strukturierte Felder** (Enums, Listen) nutzen,
 - **Parse / Align:** `parse_advisor_governance_maturity_brief` → Kern wie beim Board an den Snapshot anbinden; Advisor-Felder aus JSON übernehmen (Listen gekappt wie im Contract).
 - **LLM-Task:** `LLMTaskType.ADVISOR_GOVERNANCE_MATURITY_BRIEF` (Feature-Gate: `governance_maturity` + `llm_enabled`).
 - **Fallback ohne LLM:** `build_fallback_advisor_governance_maturity_brief_parse_result` — heuristische `recommended_focus_areas`.
-- **Einbindung:** Advisor-Portfolio (`governance_maturity_advisor_brief`), Mandanten-Snapshot-API, Markdown-Steckbrief (`render_tenant_report_markdown`), KI-Snapshot-Markdown (Präfix-Abschnitt vor LLM-Fließtext).
+- **Einbindung:** Advisor-Portfolio (`governance_maturity_advisor_brief`), Mandanten-Snapshot-API, Markdown-Steckbrief (`render_tenant_report_markdown`; zusätzlich deterministischer Abschnitt **Risiko- und Incident-Lage (NIS2/KRITIS)** siehe [advisor-priority-nis2-kritis.md](./advisor-priority-nis2-kritis.md)), KI-Snapshot-Markdown (Präfix-Abschnitt vor LLM-Fließtext).
 
 Hinweis: Ist `COMPLIANCEHUB_FEATURE_LLM_ENABLED` aktiv, kann pro Mandant im Portfolio **ein zusätzlicher LLM-Aufruf** für den Brief entstehen (Triaging). Ohne LLM nutzt das System den deterministischen Fallback.
 

--- a/docs/advisor-priority-nis2-kritis.md
+++ b/docs/advisor-priority-nis2-kritis.md
@@ -19,6 +19,8 @@ Erweiterung der **regelbasierten** `advisor_priority` im Mandanten-Portfolio. Zi
 
 Provisioning: optional `kritis_sector` im Body von `POST /api/v1/tenants/provision`.
 
+**Schema:** Die Spalte `tenants.kritis_sector` wird bei API-Start bzw. über `python scripts/migrate_all.py` idempotent nachgezogen (siehe `docs/db-migrations.md`). Ohne Migration schlagen Lese-/Schreibzugriffe auf älteren Datenbanken fehl.
+
 ## Incident-Last (90 Tage)
 
 - **low:** keine Vorfälle im Fenster
@@ -54,6 +56,23 @@ Der Tooltip-Text (`advisor_priority_explanation_de`) erhält einen kurzen Satz *
 ## CSV / JSON
 
 Export-Spalten u. a.: `nis2_entity_category`, `kritis_sector_key`, `recent_incidents_90d`, `incident_burden_level`, plus bestehende Prioritäts- und Reife-Felder.
+
+## Mandanten-Steckbrief (Markdown)
+
+Der Abschnitt **„Risiko- und Incident-Lage (NIS2/KRITIS)“** im Markdown-Report (`GET …/report?format=markdown`) ist **template-basiert** und nutzt:
+
+- `risiko_nis2_scope_label_de`, `risiko_kritis_sector_label_de` (Stammdaten),
+- Zähler 90 Tage und `risiko_incident_burden_level`, offene Vorfälle (Aggregat),
+- optional `risiko_regulatory_priority_note_de` (derselbe erklärende Zusatz wie beim Portfolio-Aufstock).
+
+Es werden **keine** Inhalte aus Einzelvorfällen ausgegeben. Goldens: `tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/`.
+
+**LLM:** Die optionale Executive Summary (`executive_summary_narrative`) erhält die Risiko-Felder zusätzlich im Fakten-JSON (`advisor_report_llm_enrichment`), damit Formulierungen ohne neue erfundene Zahlen möglich sind. Der Risiko-Abschnitt selbst bleibt deterministisch.
+
+### Gesprächshilfen für Mandantengespräche
+
+- *„Wir klassifizieren eure Einordnung nach NIS2 aus den Stammdaten; im Report seht ihr die aggregierte Incident-Last der letzten 90 Tage ohne Details zu Einzelfällen.“*
+- *„Wenn das Berater-Portfolio einen regulatorischen Aufstock gesetzt hat, steht derselbe Hinweis im Steckbrief unter ‚Berater-Portfolio (Priorität)‘ – das ist bewusst konsistent mit eurer Mandantenliste.“*
 
 ## Verwandte Dokumente
 

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -1,0 +1,47 @@
+# Datenbank-Migrationen (minimal, ohne Alembic)
+
+## Kontext
+
+Neue Spalten am SQLAlchemy-ORM (`app/models_db.py`) werden von **`Base.metadata.create_all()`** nur berücksichtigt, wenn die Tabelle **neu** angelegt wird. Bestehende Installationen (Pilot, Staging, Produktion) bekommen **kein** automatisches `ALTER TABLE`.
+
+Dafür gibt es **additive, idempotente** Migrationen in `app/db_migrations.py`, die:
+
+- fehlende Spalten per `ALTER TABLE` ergänzen,
+- ohne Datenänderung auskommen,
+- mehrfach ausgeführt werden dürfen (No-op, wenn die Spalte schon existiert).
+
+## Aktuelle Migrationen
+
+| Id | Änderung |
+|----|----------|
+| `20260326_add_tenants_kritis_sector` | `tenants.kritis_sector` – `VARCHAR(64)`, **NULL** (optional; „nicht gesetzt“ = kein KRITIS-Sektor in den Stammdaten) |
+
+## Wann läuft was?
+
+1. **API-Start (uvicorn):** In `app.main.lifespan` wird nach `create_all` immer `run_all_db_migrations(engine)` aufgerufen. Bestehende SQLite-/Postgres-Dateien erhalten fehlende Spalten beim nächsten Start.
+2. **Manuell / Deploy-Skript:** Gleiche Logik ohne Server:
+
+   ```bash
+   python scripts/migrate_all.py
+   ```
+
+   Verbindung wie die API: Umgebungsvariable **`COMPLIANCEHUB_DB_URL`** (Fallback siehe `app/db.py`).
+
+3. **Historischer Einzeleinstieg** (enthält nur die KRITIS-Spalte):
+
+   ```bash
+   python scripts/migrate_20260326_add_tenants_kritis_sector.py
+   ```
+
+## CI
+
+Die Regression liegt in **`tests/test_db_migrations_kritis_sector.py`**: Legacy-Schema ohne `kritis_sector` → Migration → Insert/Lesen über `TenantDB`.
+
+## Neue Migrationen hinzufügen
+
+1. In `app/db_migrations.py` eine Funktion `migrate_*` implementieren (Existenzprüfung per `sqlalchemy.inspect`, dann `ALTER` in `engine.begin()`).
+2. In `run_all_db_migrations` registrieren und eine stabile Id zurückgeben.
+3. Test mit „altem“ Schema ergänzen.
+4. Diese Datei und ggf. domänenspezifische Docs aktualisieren.
+
+Später kann dieselbe Liste in **Alembic** überführt werden; bis dahin bleibt das Modell bewusst klein und explizit.

--- a/scripts/migrate_20260326_add_tenants_kritis_sector.py
+++ b/scripts/migrate_20260326_add_tenants_kritis_sector.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Historical entry point: adds ``tenants.kritis_sector`` if missing.
+
+New deployments should prefer ``scripts/migrate_all.py``, which includes this step
+and future additive migrations.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from app.db import create_db_engine  # noqa: E402
+from app.db_migrations import migrate_add_tenants_kritis_sector  # noqa: E402
+
+
+def main() -> int:
+    engine = create_db_engine()
+    try:
+        if migrate_add_tenants_kritis_sector(engine):
+            print("Applied: 20260326_add_tenants_kritis_sector")
+        else:
+            print("No change (column already present or tenants table missing).")
+    finally:
+        engine.dispose()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migrate_all.py
+++ b/scripts/migrate_all.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run additive DB migrations (idempotent).
+
+Uses the same database URL as the API: ``COMPLIANCEHUB_DB_URL`` (see ``app.db``).
+
+Examples:
+
+  python scripts/migrate_all.py
+  COMPLIANCEHUB_DB_URL=postgresql+psycopg://... python scripts/migrate_all.py
+
+For local SQLite (default), this matches ``./test_compliancehub.db`` unless overridden.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from app.db import create_db_engine, get_database_url  # noqa: E402
+from app.db_migrations import run_all_db_migrations  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run ComplianceHub DB migrations.")
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        action="store_true",
+        help="Only print output when migrations were applied.",
+    )
+    args = parser.parse_args()
+    url = get_database_url()
+    engine = create_db_engine(url)
+    try:
+        applied = run_all_db_migrations(engine)
+    finally:
+        engine.dispose()
+    if applied:
+        print("Applied:", ", ".join(applied))
+    elif not args.quiet:
+        print("No pending migrations (database URL:", url, ")")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/README.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/README.md
@@ -1,0 +1,13 @@
+# Risiko- und Incident-Lage – Markdown-Goldens
+
+Diese Dateien sind der **Abschnitt** `## Risiko- und Incident-Lage (NIS2/KRITIS)` wie von
+`render_risiko_incident_lage_markdown_section` erzeugt (deterministisches Template).
+
+| Datei | Profil |
+|-------|--------|
+| `case_c_outside_nis2_no_incidents.md` | Keine NIS2-Wichtig/Wesentlich-Einordnung, keine Vorfälle 90 Tage |
+| `case_b_important_low_burden.md` | Wichtige Einrichtung, eine erfasste Vorfälle, Last mittel |
+| `case_a_essential_kritis_high.md` | Wesentliche Einrichtung, KRITIS Energie, hohe Last, offene Vorfälle, Portfolio-Hinweis |
+
+Vergleich in Tests mit normalisierten Zeilenenden (`rstrip` pro Zeile), analog zu
+`tests/test_advisor_brief_golden_scenarios.py`.

--- a/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_a_essential_kritis_high.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_a_essential_kritis_high.md
@@ -1,0 +1,17 @@
+## Risiko- und Incident-Lage (NIS2/KRITIS)
+
+**NIS2-Einordnung:** Der Mandant ist als wesentliche Einrichtung im Sinne von NIS2 eingestuft (Stammdaten).
+
+**KRITIS-Sektor:** Energie.
+
+**Vorfälle (90 Tage, aggregiert):** 6 erfasst, davon **3** mit Schweregrad „hoch“; Laststufe **hoch**. Keine Inhalte oder Personen aus Einzelfällen.
+
+**Offene/laufende Vorfälle (Register):** 2.
+
+### Kurzbeobachtungen
+
+- Engere Nachverfolgung der offenen Vorfälle ist sinnvoll (Nachweise, interne Fristen, ggf. Vorstandsinformation gemäß Policies).
+- Erhöhte Incident-Aktivität: Melde- und Dokumentationspflichten nach NIS2 sowie Anforderungen aus dem KRITIS-Dachgesetz im Blick behalten.
+- Wesentliche Einrichtung: erhöhte Erwartungen an Incident-Response, Dokumentation und IKT-Risikomanagement.
+
+**Berater-Portfolio (Priorität):** Regulatorischer Aufstock (Test); Priorität eine Stufe erhöht.

--- a/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_b_important_low_burden.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_b_important_low_burden.md
@@ -1,0 +1,13 @@
+## Risiko- und Incident-Lage (NIS2/KRITIS)
+
+**NIS2-Einordnung:** Der Mandant ist als wichtige Einrichtung im Sinne von NIS2 eingestuft (Stammdaten).
+
+**KRITIS-Sektor:** nicht hinterlegt.
+
+**Vorfälle (90 Tage, aggregiert):** 1 erfasst, davon **0** mit Schweregrad „hoch“; Laststufe **mittel**. Keine Inhalte oder Personen aus Einzelfällen.
+
+**Offene/laufende Vorfälle (Register):** keine erfasst.
+
+### Kurzbeobachtungen
+
+- Erhöhte Incident-Aktivität: Melde- und Dokumentationspflichten nach NIS2 sowie Anforderungen aus dem KRITIS-Dachgesetz im Blick behalten.

--- a/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_c_outside_nis2_no_incidents.md
+++ b/tests/fixtures/advisor-tenant-report-markdown/risiko-incident-lage/case_c_outside_nis2_no_incidents.md
@@ -1,0 +1,13 @@
+## Risiko- und Incident-Lage (NIS2/KRITIS)
+
+**NIS2-Einordnung:** Es liegt keine Einordnung als wichtige oder wesentliche Einrichtung nach NIS2 vor (bzw. außerhalb des relevanten NIS2-Scope in den Stammdaten geführt).
+
+**KRITIS-Sektor:** nicht hinterlegt.
+
+**Vorfälle (90 Tage, aggregiert):** 0 erfasst, davon **0** mit Schweregrad „hoch“; Laststufe **niedrig**. Keine Inhalte oder Personen aus Einzelfällen.
+
+**Offene/laufende Vorfälle (Register):** keine erfasst.
+
+### Kurzbeobachtungen
+
+- Keine zusätzlichen aggregierten Kurzbeobachtungen über die Kennzahlen hinaus.

--- a/tests/test_advisor_tenant_report.py
+++ b/tests/test_advisor_tenant_report.py
@@ -14,6 +14,7 @@ from app.repositories.ai_governance_actions import AIGovernanceActionRepository
 from app.repositories.ai_systems import AISystemRepository
 from app.repositories.classifications import ClassificationRepository
 from app.repositories.compliance_gap import ComplianceGapRepository
+from app.repositories.incidents import IncidentRepository
 from app.repositories.nis2_kritis_kpis import Nis2KritisKpiRepository
 from app.repositories.violations import ViolationRepository
 from app.services.advisor_tenant_report import build_advisor_tenant_report
@@ -122,6 +123,7 @@ def test_build_advisor_tenant_report_aggregates(advisor_allowlist: None) -> None
             nis2_repo=Nis2KritisKpiRepository(s),
             violation_repo=ViolationRepository(s),
             action_repo=AIGovernanceActionRepository(s),
+            incident_repo=IncidentRepository(s),
         )
     finally:
         s.close()
@@ -155,6 +157,8 @@ def test_get_advisor_tenant_report_json(advisor_allowlist: None) -> None:
     assert "eu_ai_act_readiness_score" in data
     assert "nis2_incident_readiness_percent" in data
     assert "setup_completed_steps" in data
+    assert "risiko_incidents_90d_count" in data
+    assert "risiko_incident_burden_level" in data
 
 
 def test_get_advisor_tenant_report_markdown(advisor_allowlist: None) -> None:
@@ -176,6 +180,7 @@ def test_get_advisor_tenant_report_markdown(advisor_allowlist: None) -> None:
     assert "## EU AI Act" in text
     assert "## NIS2 / KRITIS" in text
     assert "## Governance und Maßnahmen" in text
+    assert "## Risiko- und Incident-Lage (NIS2/KRITIS)" in text
 
 
 def test_advisor_tenant_report_not_linked_404(advisor_allowlist: None) -> None:
@@ -219,3 +224,4 @@ def test_render_tenant_report_markdown_structure() -> None:
     assert "X AG" in md
     assert "EU AI Act" in md
     assert "C1" in md
+    assert "## Risiko- und Incident-Lage (NIS2/KRITIS)" in md

--- a/tests/test_advisor_tenant_report_risiko_markdown.py
+++ b/tests/test_advisor_tenant_report_risiko_markdown.py
@@ -1,0 +1,99 @@
+"""Golden regression: Risiko- und Incident-Lage (NIS2/KRITIS) im Mandanten-Steckbrief."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.advisor_models import AdvisorTenantReport
+from app.services.advisor_tenant_report_markdown import render_risiko_incident_lage_markdown_section
+from app.services.advisor_tenant_report_risiko import nis2_entity_category_report_label_de
+
+_FIXTURE_DIR = (
+    Path(__file__).resolve().parent
+    / "fixtures"
+    / "advisor-tenant-report-markdown"
+    / "risiko-incident-lage"
+)
+
+
+def _normalize_markdown(text: str) -> str:
+    lines = [line.rstrip() for line in text.strip().splitlines()]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _minimal_report(**risiko: object) -> AdvisorTenantReport:
+    base = dict(
+        tenant_id="t-golden",
+        tenant_name="Golden Mandant",
+        industry="IT",
+        country="DE",
+        generated_at_utc=datetime(2025, 1, 1, tzinfo=UTC),
+        ai_systems_total=1,
+        high_risk_systems_count=0,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.5,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=100,
+        nis2_incident_readiness_percent=50.0,
+        nis2_supplier_risk_coverage_percent=50.0,
+        nis2_ot_it_segregation_mean_percent=None,
+        nis2_critical_focus_systems_count=0,
+        governance_open_actions_count=0,
+        governance_overdue_actions_count=0,
+        top_critical_requirements=[],
+        setup_completed_steps=1,
+        setup_total_steps=7,
+        setup_open_step_labels=[],
+    )
+    base.update(risiko)
+    return AdvisorTenantReport(**base)
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "report"),
+    [
+        (
+            "case_c_outside_nis2_no_incidents.md",
+            _minimal_report(
+                risiko_nis2_scope_label_de=nis2_entity_category_report_label_de("none"),
+                risiko_nis2_entity_category="none",
+                risiko_incident_burden_level="low",
+            ),
+        ),
+        (
+            "case_b_important_low_burden.md",
+            _minimal_report(
+                risiko_nis2_scope_label_de=nis2_entity_category_report_label_de("important_entity"),
+                risiko_nis2_entity_category="important_entity",
+                risiko_incidents_90d_count=1,
+                risiko_incidents_90d_high_severity=0,
+                risiko_incident_burden_level="medium",
+            ),
+        ),
+        (
+            "case_a_essential_kritis_high.md",
+            _minimal_report(
+                risiko_nis2_scope_label_de=nis2_entity_category_report_label_de("essential_entity"),
+                risiko_nis2_entity_category="essential_entity",
+                risiko_kritis_sector_label_de="Energie",
+                risiko_incidents_90d_count=6,
+                risiko_incidents_90d_high_severity=3,
+                risiko_incident_burden_level="high",
+                risiko_open_incidents_count=2,
+                risiko_regulatory_priority_note_de=(
+                    "Regulatorischer Aufstock (Test); Priorität eine Stufe erhöht."
+                ),
+            ),
+        ),
+    ],
+)
+def test_risiko_incident_lage_matches_golden(
+    fixture_name: str,
+    report: AdvisorTenantReport,
+) -> None:
+    generated = render_risiko_incident_lage_markdown_section(report)
+    expected = (_FIXTURE_DIR / fixture_name).read_text(encoding="utf-8")
+    assert _normalize_markdown(generated) == _normalize_markdown(expected)

--- a/tests/test_db_migrations_kritis_sector.py
+++ b/tests/test_db_migrations_kritis_sector.py
@@ -1,0 +1,78 @@
+"""Regression: ORM columns on existing ``tenants`` rows need additive migrations."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.orm import Session
+
+from app.db_migrations import migrate_add_tenants_kritis_sector, run_all_db_migrations
+from app.models_db import TenantDB
+
+
+def _create_legacy_tenants_table_without_kritis(url: str) -> None:
+    engine = create_engine(url, future=True, connect_args={"check_same_thread": False})
+    ddl = """
+    CREATE TABLE tenants (
+        id VARCHAR(255) PRIMARY KEY,
+        display_name VARCHAR(255) NOT NULL,
+        industry VARCHAR(128) NOT NULL,
+        country VARCHAR(64) NOT NULL DEFAULT 'DE',
+        nis2_scope VARCHAR(64) NOT NULL DEFAULT 'in_scope',
+        ai_act_scope VARCHAR(64) NOT NULL DEFAULT 'in_scope',
+        is_demo BOOLEAN NOT NULL DEFAULT 0,
+        demo_playground BOOLEAN NOT NULL DEFAULT 0,
+        created_at_utc DATETIME NOT NULL
+    )
+    """
+    with engine.begin() as conn:
+        conn.execute(text(ddl))
+    engine.dispose()
+
+
+def test_migrate_adds_kritis_sector_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "legacy.db"
+    url = f"sqlite+pysqlite:///{db_path}"
+    _create_legacy_tenants_table_without_kritis(url)
+
+    engine = create_engine(url, future=True, connect_args={"check_same_thread": False})
+    assert migrate_add_tenants_kritis_sector(engine) is True
+    assert migrate_add_tenants_kritis_sector(engine) is False
+
+    cols = {c["name"]: c for c in inspect(engine).get_columns("tenants")}
+    assert "kritis_sector" in cols
+
+    with Session(engine) as session:
+        row = TenantDB(
+            id="legacy-tenant-1",
+            display_name="Legacy AG",
+            industry="IT",
+            country="DE",
+            nis2_scope="in_scope",
+            kritis_sector="energy",
+            ai_act_scope="in_scope",
+            is_demo=False,
+            demo_playground=False,
+            created_at_utc=datetime(2025, 1, 1, tzinfo=UTC),
+        )
+        session.add(row)
+        session.commit()
+        loaded = session.get(TenantDB, "legacy-tenant-1")
+        assert loaded is not None
+        assert loaded.kritis_sector == "energy"
+
+    assert run_all_db_migrations(engine) == []
+    engine.dispose()
+
+
+def test_run_all_migrations_reports_applied_once(tmp_path) -> None:
+    db_path = tmp_path / "legacy2.db"
+    url = f"sqlite+pysqlite:///{db_path}"
+    _create_legacy_tenants_table_without_kritis(url)
+
+    engine = create_engine(url, future=True, connect_args={"check_same_thread": False})
+    applied = run_all_db_migrations(engine)
+    assert applied == ["20260326_add_tenants_kritis_sector"]
+    assert run_all_db_migrations(engine) == []
+    engine.dispose()


### PR DESCRIPTION
… kritis_sector

- Markdown-Abschnitt NIS2/KRITIS mit Template-Fakten, Risiko-Felder im Report/LLM-Facts
- Idempotente Migration tenants.kritis_sector; Lifespan + scripts/migrate_all.py
- Goldens und Tests für Risiko-Markdown und Legacy-Schema-Migration
- Docs (db-migrations, README, Advisor-NIS2/KRITIS); CI-Kommentar

Made-with: Cursor