### PR TITLE
feat(db): index ix_ai_runtime_events_tenant_system_time for OAMI/repo…

### DIFF
--- a/app/db_migrations/migrations/m20260328_ai_runtime_events_tenant_system_time_idx.py
+++ b/app/db_migrations/migrations/m20260328_ai_runtime_events_tenant_system_time_idx.py
@@ -1,0 +1,44 @@
+"""Composite index ``(tenant_id, ai_system_id, occurred_at DESC)`` for OAMI / reporting windows.
+
+Ledgerless mode (app role cannot create ``schema_migrations``): ``run_all_db_migrations`` does
+not call ``apply()`` — only ``satisfied()`` runs. If this index is missing, the migration id
+appears in ``ledgerless_unsatisfied``; create the index with a DDL-capable role
+(``python scripts/migrate_all.py``) or DBA tooling.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import index_exists, table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260328_add_ai_runtime_events_tenant_system_time_idx"
+DISPLAY_NAME = "add_ai_runtime_events_tenant_system_time_idx"
+
+INDEX_NAME = "ix_ai_runtime_events_tenant_system_time"
+
+
+def satisfied(engine: Engine) -> bool:
+    """True once the index exists (including after ``create_all`` on a fresh DB)."""
+    return index_exists(engine, "ai_runtime_events", INDEX_NAME)
+
+
+def apply(engine: Engine) -> bool:
+    """Create the index if the table exists and the index is missing (idempotent)."""
+    if not table_exists(engine, "ai_runtime_events"):
+        return False
+    if satisfied(engine):
+        return False
+    stmt = text(
+        f"CREATE INDEX IF NOT EXISTS {INDEX_NAME} ON ai_runtime_events "
+        "(tenant_id, ai_system_id, occurred_at DESC)"
+    )
+    with engine.begin() as conn:
+        conn.execute(stmt)
+    logger.info("db_migration applied: %s", MIGRATION_ID)
+    return True

--- a/app/db_migrations/util.py
+++ b/app/db_migrations/util.py
@@ -15,3 +15,10 @@ def column_exists(engine: Engine, table: str, column: str) -> bool:
     if not insp.has_table(table):
         return False
     return any(c["name"] == column for c in insp.get_columns(table))
+
+
+def index_exists(engine: Engine, table: str, index_name: str) -> bool:
+    insp = inspect(engine)
+    if not insp.has_table(table):
+        return False
+    return any(idx.get("name") == index_name for idx in insp.get_indexes(table))

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -748,6 +748,13 @@ class AiRuntimeEventTable(Base):
             "event_type",
             "occurred_at",
         ),
+        Index(
+            "ix_ai_runtime_events_tenant_system_time",
+            "tenant_id",
+            "ai_system_id",
+            "occurred_at",
+            postgresql_ops={"occurred_at": "DESC"},
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)

--- a/docs/db-migrations.md
+++ b/docs/db-migrations.md
@@ -108,8 +108,20 @@ python scripts/migrate_20260326_add_tenants_kritis_sector.py
 | Legacy KRITIS | `tests/test_db_migrations_kritis_sector.py` |
 | Discovery + `setup_notes` + Logging | `tests/test_db_migrations_discovery_and_setup_notes.py` |
 | Ledger optional (CREATE verweigert) | `tests/test_db_migrations_ledger_optional.py` |
+| `ai_runtime_events` Zeitpfad-Index | `tests/test_db_migrations_ai_runtime_events_index.py` |
 
 `conftest.py`: `DROP TABLE IF EXISTS schema_migrations` vor `drop_all`, danach `run_all_db_migrations`.
+
+## Beispiel: Index auf `ai_runtime_events`
+
+**Referenzmodul:** `app/db_migrations/migrations/m20260328_ai_runtime_events_tenant_system_time_idx.py`
+
+OAMI- und Board-/Advisor-Auswertungen filtern Laufzeit-Events typischerweise nach **Mandant**, **KI-System** und **Zeitfenster** (`occurred_at`). Der zusätzliche Index
+`ix_ai_runtime_events_tenant_system_time` auf `(tenant_id, ai_system_id, occurred_at DESC)` unterstützt genau diese Zugriffsmuster; er ergänzt die bestehenden Indizes (u. a. mit `event_type`).
+
+- **ORM:** `AiRuntimeEventTable` in `app/models_db.py` enthält denselben Index-Namen (PostgreSQL: `DESC` auf `occurred_at` via `postgresql_ops`; SQLite legt bei `create_all` einen kompatiblen Index an).
+- **Migration:** `CREATE INDEX IF NOT EXISTS …` + Introspection (`index_exists`), idempotent.
+- **Ledgerless:** siehe Docstring im Modul — ohne DDL-Rolle wird der Index nicht von der App angelegt.
 
 ## Registrierte Migrationen
 
@@ -117,6 +129,7 @@ python scripts/migrate_20260326_add_tenants_kritis_sector.py
 |----------------|--------|
 | `20260326_add_tenants_kritis_sector` | `tenants.kritis_sector` VARCHAR(64) NULL |
 | `20260327_add_tenant_ai_governance_setup_notes` | `tenant_ai_governance_setup.setup_notes` TEXT NULL (optional, DevEx-Beispiel) |
+| `20260328_add_ai_runtime_events_tenant_system_time_idx` | Index `ix_ai_runtime_events_tenant_system_time` (tenant, system, `occurred_at DESC`) |
 
 ## Später: Alembic?
 

--- a/tests/test_db_migrations_ai_runtime_events_index.py
+++ b/tests/test_db_migrations_ai_runtime_events_index.py
@@ -1,0 +1,50 @@
+"""Regression: composite index on ai_runtime_events for tenant/system/time (OAMI / reporting)."""
+
+from __future__ import annotations
+
+from sqlalchemy import create_engine, inspect, text
+
+from app.db_migrations import run_all_db_migrations
+from app.db_migrations.util import index_exists
+
+INDEX_NAME = "ix_ai_runtime_events_tenant_system_time"
+MID = "20260328_add_ai_runtime_events_tenant_system_time_idx"
+
+
+def _create_minimal_ai_runtime_events_table(url: str) -> None:
+    engine = create_engine(url, future=True, connect_args={"check_same_thread": False})
+    ddl = """
+    CREATE TABLE ai_runtime_events (
+        id VARCHAR(36) PRIMARY KEY,
+        tenant_id VARCHAR(255) NOT NULL,
+        ai_system_id VARCHAR(255) NOT NULL,
+        occurred_at DATETIME NOT NULL
+    )
+    """
+    with engine.begin() as conn:
+        conn.execute(text(ddl))
+    engine.dispose()
+
+
+def test_ai_runtime_events_time_index_applied_and_idempotent(tmp_path) -> None:
+    db_path = tmp_path / "aire_idx.db"
+    url = f"sqlite+pysqlite:///{db_path}"
+    _create_minimal_ai_runtime_events_table(url)
+
+    engine = create_engine(url, future=True, connect_args={"check_same_thread": False})
+    assert not index_exists(engine, "ai_runtime_events", INDEX_NAME)
+
+    first = run_all_db_migrations(engine)
+    assert MID in first.applied_ddl
+    assert index_exists(engine, "ai_runtime_events", INDEX_NAME)
+
+    idxs = inspect(engine).get_indexes("ai_runtime_events")
+    names = {i["name"] for i in idxs}
+    assert INDEX_NAME in names
+
+    second = run_all_db_migrations(engine)
+    assert second.applied_ddl == []
+    assert MID in second.skipped_ledger
+    assert index_exists(engine, "ai_runtime_events", INDEX_NAME)
+
+    engine.dispose()

--- a/tests/test_db_migrations_discovery_and_setup_notes.py
+++ b/tests/test_db_migrations_discovery_and_setup_notes.py
@@ -29,6 +29,7 @@ def test_discovery_skips_underscore_prefixed_modules() -> None:
     assert "_template_example" not in loaded
     assert "m20260326_add_tenants_kritis_sector" in loaded
     assert "m20260327_add_tenant_ai_governance_setup_notes" in loaded
+    assert "m20260328_ai_runtime_events_tenant_system_time_idx" in loaded
 
 
 def test_migration_ids_are_sorted() -> None:

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -88,7 +88,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     ids = summary.ledgerless_unsatisfied
     assert "20260326_add_tenants_kritis_sector" in ids
     assert "20260327_add_tenant_ai_governance_setup_notes" in ids
-    assert len(ids) == 2
+    assert "20260328_add_ai_runtime_events_tenant_system_time_idx" in ids
+    assert len(ids) == 3
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()


### PR DESCRIPTION
…rting

- Migration 20260328_add_ai_runtime_events_tenant_system_time_idx (CREATE INDEX IF NOT EXISTS)
- util.index_exists; ORM Index with postgresql_ops DESC on occurred_at
- Tests for apply/idempotency; discovery + ledgerless expectations updated
- docs/db-migrations.md example section

Made-with: Cursor