### PR TITLE
feat(oami): subtype weighting, hints, Board/Advisor wiring

### DIFF
--- a/app/advisor_client_snapshot_models.py
+++ b/app/advisor_client_snapshot_models.py
@@ -104,6 +104,9 @@ class OperationalAiMonitoringSnapshot(BaseModel):
     systems_scored: int = Field(ge=0)
     narrative_de: str = ""
     drivers_de: list[str] = Field(default_factory=list, max_length=12)
+    safety_related_runtime_incidents_90d: int = Field(default=0, ge=0)
+    availability_runtime_incidents_90d: int = Field(default=0, ge=0)
+    operational_subtype_hint_de: str | None = Field(default=None, max_length=400)
 
 
 class AdvisorClientGovernanceSnapshotResponse(BaseModel):

--- a/app/advisor_governance_maturity_brief_models.py
+++ b/app/advisor_governance_maturity_brief_models.py
@@ -54,6 +54,24 @@ class AdvisorGovernanceMaturityBriefParseResult(BaseModel):
     used_llm_client_paragraph: bool = False
 
 
+ADVISOR_RUNTIME_SAFETY_FOCUS_DE = (
+    "Sicherheitsrelevante AI-Laufzeitvorfälle reduzieren (Monitoring, Eskalation, Retraining)."
+)
+
+
+def merge_recommended_focus_areas_runtime_safety(
+    brief: AdvisorGovernanceMaturityBrief | None,
+    safety_runtime_incidents_90d: int,
+) -> AdvisorGovernanceMaturityBrief | None:
+    if brief is None or safety_runtime_incidents_90d <= 0:
+        return brief
+    areas = list(brief.recommended_focus_areas)
+    if any("Sicherheitsrelevant" in a for a in areas):
+        return brief
+    merged_areas = [ADVISOR_RUNTIME_SAFETY_FOCUS_DE, *areas]
+    return brief.model_copy(update={"recommended_focus_areas": merged_areas})
+
+
 def advisor_brief_focus_marker_de(brief: AdvisorGovernanceMaturityBrief) -> str:
     """Kurzmarke für Portfolio-Zeilen (aus strukturierten Feldern, nicht aus Freitext-Layout)."""
     if brief.recommended_focus_areas:

--- a/app/advisor_portfolio_models.py
+++ b/app/advisor_portfolio_models.py
@@ -28,6 +28,17 @@ class OperationalMonitoringPortfolioSummary(BaseModel):
 
     index: int | None = Field(default=None, ge=0, le=100)
     level: GaiOamiLevel | None = None
+    safety_related_runtime_incidents_90d: int = Field(
+        default=0,
+        ge=0,
+        description="Laufzeit-Incidents (Subtype safety_violation) im OAMI-Fenster.",
+    )
+    availability_runtime_incidents_90d: int = Field(default=0, ge=0)
+    oami_operational_hint_de: str | None = Field(
+        default=None,
+        max_length=400,
+        description="Kurz: ob Sicherheits- vs. Verfügbarkeitslage den Index prägt.",
+    )
 
 
 class AdvisorPortfolioTenantEntry(BaseModel):

--- a/app/governance_maturity_contract.py
+++ b/app/governance_maturity_contract.py
@@ -22,7 +22,7 @@ from enum import StrEnum
 from typing import Final, Literal
 
 # Bump when JSON shape or enum sets change (keep in sync with docs + frontend types).
-GOVERNANCE_MATURITY_CONTRACT_VERSION: Final[str] = "2"
+GOVERNANCE_MATURITY_CONTRACT_VERSION: Final[str] = "3"
 
 # --- Explain payload limits (single source for parser + doc) ---
 EXPLAIN_LIST_MAX_ITEMS: Final[int] = 5
@@ -236,6 +236,19 @@ def index_mapping_lines_for_prompt() -> str:
     return "\n".join(lines)
 
 
+def oami_event_subtype_context_for_prompt() -> str:
+    """
+    Kurz: OAMI nutzt weiter nur level low|medium|high; Subtype-Kategorien nur zur Einordnung.
+    """
+    return (
+        "OAMI-Laufzeitdaten: optionaler technischer ``event_subtype`` pro Incident oder "
+        "Metrikalarm (z. B. safety_violation, availability_incident, drift_high). "
+        "Sicherheitsnahe Subtypes werden im Index stärker gewichtet als reine "
+        "Verfügbarkeit — ohne konkrete Gewichtszahlen zu nennen. "
+        "JSON-Feld ``level`` für OAMI bleibt ausschließlich low | medium | high."
+    )
+
+
 def terminology_contract_for_llm_prompt() -> str:
     """
     Instruct the model: JSON `level` fields = API enums only; narrative without invented
@@ -256,7 +269,7 @@ def terminology_contract_for_llm_prompt() -> str:
         "keine Synonyme (z. B. nicht „advanced“ statt embedded).\n"
         "Alle Freitext-Felder auf Deutsch; keine neuen Akronyme für Readiness/GAI/OAMI erfinden.\n"
         "In Fließtext-Feldern: keine eigenen Synonyme für Stufen; "
-        "Ursachen und Maßnahmen sachlich.\n"
+        "Ursachen und Maßnahmen sachlich.\n" + oami_event_subtype_context_for_prompt() + "\n"
     )
 
 

--- a/app/governance_maturity_models.py
+++ b/app/governance_maturity_models.py
@@ -43,6 +43,21 @@ class OperationalAiMonitoringBlock(BaseModel):
     window_days: int | None = None
     message_de: str = ""
     drivers_de: list[str] = Field(default_factory=list, max_length=12)
+    safety_related_runtime_incident_count: int = Field(
+        default=0,
+        ge=0,
+        description="Tenant-90-Tage-Fenster: Incidents mit Subtype safety_violation.",
+    )
+    availability_runtime_incident_count: int = Field(
+        default=0,
+        ge=0,
+        description="Tenant-90-Tage: Subtype availability_incident.",
+    )
+    operational_subtype_hint_de: str | None = Field(
+        default=None,
+        max_length=400,
+        description="Kurzer Hinweis ohne numerische Gewichte (Board/Advisor).",
+    )
 
 
 class GovernanceMaturityResponse(BaseModel):

--- a/app/oami_subtype_weights.py
+++ b/app/oami_subtype_weights.py
@@ -1,0 +1,52 @@
+"""Konservative OAMI-Gewichte pro ``event_subtype`` (v1, erklärbar, ohne UI-Zahlen)."""
+
+from __future__ import annotations
+
+from typing import Final
+
+# Relativ zu Neutral 1.0; keine exponenziellen Formeln.
+_INCIDENT_WEIGHTS: Final[dict[str, float]] = {
+    "safety_violation": 1.5,
+    "sap_alert_incident": 1.0,
+    "availability_incident": 1.0,
+    "other_incident": 0.8,
+}
+
+_METRIC_BREACH_WEIGHTS: Final[dict[str, float]] = {
+    "drift_high": 1.2,
+    "performance_degradation": 1.0,
+    "other_metric_breach": 0.8,
+}
+
+# Pro Vorfall: high/critical stärker gewichtet als niedrigere Schwere (unabhängig vom Subtype).
+_COEF_INCIDENT_HIGH: Final[float] = 0.20
+_COEF_INCIDENT_OTHER_SEV: Final[float] = 0.065
+_SEV_HI: Final[frozenset[str]] = frozenset({"high", "critical"})
+
+
+def incident_subtype_oami_weight(subtype: str | None) -> float:
+    """Gewicht für einen Incident (ohne Subtype: neutral 1.0)."""
+    if not subtype or not str(subtype).strip():
+        return 1.0
+    k = str(subtype).strip().lower()
+    if k.startswith("other_"):
+        return 0.8
+    return float(_INCIDENT_WEIGHTS.get(k, 1.0))
+
+
+def metric_breach_subtype_oami_weight(subtype: str | None) -> float:
+    """Gewicht für eine Metrik-Schwellenverletzung."""
+    if not subtype or not str(subtype).strip():
+        return 1.0
+    k = str(subtype).strip().lower()
+    if k.startswith("other_"):
+        return 0.8
+    return float(_METRIC_BREACH_WEIGHTS.get(k, 1.0))
+
+
+def incident_weighted_penalty_contribution(*, subtype: str | None, severity: str | None) -> float:
+    """Summand für OAMI-Incident-Teilscore (vor Sättigung)."""
+    w = incident_subtype_oami_weight(subtype)
+    sev = (severity or "").strip().lower()
+    coef = _COEF_INCIDENT_HIGH if sev in _SEV_HI else _COEF_INCIDENT_OTHER_SEV
+    return w * coef

--- a/app/operational_monitoring_models.py
+++ b/app/operational_monitoring_models.py
@@ -100,6 +100,20 @@ class SystemMonitoringIndexOut(BaseModel):
         default_factory=dict,
         description="Nur Incidents; Schlüssel = kanonischer event_subtype.",
     )
+    metric_breach_count_by_subtype: dict[str, int] = Field(
+        default_factory=dict,
+        description="Nur metric_threshold_breach; Schlüssel = kanonischer event_subtype.",
+    )
+    safety_related_incident_count: int = Field(
+        default=0,
+        ge=0,
+        description="Anzahl Incidents mit Subtype safety_violation im Fenster.",
+    )
+    oami_operational_hint_de: str | None = Field(
+        default=None,
+        description="Kurzhinweis für Board/UI (ohne numerische Gewichte).",
+        max_length=400,
+    )
     metric_threshold_breach_count: int = 0
     distinct_active_days: int = 0
     components: OamiComponentsOut
@@ -115,3 +129,10 @@ class TenantOperationalMonitoringIndexOut(BaseModel):
     has_any_runtime_data: bool
     components: OamiComponentsOut | None = None
     explanation: OamiExplanationOut | None = None
+    runtime_incident_by_subtype: dict[str, int] = Field(
+        default_factory=dict,
+        description="Tenant-aggregat über Systeme mit Events (nur Incidents).",
+    )
+    safety_related_runtime_incident_count: int = Field(default=0, ge=0)
+    availability_runtime_incident_count: int = Field(default=0, ge=0)
+    oami_operational_hint_de: str | None = Field(default=None, max_length=400)

--- a/app/readiness_score_models.py
+++ b/app/readiness_score_models.py
@@ -76,6 +76,21 @@ class OperationalMonitoringExplanationStructured(BaseModel):
     recent_incidents_summary: str = Field(default="", max_length=2000)
     monitoring_gaps: list[str] = Field(default_factory=list, max_length=5)
     improvement_suggestions: list[str] = Field(default_factory=list, max_length=5)
+    safety_related_incidents_90d: int | None = Field(
+        default=None,
+        ge=0,
+        description="Server-seitig aus Laufzeit-Incidents (Subtype safety_violation), optional.",
+    )
+    availability_incidents_90d: int | None = Field(
+        default=None,
+        ge=0,
+        description="Server-seitig (Subtype availability_incident), optional.",
+    )
+    oami_subtype_hint_de: str | None = Field(
+        default=None,
+        max_length=400,
+        description="Kurzer Board-Hinweis ohne numerische Gewichte (serverseitig).",
+    )
 
 
 class ReadinessScoreExplainResponse(BaseModel):

--- a/app/repositories/ai_runtime_events.py
+++ b/app/repositories/ai_runtime_events.py
@@ -8,6 +8,10 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.models_db import AiRuntimeEventTable
+from app.oami_subtype_weights import (
+    incident_weighted_penalty_contribution,
+    metric_breach_subtype_oami_weight,
+)
 
 
 def _occurred_at_utc(dt: datetime) -> datetime:
@@ -78,6 +82,9 @@ class AiRuntimeEventRepository:
                 "breach_count": 0,
                 "incident_count": 0,
                 "incident_count_by_subtype": {},
+                "metric_breach_count_by_subtype": {},
+                "incident_weighted_penalty_sum": 0.0,
+                "weighted_breach_units": 0.0,
             }
         last_at = max(_occurred_at_utc(r.occurred_at) for r in rows)
         days: set[str] = set()
@@ -85,6 +92,9 @@ class AiRuntimeEventRepository:
         breach_count = 0
         incident_count = 0
         incident_by_subtype: dict[str, int] = {}
+        breach_by_subtype: dict[str, int] = {}
+        incident_penalty_sum = 0.0
+        weighted_breach = 0.0
         sev_hi = frozenset({"high", "critical"})
         for r in rows:
             d = _occurred_at_utc(r.occurred_at).date().isoformat()
@@ -97,8 +107,16 @@ class AiRuntimeEventRepository:
                 st = (getattr(r, "event_subtype", None) or "").strip().lower()
                 if st:
                     incident_by_subtype[st] = incident_by_subtype.get(st, 0) + 1
+                incident_penalty_sum += incident_weighted_penalty_contribution(
+                    subtype=st if st else None,
+                    severity=r.severity,
+                )
             if et == "metric_threshold_breach":
                 breach_count += 1
+                bst = (getattr(r, "event_subtype", None) or "").strip().lower()
+                if bst:
+                    breach_by_subtype[bst] = breach_by_subtype.get(bst, 0) + 1
+                weighted_breach += metric_breach_subtype_oami_weight(bst if bst else None)
         return {
             "event_count": len(rows),
             "last_occurred_at": last_at,
@@ -107,6 +125,9 @@ class AiRuntimeEventRepository:
             "breach_count": breach_count,
             "incident_count": incident_count,
             "incident_count_by_subtype": incident_by_subtype,
+            "metric_breach_count_by_subtype": breach_by_subtype,
+            "incident_weighted_penalty_sum": incident_penalty_sum,
+            "weighted_breach_units": weighted_breach,
         }
 
     def list_system_ids_with_events(

--- a/app/services/advisor_client_governance_snapshot.py
+++ b/app/services/advisor_client_governance_snapshot.py
@@ -21,6 +21,9 @@ from app.advisor_client_snapshot_models import (
     ReportsSummarySnapshot,
     SetupStatusSnapshot,
 )
+from app.advisor_governance_maturity_brief_models import (
+    merge_recommended_focus_areas_runtime_safety,
+)
 from app.ai_kpi_models import AiKpiSummaryResponse
 from app.ai_system_models import AISystemCriticality, AISystemRiskLevel
 from app.feature_flags import FeatureFlag, is_feature_enabled
@@ -265,6 +268,9 @@ def build_client_governance_snapshot(
             systems_scored=oami.systems_scored,
             narrative_de=expl.summary_de,
             drivers_de=list(expl.drivers_de)[:12],
+            safety_related_runtime_incidents_90d=oami.safety_related_runtime_incident_count,
+            availability_runtime_incidents_90d=oami.availability_runtime_incident_count,
+            operational_subtype_hint_de=oami.oami_operational_hint_de,
         )
     except Exception:
         logger.exception("snapshot_oami_failed tenant=%s", client_tenant_id)
@@ -275,6 +281,15 @@ def build_client_governance_snapshot(
             br = maybe_build_advisor_governance_maturity_brief_result(session, client_tenant_id)
             if br is not None:
                 gm_advisor_brief = br.brief
+                safety_ct = (
+                    int(oami_snap.safety_related_runtime_incidents_90d)
+                    if oami_snap is not None
+                    else 0
+                )
+                gm_advisor_brief = merge_recommended_focus_areas_runtime_safety(
+                    gm_advisor_brief,
+                    safety_ct,
+                )
         except Exception:
             logger.exception(
                 "snapshot_governance_maturity_advisor_brief_failed tenant=%s",

--- a/app/services/advisor_portfolio.py
+++ b/app/services/advisor_portfolio.py
@@ -8,7 +8,10 @@ from datetime import UTC, datetime
 
 from sqlalchemy.orm import Session
 
-from app.advisor_governance_maturity_brief_models import AdvisorGovernanceMaturityBrief
+from app.advisor_governance_maturity_brief_models import (
+    AdvisorGovernanceMaturityBrief,
+    merge_recommended_focus_areas_runtime_safety,
+)
 from app.advisor_portfolio_models import (
     AdvisorPortfolioResponse,
     AdvisorPortfolioTenantEntry,
@@ -213,6 +216,9 @@ def build_advisor_portfolio(
                     oami_summary = OperationalMonitoringPortfolioSummary(
                         index=ob.index,
                         level=ob.level,
+                        safety_related_runtime_incidents_90d=ob.safety_related_runtime_incident_count,
+                        availability_runtime_incidents_90d=ob.availability_runtime_incident_count,
+                        oami_operational_hint_de=ob.operational_subtype_hint_de,
                     )
             except Exception:
                 logger.exception("advisor_portfolio_governance_maturity_failed tenant=%s", tid)
@@ -222,6 +228,12 @@ def build_advisor_portfolio(
                 br = maybe_build_advisor_governance_maturity_brief_result(session, tid)
                 if br is not None:
                     gm_brief = br.brief
+                    safety_ct = (
+                        int(oami_summary.safety_related_runtime_incidents_90d)
+                        if oami_summary is not None
+                        else 0
+                    )
+                    gm_brief = merge_recommended_focus_areas_runtime_safety(gm_brief, safety_ct)
             except Exception:
                 logger.exception(
                     "advisor_portfolio_governance_maturity_brief_failed tenant=%s",

--- a/app/services/governance_maturity_service.py
+++ b/app/services/governance_maturity_service.py
@@ -98,6 +98,9 @@ def build_governance_maturity_response(
                 window_days=window_days,
                 message_de=expl.summary_de,
                 drivers_de=list(expl.drivers_de),
+                safety_related_runtime_incident_count=oami.safety_related_runtime_incident_count,
+                availability_runtime_incident_count=oami.availability_runtime_incident_count,
+                operational_subtype_hint_de=oami.oami_operational_hint_de,
             )
         else:
             oami_block = OperationalAiMonitoringBlock(
@@ -107,6 +110,9 @@ def build_governance_maturity_response(
                 window_days=window_days,
                 message_de=expl.summary_de,
                 drivers_de=list(expl.drivers_de),
+                safety_related_runtime_incident_count=0,
+                availability_runtime_incident_count=0,
+                operational_subtype_hint_de=None,
             )
     except Exception:
         logger.exception("governance_maturity_oami_failed tenant=%s", tenant_id)

--- a/app/services/oami_explanation.py
+++ b/app/services/oami_explanation.py
@@ -9,6 +9,30 @@ from app.operational_monitoring_models import (
 )
 
 
+def oami_operational_hint_de(
+    *,
+    safety_incidents: int,
+    availability_incidents: int,
+) -> str | None:
+    """Kurztext für Board/Advisor: keine Gewichtszahlen, nur Einordnung."""
+    if safety_incidents >= 2:
+        return (
+            "Mehrere sicherheitsrelevante Laufzeitvorfälle beeinflussen den Index stärker "
+            "als reine Verfügbarkeitssignale."
+        )
+    if safety_incidents == 1:
+        return (
+            "Sicherheitsrelevante Laufzeitvorfälle fließen stärker in den Index ein als "
+            "reine Verfügbarkeitssignale."
+        )
+    if availability_incidents >= 3 and safety_incidents == 0:
+        return (
+            "Die Lage ist vor allem durch Verfügbarkeits-Incidents geprägt (ohne "
+            "Sicherheits-Subtype in den Laufzeitdaten)."
+        )
+    return None
+
+
 def explain_system_oami_de(result: SystemMonitoringIndexOut) -> OamiExplanationOut:
     """Haupttreiber aus Teilscores und Zählern (Tenant-System)."""
     if not result.has_data:
@@ -42,10 +66,28 @@ def explain_system_oami_de(result: SystemMonitoringIndexOut) -> OamiExplanationO
         drivers.append("Wenige aktive Tage – mögliche Lücke in der kontinuierlichen Überwachung.")
 
     sv = int(result.incident_count_by_subtype.get("safety_violation", 0))
-    if sv > 0:
+    av = int(result.incident_count_by_subtype.get("availability_incident", 0))
+    if sv >= 2:
         drivers.append(
-            f'{sv} sicherheitsrelevante Vorfälle (event_subtype "safety_violation") — '
-            "stärkerer Einfluss auf den OAMI-Stabilitätsanteil."
+            f"Mehrere sicherheitsrelevante Incidents ({sv} im Fenster, Subtype "
+            '"safety_violation") — stärkerer Einfluss auf den operativen Monitoring-Index.'
+        )
+    elif sv == 1:
+        drivers.append(
+            'Ein sicherheitsrelevanter Incident (Subtype "safety_violation") mit '
+            "überdurchschnittlichem Gewicht im Index."
+        )
+    drift_n = int(result.metric_breach_count_by_subtype.get("drift_high", 0))
+    if drift_n >= 2:
+        drivers.append(
+            f'{drift_n} Drift-Schwellenverletzungen (Subtype "drift_high") — '
+            "stärker gewichtet als andere Metrikalarme."
+        )
+
+    if sv == 0 and av >= 2 and result.incident_count > 0:
+        drivers.append(
+            f"Schwerpunkt Verfügbarkeit: {av} Incidents mit Subtype "
+            '"availability_incident" bei fehlenden Sicherheits-Subtypes.'
         )
 
     if result.high_severity_incident_count > 0:
@@ -71,6 +113,10 @@ def explain_system_oami_de(result: SystemMonitoringIndexOut) -> OamiExplanationO
 
     if c.metric_stability >= 0.75:
         drivers.append("Metrik-Stabilität aus Sicht der Schwellenwerte günstig.")
+    elif drift_n >= 1 and c.metric_stability < 0.6:
+        drivers.append(
+            "Metrik-Stabilität durch Drift- oder Leistungsalarme belastet (Subtype-Gewichtung)."
+        )
 
     level_de = {"low": "niedrig", "medium": "mittel", "high": "hoch"}[result.level]
     summary_de = (
@@ -113,6 +159,22 @@ def explain_tenant_oami_de(result: TenantOperationalMonitoringIndexOut) -> OamiE
         drivers.append("Teils veraltete Signale – Prüfung der Datenpipelines sinnvoll.")
     if c.metric_stability >= 0.7:
         drivers.append("Metriken überwiegend stabil (wenige Schwellenverletzungen).")
+    ts = result.runtime_incident_by_subtype
+    sv_t = int(ts.get("safety_violation", 0))
+    av_t = int(ts.get("availability_incident", 0))
+    if sv_t >= 2:
+        drivers.append(
+            f"Mandantenweit {sv_t} sicherheitsrelevante Laufzeit-Incidents (90 Tage) — "
+            "Priorität für Post-Market- und Sicherheits-Governance."
+        )
+    elif sv_t == 1:
+        drivers.append(
+            "Mindestens ein sicherheitsrelevanter Laufzeit-Incident im Portfolio-Fenster."
+        )
+    elif av_t >= 3 and sv_t == 0:
+        drivers.append(
+            "Laufzeit-Incidents überwiegend Verfügbarkeit; ohne Sicherheits-Subtype in den Daten."
+        )
 
     level_de = {"low": "niedrig", "medium": "mittel", "high": "hoch"}[result.level]
     summary_de = (

--- a/app/services/operational_monitoring_index.py
+++ b/app/services/operational_monitoring_index.py
@@ -16,7 +16,11 @@ from app.operational_monitoring_models import (
 )
 from app.repositories.ai_runtime_events import AiRuntimeEventRepository
 from app.repositories.ai_systems import AISystemRepository
-from app.services.oami_explanation import explain_system_oami_de, explain_tenant_oami_de
+from app.services.oami_explanation import (
+    explain_system_oami_de,
+    explain_tenant_oami_de,
+    oami_operational_hint_de,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,28 +55,16 @@ def _coverage_component(distinct_days: int, window_days: int) -> float:
     return min(1.0, float(distinct_days) / float(max(1, d_sat)))
 
 
-def _incident_component(
-    incident_count: int,
-    incident_high: int,
-    *,
-    safety_violation_incidents: int = 0,
-) -> float:
-    """Ohne Ticket-Workflow: weniger Incidents und weniger high/critical = besser.
-
-    Zusätzlich: ``safety_violation``-Subtype (stärker gewichtet, Board/OAMI-relevant).
-    """
-    penalty = min(
-        1.0,
-        incident_high * 0.22
-        + max(0, incident_count - incident_high) * 0.07
-        + safety_violation_incidents * 0.12,
-    )
+def _incident_component(incident_weighted_penalty_sum: float) -> float:
+    """Subtype- und schweregradgewichtete Incident-Last (siehe ``oami_subtype_weights``)."""
+    penalty = min(1.0, float(incident_weighted_penalty_sum))
     return max(0.0, 1.0 - penalty)
 
 
-def _stability_component(breach_count: int, window_days: int) -> float:
+def _stability_component(weighted_breach_units: float, window_days: int) -> float:
+    """Schwellenverletzungen mit Subtype-Gewicht (z. B. Drift etwas schwerer als reine Latenz)."""
     scale = max(3.0, (window_days / 30.0) * 5.0)
-    penalty = min(1.0, float(breach_count) / scale)
+    penalty = min(1.0, float(weighted_breach_units) / scale)
     return max(0.0, 1.0 - penalty)
 
 
@@ -92,16 +84,26 @@ def _components_from_agg(
     incident_count = int(agg.get("incident_count") or 0)
     raw_sub = agg.get("incident_count_by_subtype")
     incident_by_subtype: dict[str, int] = dict(raw_sub) if isinstance(raw_sub, dict) else {}
-    safety_sv = int(incident_by_subtype.get("safety_violation", 0))
+    iwp = agg.get("incident_weighted_penalty_sum")
+    if isinstance(iwp, (int, float)):
+        incident_penalty_sum = float(iwp)
+    else:
+        # Rückwärtskompatibilität älterer Aggregationen
+        safety_sv = int(incident_by_subtype.get("safety_violation", 0))
+        incident_penalty_sum = min(
+            1.0,
+            incident_high * 0.22 + max(0, incident_count - incident_high) * 0.07 + safety_sv * 0.12,
+        )
+    wb = agg.get("weighted_breach_units")
+    if isinstance(wb, (int, float)):
+        weighted_breach = float(wb)
+    else:
+        weighted_breach = float(breach_count)
 
     f = _freshness_component(last_dt, now)
     c = _coverage_component(distinct_days, window_days)
-    i = _incident_component(
-        incident_count,
-        incident_high,
-        safety_violation_incidents=safety_sv,
-    )
-    s = _stability_component(breach_count, window_days)
+    i = _incident_component(incident_penalty_sum)
+    s = _stability_component(weighted_breach, window_days)
 
     if not has_data:
         z = OamiComponentsOut(
@@ -142,6 +144,11 @@ def compute_system_monitoring_index(
 
     raw_sub = agg.get("incident_count_by_subtype")
     inc_sub: dict[str, int] = dict(raw_sub) if isinstance(raw_sub, dict) else {}
+    raw_msub = agg.get("metric_breach_count_by_subtype")
+    msub: dict[str, int] = dict(raw_msub) if isinstance(raw_msub, dict) else {}
+    safety_n = int(inc_sub.get("safety_violation", 0))
+    avail_n = int(inc_sub.get("availability_incident", 0))
+    hint = oami_operational_hint_de(safety_incidents=safety_n, availability_incidents=avail_n)
 
     base = SystemMonitoringIndexOut(
         ai_system_id=ai_system_id,
@@ -154,6 +161,9 @@ def compute_system_monitoring_index(
         incident_count=int(agg.get("incident_count") or 0),
         high_severity_incident_count=int(agg.get("incident_high") or 0),
         incident_count_by_subtype=inc_sub,
+        metric_breach_count_by_subtype=msub,
+        safety_related_incident_count=safety_n,
+        oami_operational_hint_de=hint,
         metric_threshold_breach_count=int(agg.get("breach_count") or 0),
         distinct_active_days=int(agg.get("distinct_days") or 0),
         components=comp,
@@ -200,6 +210,10 @@ def compute_tenant_operational_monitoring_index(
             has_any_runtime_data=False,
             components=None,
             explanation=None,
+            runtime_incident_by_subtype={},
+            safety_related_runtime_incident_count=0,
+            availability_runtime_incident_count=0,
+            oami_operational_hint_de=None,
         )
         out = out.model_copy(update={"explanation": explain_tenant_oami_de(out)})
         if persist_snapshot:
@@ -215,6 +229,7 @@ def compute_tenant_operational_monitoring_index(
     weighted_index = 0.0
     wf = wc = wi = ws = 0.0
     w_sum = 0.0
+    merged_inc_subtype: dict[str, int] = {}
 
     for sid in system_ids:
         system = sys_repo.get_by_id(tenant_id, sid)
@@ -227,6 +242,17 @@ def compute_tenant_operational_monitoring_index(
         wi += w * comp.incident_stability
         ws += w * comp.metric_stability
         w_sum += w
+        raw_is = agg.get("incident_count_by_subtype")
+        if isinstance(raw_is, dict):
+            for k, v in raw_is.items():
+                try:
+                    n = int(v)
+                except (TypeError, ValueError):
+                    continue
+                if n <= 0:
+                    continue
+                ks = str(k).strip().lower()
+                merged_inc_subtype[ks] = merged_inc_subtype.get(ks, 0) + n
 
     if w_sum <= 0:
         w_sum = 1.0
@@ -238,6 +264,9 @@ def compute_tenant_operational_monitoring_index(
         incident_stability=wi / w_sum,
         metric_stability=ws / w_sum,
     )
+    sv_t = int(merged_inc_subtype.get("safety_violation", 0))
+    av_t = int(merged_inc_subtype.get("availability_incident", 0))
+    hint_t = oami_operational_hint_de(safety_incidents=sv_t, availability_incidents=av_t)
     out = TenantOperationalMonitoringIndexOut(
         tenant_id=tenant_id,
         window_days=window_days,
@@ -247,6 +276,10 @@ def compute_tenant_operational_monitoring_index(
         has_any_runtime_data=True,
         components=comp_t,
         explanation=None,
+        runtime_incident_by_subtype=dict(sorted(merged_inc_subtype.items())),
+        safety_related_runtime_incident_count=sv_t,
+        availability_runtime_incident_count=av_t,
+        oami_operational_hint_de=hint_t,
     )
     out = out.model_copy(update={"explanation": explain_tenant_oami_de(out)})
     if persist_snapshot:

--- a/app/services/readiness_explain_structured.py
+++ b/app/services/readiness_explain_structured.py
@@ -148,7 +148,39 @@ def _coerce_oami_struct(
             max_items=EXPLAIN_LIST_MAX_ITEMS,
             max_len=EXPLAIN_LIST_ITEM_MAX_CHARS,
         ),
+        safety_related_incidents_90d=None,
+        availability_incidents_90d=None,
+        oami_subtype_hint_de=None,
     )
+
+
+def _apply_oami_server_enrichment(
+    o_struct: OperationalMonitoringExplanationStructured | None,
+    enrichment: dict[str, object] | None,
+) -> OperationalMonitoringExplanationStructured | None:
+    if o_struct is None or not enrichment:
+        return o_struct
+    upd: dict[str, object] = {}
+    for key in (
+        "safety_related_incidents_90d",
+        "availability_incidents_90d",
+        "oami_subtype_hint_de",
+    ):
+        if key not in enrichment:
+            continue
+        val = enrichment[key]
+        if key == "oami_subtype_hint_de":
+            if val is not None:
+                upd[key] = str(val).strip()[:400] or None
+        else:
+            if val is None:
+                upd[key] = None
+            else:
+                try:
+                    upd[key] = max(0, int(val))
+                except (TypeError, ValueError):
+                    pass
+    return o_struct.model_copy(update=upd) if upd else o_struct
 
 
 def compose_legacy_explanation_text(
@@ -180,6 +212,7 @@ def parse_and_validate_readiness_explain_response(
     has_oami_context: bool,
     provider: str,
     model_id: str,
+    oami_operational_enrichment: dict[str, object] | None = None,
 ) -> ReadinessScoreExplainResponse:
     """
     Parse LLM JSON, validate enum levels (with snapshot fallback), build API response.
@@ -194,6 +227,7 @@ def parse_and_validate_readiness_explain_response(
         has_oami_context=has_oami_context,
         provider=provider,
         model_id=model_id,
+        oami_operational_enrichment=oami_operational_enrichment,
     )
 
 
@@ -206,6 +240,7 @@ def build_readiness_explain_response_from_llm_text(
     has_oami_context: bool,
     provider: str,
     model_id: str,
+    oami_operational_enrichment: dict[str, object] | None = None,
 ) -> ReadinessScoreExplainResponse:
     data = extract_json_object(llm_text)
     if not data:
@@ -230,6 +265,7 @@ def build_readiness_explain_response_from_llm_text(
             o_struct = o_struct.model_copy(
                 update={"level": normalize_index_level(oami_level)},
             )
+        o_struct = _apply_oami_server_enrichment(o_struct, oami_operational_enrichment)
 
     if r_struct is None:
         logger.info("readiness_explain_missing_readiness_explanation_block; partial fallback")

--- a/app/services/readiness_score_explain.py
+++ b/app/services/readiness_score_explain.py
@@ -32,6 +32,7 @@ def explain_readiness_score(
     oami_index: int | None = None
     oami_level: str | None = None
     has_oami_context = False
+    oami_enrichment: dict[str, object] | None = None
     try:
         from app.services.oami_explanation import explain_tenant_oami_de
         from app.services.operational_monitoring_index import (
@@ -56,7 +57,22 @@ def explain_readiness_score(
             "systems_scored": oami.systems_scored,
             "summary_de": expl.summary_de,
             "drivers_de": expl.drivers_de[:6],
+            "runtime_incident_by_subtype": oami.runtime_incident_by_subtype,
+            "safety_related_runtime_incidents_90d": oami.safety_related_runtime_incident_count,
+            "availability_runtime_incidents_90d": oami.availability_runtime_incident_count,
+            "oami_operational_hint_de": oami.oami_operational_hint_de,
+            "oami_subtype_note": (
+                "Laufzeit-Incidents können z. B. Subtypes safety_violation oder "
+                "availability_incident tragen; sicherheitsrelevante Subtypes zählen im Index "
+                "stärker als reine Verfügbarkeit (keine Gewichtszahlen nennen)."
+            ),
         }
+        if oami.has_any_runtime_data:
+            oami_enrichment = {
+                "safety_related_incidents_90d": oami.safety_related_runtime_incident_count,
+                "availability_incidents_90d": oami.availability_runtime_incident_count,
+                "oami_subtype_hint_de": oami.oami_operational_hint_de,
+            }
     except Exception:
         logger.exception("readiness_explain_oami_context_failed tenant=%s", tenant_id)
 
@@ -101,4 +117,5 @@ def explain_readiness_score(
         has_oami_context=has_oami_context,
         provider=str(resp.provider.value),
         model_id=resp.model_id,
+        oami_operational_enrichment=oami_enrichment,
     )

--- a/docs/governance-maturity-copy-contract.md
+++ b/docs/governance-maturity-copy-contract.md
@@ -13,7 +13,7 @@ Ziel: **stabile Enums**, **nachvollziehbare LLM-Ausgaben** und **ein gemeinsames
 
 | Feld | Wert | Zweck |
 |------|------|--------|
-| `GOVERNANCE_MATURITY_CONTRACT_VERSION` | siehe `governance_maturity_contract.py` | Wird in LLM-Prompts (`Explain-Contract-Version`) und Tests gesnapshottet. Bei Änderung am JSON-Schema oder an erlaubten Enums **Version erhöhen** und Frontend/Docs/Tests anpassen. |
+| `GOVERNANCE_MATURITY_CONTRACT_VERSION` | siehe `governance_maturity_contract.py` | Wird in LLM-Prompts (`Explain-Contract-Version`) und Tests gesnapshottet. Bei Änderung am JSON-Schema oder an erlaubten Enums **Version erhöhen** und Frontend/Docs/Tests anpassen. **v3:** Zusatzkontext zu OAMI-`event_subtype`-Kategorien in `terminology_contract_for_llm_prompt()` (Enums `low`/`medium`/`high` unverändert). |
 
 ---
 

--- a/docs/governance-operational-ai-monitoring.md
+++ b/docs/governance-operational-ai-monitoring.md
@@ -203,6 +203,14 @@ Beispiel-Gewichtung (kalibrierbar):
 
 **Level:** wie GAI: 0–39 low, 40–69 medium, 70–100 high – oder an KPI-Schwellen für Hochrisiko-Systeme gekoppelt (Policy).
 
+### 3.2.1 Subtype-Gewichtung (v1, erklärbar)
+
+**Implementierung:** `app/oami_subtype_weights.py` zusammen mit der Aggregation in `AiRuntimeEventRepository.aggregate_for_oami` und `operational_monitoring_index`.
+
+- **Ziel:** Gleiche Anzahl Vorfälle kann den Index unterschiedlich belasten: **sicherheitsnahe** Subtypes (z. B. `safety_violation`) wirken **stärker** als reine **Verfügbarkeit** (`availability_incident`). **Drift**-Breaches (`drift_high`) zählen etwas schwerer als reine **Leistungs**-Alarme (`performance_degradation`). **`other_*`-Subtypes** sind konservativ etwas **leichter** als explizit klassifizierte Codes.
+- **Keine UI-Zahlen:** Mandanten sehen Kurztexte und Zähler (z. B. „davon X sicherheitsrelevant“), **keine** ausgewiesenen Gewichtsfaktoren.
+- **Bänder:** Die Zuordnung Index → `low` | `medium` | `high` bleibt unverändert; die Kalibrierung ist bewusst moderat, damit bestehende OAMI-Stufen nicht springen.
+
 ### 3.3 Tenant-Aggregation
 
 - **Einfach:** Mittelwert über Systeme mit `risk_level` in Scope (z. B. high + limited).  

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.test.tsx
@@ -91,6 +91,9 @@ const { fetchSnap, postMd, fetchAdvisorReadiness, minimalSnapshot } = vi.hoisted
       systems_scored: 2,
       narrative_de: "Operatives Monitoring: mittlere Reife (Demo).",
       drivers_de: ["Letzte Laufzeitereignisse", "KPI-Trends"],
+      safety_related_runtime_incidents_90d: 2,
+      availability_runtime_incidents_90d: 1,
+      operational_subtype_hint_de: "Sicherheitsnahe Signale prägen den Index stärker.",
     },
     governance_maturity_advisor_brief: null,
   };
@@ -161,6 +164,7 @@ describe("AdvisorGovernanceSnapshotView", () => {
     expect(screen.getByTestId("snap-client-info")).toBeTruthy();
     expect(screen.getByTestId("snap-gai-note")).toBeTruthy();
     expect(screen.getByTestId("snap-oami")).toBeTruthy();
+    expect(screen.getByTestId("snap-oami-subtype")).toBeTruthy();
     expect(screen.getByText(/Operatives Monitoring: mittlere Reife/i)).toBeTruthy();
 
     fireEvent.click(screen.getByTestId("snap-gen-md"));

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
@@ -415,6 +415,28 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
                   </dd>
                 </div>
               </dl>
+              {(snap.operational_ai_monitoring.safety_related_runtime_incidents_90d ?? 0) > 0 ||
+              (snap.operational_ai_monitoring.availability_runtime_incidents_90d ?? 0) > 0 ||
+              snap.operational_ai_monitoring.operational_subtype_hint_de ? (
+                <div
+                  className="mt-3 rounded-md border border-slate-100 bg-slate-50/80 px-3 py-2 text-xs text-slate-700"
+                  data-testid="snap-oami-subtype"
+                >
+                  <p className="font-semibold text-slate-800">Laufzeit-Incidents nach Subtype (90 Tage)</p>
+                  <p className="mt-1 tabular-nums">
+                    Sicherheits-Subtype:{" "}
+                    {snap.operational_ai_monitoring.safety_related_runtime_incidents_90d ?? 0}
+                    <span className="mx-2 text-slate-300">|</span>
+                    Verfügbarkeit:{" "}
+                    {snap.operational_ai_monitoring.availability_runtime_incidents_90d ?? 0}
+                  </p>
+                  {snap.operational_ai_monitoring.operational_subtype_hint_de ? (
+                    <p className="mt-2 text-slate-600">
+                      {snap.operational_ai_monitoring.operational_subtype_hint_de}
+                    </p>
+                  ) : null}
+                </div>
+              ) : null}
               {snap.operational_ai_monitoring.narrative_de ? (
                 <p className="mt-3 text-sm text-slate-700">{snap.operational_ai_monitoring.narrative_de}</p>
               ) : null}

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -375,12 +375,30 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                         data-testid={`advisor-oami-cell-${t.tenant_id}`}
                       >
                         {t.operational_monitoring_summary?.level != null ? (
-                          <span title={PORTFOLIO_COL_OAMI_TOOLTIP}>
+                          <span
+                            title={[
+                              PORTFOLIO_COL_OAMI_TOOLTIP,
+                              t.operational_monitoring_summary.oami_operational_hint_de,
+                              (t.operational_monitoring_summary.safety_related_runtime_incidents_90d ??
+                                0) > 0
+                                ? `Sicherheitsrelevante Laufzeit-Incidents (90 Tage): ${t.operational_monitoring_summary.safety_related_runtime_incidents_90d}`
+                                : "",
+                            ]
+                              .filter(Boolean)
+                              .join(" ")}
+                          >
                             {t.operational_monitoring_summary.index ?? "–"}
                             <span className="text-[var(--sbs-text-muted)]">
                               {" "}
                               · {indexLevelLabelDe(t.operational_monitoring_summary.level)}
                             </span>
+                            {(t.operational_monitoring_summary.safety_related_runtime_incidents_90d ??
+                              0) > 0 ? (
+                              <span className="mt-0.5 block text-[0.6rem] leading-tight text-rose-800">
+                                Sicherheit:{" "}
+                                {t.operational_monitoring_summary.safety_related_runtime_incidents_90d}
+                              </span>
+                            ) : null}
                           </span>
                         ) : (
                           <span className="text-[var(--sbs-text-muted)]">–</span>

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -288,18 +288,42 @@ export function BoardReadinessCard({
                   ) : null}
                   {explainResult.operational_monitoring_explanation &&
                   (explainResult.operational_monitoring_explanation.improvement_suggestions.length > 0 ||
-                    explainResult.operational_monitoring_explanation.monitoring_gaps.length > 0) ? (
+                    explainResult.operational_monitoring_explanation.monitoring_gaps.length > 0 ||
+                    (explainResult.operational_monitoring_explanation.safety_related_incidents_90d ??
+                      0) > 0 ||
+                    explainResult.operational_monitoring_explanation.oami_subtype_hint_de) ? (
                     <div className="border-t border-slate-100 pt-2">
                       <p className="text-[0.65rem] font-semibold text-slate-600">{OAMI_FULL_NAME}</p>
-                      <ul className="mt-1 list-inside list-disc text-xs text-slate-600">
-                        {(
-                          explainResult.operational_monitoring_explanation.improvement_suggestions.length
-                            ? explainResult.operational_monitoring_explanation.improvement_suggestions
-                            : explainResult.operational_monitoring_explanation.monitoring_gaps
-                        ).map((line, i) => (
-                          <li key={i}>{line}</li>
-                        ))}
-                      </ul>
+                      {explainResult.operational_monitoring_explanation.oami_subtype_hint_de ? (
+                        <p
+                          className="mt-1 text-xs leading-snug text-slate-600"
+                          title="Sicherheitsnahe Laufzeit-Subtypen wirken stärker als reine Verfügbarkeit — ohne einzelne Gewichte."
+                        >
+                          {explainResult.operational_monitoring_explanation.oami_subtype_hint_de}
+                        </p>
+                      ) : null}
+                      {(explainResult.operational_monitoring_explanation.safety_related_incidents_90d ??
+                        0) > 0 ? (
+                        <p className="mt-1 text-[0.65rem] text-slate-500">
+                          Davon{" "}
+                          <span className="font-semibold text-slate-700">
+                            {explainResult.operational_monitoring_explanation.safety_related_incidents_90d}
+                          </span>{" "}
+                          sicherheitsrelevant (Laufzeit-Subtype).
+                        </p>
+                      ) : null}
+                      {explainResult.operational_monitoring_explanation.improvement_suggestions.length > 0 ||
+                      explainResult.operational_monitoring_explanation.monitoring_gaps.length > 0 ? (
+                        <ul className="mt-1 list-inside list-disc text-xs text-slate-600">
+                          {(
+                            explainResult.operational_monitoring_explanation.improvement_suggestions.length
+                              ? explainResult.operational_monitoring_explanation.improvement_suggestions
+                              : explainResult.operational_monitoring_explanation.monitoring_gaps
+                          ).map((line, i) => (
+                            <li key={i}>{line}</li>
+                          ))}
+                        </ul>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1390,6 +1390,12 @@ export interface OperationalMonitoringExplanationStructuredDto {
   recent_incidents_summary: string;
   monitoring_gaps: string[];
   improvement_suggestions: string[];
+  /** Server: Subtype safety_violation im 90-Tage-Fenster (Laufzeit-Incidents). */
+  safety_related_incidents_90d?: number | null;
+  /** Server: Subtype availability_incident. */
+  availability_incidents_90d?: number | null;
+  /** Server: Kurz-Hinweis ohne numerische Gewichte. */
+  oami_subtype_hint_de?: string | null;
 }
 
 export interface ReadinessScoreExplainResponseDto {
@@ -1460,6 +1466,9 @@ export interface AdvisorPortfolioTenantEntry {
   operational_monitoring_summary?: {
     index: number | null;
     level: string | null;
+    safety_related_runtime_incidents_90d?: number;
+    availability_runtime_incidents_90d?: number;
+    oami_operational_hint_de?: string | null;
   } | null;
   governance_maturity_advisor_brief?: AdvisorGovernanceMaturityBriefDto | null;
   advisor_priority?: "high" | "medium" | "low";
@@ -1575,6 +1584,9 @@ export interface AdvisorClientGovernanceSnapshotDto {
     systems_scored: number;
     narrative_de: string;
     drivers_de: string[];
+    safety_related_runtime_incidents_90d?: number;
+    availability_runtime_incidents_90d?: number;
+    operational_subtype_hint_de?: string | null;
   } | null;
   governance_maturity_advisor_brief?: AdvisorGovernanceMaturityBriefDto | null;
 }

--- a/frontend/src/lib/governanceMaturityDeCopy.ts
+++ b/frontend/src/lib/governanceMaturityDeCopy.ts
@@ -97,7 +97,7 @@ export const PORTFOLIO_COL_GAI_TOOLTIP = `${GAI_TOOLTIP_C_LEVEL} ${GAI_REG_HINT_
 /** Portfolio: OAMI-Spalte (Kurzform). */
 export const PORTFOLIO_COL_OAMI_SHORT = "Operatives Monitoring";
 
-export const PORTFOLIO_COL_OAMI_TOOLTIP = `${OAMI_TOOLTIP_C_LEVEL} ${OAMI_REG_HINT_SHORT}`;
+export const PORTFOLIO_COL_OAMI_TOOLTIP = `${OAMI_TOOLTIP_C_LEVEL} Sicherheitsnahe Laufzeit-Subtypen zählen im Index stärker als reine Verfügbarkeit (ohne angezeigte Gewichte). ${OAMI_REG_HINT_SHORT}`;
 
 export const PORTFOLIO_COL_EU_AI_ACT = "EU AI Act (Register)";
 

--- a/tests/fixtures/governance_maturity_mapping_snapshot.json
+++ b/tests/fixtures/governance_maturity_mapping_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2",
+  "contract_version": "3",
   "readiness_api_levels": ["basic", "managed", "embedded"],
   "readiness_level_de": {
     "basic": "Basis",

--- a/tests/fixtures/governance_maturity_oami_mapping_snapshot.json
+++ b/tests/fixtures/governance_maturity_oami_mapping_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "contract_version": "2",
+  "contract_version": "3",
   "source": "app.services.operational_monitoring_index._level_from_index",
   "index_api_levels": ["low", "medium", "high"],
   "index_level_de": {

--- a/tests/test_oami_subtype_weighting.py
+++ b/tests/test_oami_subtype_weighting.py
@@ -1,0 +1,181 @@
+"""OAMI Subtype-Gewichtung und erklärende Texte."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.advisor_governance_maturity_brief_models import (
+    AdvisorGovernanceMaturityBrief,
+    merge_recommended_focus_areas_runtime_safety,
+)
+from app.governance_maturity_summary_models import (
+    GovernanceMaturityActivitySlice,
+    GovernanceMaturityOperationalMonitoringSlice,
+    GovernanceMaturityOverallAssessment,
+    GovernanceMaturityReadinessSlice,
+    GovernanceMaturitySummary,
+)
+from app.operational_monitoring_models import OamiComponentsOut, SystemMonitoringIndexOut
+from app.services.oami_explanation import explain_system_oami_de, oami_operational_hint_de
+from app.services.operational_monitoring_index import _components_from_agg
+
+
+def _minimal_summary() -> GovernanceMaturitySummary:
+    oa = GovernanceMaturityOverallAssessment(
+        level="medium",
+        short_summary="x",
+        key_risks=[],
+        key_strengths=[],
+    )
+    return GovernanceMaturitySummary(
+        readiness=GovernanceMaturityReadinessSlice(score=50, level="managed", short_reason="r"),
+        activity=GovernanceMaturityActivitySlice(index=50, level="medium", short_reason="a"),
+        operational_monitoring=GovernanceMaturityOperationalMonitoringSlice(
+            index=50,
+            level="medium",
+            short_reason="o",
+        ),
+        overall_assessment=oa,
+    )
+
+
+def test_oami_weighted_incidents_safety_lowers_score_vs_availability() -> None:
+    now = datetime.now(UTC)
+    wd = 90
+    avail_sum = 3 * 1.0 * 0.065
+    safe_sum = 3 * 1.5 * 0.065
+    agg_a = {
+        "event_count": 20,
+        "last_occurred_at": now,
+        "distinct_days": 10,
+        "incident_high": 0,
+        "breach_count": 0,
+        "incident_count": 3,
+        "incident_count_by_subtype": {"availability_incident": 3},
+        "metric_breach_count_by_subtype": {},
+        "incident_weighted_penalty_sum": avail_sum,
+        "weighted_breach_units": 0.0,
+    }
+    agg_s = {
+        **agg_a,
+        "incident_count_by_subtype": {"safety_violation": 3},
+        "incident_weighted_penalty_sum": safe_sum,
+    }
+    _, score_a, _ = _components_from_agg(agg_a, now=now, window_days=wd)
+    _, score_s, _ = _components_from_agg(agg_s, now=now, window_days=wd)
+    assert score_a > score_s
+
+
+def test_oami_weighted_metric_breach_drift_hurts_more_than_performance() -> None:
+    now = datetime.now(UTC)
+    wd = 90
+    scale = max(3.0, (wd / 30.0) * 5.0)
+    perf_units = 3 * 1.0
+    drift_units = 3 * 1.2
+    agg_p = {
+        "event_count": 15,
+        "last_occurred_at": now,
+        "distinct_days": 8,
+        "incident_high": 0,
+        "breach_count": 3,
+        "incident_count": 0,
+        "incident_count_by_subtype": {},
+        "metric_breach_count_by_subtype": {"performance_degradation": 3},
+        "incident_weighted_penalty_sum": 0.0,
+        "weighted_breach_units": perf_units,
+    }
+    agg_d = {
+        **agg_p,
+        "metric_breach_count_by_subtype": {"drift_high": 3},
+        "weighted_breach_units": drift_units,
+    }
+    _, score_p, _ = _components_from_agg(agg_p, now=now, window_days=wd)
+    _, score_d, _ = _components_from_agg(agg_d, now=now, window_days=wd)
+    assert score_p > score_d
+    assert drift_units / scale > perf_units / scale
+
+
+def test_explain_system_mentions_multiple_safety_subtypes() -> None:
+    idx = SystemMonitoringIndexOut(
+        ai_system_id="s1",
+        tenant_id="t1",
+        window_days=90,
+        operational_monitoring_index=55,
+        level="medium",
+        has_data=True,
+        last_event_at=datetime.now(UTC),
+        incident_count=2,
+        high_severity_incident_count=0,
+        incident_count_by_subtype={"safety_violation": 2},
+        metric_breach_count_by_subtype={},
+        safety_related_incident_count=2,
+        oami_operational_hint_de=None,
+        metric_threshold_breach_count=0,
+        distinct_active_days=5,
+        components=OamiComponentsOut(
+            freshness=0.8,
+            activity_days=0.5,
+            incident_stability=0.5,
+            metric_stability=0.9,
+        ),
+    )
+    out = explain_system_oami_de(idx)
+    joined = " ".join(out.drivers_de)
+    assert "Mehrere sicherheitsrelevante" in joined
+    assert "safety_violation" in joined
+
+
+def test_explain_system_mentions_drift_subtypes_when_repeated() -> None:
+    idx = SystemMonitoringIndexOut(
+        ai_system_id="s1",
+        tenant_id="t1",
+        window_days=90,
+        operational_monitoring_index=50,
+        level="medium",
+        has_data=True,
+        last_event_at=datetime.now(UTC),
+        incident_count=0,
+        high_severity_incident_count=0,
+        incident_count_by_subtype={},
+        metric_breach_count_by_subtype={"drift_high": 2},
+        safety_related_incident_count=0,
+        oami_operational_hint_de=None,
+        metric_threshold_breach_count=2,
+        distinct_active_days=5,
+        components=OamiComponentsOut(
+            freshness=0.8,
+            activity_days=0.5,
+            incident_stability=0.9,
+            metric_stability=0.4,
+        ),
+    )
+    out = explain_system_oami_de(idx)
+    assert any("drift_high" in d.lower() for d in out.drivers_de)
+
+
+def test_oami_operational_hint_safety_thresholds() -> None:
+    assert oami_operational_hint_de(safety_incidents=0, availability_incidents=0) is None
+    assert oami_operational_hint_de(safety_incidents=1, availability_incidents=0) is not None
+    h2 = oami_operational_hint_de(safety_incidents=2, availability_incidents=0)
+    assert h2 is not None
+    assert "Mehrere" in h2
+
+
+def test_merge_advisor_brief_adds_runtime_safety_focus() -> None:
+    brief = AdvisorGovernanceMaturityBrief(
+        governance_maturity_summary=_minimal_summary(),
+        recommended_focus_areas=["Anderes Thema"],
+    )
+    merged = merge_recommended_focus_areas_runtime_safety(brief, 1)
+    assert merged is not None
+    assert len(merged.recommended_focus_areas) >= 2
+    assert "Sicherheitsrelevante AI-Laufzeitvorfälle" in merged.recommended_focus_areas[0]
+
+
+def test_merge_advisor_brief_idempotent_when_already_safety_focus() -> None:
+    brief = AdvisorGovernanceMaturityBrief(
+        governance_maturity_summary=_minimal_summary(),
+        recommended_focus_areas=["Sicherheitsrelevante Registerpflege"],
+    )
+    merged = merge_recommended_focus_areas_runtime_safety(brief, 2)
+    assert merged.recommended_focus_areas == brief.recommended_focus_areas

--- a/tests/test_readiness_explain_structured.py
+++ b/tests/test_readiness_explain_structured.py
@@ -181,3 +181,45 @@ def test_oami_struct_coerced_when_context_present() -> None:
     )
     assert out.operational_monitoring_explanation is not None
     assert out.operational_monitoring_explanation.level == "medium"
+
+
+def test_readiness_explain_oami_server_enrichment_merged() -> None:
+    snap = _snapshot()
+    llm = """
+    {
+      "readiness_explanation": {
+        "score": 55,
+        "level": "managed",
+        "short_reason": "ok",
+        "drivers_positive": [],
+        "drivers_negative": [],
+        "regulatory_focus": ""
+      },
+      "operational_monitoring_explanation": {
+        "index": 50,
+        "level": "medium",
+        "recent_incidents_summary": "",
+        "monitoring_gaps": [],
+        "improvement_suggestions": []
+      }
+    }
+    """
+    out = build_readiness_explain_response_from_llm_text(
+        llm,
+        snapshot=snap,
+        oami_index=50,
+        oami_level="medium",
+        has_oami_context=True,
+        provider="x",
+        model_id="y",
+        oami_operational_enrichment={
+            "safety_related_incidents_90d": 2,
+            "availability_incidents_90d": 1,
+            "oami_subtype_hint_de": "Sicherheitsnahe Signale wiegen stärker.",
+        },
+    )
+    assert out.operational_monitoring_explanation is not None
+    om = out.operational_monitoring_explanation
+    assert om.safety_related_incidents_90d == 2
+    assert om.availability_incidents_90d == 1
+    assert om.oami_subtype_hint_de == "Sicherheitsnahe Signale wiegen stärker."


### PR DESCRIPTION
- Add oami_subtype_weights; aggregate weighted incident penalty and breach units.
- Extend OAMI models, governance maturity block, portfolio and snapshot payloads.
- Contract v3 + LLM subtype context; readiness explain server enrichment.
- Advisor focus merge for safety runtime incidents; UI tooltips and subtype panels.
- Docs + tests for scoring, explanations, and structured explain merge.

Made-with: Cursor