### PR TITLE
feat(incidents): tenant drilldown by AI system and supplier source

### DIFF
--- a/app/incident_drilldown_models.py
+++ b/app/incident_drilldown_models.py
@@ -1,0 +1,44 @@
+"""DTOs: Incident-Drilldown je KI-System und Lieferant (Laufzeit, aggregiert)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class IncidentDrilldownCategoryCounts(BaseModel):
+    """Rohzähler klassifizierter Laufzeit-Incidents im Fenster (nur ``event_type=incident``)."""
+
+    safety: int = Field(ge=0)
+    availability: int = Field(ge=0)
+    other: int = Field(ge=0)
+
+
+class TenantIncidentDrilldownItem(BaseModel):
+    ai_system_id: str
+    ai_system_name: str
+    supplier_label_de: str = Field(
+        description="Anzeige-Label für die dominante Event-Quelle (z. B. SAP AI Core).",
+    )
+    event_source: str = Field(
+        description="Rohwert ``source`` aus ai_runtime_events (API/Export).",
+    )
+    incident_total_90d: int = Field(ge=0)
+    incident_count_by_category: IncidentDrilldownCategoryCounts
+    weighted_incident_share_safety: float = Field(ge=0.0, le=1.0)
+    weighted_incident_share_availability: float = Field(ge=0.0, le=1.0)
+    weighted_incident_share_other: float = Field(ge=0.0, le=1.0)
+    oami_local_hint_de: str = Field(default="", max_length=200)
+
+
+class TenantIncidentDrilldownOut(BaseModel):
+    tenant_id: str
+    window_days: int = Field(ge=1, le=366)
+    systems_with_runtime_events: int = Field(
+        ge=0,
+        description="Systeme mit mindestens einem Laufzeit-Event im Fenster.",
+    )
+    systems_with_incidents: int = Field(
+        ge=0,
+        description="Systeme mit mindestens einem Incident im Fenster (Einträge in items).",
+    )
+    items: list[TenantIncidentDrilldownItem] = Field(default_factory=list)

--- a/app/main.py
+++ b/app/main.py
@@ -149,6 +149,7 @@ from app.feature_flags import (
 )
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturityBoardSummaryParseResult
+from app.incident_drilldown_models import TenantIncidentDrilldownOut
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
 from app.llm_models import LLMTaskType
 from app.models import (
@@ -337,6 +338,10 @@ from app.services.tenant_ai_governance_setup import (
 from app.services.tenant_compliance_overview import (
     TenantComplianceOverview,
     compute_tenant_compliance_overview,
+)
+from app.services.tenant_incident_drilldown import (
+    compute_tenant_incident_drilldown,
+    tenant_incident_drilldown_to_csv,
 )
 from app.services.tenant_provisioning import provision_tenant
 from app.services.tenant_usage_metrics import compute_tenant_usage_metrics
@@ -2907,6 +2912,42 @@ def get_advisor_tenant_governance_maturity(
 
 
 @app.get(
+    "/api/v1/advisors/{advisor_id}/tenants/{tenant_id}/incident-drilldown",
+    response_model=None,
+    tags=["advisors"],
+)
+def get_advisor_tenant_incident_drilldown(
+    _ff_gm: Annotated[None, Depends(create_feature_guard(FeatureFlag.governance_maturity))],
+    _ff_adv: Annotated[None, Depends(create_feature_guard(FeatureFlag.advisor_workspace))],
+    advisor_id: Annotated[str, Depends(require_advisor_api_access)],
+    tenant_id: str,
+    session: Annotated[Session, Depends(get_session)],
+    advisor_repo: Annotated[AdvisorTenantRepository, Depends(get_advisor_tenant_repository)],
+    window_days: Annotated[int, Query(ge=1, le=366)] = 90,
+    export_format: Annotated[Literal["json", "csv"], Query(alias="format")] = "json",
+) -> TenantIncidentDrilldownOut | Response:
+    """
+    Incident-Drilldown je KI-System und dominanter Laufzeit-Quelle (Berater, verknüpfter Mandant).
+    CSV für interne Auswertung; keine Roh-Events, nur Aggregationen.
+    """
+    if advisor_repo.get_link(advisor_id, tenant_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Tenant not linked to this advisor",
+        )
+    data = compute_tenant_incident_drilldown(session, tenant_id, window_days=window_days)
+    if export_format == "csv":
+        body = tenant_incident_drilldown_to_csv(data)
+        fname = f"incident-drilldown-{tenant_id}.csv"
+        return Response(
+            content=body.encode("utf-8"),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": _evidence_content_disposition(fname)},
+        )
+    return data
+
+
+@app.get(
     "/api/v1/advisors/{advisor_id}/tenants/{tenant_id}/report",
     tags=["advisors"],
     response_model=None,
@@ -3933,6 +3974,37 @@ def get_tenant_operational_monitoring_index(
         window_days=window_days,
         persist_snapshot=False,
     )
+
+
+@app.get(
+    "/api/v1/tenants/{tenant_id}/incident-drilldown",
+    response_model=None,
+    tags=["tenants"],
+)
+def get_tenant_incident_drilldown(
+    tenant_id: str,
+    _ff_gm: Annotated[None, Depends(create_feature_guard(FeatureFlag.governance_maturity))],
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    window_days: Annotated[int, Query(ge=1, le=366)] = 90,
+    export_format: Annotated[Literal["json", "csv"], Query(alias="format")] = "json",
+) -> TenantIncidentDrilldownOut | Response:
+    """
+    Incident-Drilldown (Mandant, API-Key muss zu tenant_id passen). CSV optional.
+    Nicht für anonyme Self-Service-Endnutzer gedacht.
+    """
+    if tenant_id != auth_context.tenant_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Tenant mismatch")
+    data = compute_tenant_incident_drilldown(session, tenant_id, window_days=window_days)
+    if export_format == "csv":
+        body = tenant_incident_drilldown_to_csv(data)
+        fname = f"incident-drilldown-{tenant_id}.csv"
+        return Response(
+            content=body.encode("utf-8"),
+            media_type="text/csv; charset=utf-8",
+            headers={"Content-Disposition": _evidence_content_disposition(fname)},
+        )
+    return data
 
 
 @app.get(

--- a/app/oami_subtype_weights.py
+++ b/app/oami_subtype_weights.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Final
+from typing import Final, Literal
+
+IncidentOamiCategory = Literal["safety", "availability", "other"]
 
 # Relativ zu Neutral 1.0; keine exponenziellen Formeln.
 _INCIDENT_WEIGHTS: Final[dict[str, float]] = {
@@ -22,6 +24,18 @@ _METRIC_BREACH_WEIGHTS: Final[dict[str, float]] = {
 _COEF_INCIDENT_HIGH: Final[float] = 0.20
 _COEF_INCIDENT_OTHER_SEV: Final[float] = 0.065
 _SEV_HI: Final[frozenset[str]] = frozenset({"high", "critical"})
+
+
+def incident_subtype_oami_category(subtype: str | None) -> IncidentOamiCategory:
+    """Gruppiert kanonische Incident-``event_subtype``-Schlüssel für OAMI/Board/Drilldown."""
+    if not subtype or not str(subtype).strip():
+        return "other"
+    k = str(subtype).strip().lower()
+    if k in ("safety_violation", "bias_discrimination_incident"):
+        return "safety"
+    if k == "availability_incident":
+        return "availability"
+    return "other"
 
 
 def incident_subtype_oami_weight(subtype: str | None) -> float:

--- a/app/services/oami_incident_subtype_profile_board.py
+++ b/app/services/oami_incident_subtype_profile_board.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal
 
 from app.ai_governance_models import (
     OAMI_SUBTYPE_CHART_NOTE_DE,
@@ -11,19 +10,10 @@ from app.ai_governance_models import (
     OamiIncidentSubtypeProfile,
 )
 from app.governance_maturity_contract import INDEX_LEVEL_DE
-from app.oami_subtype_weights import incident_subtype_oami_weight
+from app.oami_subtype_weights import incident_subtype_oami_category, incident_subtype_oami_weight
 from app.operational_monitoring_models import TenantOperationalMonitoringIndexOut
 
 logger = logging.getLogger(__name__)
-
-
-def _incident_subtype_category(subtype: str) -> Literal["safety", "availability", "other"]:
-    k = subtype.strip().lower()
-    if k in ("safety_violation", "bias_discrimination_incident"):
-        return "safety"
-    if k == "availability_incident":
-        return "availability"
-    return "other"
 
 
 def _trim_board_sentence(text: str, *, max_len: int = 240) -> str:
@@ -101,7 +91,7 @@ def build_oami_incident_subtype_profile_for_board(
             if n <= 0:
                 continue
             ks = str(raw_k).strip().lower()
-            cat = _incident_subtype_category(ks)
+            cat = incident_subtype_oami_category(ks)
             w = incident_subtype_oami_weight(ks)
             burden[cat] += float(n) * w
             counts[cat] += n

--- a/app/services/tenant_incident_drilldown.py
+++ b/app/services/tenant_incident_drilldown.py
@@ -1,0 +1,181 @@
+"""Aggregierter Incident-Drilldown pro KI-System und dominanter Event-Quelle (Lieferant)."""
+
+from __future__ import annotations
+
+import csv
+import io
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from app.incident_drilldown_models import (
+    IncidentDrilldownCategoryCounts,
+    TenantIncidentDrilldownItem,
+    TenantIncidentDrilldownOut,
+)
+from app.oami_subtype_weights import incident_subtype_oami_category, incident_subtype_oami_weight
+from app.repositories.ai_runtime_events import AiRuntimeEventRepository
+from app.repositories.ai_systems import AISystemRepository
+
+_SUPPLIER_LABEL_DE: dict[str, str] = {
+    "sap_ai_core": "SAP AI Core",
+    "sap_btp_event_mesh": "SAP BTP Event Mesh",
+    "manual_import": "Manuell / Custom",
+    "other_provider": "Sonstiger Anbieter",
+}
+
+
+def event_source_supplier_label_de(source: str) -> str:
+    s = (source or "").strip().lower()
+    if s in _SUPPLIER_LABEL_DE:
+        return _SUPPLIER_LABEL_DE[s]
+    if not s:
+        return "Unbekannt"
+    return s.replace("_", " ").title()
+
+
+def _local_hint_de(
+    *,
+    sh: float,
+    av: float,
+    ot: float,
+    total: int,
+) -> str:
+    if total <= 0:
+        return ""
+    if sh >= 0.45 and sh > av and sh > ot:
+        return "Schwerpunkt: sicherheitsrelevante Laufzeit-Incidents (OAMI-Gewichtung)."
+    if av >= 0.45 and av > sh and av > ot:
+        return "Schwerpunkt: Verfügbarkeits-Incidents (Betriebsstabilität)."
+    if total <= 3:
+        return "Wenige klassifizierte Incidents; Einordnung mit Vorsicht nutzen."
+    return "Ausgewogene Verteilung der Incident-Subtypen im Systemfenster."
+
+
+def compute_tenant_incident_drilldown(
+    session: Session,
+    tenant_id: str,
+    *,
+    window_days: int = 90,
+) -> TenantIncidentDrilldownOut:
+    now = datetime.now(UTC)
+    since = now - timedelta(days=window_days)
+    until = now
+    ev_repo = AiRuntimeEventRepository(session)
+    sys_repo = AISystemRepository(session)
+    system_ids = sorted(ev_repo.list_system_ids_with_events(tenant_id, since=since, until=until))
+    items: list[TenantIncidentDrilldownItem] = []
+    with_incidents = 0
+
+    for sid in system_ids:
+        inc_rows = [
+            r
+            for r in ev_repo.list_in_window(tenant_id, sid, since=since, until=until)
+            if str(r.event_type).lower() == "incident"
+        ]
+        inc_total = len(inc_rows)
+        if inc_total <= 0:
+            continue
+        with_incidents += 1
+        safety_c = availability_c = other_c = 0
+        burden = {"safety": 0.0, "availability": 0.0, "other": 0.0}
+        for r in inc_rows:
+            st_raw = (getattr(r, "event_subtype", None) or "").strip().lower()
+            st_key = st_raw if st_raw else None
+            cat = incident_subtype_oami_category(st_key)
+            w = incident_subtype_oami_weight(st_key)
+            burden[cat] += w
+            if cat == "safety":
+                safety_c += 1
+            elif cat == "availability":
+                availability_c += 1
+            else:
+                other_c += 1
+        counts = IncidentDrilldownCategoryCounts(
+            safety=safety_c,
+            availability=availability_c,
+            other=other_c,
+        )
+
+        total_b = sum(burden.values())
+        if total_b <= 0:
+            sh = av = ot = 1.0 / 3.0
+        else:
+            sh = burden["safety"] / total_b
+            av = burden["availability"] / total_b
+            ot = burden["other"] / total_b
+
+        cnt = Counter((r.source or "").strip().lower() or "unknown" for r in inc_rows)
+        src = sorted(cnt.items(), key=lambda kv: (-kv[1], kv[0]))[0][0] if cnt else ""
+        label = event_source_supplier_label_de(src)
+        system = sys_repo.get_by_id(tenant_id, sid)
+        name = system.name if system else sid
+
+        items.append(
+            TenantIncidentDrilldownItem(
+                ai_system_id=sid,
+                ai_system_name=name,
+                supplier_label_de=label,
+                event_source=src or "unknown",
+                incident_total_90d=inc_total,
+                incident_count_by_category=counts,
+                weighted_incident_share_safety=round(sh, 4),
+                weighted_incident_share_availability=round(av, 4),
+                weighted_incident_share_other=round(ot, 4),
+                oami_local_hint_de=_local_hint_de(sh=sh, av=av, ot=ot, total=inc_total),
+            ),
+        )
+
+    return TenantIncidentDrilldownOut(
+        tenant_id=tenant_id,
+        window_days=window_days,
+        systems_with_runtime_events=len(system_ids),
+        systems_with_incidents=with_incidents,
+        items=sorted(items, key=lambda x: (-x.incident_total_90d, x.ai_system_id)),
+    )
+
+
+def tenant_incident_drilldown_to_csv(data: TenantIncidentDrilldownOut) -> str:
+    """UTF-8 CSV für interne Auswertung (keine Roh-Event-IDs)."""
+    buf = io.StringIO()
+    w = csv.writer(buf)
+    w.writerow(
+        [
+            "tenant_id",
+            "window_days",
+            "ai_system_id",
+            "ai_system_name",
+            "event_source",
+            "supplier_label_de",
+            "incident_total_90d",
+            "count_safety",
+            "count_availability",
+            "count_other",
+            "weighted_share_safety",
+            "weighted_share_availability",
+            "weighted_share_other",
+            "oami_local_hint_de",
+        ],
+    )
+    for it in data.items:
+        c = it.incident_count_by_category
+        w.writerow(
+            [
+                data.tenant_id,
+                data.window_days,
+                it.ai_system_id,
+                it.ai_system_name,
+                it.event_source,
+                it.supplier_label_de,
+                it.incident_total_90d,
+                c.safety,
+                c.availability,
+                c.other,
+                it.weighted_incident_share_safety,
+                it.weighted_incident_share_availability,
+                it.weighted_incident_share_other,
+                it.oami_local_hint_de,
+            ],
+        )
+    return buf.getvalue()

--- a/docs/governance-operational-ai-monitoring.md
+++ b/docs/governance-operational-ai-monitoring.md
@@ -373,6 +373,7 @@ Mindestumfang (ohne Payload-Inhalte, DSGVO-minimiert):
 | Governance Maturity | `app/services/governance_maturity_service.py`, `GET .../governance-maturity` |
 | Board / Advisor | `app/main.py` (Board-Report), `app/services/board_report_markdown.py`, `app/services/advisor_client_governance_snapshot.py` |
 | OAMI Subtype-Profil (Board) | `app/services/oami_incident_subtype_profile_board.py`, `app/ai_governance_models.py` → `OamiIncidentSubtypeProfile`; optionaler Markdown-Block „Incident-Subtypen“ + Feld `oami_subtype_profile` im AI-Compliance-Board-Report-LLM-Input |
+| Incident-Drilldown (System / Lieferant) | [`incidents-supplier-drilldowns.md`](./incidents-supplier-drilldowns.md), `app/services/tenant_incident_drilldown.py`, `GET .../incident-drilldown` |
 | Demo-Sperre Ingest | `app/services/runtime_events_demo_guard.py` |
 | Workspace-Telemetrie (getrennt) | `app/services/workspace_telemetry.py` |
 

--- a/docs/incidents-supplier-drilldowns.md
+++ b/docs/incidents-supplier-drilldowns.md
@@ -1,0 +1,47 @@
+# Incident-Drilldown: KI-System und Lieferant (Laufzeit)
+
+## Zweck
+
+Der **Incident-Drilldown** fasst **Laufzeit-Incidents** (`event_type=incident` in `ai_runtime_events`) **pro KI-System** und **dominanter Event-Quelle** (`source`, z. B. `sap_ai_core`) im wählbaren Fenster (Standard **90 Tage**) zusammen. Er richtet sich an **Berater** und **interne** Nutzer mit Mandanten-API-Key – nicht an anonyme Endnutzer.
+
+## Inhalt (Aggregation)
+
+- **Zähler** pro Subtyp-Kategorie (**Sicherheit**, **Verfügbarkeit**, **Sonstige**) – gleiche Taxonomie wie OAMI/Board (`incident_subtype_oami_category` in `app/oami_subtype_weights.py`).
+- **Gewichtete Anteile** pro Kategorie auf Basis von `incident_subtype_oami_weight` (wie beim Board-Subtype-Profil, ohne Rohkoeffizienten in der API zu erklären).
+- **Lieferant / Quelle:** dominanter `source`-Wert im Fenster (häufigster bei Gleichstand lexikographisch stabiler Tie-Break).
+- **`oami_local_hint_de`:** ein kurzer deutscher Satz (Safety-/Availability-Fokus, ausgewogen, wenige Fälle).
+
+Keine Roh-Payloads von Prompts/Outputs, keine personenbezogenen Freitexte – nur technische Aggregationen.
+
+## Bezug zu OAMI und Board
+
+| Ebene | Artefakt |
+|-------|-----------|
+| Mandant | `TenantOperationalMonitoringIndexOut`, Board **OAMI-Subtype-Profil** (gewichtete Anteile über alle Systeme) |
+| System | **Incident-Drilldown**-Zeilen je `ai_system_id` |
+
+Der Drilldown beantwortet: *Welches System und welche Anbindung (Quelle) trägt zu Incidents bei?* Das Board-Profil bleibt die **komprimierte Mandanten-Sicht**.
+
+## API
+
+| Methode | Pfad | Auth |
+|---------|------|------|
+| `GET` | `/api/v1/tenants/{tenant_id}/incident-drilldown?window_days=90&format=json` | `x-api-key` + `x-tenant-id`; Pfad **muss** zu `x-tenant-id` passen |
+| `GET` | `/api/v1/advisors/{advisor_id}/tenants/{tenant_id}/incident-drilldown?…` | `x-api-key` + `x-advisor-id` (wie andere Advisor-Routen); Mandant muss in `advisor_tenants` verknüpft sein |
+
+Query **`format`:** `json` (Standard) oder `csv` (UTF-8, Download-Header).
+
+**Feature-Flag:** `governance_maturity` (wie Tenant-OAMI). Advisor-Zusatz: `advisor_workspace`.
+
+## UI-Integration (Skizze)
+
+- **Advisor Governance-Snapshot / Mandanten-Detail:** Abschnitt *„Incident-Drilldown (System / Lieferant)“* – Tabelle: `ai_system_name`, `supplier_label_de`, `incident_total_90d`, Spalten für Kategoriezähler oder ein einfaches Badge aus den gewichteten Anteilen; Tooltip mit `oami_local_hint_de`.
+- **Intern:** CSV-Export-Link auf `format=csv` für Analyse in Excel/Sheets.
+
+## Code
+
+- Modelle: `app/incident_drilldown_models.py`
+- Logik: `app/services/tenant_incident_drilldown.py`
+- Endpunkte: `app/main.py`
+
+*Version: 1.0 – ergänzend zu `governance-operational-ai-monitoring.md`.*

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -531,6 +531,32 @@ export interface OamiIncidentSubtypeProfileDto {
   category_labels_de: Record<string, string>;
 }
 
+/** Incident-Drilldown je KI-System / Lieferant (Advisor & Mandant, siehe docs/incidents-supplier-drilldowns.md). */
+export interface TenantIncidentDrilldownItemDto {
+  ai_system_id: string;
+  ai_system_name: string;
+  supplier_label_de: string;
+  event_source: string;
+  incident_total_90d: number;
+  incident_count_by_category: {
+    safety: number;
+    availability: number;
+    other: number;
+  };
+  weighted_incident_share_safety: number;
+  weighted_incident_share_availability: number;
+  weighted_incident_share_other: number;
+  oami_local_hint_de: string;
+}
+
+export interface TenantIncidentDrilldownOutDto {
+  tenant_id: string;
+  window_days: number;
+  systems_with_runtime_events: number;
+  systems_with_incidents: number;
+  items: TenantIncidentDrilldownItemDto[];
+}
+
 /** OAMI-Abschnitt im Board-Governance-Report (90-Tage-Laufzeitfenster). */
 export interface BoardOperationalMonitoringSectionDto {
   index_value: number;

--- a/tests/test_tenant_incident_drilldown.py
+++ b/tests/test_tenant_incident_drilldown.py
@@ -1,0 +1,238 @@
+"""Incident-Drilldown: Aggregation und API (Mandant / Advisor)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.db import SessionLocal
+from app.main import app
+from app.repositories.advisor_tenants import AdvisorTenantRepository
+from app.services.tenant_incident_drilldown import (
+    compute_tenant_incident_drilldown,
+    event_source_supplier_label_de,
+    tenant_incident_drilldown_to_csv,
+)
+
+client = TestClient(app)
+
+ADV_DR = "advisor-drill@example.com"
+API_KEY = "board-kpi-key"
+T_DRILL = "drill-tenant-a"
+T_OTHER = "drill-tenant-b"
+
+
+@pytest.fixture
+def advisor_allowlist(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_ADVISOR_IDS", ADV_DR)
+
+
+def _adv_headers() -> dict[str, str]:
+    return {"x-api-key": API_KEY, "x-advisor-id": ADV_DR}
+
+
+def _seed_advisor_link() -> None:
+    s = SessionLocal()
+    try:
+        AdvisorTenantRepository(s).upsert_link(
+            advisor_id=ADV_DR,
+            tenant_id=T_DRILL,
+            tenant_display_name="Drill GmbH",
+            industry="IT",
+            country="DE",
+        )
+    finally:
+        s.close()
+
+
+def _create_system(tenant_id: str, system_id: str, name: str) -> None:
+    r = client.post(
+        "/api/v1/ai-systems",
+        json={
+            "id": system_id,
+            "name": name,
+            "description": "d",
+            "business_unit": "BU",
+            "risk_level": "high",
+            "ai_act_category": "high_risk",
+            "gdpr_dpia_required": False,
+            "owner_email": "",
+            "criticality": "medium",
+            "data_sensitivity": "internal",
+            "has_incident_runbook": False,
+            "has_supplier_risk_register": False,
+            "has_backup_runbook": False,
+        },
+        headers={"x-api-key": API_KEY, "x-tenant-id": tenant_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _ingest_incidents(
+    tenant_id: str,
+    system_id: str,
+    events: list[dict],
+) -> None:
+    r = client.post(
+        f"/api/v1/ai-systems/{system_id}/runtime-events",
+        json={"events": events},
+        headers={"x-api-key": API_KEY, "x-tenant-id": tenant_id},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_event_source_supplier_label_de() -> None:
+    assert event_source_supplier_label_de("sap_ai_core") == "SAP AI Core"
+    assert "Custom" in event_source_supplier_label_de("manual_import")
+
+
+def test_compute_drilldown_multi_system_mixed_sources() -> None:
+    tid = f"drill-u-{uuid.uuid4().hex[:10]}"
+    _create_system(tid, "sys-a", "System A")
+    _create_system(tid, "sys-b", "System B")
+    now = datetime.now(UTC)
+    base = now.isoformat()
+    _ingest_incidents(
+        tid,
+        "sys-a",
+        [
+            {
+                "source_event_id": f"e-{uuid.uuid4().hex[:8]}-1",
+                "source": "sap_ai_core",
+                "event_type": "incident",
+                "event_subtype": "safety_violation",
+                "severity": "high",
+                "occurred_at": base,
+            },
+            {
+                "source_event_id": f"e-{uuid.uuid4().hex[:8]}-2",
+                "source": "sap_ai_core",
+                "event_type": "incident",
+                "event_subtype": "safety_violation",
+                "severity": "medium",
+                "occurred_at": base,
+            },
+        ],
+    )
+    _ingest_incidents(
+        tid,
+        "sys-b",
+        [
+            {
+                "source_event_id": f"e-{uuid.uuid4().hex[:8]}-3",
+                "source": "manual_import",
+                "event_type": "incident",
+                "event_subtype": "availability_incident",
+                "severity": "low",
+                "occurred_at": base,
+            },
+        ],
+    )
+    with SessionLocal() as s:
+        out = compute_tenant_incident_drilldown(s, tid, window_days=90)
+    assert out.tenant_id == tid
+    assert out.systems_with_incidents == 2
+    assert len(out.items) == 2
+    by_id = {x.ai_system_id: x for x in out.items}
+    assert by_id["sys-a"].incident_total_90d == 2
+    assert by_id["sys-a"].incident_count_by_category.safety == 2
+    assert by_id["sys-a"].supplier_label_de == "SAP AI Core"
+    assert by_id["sys-b"].incident_count_by_category.availability == 1
+    lbl_b = by_id["sys-b"].supplier_label_de
+    assert "Manuell" in lbl_b or "Custom" in lbl_b
+    csv_text = tenant_incident_drilldown_to_csv(out)
+    assert "ai_system_id" in csv_text
+    assert "sys-a" in csv_text
+
+
+def test_tenant_incident_drilldown_api_403_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    r = client.get(
+        f"/api/v1/tenants/{T_OTHER}/incident-drilldown",
+        headers={"x-api-key": API_KEY, "x-tenant-id": T_DRILL},
+    )
+    assert r.status_code == 403
+
+
+def test_tenant_incident_drilldown_api_csv(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    tid = f"drill-api-{uuid.uuid4().hex[:10]}"
+    _create_system(tid, "sys-c", "C")
+    now = datetime.now(UTC)
+    _ingest_incidents(
+        tid,
+        "sys-c",
+        [
+            {
+                "source_event_id": f"e-{uuid.uuid4().hex[:8]}",
+                "source": "other_provider",
+                "event_type": "incident",
+                "event_subtype": "other_incident",
+                "severity": "low",
+                "occurred_at": now.isoformat(),
+            },
+        ],
+    )
+    r = client.get(
+        f"/api/v1/tenants/{tid}/incident-drilldown",
+        params={"format": "csv"},
+        headers={"x-api-key": API_KEY, "x-tenant-id": tid},
+    )
+    assert r.status_code == 200
+    assert "text/csv" in r.headers.get("content-type", "")
+    assert "sys-c" in r.text
+
+
+def test_advisor_incident_drilldown_404_unlinked(
+    advisor_allowlist: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_ADVISOR_WORKSPACE", "true")
+    r = client.get(
+        f"/api/v1/advisors/{ADV_DR}/tenants/{T_OTHER}/incident-drilldown",
+        headers=_adv_headers(),
+    )
+    assert r.status_code == 404
+
+
+def test_advisor_incident_drilldown_200(
+    advisor_allowlist: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_GOVERNANCE_MATURITY", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_ADVISOR_WORKSPACE", "true")
+    _seed_advisor_link()
+    _create_system(T_DRILL, "sys-d", "D")
+    now = datetime.now(UTC)
+    _ingest_incidents(
+        T_DRILL,
+        "sys-d",
+        [
+            {
+                "source_event_id": f"e-{uuid.uuid4().hex[:8]}",
+                "source": "sap_ai_core",
+                "event_type": "incident",
+                "event_subtype": "availability_incident",
+                "severity": "medium",
+                "occurred_at": now.isoformat(),
+            },
+        ],
+    )
+    r = client.get(
+        f"/api/v1/advisors/{ADV_DR}/tenants/{T_DRILL}/incident-drilldown",
+        headers=_adv_headers(),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["tenant_id"] == T_DRILL
+    assert body["systems_with_incidents"] >= 1
+    assert len(body["items"]) >= 1
+    assert body["items"][0]["ai_system_id"] == "sys-d"


### PR DESCRIPTION
Add incident_subtype_oami_category for shared OAMI taxonomy; compute per-system incident counts, weighted subtype shares, dominant source labels; GET for tenant (key match) and advisor (linked tenant) with optional CSV. Document API and UI sketch; extend frontend DTOs.

Made-with: Cursor