### PR TITLE
feat(board): OAMI incident-subtype profile in governance report

### DIFF
--- a/app/ai_compliance_board_report_models.py
+++ b/app/ai_compliance_board_report_models.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from app.ai_governance_models import OamiIncidentSubtypeProfile
 from app.governance_maturity_summary_models import GovernanceMaturitySummary
 
 
@@ -109,6 +110,12 @@ class AiComplianceBoardReportInput(BaseModel):
     governance_maturity_executive_paragraph_de: str | None = Field(
         default=None,
         description="Fixer Executive-Overview-Absatz zur Governance-Reife (wörtlich übernehmen).",
+    )
+    oami_subtype_profile: OamiIncidentSubtypeProfile | None = Field(
+        default=None,
+        description=(
+            "Optional: gewichtete OAMI-Incident-Subtypen (Board-Markdown-Parität, LLM-Kontext)."
+        ),
     )
 
 

--- a/app/ai_governance_models.py
+++ b/app/ai_governance_models.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.compliance_gap_models import AIComplianceOverview
 from app.incident_models import AIIncidentOverview
@@ -151,6 +151,59 @@ class AIKpiAlertExport(BaseModel):
     alerts: list[AIKpiAlert]
 
 
+OAMI_SUBTYPE_CHART_NOTE_DE = (
+    "Relative Darstellung; sicherheitsrelevante Incidents sind im OAMI "
+    "stärker gewichtet als rein verfügbarkeitsbezogene."
+)
+
+
+class OamiIncidentCategoryCounts(BaseModel):
+    """Rohzähler je Subtyp-Kategorie (nur Laufzeit-Incidents, 90-Tage-Fenster)."""
+
+    safety: int = Field(ge=0)
+    availability: int = Field(ge=0)
+    other: int = Field(ge=0)
+
+
+class OamiIncidentSubtypeProfile(BaseModel):
+    """Gewichtete Subtype-Einordnung für Board-Markdown, LLM-Input und spätere PDF/Charts."""
+
+    incident_weighted_share_safety: float = Field(ge=0.0, le=1.0)
+    incident_weighted_share_availability: float = Field(ge=0.0, le=1.0)
+    incident_weighted_share_other: float = Field(ge=0.0, le=1.0)
+    incident_count_by_category: OamiIncidentCategoryCounts
+    oami_subtype_narrative_de: str = Field(default="", max_length=280)
+    chart_note_de: str = Field(default=OAMI_SUBTYPE_CHART_NOTE_DE, max_length=400)
+    category_labels_de: dict[str, str] = Field(
+        default_factory=lambda: {
+            "safety": "Sicherheit",
+            "availability": "Verfügbarkeit",
+            "other": "Sonstige",
+        },
+    )
+
+    @model_validator(mode="after")
+    def _normalize_shares(self) -> OamiIncidentSubtypeProfile:
+        s = (
+            self.incident_weighted_share_safety
+            + self.incident_weighted_share_availability
+            + self.incident_weighted_share_other
+        )
+        if s <= 0:
+            return self
+        if abs(s - 1.0) > 0.02:
+            return self.model_copy(
+                update={
+                    "incident_weighted_share_safety": self.incident_weighted_share_safety / s,
+                    "incident_weighted_share_availability": (
+                        self.incident_weighted_share_availability / s
+                    ),
+                    "incident_weighted_share_other": self.incident_weighted_share_other / s,
+                },
+            )
+        return self
+
+
 class BoardOperationalMonitoringSection(BaseModel):
     """OAMI-Zusammenfassung für Board (90-Tage-Fenster, mandantenweit)."""
 
@@ -161,6 +214,10 @@ class BoardOperationalMonitoringSection(BaseModel):
     systems_scored: int = Field(ge=0)
     summary_de: str = ""
     drivers_de: list[str] = Field(default_factory=list, max_length=12)
+    oami_incident_subtype_profile: OamiIncidentSubtypeProfile | None = Field(
+        default=None,
+        description="Optional: gewichtete Incident-Subtypen für Board-Text und Export-Charts.",
+    )
 
 
 class AIBoardGovernanceReport(BaseModel):

--- a/app/main.py
+++ b/app/main.py
@@ -317,6 +317,9 @@ from app.services.nis2_kritis_alert_signals import build_nis2_kritis_alert_signa
 from app.services.nis2_kritis_drilldown import build_nis2_kritis_kpi_drilldown
 from app.services.nis2_kritis_kpis import recommended_kpis_for_ai_system
 from app.services.oami_explanation import explain_tenant_oami_de
+from app.services.oami_incident_subtype_profile_board import (
+    build_oami_incident_subtype_profile_for_board,
+)
 from app.services.operational_monitoring_index import (
     compute_system_monitoring_index,
     compute_tenant_operational_monitoring_index,
@@ -1992,6 +1995,7 @@ def _build_board_report(
             persist_snapshot=False,
         )
         ex = explain_tenant_oami_de(to)
+        subtype_prof = build_oami_incident_subtype_profile_for_board(to)
         operational_monitoring = BoardOperationalMonitoringSection(
             index_value=to.operational_monitoring_index,
             level=str(to.level),
@@ -2000,6 +2004,7 @@ def _build_board_report(
             systems_scored=to.systems_scored,
             summary_de=ex.summary_de,
             drivers_de=list(ex.drivers_de)[:8],
+            oami_incident_subtype_profile=subtype_prof,
         )
     except Exception:
         logger.exception("board_report_operational_monitoring_failed tenant_id=%s", tenant_id)

--- a/app/services/ai_compliance_board_report_input.py
+++ b/app/services/ai_compliance_board_report_input.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 from sqlalchemy.orm import Session
@@ -17,6 +18,12 @@ from app.repositories.ai_systems import AISystemRepository
 from app.services.ai_kpi_service import build_board_report_kpi_briefs
 from app.services.cross_regulation import build_cross_regulation_summary
 from app.services.cross_regulation_gaps import compute_cross_regulation_gaps
+from app.services.oami_incident_subtype_profile_board import (
+    build_oami_incident_subtype_profile_for_board,
+)
+from app.services.operational_monitoring_index import compute_tenant_operational_monitoring_index
+
+logger = logging.getLogger(__name__)
 
 _CRIT_ORDER = {"high": 0, "medium": 1, "low": 2}
 _FW_RISK = {
@@ -144,6 +151,23 @@ def assemble_ai_compliance_board_report_input(
     else:
         hr_kpis, port_kpis = [], []
 
+    oami_subtype_profile = None
+    try:
+        toami = compute_tenant_operational_monitoring_index(
+            session,
+            tenant_id,
+            window_days=90,
+            persist_snapshot=False,
+        )
+        oami_subtype_profile = build_oami_incident_subtype_profile_for_board(toami)
+    except Exception as exc:
+        logger.warning(
+            "board_report_input_oami_subtype_skipped tenant_id=%s err=%s",
+            tenant_id,
+            type(exc).__name__,
+        )
+        oami_subtype_profile = None
+
     return AiComplianceBoardReportInput(
         tenant_id=tenant_id,
         audience_type=audience_type,
@@ -155,4 +179,5 @@ def assemble_ai_compliance_board_report_input(
         trend_note="Keine historische Trendzeitreihe in dieser Version hinterlegt.",
         high_risk_kpi_summaries=hr_kpis,
         kpi_portfolio_aggregates=port_kpis,
+        oami_subtype_profile=oami_subtype_profile,
     )

--- a/app/services/ai_compliance_board_report_llm.py
+++ b/app/services/ai_compliance_board_report_llm.py
@@ -48,6 +48,23 @@ def build_board_report_user_prompt(inp: AiComplianceBoardReportInput) -> str:
             "Optional **ein** weiterer kurzer Absatz (höchstens 3 Sätze) zur Einordnung der "
             "übrigen Report-Daten — ohne die Governance-Kernaussage zu wiederholen.\n"
         )
+    oami_subtype = ""
+    if inp.oami_subtype_profile is not None:
+        oami_subtype = (
+            "\n**OAMI Incident-Subtypen:** Das JSON enthält `oami_subtype_profile` "
+            "(normierte Anteile Sicherheit/Verfügbarkeit/Sonstige, Kurznarrativ deutsch). "
+            "Unter „## Status & Kennzahlen“ optional einen Unterpunkt "
+            "**Operatives AI-Monitoring – Incident-Subtypen** mit 2–3 knappen Bullets "
+            "(C-Level, keine Rohgewichte, keine Melde- oder Rechtsqualifikation). "
+            "Wenn `oami_subtype_profile` null ist, diesen Unterpunkt weglassen.\n"
+            "Referenz-Töne (nur Stil, nicht wörtlich wiederholen, falls nicht passend):\n"
+            "- Sicherheitsfokus: Post-Market/Eskalation für Sicherheitssignale priorisieren.\n"
+            "- Verfügbarkeit: Betriebsstabilität, Service-Recovery, "
+            "Abgrenzung zu Safety-Vorfällen.\n"
+            "- Niedrig/benign: wenige unspezifische Incidents; "
+            "Datenaktualität und Überwachung stärken.\n"
+        )
+
     status_gov = ""
     if inp.governance_maturity_summary is not None:
         status_gov = (
@@ -73,6 +90,7 @@ def build_board_report_user_prompt(inp: AiComplianceBoardReportInput) -> str:
         "(EU AI Act, NIS2, ISO 42001/27001, DSGVO etc.).\n"
         "## Status & Kennzahlen\n"
         "Coverage-Übersicht pro Framework, relevante KI-Inventar-Kennzahlen aus dem JSON.\n"
+        f"{oami_subtype}"
         f"{status_gov}"
         "## AI Performance & Risk KPIs\n"
         "Nutze high_risk_kpi_summaries und kpi_portfolio_aggregates aus dem JSON (falls leer: "

--- a/app/services/board_report_markdown.py
+++ b/app/services/board_report_markdown.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from app.ai_governance_models import AIBoardGovernanceReport
+from app.ai_governance_models import (
+    AIBoardGovernanceReport,
+    BoardOperationalMonitoringSection,
+    OamiIncidentSubtypeProfile,
+)
 
 
 def _fmt_pct(value: float) -> str:
@@ -13,6 +17,68 @@ def _fmt_pct(value: float) -> str:
 
 def _fmt_date(dt: datetime) -> str:
     return dt.strftime("%d.%m.%Y")
+
+
+_BULLET_SAFETY_SUBTYPE_DE = (
+    "Im Berichtszeitraum überwiegen bzw. sind anteilig stark sicherheitsrelevante "
+    "Laufzeit-Incidents (z. B. sicherheitsbezogene Vorfälle im KI-Betrieb). "
+    "Diese fließen im OAMI stärker in die Bewertung ein als reine Verfügbarkeitssignale."
+)
+
+_BULLET_AVAILABILITY_SUBTYPE_DE = (
+    "Verfügbarkeits- und leistungsbezogene Signale (Betriebsstabilität, Metrik-Schwellen) "
+    "machen den größeren Teil der sichtbaren Last aus bzw. dominieren das Laufzeitbild."
+)
+
+_BULLET_BALANCED_SUBTYPE_DE = (
+    "Die sichtbare Incident-Last verteilt sich über mehrere Subtyp-Kategorien; es liegt "
+    "keine einseitige Dominanz von Sicherheits- gegenüber Verfügbarkeitssignalen vor."
+)
+
+
+def _append_oami_subtype_markdown_block(
+    lines: list[str],
+    om: BoardOperationalMonitoringSection,
+    profile: OamiIncidentSubtypeProfile,
+) -> None:
+    sh = profile.incident_weighted_share_safety
+    av = profile.incident_weighted_share_availability
+    ot = profile.incident_weighted_share_other
+    safety_dom = sh >= 0.45 and sh > av and sh > ot
+    avail_dom = av >= 0.45 and av > sh and av > ot
+
+    lines.append("")
+    lines.append("### Operatives AI-Monitoring – Incident-Subtypen")
+    lines.append("")
+    lines.append(
+        "Einordnung der Laufzeit-Incidents für den OAMI – ohne Melde- oder Rechtsqualifikation.",
+    )
+    lines.append("")
+    if safety_dom:
+        lines.append(f"- {_BULLET_SAFETY_SUBTYPE_DE}")
+    elif avail_dom:
+        lines.append(f"- {_BULLET_AVAILABILITY_SUBTYPE_DE}")
+    else:
+        lines.append(f"- {_BULLET_BALANCED_SUBTYPE_DE}")
+
+    if (profile.oami_subtype_narrative_de or "").strip():
+        lines.append(f"- {profile.oami_subtype_narrative_de.strip()}")
+
+    ps = round(sh * 100)
+    pa = round(av * 100)
+    po = round(ot * 100)
+    lbl = profile.category_labels_de
+    lines.append(
+        f"- Verteilung (gewichteter Fokus, normiert): "
+        f"{lbl.get('safety', 'Sicherheit')} ca. {ps} %, "
+        f"{lbl.get('availability', 'Verfügbarkeit')} ca. {pa} %, "
+        f"{lbl.get('other', 'Sonstige')} ca. {po} %.",
+    )
+    lines.append("")
+    lines.append("<!-- chart:oami-subtype-shares -->")
+    lines.append("")
+    lines.append(f"*Hinweis Diagramm (Export):* {profile.chart_note_de}")
+    lines.append("")
 
 
 def render_board_report_markdown(report: AIBoardGovernanceReport) -> str:
@@ -87,6 +153,9 @@ def render_board_report_markdown(report: AIBoardGovernanceReport) -> str:
         lines.append(f"  - Kurzfassung: {om.summary_de}")
         for d in om.drivers_de[:5]:
             lines.append(f"  - Treiber: {d}")
+        prof = om.oami_incident_subtype_profile
+        if prof is not None:
+            _append_oami_subtype_markdown_block(lines, om, prof)
     lines.extend(["", "---", "", "## 2. KPIs", ""])
 
     # KPIs als Tabelle

--- a/app/services/oami_incident_subtype_profile_board.py
+++ b/app/services/oami_incident_subtype_profile_board.py
@@ -1,0 +1,143 @@
+"""OAMI Incident-Subtype-Profil für Board-Report (Logik; Modelle: ``ai_governance_models``)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Literal
+
+from app.ai_governance_models import (
+    OAMI_SUBTYPE_CHART_NOTE_DE,
+    OamiIncidentCategoryCounts,
+    OamiIncidentSubtypeProfile,
+)
+from app.governance_maturity_contract import INDEX_LEVEL_DE
+from app.oami_subtype_weights import incident_subtype_oami_weight
+from app.operational_monitoring_models import TenantOperationalMonitoringIndexOut
+
+logger = logging.getLogger(__name__)
+
+
+def _incident_subtype_category(subtype: str) -> Literal["safety", "availability", "other"]:
+    k = subtype.strip().lower()
+    if k in ("safety_violation", "bias_discrimination_incident"):
+        return "safety"
+    if k == "availability_incident":
+        return "availability"
+    return "other"
+
+
+def _trim_board_sentence(text: str, *, max_len: int = 240) -> str:
+    t = text.strip()
+    if len(t) <= max_len:
+        return t
+    cut = t[: max_len - 1]
+    if " " in cut:
+        cut = cut.rsplit(" ", 1)[0]
+    return cut + "…"
+
+
+def _narrative_for_profile(
+    *,
+    level_api: str,
+    index: int,
+    safety_driven: bool,
+    availability_driven: bool,
+    incidents_positive: bool,
+) -> str:
+    level_de = INDEX_LEVEL_DE.get(level_api, level_api)
+    if safety_driven:
+        base = (
+            f"Der OAMI liegt auf Stufe {level_de} (Index {index}/100); maßgeblich sind "
+            "wenige, aber sicherheitsrelevante Laufzeit-Incidents – das Board sollte "
+            "Post-Market- und Eskalationspfade für Sicherheitssignale priorisieren, "
+            "nicht nur Verfügbarkeit."
+        )
+    elif availability_driven:
+        base = (
+            f"Der OAMI steht auf Stufe {level_de} (Index {index}/100); das Laufzeitbild wird "
+            "überwiegend von Verfügbarkeits-Incidents getragen – Fokus auf Betriebsstabilität, "
+            "Service-Recovery und klare Abgrenzung zu sicherheitsklassifizierten Vorfällen."
+        )
+    elif str(level_api) == "low" and incidents_positive:
+        base = (
+            f"Der OAMI ist auf Stufe {level_de} (Index {index}/100); sichtbare Incidents sind "
+            "selten und überwiegend unspezifisch – dennoch sollten Datenaktualität und "
+            "kontinuierliche Überwachung verbessert werden, damit das Bild belastbar bleibt."
+        )
+    else:
+        base = (
+            f"Der OAMI steht auf Stufe {level_de} (Index {index}/100); die gewichtete "
+            "Incident-Last verteilt sich ausgewogen zwischen Sicherheits-, Verfügbarkeits- "
+            "und sonstigen Signalen ohne einseitige Dominanz einer Subtyp-Kategorie."
+        )
+    return _trim_board_sentence(base)
+
+
+def build_oami_incident_subtype_profile_for_board(
+    tenant_oami: TenantOperationalMonitoringIndexOut,
+) -> OamiIncidentSubtypeProfile | None:
+    """
+    Liefert Profil nur wenn Mandant Laufzeitdaten hat und Subtype-Kontext sinnvoll ist.
+    """
+    if not tenant_oami.has_any_runtime_data:
+        return None
+
+    by_sub = dict(tenant_oami.runtime_incident_by_subtype)
+    inc_total = sum(int(v) for v in by_sub.values() if int(v) > 0)
+    hint = (tenant_oami.oami_operational_hint_de or "").strip()
+
+    if inc_total <= 0 and not hint:
+        return None
+
+    burden = {"safety": 0.0, "availability": 0.0, "other": 0.0}
+    counts = {"safety": 0, "availability": 0, "other": 0}
+
+    if inc_total > 0:
+        for raw_k, raw_v in by_sub.items():
+            try:
+                n = int(raw_v)
+            except (TypeError, ValueError):
+                continue
+            if n <= 0:
+                continue
+            ks = str(raw_k).strip().lower()
+            cat = _incident_subtype_category(ks)
+            w = incident_subtype_oami_weight(ks)
+            burden[cat] += float(n) * w
+            counts[cat] += n
+    else:
+        for k in burden:
+            burden[k] = 1.0 / 3.0
+
+    total_burden = sum(burden.values())
+    if total_burden <= 0:
+        logger.debug("oami_subtype_profile_zero_burden tenant=%s", tenant_oami.tenant_id)
+        return None
+
+    sh = burden["safety"] / total_burden
+    av = burden["availability"] / total_burden
+    ot = burden["other"] / total_burden
+
+    safety_driven = sh >= 0.45 and sh > av and sh > ot
+    availability_driven = av >= 0.45 and av > sh and av > ot
+
+    narrative = _narrative_for_profile(
+        level_api=str(tenant_oami.level),
+        index=int(tenant_oami.operational_monitoring_index),
+        safety_driven=safety_driven,
+        availability_driven=availability_driven,
+        incidents_positive=inc_total > 0,
+    )
+
+    return OamiIncidentSubtypeProfile(
+        incident_weighted_share_safety=sh,
+        incident_weighted_share_availability=av,
+        incident_weighted_share_other=ot,
+        incident_count_by_category=OamiIncidentCategoryCounts(
+            safety=counts["safety"],
+            availability=counts["availability"],
+            other=counts["other"],
+        ),
+        oami_subtype_narrative_de=narrative,
+        chart_note_de=OAMI_SUBTYPE_CHART_NOTE_DE,
+    )

--- a/docs/governance-operational-ai-monitoring.md
+++ b/docs/governance-operational-ai-monitoring.md
@@ -372,6 +372,7 @@ Mindestumfang (ohne Payload-Inhalte, DSGVO-minimiert):
 | OAMI & Erklärungen | `app/services/operational_monitoring_index.py`, `app/services/oami_explanation.py` |
 | Governance Maturity | `app/services/governance_maturity_service.py`, `GET .../governance-maturity` |
 | Board / Advisor | `app/main.py` (Board-Report), `app/services/board_report_markdown.py`, `app/services/advisor_client_governance_snapshot.py` |
+| OAMI Subtype-Profil (Board) | `app/services/oami_incident_subtype_profile_board.py`, `app/ai_governance_models.py` → `OamiIncidentSubtypeProfile`; optionaler Markdown-Block „Incident-Subtypen“ + Feld `oami_subtype_profile` im AI-Compliance-Board-Report-LLM-Input |
 | Demo-Sperre Ingest | `app/services/runtime_events_demo_guard.py` |
 | Workspace-Telemetrie (getrennt) | `app/services/workspace_telemetry.py` |
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -516,6 +516,33 @@ export function fetchBoardAlertsExport(format?: "json" | "csv"): string {
   return `/api/board/alerts/export?format=${format ?? "json"}`;
 }
 
+/** Gewichtete OAMI-Incident-Subtypen (Board-Markdown / spätere Charts). */
+export interface OamiIncidentSubtypeProfileDto {
+  incident_weighted_share_safety: number;
+  incident_weighted_share_availability: number;
+  incident_weighted_share_other: number;
+  incident_count_by_category: {
+    safety: number;
+    availability: number;
+    other: number;
+  };
+  oami_subtype_narrative_de: string;
+  chart_note_de: string;
+  category_labels_de: Record<string, string>;
+}
+
+/** OAMI-Abschnitt im Board-Governance-Report (90-Tage-Laufzeitfenster). */
+export interface BoardOperationalMonitoringSectionDto {
+  index_value: number;
+  level: string;
+  window_days: number;
+  has_data: boolean;
+  systems_scored: number;
+  summary_de: string;
+  drivers_de: string[];
+  oami_incident_subtype_profile?: OamiIncidentSubtypeProfileDto | null;
+}
+
 /** Vorstands-/Aufsichtsreport: alle AI-Governance-Kennzahlen gebündelt. */
 export interface AIBoardGovernanceReport {
   tenant_id: string;
@@ -526,6 +553,7 @@ export interface AIBoardGovernanceReport {
   incidents_overview: AIIncidentOverview;
   supplier_risk_overview: AISupplierRiskOverview;
   alerts: AIKpiAlert[];
+  operational_monitoring?: BoardOperationalMonitoringSectionDto | null;
 }
 
 export async function fetchBoardGovernanceReport(): Promise<AIBoardGovernanceReport> {

--- a/tests/test_ai_board_report_markdown_oami_subtype.py
+++ b/tests/test_ai_board_report_markdown_oami_subtype.py
@@ -1,0 +1,120 @@
+"""Board-Markdown: optionaler OAMI-Incident-Subtype-Block."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.ai_governance_models import (
+    AIBoardGovernanceReport,
+    AIBoardKpiSummary,
+    BoardOperationalMonitoringSection,
+    OamiIncidentCategoryCounts,
+    OamiIncidentSubtypeProfile,
+)
+from app.compliance_gap_models import AIComplianceOverview
+from app.incident_models import AIIncidentOverview, BySeverityEntry, IncidentSeverity
+from app.services.board_report_markdown import render_board_report_markdown
+from app.supplier_risk_models import AISupplierRiskOverview
+
+
+def _minimal_report(*, om: BoardOperationalMonitoringSection | None) -> AIBoardGovernanceReport:
+    kpis = AIBoardKpiSummary(
+        tenant_id="t1",
+        ai_systems_total=1,
+        active_ai_systems=1,
+        high_risk_systems=0,
+        open_policy_violations=0,
+        board_maturity_score=0.5,
+        compliance_coverage_score=0.5,
+        risk_governance_score=0.5,
+        operational_resilience_score=0.5,
+        responsible_ai_score=0.5,
+        high_risk_systems_without_dpia=0,
+        critical_systems_without_owner=0,
+        nis2_control_gaps=0,
+        nis2_incident_readiness_ratio=0.5,
+        nis2_supplier_risk_coverage_ratio=0.5,
+        iso42001_governance_score=0.5,
+        score_change_vs_last_quarter=0.0,
+        incidents_last_quarter=0,
+        complaints_last_quarter=0,
+    )
+    compliance = AIComplianceOverview(
+        tenant_id="t1",
+        overall_readiness=0.5,
+        high_risk_systems_with_full_controls=0,
+        high_risk_systems_with_critical_gaps=0,
+        top_critical_requirements=[],
+        deadline="2026-08-02",
+        days_remaining=100,
+    )
+    incidents = AIIncidentOverview(
+        tenant_id="t1",
+        total_incidents_last_12_months=0,
+        open_incidents=0,
+        major_incidents_last_12_months=0,
+        by_severity=[BySeverityEntry(severity=IncidentSeverity.low, count=0)],
+    )
+    supplier = AISupplierRiskOverview(
+        tenant_id="t1",
+        total_systems_with_suppliers=0,
+        systems_without_supplier_risk_register=0,
+        critical_suppliers_total=0,
+        critical_suppliers_without_controls=0,
+        by_risk_level=[],
+    )
+    return AIBoardGovernanceReport(
+        tenant_id="t1",
+        generated_at=datetime.now(UTC),
+        period="last_12_months",
+        kpis=kpis,
+        compliance_overview=compliance,
+        incidents_overview=incidents,
+        supplier_risk_overview=supplier,
+        alerts=[],
+        operational_monitoring=om,
+    )
+
+
+def test_markdown_includes_subtype_heading_when_profile_set() -> None:
+    prof = OamiIncidentSubtypeProfile(
+        incident_weighted_share_safety=0.7,
+        incident_weighted_share_availability=0.2,
+        incident_weighted_share_other=0.1,
+        incident_count_by_category=OamiIncidentCategoryCounts(
+            safety=3,
+            availability=1,
+            other=0,
+        ),
+        oami_subtype_narrative_de="Kurztext für den Test.",
+    )
+    om = BoardOperationalMonitoringSection(
+        index_value=65,
+        level="medium",
+        window_days=90,
+        has_data=True,
+        systems_scored=2,
+        summary_de="s",
+        drivers_de=["d1"],
+        oami_incident_subtype_profile=prof,
+    )
+    md = render_board_report_markdown(_minimal_report(om=om))
+    assert "### Operatives AI-Monitoring – Incident-Subtypen" in md
+    assert "chart:oami-subtype-shares" in md
+    assert "Kurztext für den Test." in md
+    assert "gewichteter Fokus" in md
+
+
+def test_markdown_omits_subtype_block_without_profile() -> None:
+    om = BoardOperationalMonitoringSection(
+        index_value=50,
+        level="medium",
+        window_days=90,
+        has_data=True,
+        systems_scored=1,
+        summary_de="s",
+        drivers_de=[],
+        oami_incident_subtype_profile=None,
+    )
+    md = render_board_report_markdown(_minimal_report(om=om))
+    assert "### Operatives AI-Monitoring – Incident-Subtypen" not in md

--- a/tests/test_board_report_kpi_prompt.py
+++ b/tests/test_board_report_kpi_prompt.py
@@ -15,3 +15,28 @@ def test_board_report_user_prompt_includes_ai_performance_kpi_heading() -> None:
     prompt = build_board_report_user_prompt(inp)
     assert "AI Performance & Risk KPIs" in prompt
     assert "high_risk_kpi_summaries" in prompt
+
+
+def test_board_report_user_prompt_includes_oami_subtype_when_profile_set() -> None:
+    from app.ai_governance_models import OamiIncidentCategoryCounts, OamiIncidentSubtypeProfile
+
+    prof = OamiIncidentSubtypeProfile(
+        incident_weighted_share_safety=0.5,
+        incident_weighted_share_availability=0.25,
+        incident_weighted_share_other=0.25,
+        incident_count_by_category=OamiIncidentCategoryCounts(
+            safety=1,
+            availability=1,
+            other=0,
+        ),
+        oami_subtype_narrative_de="Test.",
+    )
+    inp = AiComplianceBoardReportInput(
+        tenant_id="t-1",
+        audience_type="board",
+        language="de",
+        oami_subtype_profile=prof,
+    )
+    prompt = build_board_report_user_prompt(inp)
+    assert "OAMI Incident-Subtypen" in prompt
+    assert "oami_subtype_profile" in prompt

--- a/tests/test_oami_incident_subtype_profile_board.py
+++ b/tests/test_oami_incident_subtype_profile_board.py
@@ -1,0 +1,101 @@
+"""Unit-Tests: OAMI Incident-Subtype-Profil für Board-Report."""
+
+from __future__ import annotations
+
+from app.operational_monitoring_models import TenantOperationalMonitoringIndexOut
+from app.services.oami_incident_subtype_profile_board import (
+    build_oami_incident_subtype_profile_for_board,
+)
+
+
+def _tenant(
+    *,
+    has_data: bool,
+    by_sub: dict[str, int],
+    level: str = "medium",
+    index: int = 60,
+    hint: str | None = None,
+) -> TenantOperationalMonitoringIndexOut:
+    sv = int(by_sub.get("safety_violation", 0))
+    av = int(by_sub.get("availability_incident", 0))
+    return TenantOperationalMonitoringIndexOut(
+        tenant_id="t-test",
+        window_days=90,
+        operational_monitoring_index=index,
+        level=level,  # type: ignore[arg-type]
+        systems_scored=2 if has_data else 0,
+        has_any_runtime_data=has_data,
+        components=None,
+        explanation=None,
+        runtime_incident_by_subtype=dict(by_sub),
+        safety_related_runtime_incident_count=sv,
+        availability_runtime_incident_count=av,
+        oami_operational_hint_de=hint,
+    )
+
+
+def test_profile_none_without_runtime_data() -> None:
+    to = _tenant(has_data=False, by_sub={})
+    assert build_oami_incident_subtype_profile_for_board(to) is None
+
+
+def test_profile_none_without_incidents_or_hint() -> None:
+    to = _tenant(has_data=True, by_sub={})
+    assert build_oami_incident_subtype_profile_for_board(to) is None
+
+
+def test_profile_safety_dominant_shares_and_narrative() -> None:
+    to = _tenant(
+        has_data=True,
+        by_sub={"safety_violation": 3, "availability_incident": 1},
+        level="medium",
+        index=65,
+    )
+    p = build_oami_incident_subtype_profile_for_board(to)
+    assert p is not None
+    assert p.incident_weighted_share_safety > p.incident_weighted_share_availability
+    assert p.incident_count_by_category.safety == 3
+    assert p.incident_count_by_category.availability == 1
+    narr = p.oami_subtype_narrative_de.lower()
+    assert "sicherheit" in narr or "sicherheits" in narr
+
+
+def test_profile_availability_dominant() -> None:
+    to = _tenant(
+        has_data=True,
+        by_sub={"availability_incident": 9},
+        level="medium",
+        index=60,
+    )
+    p = build_oami_incident_subtype_profile_for_board(to)
+    assert p is not None
+    assert p.incident_weighted_share_availability == 1.0
+    assert "Verfügbarkeit" in p.oami_subtype_narrative_de
+
+
+def test_profile_low_other_incidents_uses_benign_narrative() -> None:
+    to = _tenant(
+        has_data=True,
+        by_sub={"other_incident": 2},
+        level="low",
+        index=37,
+    )
+    p = build_oami_incident_subtype_profile_for_board(to)
+    assert p is not None
+    narr = p.oami_subtype_narrative_de
+    assert "niedrig" in narr.lower() or "Stufe" in narr
+
+
+def test_shares_sum_to_one() -> None:
+    to = _tenant(
+        has_data=True,
+        by_sub={"safety_violation": 1, "availability_incident": 1, "other_incident": 1},
+    )
+    p = build_oami_incident_subtype_profile_for_board(to)
+    assert p is not None
+    s = (
+        p.incident_weighted_share_safety
+        + p.incident_weighted_share_availability
+        + p.incident_weighted_share_other
+    )
+    assert abs(s - 1.0) < 0.02


### PR DESCRIPTION
Add weighted subtype shares, counts, and DE narrative; attach to BoardOperationalMonitoringSection and optional Markdown H3 block with chart placeholder. Wire profile into AI compliance board report LLM input and extend user prompt. Update frontend API types and docs; add tests.

Made-with: Cursor