### PR TITLE
feat(advisor): align governance brief with incident drilldown

### DIFF
--- a/app/services/advisor_brief_drilldown_alignment.py
+++ b/app/services/advisor_brief_drilldown_alignment.py
@@ -1,0 +1,93 @@
+"""Regelbasierte Abstimmung: Governance-Maturity-Brief ↔ Incident-Drilldown (Laufzeit)."""
+
+from __future__ import annotations
+
+from app.advisor_governance_maturity_brief_models import AdvisorGovernanceMaturityBrief
+from app.incident_drilldown_models import TenantIncidentDrilldownOut
+from app.services.incident_drilldown_signal_utils import (
+    drilldown_mandate_pattern,
+    top_ai_system_names_for_brief,
+)
+
+# Hochlevel-Fokus (keine Systemnamen)
+FOCUS_SAFETY_DRILLDOWN_DE = (
+    "Sicherheitsrelevante Incidents und Post-Market-Monitoring (OAMI, Eskalation, Nachweise)."
+)
+FOCUS_AVAILABILITY_DRILLDOWN_DE = (
+    "Betriebsstabilität und Verfügbarkeit der KI-Systeme (Recovery, SLAs, Betriebsführung)."
+)
+FOCUS_MONITORING_COVERAGE_DE = (
+    "Monitoring-Abdeckung und Datenaktualität der Laufzeit-Signale verbessern."
+)
+
+
+def _focus_line_for_pattern(pattern: str) -> str:
+    if pattern == "safety":
+        return FOCUS_SAFETY_DRILLDOWN_DE
+    if pattern == "availability":
+        return FOCUS_AVAILABILITY_DRILLDOWN_DE
+    return FOCUS_MONITORING_COVERAGE_DE
+
+
+def _focus_effectively_present(areas: list[str], candidate: str) -> bool:
+    c = candidate.casefold()
+    needles: list[str]
+    if "sicherheitsrelevant" in c or "post-market" in c:
+        needles = ["sicherheitsrelevant", "post-market", "post market", "laufzeitvor"]
+    elif "verfügbarkeit" in c or "betriebsstabilität" in c:
+        needles = ["verfügbarkeit", "betriebsstabilität", "recovery"]
+    else:
+        needles = ["monitoring-abdeckung", "laufzeit-signale", "datenaktualität"]
+    return any(any(n in a.casefold() for n in needles) for a in areas)
+
+
+def _client_system_bridge(pattern: str, names: list[str]) -> str | None:
+    if pattern == "benign_low" or not names:
+        return None
+    label = "Safety-Signalen" if pattern == "safety" else "Verfügbarkeits-Signalen"
+    if len(names) >= 2:
+        return (
+            f"Im Fokus stehen aktuell vor allem die Systeme „{names[0]}“ und „{names[1]}“ "
+            f"({label})."
+        )
+    return f"Im Fokus steht aktuell vor allem das System „{names[0]}“ ({label})."
+
+
+def apply_drilldown_alignment_to_brief(
+    brief: AdvisorGovernanceMaturityBrief,
+    drilldown: TenantIncidentDrilldownOut | None,
+) -> AdvisorGovernanceMaturityBrief:
+    """Ergänzt Fokusliste und optional Mandantenabsatz aus Laufzeit-Drilldown.
+
+    Systemnamen höchstens kurz im Absatz; Fokuszeilen bleiben strategisch.
+    """
+    if drilldown is None or not drilldown.items:
+        return brief
+
+    total_incidents = sum(x.incident_total_90d for x in drilldown.items)
+    if total_incidents <= 0:
+        return brief
+
+    pattern = drilldown_mandate_pattern(drilldown.items)
+    candidate = _focus_line_for_pattern(pattern)
+    areas = list(brief.recommended_focus_areas)
+    if pattern == "benign_low":
+        areas = [a for a in areas if a != FOCUS_MONITORING_COVERAGE_DE]
+        if not areas or areas[0] != FOCUS_MONITORING_COVERAGE_DE:
+            areas = [FOCUS_MONITORING_COVERAGE_DE, *areas]
+    elif not _focus_effectively_present(areas, candidate):
+        areas = [candidate, *areas]
+
+    names = top_ai_system_names_for_brief(drilldown.items, limit=2)
+    bridge = _client_system_bridge(pattern, names)
+    para = (brief.client_ready_paragraph_de or "").strip()
+    if bridge:
+        para = f"{para} {bridge}".strip() if para else bridge
+        para = para[:600]
+
+    return brief.model_copy(
+        update={
+            "recommended_focus_areas": areas,
+            "client_ready_paragraph_de": para or None,
+        },
+    )

--- a/app/services/advisor_governance_maturity_brief_llm.py
+++ b/app/services/advisor_governance_maturity_brief_llm.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING
 from app.feature_flags import FeatureFlag, is_feature_enabled
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturitySummary
+from app.incident_drilldown_models import TenantIncidentDrilldownOut
 from app.llm_models import LLMTaskType
+from app.services.advisor_brief_drilldown_alignment import apply_drilldown_alignment_to_brief
 from app.services.advisor_governance_maturity_brief_parse import (
     AdvisorGovernanceMaturityBriefParseResult,
     build_fallback_advisor_governance_maturity_brief_parse_result,
@@ -19,6 +21,7 @@ from app.services.advisor_governance_maturity_brief_prompt import (
 )
 from app.services.governance_maturity_service import build_governance_maturity_response
 from app.services.llm_router import LLMRouter
+from app.services.tenant_incident_drilldown import compute_tenant_incident_drilldown
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -50,11 +53,31 @@ def render_advisor_governance_maturity_brief(
     return parse_advisor_governance_maturity_brief(resp.text or "", snapshot)
 
 
+def _maybe_align_brief_with_drilldown(
+    session: Session | None,
+    tenant_id: str,
+    result: AdvisorGovernanceMaturityBriefParseResult,
+    incident_drilldown: TenantIncidentDrilldownOut | None,
+) -> AdvisorGovernanceMaturityBriefParseResult:
+    dd: TenantIncidentDrilldownOut | None = incident_drilldown
+    if dd is None and session is not None:
+        try:
+            dd = compute_tenant_incident_drilldown(session, tenant_id, window_days=90)
+        except Exception:
+            logger.exception("advisor_brief_drilldown_compute_failed tenant=%s", tenant_id)
+            dd = None
+    if dd is None:
+        return result
+    aligned = apply_drilldown_alignment_to_brief(result.brief, dd)
+    return result.model_copy(update={"brief": aligned})
+
+
 def maybe_build_advisor_governance_maturity_brief_result(
     session: Session | None,
     tenant_id: str,
     *,
     board_summary: GovernanceMaturitySummary | None = None,
+    incident_drilldown: TenantIncidentDrilldownOut | None = None,
 ) -> AdvisorGovernanceMaturityBriefParseResult | None:
     """
     Wenn Governance-Maturity aktiv: Brief (LLM falls erlaubt, sonst deterministisch).
@@ -70,10 +93,12 @@ def maybe_build_advisor_governance_maturity_brief_result(
         return None
 
     if is_feature_enabled(FeatureFlag.llm_enabled, tenant_id, session=session):
-        return render_advisor_governance_maturity_brief(
+        out = render_advisor_governance_maturity_brief(
             session,
             tenant_id,
             snapshot,
             board_summary=board_summary,
         )
-    return build_fallback_advisor_governance_maturity_brief_parse_result(snapshot)
+    else:
+        out = build_fallback_advisor_governance_maturity_brief_parse_result(snapshot)
+    return _maybe_align_brief_with_drilldown(session, tenant_id, out, incident_drilldown)

--- a/app/services/advisor_report_llm_enrichment.py
+++ b/app/services/advisor_report_llm_enrichment.py
@@ -55,7 +55,11 @@ def enrich_advisor_tenant_report_with_governance_maturity_brief(
     report: AdvisorTenantReport,
 ) -> AdvisorTenantReport:
     """Setzt optional `governance_maturity_advisor_brief` (Feature governance_maturity)."""
-    res = maybe_build_advisor_governance_maturity_brief_result(session, tenant_id)
+    res = maybe_build_advisor_governance_maturity_brief_result(
+        session,
+        tenant_id,
+        incident_drilldown=report.incident_drilldown_snapshot,
+    )
     if res is None:
         return report
     return report.model_copy(update={"governance_maturity_advisor_brief": res.brief})

--- a/app/services/advisor_tenant_report_incident_drilldown_md.py
+++ b/app/services/advisor_tenant_report_incident_drilldown_md.py
@@ -5,41 +5,24 @@ from __future__ import annotations
 from typing import Literal
 
 from app.incident_drilldown_models import TenantIncidentDrilldownItem, TenantIncidentDrilldownOut
+from app.services.incident_drilldown_signal_utils import (
+    DRILLDOWN_LOW_TOTAL_THRESHOLD,
+    is_availability_driven_item,
+    is_safety_driven_item,
+    rank_drilldown_items_by_volume,
+)
 
-_DOMINANCE = 0.45
 _MAX_BULLETS = 5
-_LOW_TOTAL_THRESHOLD = 3
 
 DominantKind = Literal["safety", "availability", "other"]
 
 
-def _is_safety_driven(it: TenantIncidentDrilldownItem) -> bool:
-    s = it.weighted_incident_share_safety
-    a = it.weighted_incident_share_availability
-    o = it.weighted_incident_share_other
-    return s >= _DOMINANCE and s > a and s > o
-
-
-def _is_availability_driven(it: TenantIncidentDrilldownItem) -> bool:
-    s = it.weighted_incident_share_safety
-    a = it.weighted_incident_share_availability
-    o = it.weighted_incident_share_other
-    return a >= _DOMINANCE and a > s and a > o
-
-
 def _dominant_kind(it: TenantIncidentDrilldownItem) -> DominantKind:
-    if _is_safety_driven(it):
+    if is_safety_driven_item(it):
         return "safety"
-    if _is_availability_driven(it):
+    if is_availability_driven_item(it):
         return "availability"
     return "other"
-
-
-def _ranked_items(items: list[TenantIncidentDrilldownItem]) -> list[TenantIncidentDrilldownItem]:
-    return sorted(
-        items,
-        key=lambda x: (-x.incident_total_90d, -x.weighted_incident_share_safety, x.ai_system_name),
-    )
 
 
 def _select_for_report(
@@ -48,7 +31,7 @@ def _select_for_report(
     """Bis zu fünf Systeme; Safety- und Availability-Treiber, falls im Datenbestand vorhanden."""
     if not items:
         return []
-    ranked = _ranked_items(items)
+    ranked = rank_drilldown_items_by_volume(items)
     seen: set[str] = set()
     out: list[TenantIncidentDrilldownItem] = []
 
@@ -59,11 +42,11 @@ def _select_for_report(
         out.append(it)
 
     for it in ranked:
-        if _is_safety_driven(it):
+        if is_safety_driven_item(it):
             add(it)
             break
     for it in ranked:
-        if _is_availability_driven(it):
+        if is_availability_driven_item(it):
             add(it)
             break
     for it in ranked:
@@ -112,6 +95,8 @@ def _bullet_for_item(it: TenantIncidentDrilldownItem) -> str:
 
 def build_incident_system_supplier_drilldown_section(
     drilldown: TenantIncidentDrilldownOut | None,
+    *,
+    include_governance_brief_bridge: bool = False,
 ) -> str | None:
     """Markdown-Block mit Überschrift ###, oder None ohne sinnvollen Drilldown.
 
@@ -131,11 +116,17 @@ def build_incident_system_supplier_drilldown_section(
         "*Überblick zu den KI-Systemen und Lieferanten, die die Incident- und OAMI-Lage "
         "im Berichtszeitraum prägen.*"
     )
+    bridge = ""
+    if include_governance_brief_bridge:
+        bridge = (
+            "*Die nachfolgenden Systeme und Lieferanten spiegeln die oben genannten Schwerpunkte "
+            "des Governance-Kurzbriefs wider.*\n\n"
+        )
     intro_a = (
         "Die folgende Einordnung basiert auf aggregierten Laufzeit-Incidents "
         "(ohne Einzelfall-Inhalte) und der mandantenweiten OAMI-Gewichtung."
     )
-    if total_incidents <= _LOW_TOTAL_THRESHOLD:
+    if total_incidents <= DRILLDOWN_LOW_TOTAL_THRESHOLD:
         intro_b = (
             "Im Berichtszeitraum wurden nur wenige Incidents beobachtet; kein System dominiert die "
             "OAMI-Lage. Die genannten Systeme sind dennoch die größten relativen Treiber "
@@ -149,5 +140,6 @@ def build_incident_system_supplier_drilldown_section(
 
     bullets = "\n".join(_bullet_for_item(it) for it in selected)
     return (
-        f"### System- und Lieferanten-Drilldown\n\n{subtitle}\n\n{intro_a} {intro_b}\n\n{bullets}\n"
+        f"### System- und Lieferanten-Drilldown\n\n{subtitle}\n\n{bridge}"
+        f"{intro_a} {intro_b}\n\n{bullets}\n"
     )

--- a/app/services/advisor_tenant_report_markdown.py
+++ b/app/services/advisor_tenant_report_markdown.py
@@ -132,24 +132,28 @@ def render_tenant_report_markdown(report: AdvisorTenantReport) -> str:
             + "\n"
         )
 
-    risiko_md = render_risiko_incident_lage_markdown_section(report)
-    drill_md = build_incident_system_supplier_drilldown_section(report.incident_drilldown_snapshot)
+    risiko_only_md = render_risiko_incident_lage_markdown_section(report)
+    drill_md = build_incident_system_supplier_drilldown_section(
+        report.incident_drilldown_snapshot,
+        include_governance_brief_bridge=report.governance_maturity_advisor_brief is not None,
+    )
+    risk_block = risiko_only_md
     if drill_md:
-        risiko_md = f"{risiko_md}\n\n{drill_md}"
+        risk_block = f"{risiko_only_md}\n\n{drill_md}"
 
     return f"""# Compliance Hub Mandanten-Steckbrief – {report.tenant_name}
 
 **Mandanten-ID:** `{report.tenant_id}`  
 **Stand (UTC):** {report.generated_at_utc.isoformat()}
 {gm_brief_block}{narrative_block}
+{risk_block}
+
 ## Profil
 
 - Branche / Region: {loc}
 - KI-Systeme gesamt: **{report.ai_systems_total}**
 - High-Risk-Systeme (Register): **{report.high_risk_systems_count}**
 - High-Risk mit vollständigen Essential-Controls: **{report.high_risk_with_full_controls_count}**
-
-{risiko_md}
 
 ## EU AI Act
 

--- a/app/services/incident_drilldown_signal_utils.py
+++ b/app/services/incident_drilldown_signal_utils.py
@@ -1,0 +1,72 @@
+"""Dominanz, Ranking und Muster aus TenantIncidentDrilldown (Brief + Markdown)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from app.incident_drilldown_models import TenantIncidentDrilldownItem
+
+OAMI_INCIDENT_DOMINANCE_THRESHOLD = 0.45
+DRILLDOWN_LOW_TOTAL_THRESHOLD = 3
+
+DrilldownMandatePattern = Literal["safety", "availability", "benign_low"]
+
+
+def is_safety_driven_item(it: TenantIncidentDrilldownItem) -> bool:
+    s = it.weighted_incident_share_safety
+    a = it.weighted_incident_share_availability
+    o = it.weighted_incident_share_other
+    return s >= OAMI_INCIDENT_DOMINANCE_THRESHOLD and s > a and s > o
+
+
+def is_availability_driven_item(it: TenantIncidentDrilldownItem) -> bool:
+    s = it.weighted_incident_share_safety
+    a = it.weighted_incident_share_availability
+    o = it.weighted_incident_share_other
+    return a >= OAMI_INCIDENT_DOMINANCE_THRESHOLD and a > s and a > o
+
+
+def rank_drilldown_items_by_volume(
+    items: list[TenantIncidentDrilldownItem],
+) -> list[TenantIncidentDrilldownItem]:
+    return sorted(
+        items,
+        key=lambda x: (-x.incident_total_90d, -x.weighted_incident_share_safety, x.ai_system_name),
+    )
+
+
+def drilldown_mandate_pattern(items: list[TenantIncidentDrilldownItem]) -> DrilldownMandatePattern:
+    """Aggregiertes Lagebild für Brief-Fokus (nicht zeilenweise)."""
+    total = sum(i.incident_total_90d for i in items)
+    if total <= 0:
+        return "benign_low"
+    if total <= DRILLDOWN_LOW_TOTAL_THRESHOLD:
+        return "benign_low"
+    s_vol = sum(i.incident_total_90d for i in items if is_safety_driven_item(i))
+    a_vol = sum(i.incident_total_90d for i in items if is_availability_driven_item(i))
+    if s_vol == 0 and a_vol == 0:
+        return "benign_low"
+    if s_vol >= a_vol and s_vol > 0:
+        return "safety"
+    if a_vol > 0:
+        return "availability"
+    return "benign_low"
+
+
+def top_ai_system_names_for_brief(
+    items: list[TenantIncidentDrilldownItem],
+    *,
+    limit: int = 2,
+) -> list[str]:
+    """Bis zu ``limit`` Anzeigenamen, nach Incident-Volumen sortiert."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for it in rank_drilldown_items_by_volume(items):
+        label = (it.ai_system_name or "").strip() or it.ai_system_id
+        if label in seen:
+            continue
+        seen.add(label)
+        out.append(label)
+        if len(out) >= limit:
+            break
+    return out

--- a/docs/advisor-governance-maturity-brief.md
+++ b/docs/advisor-governance-maturity-brief.md
@@ -28,12 +28,49 @@ Die UI und Integrationen sollen **strukturierte Felder** (Enums, Listen) nutzen,
 
 **JSON-Schema-Hinweise für das LLM:** `advisor_governance_maturity_brief_json_schema_instructions()` in `app/governance_maturity_contract.py` (Schema-Version `ADVISOR_GOVERNANCE_MATURITY_BRIEF_SCHEMA_VERSION`). Die Governance-Maturity-**Contract-Version** (`GOVERNANCE_MATURITY_CONTRACT_VERSION`) bleibt für Enums und Terminologie maßgeblich.
 
+## Abgleich mit Incident-Drilldown (Laufzeit)
+
+Nach LLM-Parse bzw. Fallback wendet `maybe_build_advisor_governance_maturity_brief_result` eine **regelbasierte Abstimmung** mit dem 90-Tage-**Incident-Drilldown** an (`apply_drilldown_alignment_to_brief` in `app/services/advisor_brief_drilldown_alignment.py`). Derselbe Aggregat wie `GET …/incident-drilldown` wird dabei genutzt (optional vorgegeben, sonst frisch berechnet).
+
+| Drilldown-Muster (OAMI-Gewichte, Summe über Systeme) | Erste Fokuszeile (kanonisch, ohne Systemnamen) |
+|-----------------------------------------------------|-----------------------------------------------|
+| Dominanz **Sicherheit** (Volumen Safety ≥ Availability) | Sicherheitsrelevante Incidents und Post-Market-Monitoring (OAMI, Eskalation, Nachweise). |
+| Dominanz **Verfügbarkeit** | Betriebsstabilität und Verfügbarkeit der KI-Systeme (Recovery, SLAs, Betriebsführung). |
+| **Wenige / ausgewogene** Incidents (niedrige Gesamtzahl oder keine klare Dominanz) | Monitoring-Abdeckung und Datenaktualität der Laufzeit-Signale verbessern. |
+
+- **`client_ready_paragraph_de`:** Bei Safety- oder Verfügbarkeits-Muster werden optional **bis zu zwei** Top-Systemnamen aus dem Drilldown ergänzt („Im Fokus stehen … Safety-/Verfügbarkeits-Signalen“); keine Roh-Gewichte.
+- **Markdown-Steckbrief:** Reihenfolge **Governance-Kurzbrief → Risiko-/Incident-Lage → System- und Lieferanten-Drilldown → Profil → …** Der Drilldown kann einen **Brückensatz** enthalten, der auf den Kurzbrief verweist, wenn ein Brief vorliegt.
+
+### Beispiel Abgleich (Auszug)
+
+**Nach Alignment (Safety-Muster, ein System „ClaimsBot“):** `recommended_focus_areas[0]` = kanonische Safety-Zeile; Absatz endet z. B. mit „… Systeme „ClaimsBot“ (Safety-Signalen).“
+
+**Markdown (gekürzt):**
+
+```markdown
+## Governance-Reife – Kurzüberblick
+…
+- Sicherheitsrelevante Incidents und Post-Market-Monitoring (OAMI, Eskalation, Nachweise).
+- …
+
+## Risiko- und Incident-Lage (NIS2/KRITIS)
+…
+
+### System- und Lieferanten-Drilldown
+*Die nachfolgenden Systeme und Lieferanten spiegeln die oben genannten Schwerpunkte des Governance-Kurzbriefs wider.*
+…
+- **ClaimsBot** (Lieferant: SAP AI Core) zeigt … sicherheitsrelevante Incidents …
+```
+
+Details zur Drilldown-API: [`incidents-supplier-drilldowns.md`](./incidents-supplier-drilldowns.md).
+
 ## Backend-Flow
 
 - **Prompt:** `build_advisor_governance_maturity_brief_prompt(snapshot, board_summary | None)` — optionaler Board-Kern nur zur inhaltlichen Konsistenz, ohne neue Fakten.
 - **Parse / Align:** `parse_advisor_governance_maturity_brief` → Kern wie beim Board an den Snapshot anbinden; Advisor-Felder aus JSON übernehmen (Listen gekappt wie im Contract).
 - **LLM-Task:** `LLMTaskType.ADVISOR_GOVERNANCE_MATURITY_BRIEF` (Feature-Gate: `governance_maturity` + `llm_enabled`).
 - **Fallback ohne LLM:** `build_fallback_advisor_governance_maturity_brief_parse_result` — heuristische `recommended_focus_areas`.
+- **Drilldown-Abgleich:** `maybe_build_advisor_governance_maturity_brief_result` → `_maybe_align_brief_with_drilldown` (siehe Abschnitt oben).
 - **Einbindung:** Advisor-Portfolio (`governance_maturity_advisor_brief`), Mandanten-Snapshot-API, Markdown-Steckbrief (`render_tenant_report_markdown`; zusätzlich deterministischer Abschnitt **Risiko- und Incident-Lage (NIS2/KRITIS)** siehe [advisor-priority-nis2-kritis.md](./advisor-priority-nis2-kritis.md)), KI-Snapshot-Markdown (Präfix-Abschnitt vor LLM-Fließtext).
 
 Hinweis: Ist `COMPLIANCEHUB_FEATURE_LLM_ENABLED` aktiv, kann pro Mandant im Portfolio **ein zusätzlicher LLM-Aufruf** für den Brief entstehen (Triaging). Ohne LLM nutzt das System den deterministischen Fallback.
@@ -155,6 +192,7 @@ Aus Sicht der KI-Governance empfehlen wir, operatives Monitoring und die offenen
 ## Tests
 
 - `tests/test_advisor_governance_maturity_brief_parse.py` — Parse, Align, Fallback, Markdown, Prompt-Marker.
+- `tests/test_advisor_brief_drilldown_alignment.py` — Drilldown-Muster → Fokuszeilen, Mandantenabsatz, Steckbrief-Reihenfolge.
 - `tests/test_advisor_brief_golden_scenarios.py` — Szenarien A–D: Fake-LLM-JSON, konservatives Level, Markdown-Goldens, Einbettung im Mandanten-Steckbrief.
 - `tests/test_governance_maturity_contract.py::test_advisor_brief_json_schema_instructions_shape` — Contract-String.
 - Legacy-Fixture: `tests/fixtures/advisor_governance_maturity_brief_golden/response_ok.json`.

--- a/docs/incidents-supplier-drilldowns.md
+++ b/docs/incidents-supplier-drilldowns.md
@@ -40,7 +40,7 @@ Query **`format`:** `json` (Standard) oder `csv` (UTF-8, Download-Header).
 
 ## Mandanten-Steckbrief (Markdown)
 
-Bei `GET .../report?format=markdown` wird nach dem Block **„Risiko- und Incident-Lage“** optional ein Abschnitt **„System- und Lieferanten-Drilldown“** eingefügt (Überschrift `###`), sofern im 90-Tage-Fenster aggregierte Laufzeit-Incidents vorliegen. Inhalt: bis zu fünf priorisierte KI-Systeme mit Lieferanten-Label und qualitativer Safety-/Verfügbarkeits-Einordnung (ohne Roh-Gewichte im Text). Implementierung: `build_incident_system_supplier_drilldown_section` in `app/services/advisor_tenant_report_incident_drilldown_md.py`; Daten kommen aus dem gleichen `compute_tenant_incident_drilldown` wie die JSON-API.
+Bei `GET .../report?format=markdown` steht der Drilldown **nach** dem Block **„Risiko- und Incident-Lage“** und **nach** dem optionalen **Governance-Reife-Kurzbrief** (siehe [`advisor-governance-maturity-brief.md`](./advisor-governance-maturity-brief.md): gleiche Datenbasis stützt kanonische Fokuszeilen im Brief). Optionaler Brückensatz verknüpft Kurzbrief und Systemliste. Inhalt: bis zu fünf priorisierte KI-Systeme mit Lieferanten-Label und qualitativer Safety-/Verfügbarkeits-Einordnung (ohne Roh-Gewichte im Text). Implementierung: `build_incident_system_supplier_drilldown_section` in `app/services/advisor_tenant_report_incident_drilldown_md.py`; Daten: `compute_tenant_incident_drilldown` wie die JSON-API.
 
 ## Code
 

--- a/tests/test_advisor_brief_drilldown_alignment.py
+++ b/tests/test_advisor_brief_drilldown_alignment.py
@@ -1,0 +1,208 @@
+"""Tests: Abgleich AdvisorGovernanceMaturityBrief mit Incident-Drilldown."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from advisor_brief_scenario_snapshots import SCENARIO_SNAPSHOTS
+
+from app.advisor_models import AdvisorTenantReport, TenantReportCriticalRequirementItem
+from app.incident_drilldown_models import (
+    IncidentDrilldownCategoryCounts,
+    TenantIncidentDrilldownItem,
+    TenantIncidentDrilldownOut,
+)
+from app.services.advisor_brief_drilldown_alignment import (
+    FOCUS_AVAILABILITY_DRILLDOWN_DE,
+    FOCUS_MONITORING_COVERAGE_DE,
+    FOCUS_SAFETY_DRILLDOWN_DE,
+    apply_drilldown_alignment_to_brief,
+)
+from app.services.advisor_governance_maturity_brief_parse import (
+    build_fallback_advisor_governance_maturity_brief_parse_result,
+)
+from app.services.advisor_tenant_report_markdown import render_tenant_report_markdown
+
+
+def _item(
+    *,
+    sid: str,
+    name: str,
+    supplier: str = "SAP AI Core",
+    total: int,
+    ws: float,
+    wa: float,
+    wo: float,
+) -> TenantIncidentDrilldownItem:
+    return TenantIncidentDrilldownItem(
+        ai_system_id=sid,
+        ai_system_name=name,
+        supplier_label_de=supplier,
+        event_source="sap_ai_core",
+        incident_total_90d=total,
+        incident_count_by_category=IncidentDrilldownCategoryCounts(
+            safety=int(ws * 10),
+            availability=int(wa * 10),
+            other=int(wo * 10),
+        ),
+        weighted_incident_share_safety=ws,
+        weighted_incident_share_availability=wa,
+        weighted_incident_share_other=wo,
+        oami_local_hint_de="",
+    )
+
+
+def _brief_base():
+    snap = SCENARIO_SNAPSHOTS["a"]
+    return build_fallback_advisor_governance_maturity_brief_parse_result(snap).brief
+
+
+def test_alignment_prepends_safety_focus_when_safety_dominant_drilldown() -> None:
+    brief = _brief_base()
+    dd_items = [
+        _item(sid="s1", name="SafetyBot", total=12, ws=0.55, wa=0.25, wo=0.2),
+    ]
+    dd = TenantIncidentDrilldownOut(
+        tenant_id="t",
+        window_days=90,
+        systems_with_runtime_events=1,
+        systems_with_incidents=1,
+        items=dd_items,
+    )
+    out = apply_drilldown_alignment_to_brief(brief, dd)
+    assert out.recommended_focus_areas[0] == FOCUS_SAFETY_DRILLDOWN_DE
+    assert "SafetyBot" in (out.client_ready_paragraph_de or "")
+    assert "Safety-Signalen" in (out.client_ready_paragraph_de or "")
+
+
+def test_alignment_prepends_availability_focus() -> None:
+    brief = _brief_base()
+    dd = TenantIncidentDrilldownOut(
+        tenant_id="t",
+        window_days=90,
+        systems_with_runtime_events=1,
+        systems_with_incidents=1,
+        items=[
+            _item(sid="a", name="Lat", total=15, ws=0.2, wa=0.55, wo=0.25),
+        ],
+    )
+    out = apply_drilldown_alignment_to_brief(brief, dd)
+    assert out.recommended_focus_areas[0] == FOCUS_AVAILABILITY_DRILLDOWN_DE
+    assert "Lat" in (out.client_ready_paragraph_de or "")
+    assert "Verfügbarkeits-Signalen" in (out.client_ready_paragraph_de or "")
+
+
+def test_markdown_low_incidents_wenige_wording_and_monitoring_focus() -> None:
+    dd = TenantIncidentDrilldownOut(
+        tenant_id="t",
+        window_days=90,
+        systems_with_runtime_events=1,
+        systems_with_incidents=1,
+        items=[
+            _item(sid="q", name="Quiet", total=2, ws=0.34, wa=0.33, wo=0.33),
+        ],
+    )
+    brief = apply_drilldown_alignment_to_brief(_brief_base(), dd)
+    r = AdvisorTenantReport(
+        tenant_id="t-x",
+        tenant_name="X AG",
+        industry="IT",
+        country="DE",
+        generated_at_utc=datetime.now(UTC),
+        ai_systems_total=3,
+        high_risk_systems_count=1,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.5,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=100,
+        nis2_incident_readiness_percent=80.0,
+        nis2_supplier_risk_coverage_percent=70.0,
+        nis2_ot_it_segregation_mean_percent=60.0,
+        nis2_critical_focus_systems_count=0,
+        governance_open_actions_count=0,
+        governance_overdue_actions_count=0,
+        top_critical_requirements=[
+            TenantReportCriticalRequirementItem(code="C1", name="Gap", affected_systems_count=1),
+        ],
+        setup_completed_steps=4,
+        setup_total_steps=7,
+        setup_open_step_labels=[],
+        governance_maturity_advisor_brief=brief,
+        incident_drilldown_snapshot=dd,
+    )
+    md = render_tenant_report_markdown(r)
+    assert "nur wenige Incidents beobachtet" in md
+    assert "Monitoring-Abdeckung" in md
+
+
+def test_alignment_benign_low_uses_monitoring_focus_and_no_system_bridge() -> None:
+    brief = _brief_base()
+    dd = TenantIncidentDrilldownOut(
+        tenant_id="t",
+        window_days=90,
+        systems_with_runtime_events=1,
+        systems_with_incidents=1,
+        items=[
+            _item(sid="q", name="Quiet", total=2, ws=0.34, wa=0.33, wo=0.33),
+        ],
+    )
+    out = apply_drilldown_alignment_to_brief(brief, dd)
+    assert out.recommended_focus_areas[0] == FOCUS_MONITORING_COVERAGE_DE
+    para = out.client_ready_paragraph_de
+    assert para is None or "Im Fokus stehen" not in para
+
+
+def test_markdown_coherence_brief_risiko_drilldown_profil() -> None:
+    brief = apply_drilldown_alignment_to_brief(
+        _brief_base(),
+        TenantIncidentDrilldownOut(
+            tenant_id="t",
+            window_days=90,
+            systems_with_runtime_events=1,
+            systems_with_incidents=1,
+            items=[_item(sid="s1", name="CoherentSys", total=10, ws=0.55, wa=0.22, wo=0.23)],
+        ),
+    )
+    r = AdvisorTenantReport(
+        tenant_id="t-x",
+        tenant_name="X AG",
+        industry="IT",
+        country="DE",
+        generated_at_utc=datetime.now(UTC),
+        ai_systems_total=3,
+        high_risk_systems_count=1,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.5,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=100,
+        nis2_incident_readiness_percent=80.0,
+        nis2_supplier_risk_coverage_percent=70.0,
+        nis2_ot_it_segregation_mean_percent=60.0,
+        nis2_critical_focus_systems_count=0,
+        governance_open_actions_count=0,
+        governance_overdue_actions_count=0,
+        top_critical_requirements=[
+            TenantReportCriticalRequirementItem(code="C1", name="Gap", affected_systems_count=1),
+        ],
+        setup_completed_steps=4,
+        setup_total_steps=7,
+        setup_open_step_labels=[],
+        governance_maturity_advisor_brief=brief,
+        incident_drilldown_snapshot=TenantIncidentDrilldownOut(
+            tenant_id="t-x",
+            window_days=90,
+            systems_with_runtime_events=1,
+            systems_with_incidents=1,
+            items=[_item(sid="s1", name="CoherentSys", total=10, ws=0.55, wa=0.22, wo=0.23)],
+        ),
+    )
+    md = render_tenant_report_markdown(r)
+    gidx = md.index("## Governance-Reife – Kurzüberblick")
+    ridx = md.index("## Risiko- und Incident-Lage (NIS2/KRITIS)")
+    didx = md.index("### System- und Lieferanten-Drilldown")
+    pidx = md.index("## Profil")
+    eidx = md.index("## EU AI Act")
+    assert gidx < ridx < didx < pidx < eidx
+    assert "Governance-Kurzbriefs wider" in md
+    assert "**CoherentSys**" in md
+    assert FOCUS_SAFETY_DRILLDOWN_DE.split()[0] in md

--- a/tests/test_advisor_tenant_report_incident_drilldown_md.py
+++ b/tests/test_advisor_tenant_report_incident_drilldown_md.py
@@ -187,6 +187,18 @@ def test_high_volume_safety_template() -> None:
     assert "überwiegend sicherheitsrelevant" in md
 
 
+def test_drilldown_includes_governance_brief_bridge_when_requested() -> None:
+    dd = _out([_item(sid="z", name="BridgeSys", total=5, ws=0.55, wa=0.22, wo=0.23)])
+    with_bridge = build_incident_system_supplier_drilldown_section(
+        dd,
+        include_governance_brief_bridge=True,
+    )
+    without = build_incident_system_supplier_drilldown_section(dd)
+    assert with_bridge is not None and without is not None
+    assert "Governance-Kurzbriefs wider" in with_bridge
+    assert "Governance-Kurzbriefs wider" not in without
+
+
 def test_render_full_markdown_inserts_drilldown_before_eu_ai_act_section() -> None:
     from datetime import UTC, datetime
 
@@ -223,6 +235,7 @@ def test_render_full_markdown_inserts_drilldown_before_eu_ai_act_section() -> No
     md = render_tenant_report_markdown(r)
     ridx = md.index("## Risiko- und Incident-Lage (NIS2/KRITIS)")
     didx = md.index("### System- und Lieferanten-Drilldown")
+    pidx = md.index("## Profil")
     eidx = md.index("## EU AI Act")
-    assert ridx < didx < eidx
+    assert ridx < didx < pidx < eidx
     assert "**ReportSys**" in md


### PR DESCRIPTION
Add drilldown signal utils and apply_drilldown_alignment_to_brief for focus areas and optional client paragraph (up to two system names). Wire alignment into maybe_build_advisor_governance_maturity_brief_result; pass snapshot drilldown from tenant report enrichment. Reorder Markdown: brief, risk block + drilldown, then Profil; optional bridge from drilldown to brief. Document flow and add tests.

Made-with: Cursor