### PR TITLE
feat(advisor): incident drilldown UI, snapshot panel, portfolio link

### DIFF
--- a/frontend/src/app/advisor/clients/[tenantId]/incident-drilldown/page.tsx
+++ b/frontend/src/app/advisor/clients/[tenantId]/incident-drilldown/page.tsx
@@ -1,0 +1,21 @@
+import { AdvisorIncidentDrilldownPanel } from "@/components/advisor/AdvisorIncidentDrilldownPanel";
+import { ADVISOR_ID_FROM_ENV, isAdvisorNavEnabled } from "@/lib/api";
+import { featureAdvisorWorkspace, featureGovernanceMaturity } from "@/lib/config";
+import { notFound } from "next/navigation";
+
+export default async function AdvisorClientIncidentDrilldownPage({
+  params,
+}: {
+  params: Promise<{ tenantId: string }>;
+}) {
+  const { tenantId: raw } = await params;
+  const decoded = decodeURIComponent(raw);
+  if (!isAdvisorNavEnabled() || !featureAdvisorWorkspace() || !featureGovernanceMaturity()) {
+    notFound();
+  }
+  const advisorId = ADVISOR_ID_FROM_ENV;
+  if (!advisorId) {
+    notFound();
+  }
+  return <AdvisorIncidentDrilldownPanel advisorId={advisorId} clientTenantId={decoded} variant="full" />;
+}

--- a/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
+++ b/frontend/src/components/advisor/AdvisorGovernanceSnapshotView.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import React, { useCallback, useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 
+import { AdvisorIncidentDrilldownPanel } from "@/components/advisor/AdvisorIncidentDrilldownPanel";
 import {
   ADVISOR_ID_FROM_ENV,
   fetchAdvisorClientGovernanceSnapshot,
@@ -452,6 +453,8 @@ export function AdvisorGovernanceSnapshotView({ clientTenantId }: { clientTenant
               ) : null}
             </section>
           ) : null}
+
+          <AdvisorIncidentDrilldownPanel advisorId={advisorId} clientTenantId={clientTenantId} variant="snapshot" />
 
           <section className={CH_CARD} data-testid="snap-setup">
             <p className={CH_SECTION_LABEL}>AI Governance Setup &amp; Playbook</p>

--- a/frontend/src/components/advisor/AdvisorIncidentDrilldownPanel.test.tsx
+++ b/frontend/src/components/advisor/AdvisorIncidentDrilldownPanel.test.tsx
@@ -1,0 +1,138 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { TenantIncidentDrilldownOutDto } from "@/lib/api";
+
+import { AdvisorIncidentDrilldownPanel } from "./AdvisorIncidentDrilldownPanel";
+
+const governanceMaturity = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock("@/lib/config", () => ({
+  featureGovernanceMaturity: governanceMaturity,
+}));
+
+const fetchDrilldown = vi.hoisted(() => vi.fn());
+const fetchCsv = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    fetchAdvisorTenantIncidentDrilldown: fetchDrilldown,
+    fetchAdvisorTenantIncidentDrilldownCsvBlob: fetchCsv,
+  };
+});
+
+function dtoWithItems(items: TenantIncidentDrilldownOutDto["items"]): TenantIncidentDrilldownOutDto {
+  return {
+    tenant_id: "tenant-x",
+    window_days: 90,
+    systems_with_runtime_events: items.length,
+    systems_with_incidents: items.length,
+    items,
+  };
+}
+
+const twoItemsDto = dtoWithItems([
+  {
+    ai_system_id: "sys-high",
+    ai_system_name: "System Viel",
+    supplier_label_de: "SAP AI Core",
+    event_source: "sap_ai_core",
+    incident_total_90d: 12,
+    incident_count_by_category: { safety: 8, availability: 2, other: 2 },
+    weighted_incident_share_safety: 0.55,
+    weighted_incident_share_availability: 0.25,
+    weighted_incident_share_other: 0.2,
+    oami_local_hint_de: "Safety-Schwerpunkt.",
+  },
+  {
+    ai_system_id: "sys-low",
+    ai_system_name: "System Wenig",
+    supplier_label_de: "Manuell / Custom",
+    event_source: "manual_import",
+    incident_total_90d: 3,
+    incident_count_by_category: { safety: 0, availability: 2, other: 1 },
+    weighted_incident_share_safety: 0.15,
+    weighted_incident_share_availability: 0.55,
+    weighted_incident_share_other: 0.3,
+    oami_local_hint_de: "Verfügbarkeit dominiert.",
+  },
+]);
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+  governanceMaturity.mockReturnValue(true);
+});
+
+describe("AdvisorIncidentDrilldownPanel", () => {
+  it("hides section when backend returns no drilldown items", async () => {
+    fetchDrilldown.mockResolvedValue(dtoWithItems([]));
+    render(<AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="snapshot" />);
+    await waitFor(() => {
+      expect(screen.queryByTestId("advisor-incident-drilldown-loading")).toBeNull();
+    });
+    expect(screen.queryByTestId("advisor-incident-drilldown-section")).toBeNull();
+  });
+
+  it("renders table rows from mocked drilldown and default sort (highest total first)", async () => {
+    fetchDrilldown.mockResolvedValue(twoItemsDto);
+    render(<AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="snapshot" />);
+    await waitFor(() => {
+      expect(screen.getByTestId("advisor-incident-drilldown-section")).toBeTruthy();
+    });
+    expect(screen.getByText("Incidents nach KI-System und Lieferant")).toBeTruthy();
+    expect(screen.getByText("90-Tage-Überblick zu Laufzeit-Incidents und OAMI-Treibern.")).toBeTruthy();
+    const rows = screen.getAllByRole("row");
+    const bodyRows = rows.slice(1);
+    expect(bodyRows).toHaveLength(2);
+    expect(within(bodyRows[0]).getByText("System Viel")).toBeTruthy();
+    expect(within(bodyRows[1]).getByText("System Wenig")).toBeTruthy();
+  });
+
+  it("filters by supplier and shows empty-filter message when no match", async () => {
+    fetchDrilldown.mockResolvedValue(twoItemsDto);
+    render(<AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="snapshot" />);
+    await waitFor(() => screen.getByTestId("advisor-incident-drilldown-section"));
+    const supplierSelect = screen.getByTestId("advisor-drilldown-filter-supplier");
+    fireEvent.change(supplierSelect, { target: { value: "sap_ai_core" } });
+    await waitFor(() => {
+      expect(screen.getByText("System Viel")).toBeTruthy();
+      expect(screen.queryByText("System Wenig")).toBeNull();
+    });
+    fireEvent.change(supplierSelect, { target: { value: "sap_btp_event_mesh" } });
+    await waitFor(() => {
+      expect(screen.getByTestId("advisor-drilldown-empty-filter")).toBeTruthy();
+    });
+  });
+
+  it("filters by OAMI focus (safety-dominant)", async () => {
+    fetchDrilldown.mockResolvedValue(twoItemsDto);
+    render(<AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="snapshot" />);
+    await waitFor(() => screen.getByTestId("advisor-incident-drilldown-section"));
+    fireEvent.change(screen.getByTestId("advisor-drilldown-filter-focus"), {
+      target: { value: "safety_dominant" },
+    });
+    await waitFor(() => {
+      expect(screen.getByText("System Viel")).toBeTruthy();
+      expect(screen.queryByText("System Wenig")).toBeNull();
+    });
+  });
+
+  it("returns null when governance maturity feature is off", () => {
+    governanceMaturity.mockReturnValue(false);
+    const { container } = render(
+      <AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="snapshot" />,
+    );
+    expect(container.firstChild).toBeNull();
+    expect(fetchDrilldown).not.toHaveBeenCalled();
+  });
+
+  it("full variant shows Export CSV", async () => {
+    fetchDrilldown.mockResolvedValue(twoItemsDto);
+    render(<AdvisorIncidentDrilldownPanel advisorId="adv@x" clientTenantId="t-1" variant="full" />);
+    await waitFor(() => screen.getByTestId("advisor-incident-drilldown-full"));
+    expect(screen.getByTestId("advisor-drilldown-export-csv")).toBeTruthy();
+  });
+});

--- a/frontend/src/components/advisor/AdvisorIncidentDrilldownPanel.tsx
+++ b/frontend/src/components/advisor/AdvisorIncidentDrilldownPanel.tsx
@@ -1,0 +1,376 @@
+"use client";
+
+import Link from "next/link";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  fetchAdvisorTenantIncidentDrilldown,
+  fetchAdvisorTenantIncidentDrilldownCsvBlob,
+} from "@/lib/api";
+import {
+  type AdvisorIncidentDrilldownItem,
+  type AdvisorIncidentDrilldownOut,
+  type CategoryFocusFilterId,
+  SUPPLIER_FILTER_OPTIONS,
+  CATEGORY_FOCUS_OPTIONS,
+  applyDrilldownFilters,
+  isAvailabilityDominant,
+  isSafetyDominant,
+  mapTenantDrilldownDtoToAdvisorOut,
+  type SupplierFilterId,
+} from "@/lib/advisorIncidentDrilldownModel";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL, CH_SHELL } from "@/lib/boardLayout";
+import { featureGovernanceMaturity } from "@/lib/config";
+
+function FocusBadges({ it }: { it: AdvisorIncidentDrilldownItem }) {
+  const s = isSafetyDominant(it);
+  const a = isAvailabilityDominant(it);
+  return (
+    <div className="flex flex-wrap gap-1">
+      {s ? (
+        <span
+          className="rounded bg-amber-100 px-1.5 py-0.5 text-[0.65rem] font-semibold text-amber-950"
+          title="Gewichteter Schwerpunkt Sicherheit (OAMI-Logik)"
+        >
+          Safety
+        </span>
+      ) : null}
+      {a ? (
+        <span
+          className="rounded bg-sky-100 px-1.5 py-0.5 text-[0.65rem] font-semibold text-sky-950"
+          title="Gewichteter Schwerpunkt Verfügbarkeit"
+        >
+          Verfügbarkeit
+        </span>
+      ) : null}
+      {!s && !a ? (
+        <span className="rounded bg-slate-100 px-1.5 py-0.5 text-[0.65rem] font-medium text-slate-700">
+          Ausgewogen
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function DrilldownTable({
+  rows,
+  compact,
+}: {
+  rows: AdvisorIncidentDrilldownItem[];
+  compact: boolean;
+}) {
+  return (
+    <div className="mt-3 overflow-x-auto">
+      <table className="min-w-[520px] w-full border-collapse text-left text-sm">
+        <thead>
+          <tr className="border-b border-slate-200 text-xs uppercase text-slate-500">
+            <th className="py-2 pr-2">System</th>
+            <th className="py-2 pr-2">Lieferant</th>
+            <th className="py-2 pr-2 tabular-nums">Σ</th>
+            {!compact ? (
+              <>
+                <th className="py-2 pr-2 tabular-nums" title="Rohzähler Sicherheit / Verfügbarkeit / Sonstige">
+                  S / V / O
+                </th>
+                <th className="py-2 pr-2 tabular-nums" title="Gewichtete Anteile (normiert)">
+                  % S / V
+                </th>
+              </>
+            ) : null}
+            <th className="py-2">Fokus</th>
+            {!compact ? <th className="py-2">Hinweis</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((it) => (
+            <tr key={it.aiSystemId} className="border-b border-slate-100">
+              <td className="py-2 pr-2 font-medium text-slate-900">{it.aiSystemName}</td>
+              <td className="py-2 pr-2 text-slate-700">{it.supplierSourceLabelDe}</td>
+              <td className="py-2 pr-2 tabular-nums text-slate-800">{it.incidentCountTotal}</td>
+              {!compact ? (
+                <>
+                  <td className="py-2 pr-2 tabular-nums text-xs text-slate-600">
+                    {it.incidentCountByCategory.safety} / {it.incidentCountByCategory.availability} /{" "}
+                    {it.incidentCountByCategory.other}
+                  </td>
+                  <td className="py-2 pr-2 tabular-nums text-xs text-slate-600">
+                    {Math.round(it.weightedShareSafety * 100)} /{" "}
+                    {Math.round(it.weightedShareAvailability * 100)}
+                  </td>
+                </>
+              ) : null}
+              <td className="py-2">
+                <FocusBadges it={it} />
+              </td>
+              {!compact ? (
+                <td className="max-w-[220px] py-2 text-xs text-slate-600" title={it.localOamiHintDe}>
+                  {it.localOamiHintDe}
+                </td>
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export type AdvisorIncidentDrilldownPanelProps = {
+  advisorId: string;
+  clientTenantId: string;
+  /** snapshot: Karte im Governance-Snapshot; full: Detailseite mit Export. */
+  variant?: "snapshot" | "full";
+};
+
+export function AdvisorIncidentDrilldownPanel({
+  advisorId,
+  clientTenantId,
+  variant = "snapshot",
+}: AdvisorIncidentDrilldownPanelProps) {
+  const [raw, setRaw] = useState<AdvisorIncidentDrilldownOut | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(true);
+  const [supplier, setSupplier] = useState<SupplierFilterId>("all");
+  const [focus, setFocus] = useState<CategoryFocusFilterId>("all");
+  const [modalOpen, setModalOpen] = useState(false);
+  const [csvBusy, setCsvBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!featureGovernanceMaturity() || !advisorId) {
+      setRaw(null);
+      setBusy(false);
+      return;
+    }
+    setBusy(true);
+    setErr(null);
+    try {
+      const dto = await fetchAdvisorTenantIncidentDrilldown(advisorId, clientTenantId, 90);
+      const mapped = mapTenantDrilldownDtoToAdvisorOut(dto, new Date().toISOString());
+      setRaw(mapped);
+    } catch (e) {
+      setRaw(null);
+      setErr(e instanceof Error ? e.message : "Drilldown nicht verfügbar");
+    } finally {
+      setBusy(false);
+    }
+  }, [advisorId, clientTenantId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    if (!raw?.items.length) {
+      return [];
+    }
+    return applyDrilldownFilters(raw.items, supplier, focus);
+  }, [raw, supplier, focus]);
+
+  const exportCsv = async () => {
+    setCsvBusy(true);
+    try {
+      const blob = await fetchAdvisorTenantIncidentDrilldownCsvBlob(advisorId, clientTenantId, 90);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `incident-drilldown-${clientTenantId.slice(0, 24)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "CSV-Export fehlgeschlagen");
+    } finally {
+      setCsvBusy(false);
+    }
+  };
+
+  if (!featureGovernanceMaturity()) {
+    return null;
+  }
+
+  if (busy && !raw) {
+    return variant === "snapshot" ? (
+      <section className={CH_CARD} data-testid="advisor-incident-drilldown-loading">
+        <p className={CH_SECTION_LABEL}>Incidents nach KI-System und Lieferant</p>
+        <p className="mt-2 text-sm text-slate-600">Lade Drilldown…</p>
+      </section>
+    ) : (
+      <div className={CH_SHELL} data-testid="advisor-incident-drilldown-loading">
+        <p className="text-sm text-slate-600">Lade Drilldown…</p>
+      </div>
+    );
+  }
+
+  if (err && !raw) {
+    return variant === "snapshot" ? (
+      <section className={CH_CARD} data-testid="advisor-incident-drilldown-error">
+        <p className={CH_SECTION_LABEL}>Incidents nach KI-System und Lieferant</p>
+        <p className="mt-2 text-sm text-rose-800">{err}</p>
+      </section>
+    ) : (
+      <div className={CH_SHELL} data-testid="advisor-incident-drilldown-error">
+        <p className="text-sm text-rose-800">{err}</p>
+      </div>
+    );
+  }
+
+  if (!raw || raw.items.length === 0) {
+    return null;
+  }
+
+  const detailHref = `/advisor/clients/${encodeURIComponent(clientTenantId)}/incident-drilldown`;
+
+  const inner = (
+    <>
+      <div className="mt-2 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
+        <label className="flex flex-col gap-1 text-xs text-slate-600">
+          <span className="font-semibold text-slate-700">Lieferant</span>
+          <select
+            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900"
+            value={supplier}
+            onChange={(e) => setSupplier(e.target.value as SupplierFilterId)}
+            data-testid="advisor-drilldown-filter-supplier"
+          >
+            {SUPPLIER_FILTER_OPTIONS.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-slate-600">
+          <span className="font-semibold text-slate-700">Fokus (OAMI)</span>
+          <select
+            className="rounded border border-slate-200 bg-white px-2 py-1.5 text-sm text-slate-900"
+            value={focus}
+            onChange={(e) => setFocus(e.target.value as CategoryFocusFilterId)}
+            data-testid="advisor-drilldown-filter-focus"
+          >
+            {CATEGORY_FOCUS_OPTIONS.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          className={`${CH_BTN_SECONDARY} text-xs self-start sm:self-auto`}
+          onClick={() => void load()}
+          data-testid="advisor-drilldown-refresh"
+        >
+          Aktualisieren
+        </button>
+      </div>
+
+      <p className="mt-2 text-xs text-slate-500">
+        Fenster: {raw.windowDays} Tage · Systeme mit Incidents: {raw.systemsWithIncidents} · Stand:{" "}
+        {raw.generatedAt.slice(0, 19).replace("T", " ")} UTC
+      </p>
+
+      {filtered.length === 0 ? (
+        <p className="mt-4 text-sm text-slate-600" data-testid="advisor-drilldown-empty-filter">
+          Keine Zeilen für die gewählten Filter.
+        </p>
+      ) : (
+        <DrilldownTable rows={filtered} compact={variant === "snapshot"} />
+      )}
+
+      {variant === "snapshot" ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={`${CH_BTN_SECONDARY} text-xs`}
+            onClick={() => setModalOpen(true)}
+            data-testid="advisor-drilldown-open-modal"
+          >
+            Details anzeigen
+          </button>
+          <Link href={detailHref} className={`${CH_BTN_SECONDARY} inline-flex items-center text-xs no-underline`}>
+            Vollansicht
+          </Link>
+        </div>
+      ) : (
+        <div className="mt-4 flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={`${CH_BTN_PRIMARY} text-xs`}
+            disabled={csvBusy}
+            onClick={() => void exportCsv()}
+            data-testid="advisor-drilldown-export-csv"
+          >
+            {csvBusy ? "Export…" : "Export CSV"}
+          </button>
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <>
+      {variant === "snapshot" ? (
+        <section className={CH_CARD} data-testid="advisor-incident-drilldown-section">
+          <p className={CH_SECTION_LABEL}>Incidents nach KI-System und Lieferant</p>
+          <p className="mt-1 text-xs text-slate-600">
+            90-Tage-Überblick zu Laufzeit-Incidents und OAMI-Treibern.
+          </p>
+          {inner}
+        </section>
+      ) : (
+        <div className={CH_SHELL} data-testid="advisor-incident-drilldown-full">
+          <header className="mb-6">
+            <p className="text-[0.7rem] font-bold uppercase tracking-[0.14em] text-cyan-800">Berater</p>
+            <h1 className="mt-2 text-xl font-bold text-slate-900">Incident-Drilldown</h1>
+            <p className="mt-1 font-mono text-sm text-slate-600">{clientTenantId}</p>
+            <p className="mt-2 max-w-2xl text-sm text-slate-600">
+              Welche KI-Systeme und Lieferanten treiben Laufzeit-Incidents und das operative Monitoring (OAMI)?
+              Kurzhinweise folgen der mandantenweiten OAMI-Subtype-Gewichtung.
+            </p>
+            <div className="mt-3">
+              <Link href={`/advisor/clients/${encodeURIComponent(clientTenantId)}/governance-snapshot`} className="text-xs text-cyan-800 underline">
+                Zurück zum Governance-Snapshot
+              </Link>
+            </div>
+          </header>
+          <div className={CH_CARD}>{inner}</div>
+        </div>
+      )}
+
+      {modalOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="advisor-drilldown-modal-title"
+          data-testid="advisor-drilldown-modal"
+        >
+          <div className="max-h-[90vh] w-full max-w-4xl overflow-y-auto rounded-xl bg-white p-5 shadow-xl">
+            <h2 id="advisor-drilldown-modal-title" className="text-lg font-bold text-slate-900">
+              Incident-Drilldown – Details
+            </h2>
+            <p className="mt-1 text-sm text-slate-600">
+              Vollständige Tabelle inkl. Kategoriezählern und Kurzhinweisen.
+            </p>
+            <DrilldownTable rows={filtered} compact={false} />
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                className={`${CH_BTN_SECONDARY} text-xs`}
+                onClick={() => setModalOpen(false)}
+              >
+                Schließen
+              </button>
+              <button
+                type="button"
+                className={`${CH_BTN_PRIMARY} text-xs`}
+                disabled={csvBusy}
+                onClick={() => void exportCsv()}
+              >
+                {csvBusy ? "Export…" : "CSV exportieren"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.test.tsx
@@ -223,5 +223,14 @@ describe("AdvisorPortfolioTable", () => {
     expect(screen.queryByTestId("advisor-gai-cell-t-demo-1")).toBeNull();
     expect(screen.queryByRole("columnheader", { name: /Reife-Brief/i })).toBeNull();
     expect(screen.queryByTestId("advisor-gm-brief-t-demo-1")).toBeNull();
+    expect(screen.queryByTestId("advisor-incident-drilldown-link-t-demo-1")).toBeNull();
+  });
+
+  it("links to incident drilldown per tenant when governance maturity is on", () => {
+    portfolioFeatureFlags.governanceMaturity = true;
+    render(<AdvisorPortfolioTable rows={sampleRows} advisorId="advisor-demo@example.com" />);
+    const link = screen.getByTestId("advisor-incident-drilldown-link-t-demo-1");
+    expect(link.getAttribute("href")).toBe("/advisor/clients/t-demo-1/incident-drilldown");
+    expect(link.textContent).toContain("Incident-Drilldown");
   });
 });

--- a/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
+++ b/frontend/src/components/advisor/AdvisorPortfolioTable.tsx
@@ -158,6 +158,12 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                   >
                     Reife-Brief
                   </th>
+                  <th
+                    title="90-Tage-Laufzeit-Incidents und OAMI-Treiber nach KI-System und Lieferant"
+                    className="max-w-[8rem]"
+                  >
+                    Incident-Drilldown
+                  </th>
                 </>
               ) : null}
               {snapUi ? <th>Snapshot</th> : null}
@@ -418,6 +424,16 @@ export function AdvisorPortfolioTable({ rows, advisorId }: AdvisorPortfolioTable
                         ) : (
                           <span className="text-[var(--sbs-text-muted)]">–</span>
                         )}
+                      </td>
+                      <td className="align-top">
+                        <Link
+                          href={`/advisor/clients/${encodeURIComponent(t.tenant_id)}/incident-drilldown`}
+                          className={`${CH_BTN_SECONDARY} inline-block text-xs no-underline`}
+                          title="Vollansicht: Incidents nach KI-System und Lieferant (OAMI-Logik)"
+                          data-testid={`advisor-incident-drilldown-link-${t.tenant_id}`}
+                        >
+                          Incident-Drilldown
+                        </Link>
                       </td>
                     </>
                   ) : null}

--- a/frontend/src/lib/advisorIncidentDrilldownModel.test.ts
+++ b/frontend/src/lib/advisorIncidentDrilldownModel.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import type { TenantIncidentDrilldownOutDto } from "@/lib/api";
+
+import {
+  applyDrilldownFilters,
+  isAvailabilityDominant,
+  isSafetyDominant,
+  mapTenantDrilldownDtoToAdvisorOut,
+  matchesSupplierFilter,
+  sortDrilldownItems,
+  type AdvisorIncidentDrilldownItem,
+} from "./advisorIncidentDrilldownModel";
+
+function item(p: Partial<AdvisorIncidentDrilldownItem>): AdvisorIncidentDrilldownItem {
+  return {
+    aiSystemId: p.aiSystemId ?? "id",
+    aiSystemName: p.aiSystemName ?? "Name",
+    supplierSourceLabelDe: p.supplierSourceLabelDe ?? "SAP AI Core",
+    eventSource: p.eventSource ?? "sap_ai_core",
+    incidentCountTotal: p.incidentCountTotal ?? 0,
+    incidentCountByCategory: p.incidentCountByCategory ?? { safety: 0, availability: 0, other: 0 },
+    weightedShareSafety: p.weightedShareSafety ?? 0,
+    weightedShareAvailability: p.weightedShareAvailability ?? 0,
+    weightedShareOther: p.weightedShareOther ?? 0,
+    localOamiHintDe: p.localOamiHintDe ?? "",
+  };
+}
+
+describe("mapTenantDrilldownDtoToAdvisorOut", () => {
+  it("maps snake_case DTO to camelCase view model", () => {
+    const dto: TenantIncidentDrilldownOutDto = {
+      tenant_id: "t-1",
+      window_days: 90,
+      systems_with_runtime_events: 4,
+      systems_with_incidents: 2,
+      items: [
+        {
+          ai_system_id: "as-1",
+          ai_system_name: "Bot A",
+          supplier_label_de: "SAP AI Core",
+          event_source: "sap_ai_core",
+          incident_total_90d: 3,
+          incident_count_by_category: { safety: 2, availability: 1, other: 0 },
+          weighted_incident_share_safety: 0.55,
+          weighted_incident_share_availability: 0.3,
+          weighted_incident_share_other: 0.15,
+          oami_local_hint_de: "Sicherheitsnahe Signale überwiegen.",
+        },
+      ],
+    };
+    const out = mapTenantDrilldownDtoToAdvisorOut(dto, "2026-03-29T12:00:00.000Z");
+    expect(out.tenantId).toBe("t-1");
+    expect(out.windowDays).toBe(90);
+    expect(out.generatedAt).toBe("2026-03-29T12:00:00.000Z");
+    expect(out.items[0]).toMatchObject({
+      aiSystemId: "as-1",
+      aiSystemName: "Bot A",
+      supplierSourceLabelDe: "SAP AI Core",
+      eventSource: "sap_ai_core",
+      incidentCountTotal: 3,
+      incidentCountByCategory: { safety: 2, availability: 1, other: 0 },
+      weightedShareSafety: 0.55,
+      weightedShareAvailability: 0.3,
+      weightedShareOther: 0.15,
+      localOamiHintDe: "Sicherheitsnahe Signale überwiegen.",
+    });
+  });
+});
+
+describe("dominance & filters", () => {
+  it("isSafetyDominant when safety share >= 0.45 and strictly highest", () => {
+    expect(isSafetyDominant(item({ weightedShareSafety: 0.45, weightedShareAvailability: 0.3, weightedShareOther: 0.25 }))).toBe(true);
+    expect(isSafetyDominant(item({ weightedShareSafety: 0.44, weightedShareAvailability: 0.3, weightedShareOther: 0.26 }))).toBe(false);
+    expect(isSafetyDominant(item({ weightedShareSafety: 0.5, weightedShareAvailability: 0.5, weightedShareOther: 0 }))).toBe(false);
+  });
+
+  it("isAvailabilityDominant mirrors safety rule", () => {
+    expect(isAvailabilityDominant(item({ weightedShareSafety: 0.2, weightedShareAvailability: 0.5, weightedShareOther: 0.3 }))).toBe(true);
+  });
+
+  it("matchesSupplierFilter for sap_ai_core and other", () => {
+    const sap = item({ eventSource: "sap_ai_core" });
+    const custom = item({ eventSource: "manual_import" });
+    expect(matchesSupplierFilter(sap, "sap_ai_core")).toBe(true);
+    expect(matchesSupplierFilter(custom, "sap_ai_core")).toBe(false);
+    expect(matchesSupplierFilter(sap, "other")).toBe(false);
+    expect(matchesSupplierFilter(custom, "other")).toBe(false);
+    expect(matchesSupplierFilter(item({ eventSource: "weird" }), "other")).toBe(true);
+  });
+});
+
+describe("sortDrilldownItems & applyDrilldownFilters", () => {
+  it("sorts by incident total desc, then safety share desc", () => {
+    const a = item({ aiSystemId: "a", aiSystemName: "A", incidentCountTotal: 5, weightedShareSafety: 0.4 });
+    const b = item({ aiSystemId: "b", aiSystemName: "B", incidentCountTotal: 10, weightedShareSafety: 0.2 });
+    const c = item({ aiSystemId: "c", aiSystemName: "C", incidentCountTotal: 10, weightedShareSafety: 0.6 });
+    const sorted = sortDrilldownItems([a, b, c]);
+    expect(sorted.map((x) => x.aiSystemId)).toEqual(["c", "b", "a"]);
+  });
+
+  it("applyDrilldownFilters filters by supplier and focus then sorts", () => {
+    const rows = [
+      item({
+        aiSystemId: "1",
+        aiSystemName: "S1",
+        eventSource: "sap_ai_core",
+        incidentCountTotal: 8,
+        weightedShareSafety: 0.5,
+        weightedShareAvailability: 0.25,
+        weightedShareOther: 0.25,
+      }),
+      item({
+        aiSystemId: "2",
+        aiSystemName: "S2",
+        eventSource: "manual_import",
+        incidentCountTotal: 20,
+        weightedShareSafety: 0.2,
+        weightedShareAvailability: 0.5,
+        weightedShareOther: 0.3,
+      }),
+    ];
+    const safetyOnly = applyDrilldownFilters(rows, "all", "safety_dominant");
+    expect(safetyOnly).toHaveLength(1);
+    expect(safetyOnly[0].aiSystemId).toBe("1");
+
+    const sapOnly = applyDrilldownFilters(rows, "sap_ai_core", "all");
+    expect(sapOnly).toHaveLength(1);
+    expect(sapOnly[0].aiSystemId).toBe("1");
+  });
+});

--- a/frontend/src/lib/advisorIncidentDrilldownModel.ts
+++ b/frontend/src/lib/advisorIncidentDrilldownModel.ts
@@ -1,0 +1,152 @@
+/**
+ * View-Model für Advisor Incident-Drilldown (camelCase, von API snake_case gemappt).
+ */
+
+import type { TenantIncidentDrilldownItemDto, TenantIncidentDrilldownOutDto } from "@/lib/api";
+
+export interface AdvisorIncidentDrilldownItem {
+  aiSystemId: string;
+  aiSystemName: string;
+  supplierSourceLabelDe: string;
+  eventSource: string;
+  incidentCountTotal: number;
+  incidentCountByCategory: {
+    safety: number;
+    availability: number;
+    other: number;
+  };
+  weightedShareSafety: number;
+  weightedShareAvailability: number;
+  weightedShareOther: number;
+  localOamiHintDe: string;
+}
+
+export interface AdvisorIncidentDrilldownOut {
+  tenantId: string;
+  windowDays: number;
+  /** ISO-Zeitpunkt des Client-Fetch (API liefert kein separates generated_at). */
+  generatedAt: string;
+  systemsWithRuntimeEvents: number;
+  systemsWithIncidents: number;
+  items: AdvisorIncidentDrilldownItem[];
+}
+
+export type SupplierFilterId = "all" | "sap_ai_core" | "sap_btp_event_mesh" | "manual_import" | "other";
+
+export type CategoryFocusFilterId = "all" | "safety_dominant" | "availability_dominant" | "balanced_low";
+
+const DOMINANCE = 0.45;
+
+export function mapTenantDrilldownDtoToAdvisorOut(
+  dto: TenantIncidentDrilldownOutDto,
+  generatedAtIso: string,
+): AdvisorIncidentDrilldownOut {
+  return {
+    tenantId: dto.tenant_id,
+    windowDays: dto.window_days,
+    generatedAt: generatedAtIso,
+    systemsWithRuntimeEvents: dto.systems_with_runtime_events,
+    systemsWithIncidents: dto.systems_with_incidents,
+    items: dto.items.map(mapItem),
+  };
+}
+
+function mapItem(it: TenantIncidentDrilldownItemDto): AdvisorIncidentDrilldownItem {
+  return {
+    aiSystemId: it.ai_system_id,
+    aiSystemName: it.ai_system_name,
+    supplierSourceLabelDe: it.supplier_label_de,
+    eventSource: it.event_source,
+    incidentCountTotal: it.incident_total_90d,
+    incidentCountByCategory: { ...it.incident_count_by_category },
+    weightedShareSafety: it.weighted_incident_share_safety,
+    weightedShareAvailability: it.weighted_incident_share_availability,
+    weightedShareOther: it.weighted_incident_share_other,
+    localOamiHintDe: it.oami_local_hint_de,
+  };
+}
+
+export function isSafetyDominant(it: AdvisorIncidentDrilldownItem): boolean {
+  const { weightedShareSafety: s, weightedShareAvailability: a, weightedShareOther: o } = it;
+  return s >= DOMINANCE && s > a && s > o;
+}
+
+export function isAvailabilityDominant(it: AdvisorIncidentDrilldownItem): boolean {
+  const { weightedShareSafety: s, weightedShareAvailability: a, weightedShareOther: o } = it;
+  return a >= DOMINANCE && a > s && a > o;
+}
+
+export function isBalancedOrLow(it: AdvisorIncidentDrilldownItem): boolean {
+  if (it.incidentCountTotal <= 3) {
+    return true;
+  }
+  return !isSafetyDominant(it) && !isAvailabilityDominant(it);
+}
+
+export function matchesSupplierFilter(
+  it: AdvisorIncidentDrilldownItem,
+  filter: SupplierFilterId,
+): boolean {
+  if (filter === "all") {
+    return true;
+  }
+  const es = (it.eventSource || "").toLowerCase();
+  if (filter === "other") {
+    return !["sap_ai_core", "sap_btp_event_mesh", "manual_import"].includes(es);
+  }
+  return es === filter;
+}
+
+export function matchesCategoryFocusFilter(
+  it: AdvisorIncidentDrilldownItem,
+  filter: CategoryFocusFilterId,
+): boolean {
+  if (filter === "all") {
+    return true;
+  }
+  if (filter === "safety_dominant") {
+    return isSafetyDominant(it);
+  }
+  if (filter === "availability_dominant") {
+    return isAvailabilityDominant(it);
+  }
+  return isBalancedOrLow(it);
+}
+
+/** Standardsortierung: meiste Incidents zuerst, dann höchster Safety-Anteil. */
+export function sortDrilldownItems(items: AdvisorIncidentDrilldownItem[]): AdvisorIncidentDrilldownItem[] {
+  return [...items].sort((a, b) => {
+    if (b.incidentCountTotal !== a.incidentCountTotal) {
+      return b.incidentCountTotal - a.incidentCountTotal;
+    }
+    if (b.weightedShareSafety !== a.weightedShareSafety) {
+      return b.weightedShareSafety - a.weightedShareSafety;
+    }
+    return a.aiSystemName.localeCompare(b.aiSystemName, "de");
+  });
+}
+
+export function applyDrilldownFilters(
+  items: AdvisorIncidentDrilldownItem[],
+  supplier: SupplierFilterId,
+  focus: CategoryFocusFilterId,
+): AdvisorIncidentDrilldownItem[] {
+  return sortDrilldownItems(
+    items.filter((it) => matchesSupplierFilter(it, supplier) && matchesCategoryFocusFilter(it, focus)),
+  );
+}
+
+export const SUPPLIER_FILTER_OPTIONS: { id: SupplierFilterId; label: string }[] = [
+  { id: "all", label: "Alle Lieferanten" },
+  { id: "sap_ai_core", label: "SAP AI Core" },
+  { id: "sap_btp_event_mesh", label: "SAP BTP Event Mesh" },
+  { id: "manual_import", label: "Manuell / Custom" },
+  { id: "other", label: "Sonstige" },
+];
+
+export const CATEGORY_FOCUS_OPTIONS: { id: CategoryFocusFilterId; label: string }[] = [
+  { id: "all", label: "Alle Fokus-Typen" },
+  { id: "safety_dominant", label: "Safety-dominant" },
+  { id: "availability_dominant", label: "Verfügbarkeit-dominant" },
+  { id: "balanced_low", label: "Ausgewogen / wenige Fälle" },
+];

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1693,6 +1693,50 @@ export async function postAdvisorGovernanceSnapshotMarkdown(
   return res.json() as Promise<{ markdown: string; provider: string; model_id: string }>;
 }
 
+/** Incident-Drilldown (Advisor → verknüpfter Mandant), JSON. */
+export async function fetchAdvisorTenantIncidentDrilldown(
+  advisorId: string,
+  clientTenantId: string,
+  windowDays = 90,
+): Promise<TenantIncidentDrilldownOutDto> {
+  const aid = encodeURIComponent(advisorId);
+  const tid = encodeURIComponent(clientTenantId);
+  const url = `${API_BASE_URL}/api/v1/advisors/${aid}/tenants/${tid}/incident-drilldown?window_days=${windowDays}`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-advisor-id": advisorId,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Incident drilldown failed: ${res.status}`);
+  }
+  return res.json() as Promise<TenantIncidentDrilldownOutDto>;
+}
+
+/** Incident-Drilldown als CSV-Blob (UTF-8). */
+export async function fetchAdvisorTenantIncidentDrilldownCsvBlob(
+  advisorId: string,
+  clientTenantId: string,
+  windowDays = 90,
+): Promise<Blob> {
+  const aid = encodeURIComponent(advisorId);
+  const tid = encodeURIComponent(clientTenantId);
+  const url = `${API_BASE_URL}/api/v1/advisors/${aid}/tenants/${tid}/incident-drilldown?window_days=${windowDays}&format=csv`;
+  const res = await fetch(url, {
+    headers: {
+      "x-api-key": API_KEY,
+      "x-advisor-id": advisorId,
+    },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Incident drilldown CSV failed: ${res.status}`);
+  }
+  return res.blob();
+}
+
 export interface AdvisorBoardReportListRowDto {
   tenant_id: string;
   tenant_display_name: string | null;


### PR DESCRIPTION
Add tenant incident drilldown types, API client, and AdvisorIncidentDrilldownPanel for governance snapshot and full page with CSV export. Integrate the snapshot section after OAMI. Add per-tenant Incident-Drilldown column in the advisor portfolio table when governance maturity is enabled. Include Vitest coverage for the panel, model helpers, and portfolio link href.

Made-with: Cursor