### PR TITLE
test(advisor): E2E golden fixtures for tenant report pipeline

### DIFF
--- a/docs/advisor-governance-maturity-brief.md
+++ b/docs/advisor-governance-maturity-brief.md
@@ -194,6 +194,7 @@ Aus Sicht der KI-Governance empfehlen wir, operatives Monitoring und die offenen
 - `tests/test_advisor_governance_maturity_brief_parse.py` — Parse, Align, Fallback, Markdown, Prompt-Marker.
 - `tests/test_advisor_brief_drilldown_alignment.py` — Drilldown-Muster → Fokuszeilen, Mandantenabsatz, Steckbrief-Reihenfolge.
 - `tests/test_advisor_brief_golden_scenarios.py` — Szenarien A–D: Fake-LLM-JSON, konservatives Level, Markdown-Goldens, Einbettung im Mandanten-Steckbrief.
+- **`tests/test_advisor_report_e2e_safety_dominant.py`** — End-to-end-Golden für den **Mandanten-Steckbrief**: Maturity-Snapshot + Drilldown → `apply_drilldown_alignment_to_brief` → voller Markdown (Brief, Risiko, Drilldown, Reihenfolge). Fixtures: `tests/fixtures/advisor-report-e2e/` (`safety_dominant_case`, `benign_low_case`). Bei Änderungen an Brief-, Risiko- oder Drilldown-Formulierungen Goldens und `expected_assertions.json` anpassen.
 - `tests/test_governance_maturity_contract.py::test_advisor_brief_json_schema_instructions_shape` — Contract-String.
 - Legacy-Fixture: `tests/fixtures/advisor_governance_maturity_brief_golden/response_ok.json`.
 

--- a/docs/incidents-supplier-drilldowns.md
+++ b/docs/incidents-supplier-drilldowns.md
@@ -42,6 +42,8 @@ Query **`format`:** `json` (Standard) oder `csv` (UTF-8, Download-Header).
 
 Bei `GET .../report?format=markdown` steht der Drilldown **nach** dem Block **„Risiko- und Incident-Lage“** und **nach** dem optionalen **Governance-Reife-Kurzbrief** (siehe [`advisor-governance-maturity-brief.md`](./advisor-governance-maturity-brief.md): gleiche Datenbasis stützt kanonische Fokuszeilen im Brief). Optionaler Brückensatz verknüpft Kurzbrief und Systemliste. Inhalt: bis zu fünf priorisierte KI-Systeme mit Lieferanten-Label und qualitativer Safety-/Verfügbarkeits-Einordnung (ohne Roh-Gewichte im Text). Implementierung: `build_incident_system_supplier_drilldown_section` in `app/services/advisor_tenant_report_incident_drilldown_md.py`; Daten: `compute_tenant_incident_drilldown` wie die JSON-API.
 
+**E2E-Golden:** `tests/test_advisor_report_e2e_safety_dominant.py`, Fixtures `tests/fixtures/advisor-report-e2e/`.
+
 ## Code
 
 - Modelle: `app/incident_drilldown_models.py`

--- a/tests/fixtures/advisor-report-e2e/README.md
+++ b/tests/fixtures/advisor-report-e2e/README.md
@@ -1,0 +1,12 @@
+# Advisor tenant report – E2E golden scenarios
+
+End-to-end fixtures for the **Markdown Steckbrief** pipeline: Governance-Maturity-Brief (after `apply_drilldown_alignment_to_brief`), **Risiko-/Incident-Lage**, and **System- und Lieferanten-Drilldown**.
+
+| Ordner | Zweck |
+|--------|--------|
+| `safety_dominant_case/` | Managed Readiness, mittleres GAI/OAMI, Laufzeit-Drilldown mit Safety-Treiber (System A) und Availability-Treiber (System B); NIS2 wichtige Einrichtung, hohe Incident-Last im Risiko-Abschnitt. |
+| `benign_low_case/` | Basic/low/low Maturity, sehr wenige Laufzeit-Incidents; Fokus Monitoring-Abdeckung, Drilldown-Text „wenige Incidents“, kein System-Fokus im Mandantenabsatz. |
+
+**Tests:** `tests/test_advisor_report_e2e_safety_dominant.py`
+
+Änderungen an `apply_drilldown_alignment_to_brief`, `render_risiko_incident_lage_markdown_section`, `build_incident_system_supplier_drilldown_section` oder `render_tenant_report_markdown` sollten gegen diese Szenarien geprüft werden; bei bewussten Textanpassungen die erwarteten `.md`-Fragmente und `expected_assertions.json` mitaktualisieren.

--- a/tests/fixtures/advisor-report-e2e/benign_low_case/expected_assertions.json
+++ b/tests/fixtures/advisor-report-e2e/benign_low_case/expected_assertions.json
@@ -1,0 +1,15 @@
+{
+  "brief_after_alignment": {
+    "recommended_focus_areas_0": "Monitoring-Abdeckung und Datenaktualität der Laufzeit-Signale verbessern.",
+    "client_ready_paragraph_de": null
+  },
+  "full_markdown_must_contain": [
+    "Monitoring-Abdeckung",
+    "nur wenige Incidents beobachtet",
+    "**QuietSvc**",
+    "## Profil"
+  ],
+  "full_markdown_must_not_contain": [
+    "Im Fokus stehen aktuell vor allem die Systeme"
+  ]
+}

--- a/tests/fixtures/advisor-report-e2e/benign_low_case/governance_maturity_snapshot.json
+++ b/tests/fixtures/advisor-report-e2e/benign_low_case/governance_maturity_snapshot.json
@@ -1,0 +1,27 @@
+{
+  "tenant_id": "e2e-golden-benign-tenant",
+  "computed_at": "2025-06-01T12:00:00+00:00",
+  "readiness": {
+    "score": 38,
+    "level": "basic",
+    "interpretation": "Struktureller Aufbau am Anfang."
+  },
+  "governance_activity": {
+    "index": 30,
+    "level": "low",
+    "window_days": 90,
+    "last_computed_at": "2025-06-01T12:00:00+00:00",
+    "components": null
+  },
+  "operational_ai_monitoring": {
+    "status": "active",
+    "index": 28,
+    "level": "low",
+    "window_days": 90,
+    "message_de": "Wenige belastbare Laufzeit-Signale im Fenster.",
+    "drivers_de": [],
+    "safety_related_runtime_incident_count": 0,
+    "availability_runtime_incident_count": 1,
+    "operational_subtype_hint_de": null
+  }
+}

--- a/tests/fixtures/advisor-report-e2e/benign_low_case/incident_drilldown.json
+++ b/tests/fixtures/advisor-report-e2e/benign_low_case/incident_drilldown.json
@@ -1,0 +1,24 @@
+{
+  "tenant_id": "e2e-golden-benign-tenant",
+  "window_days": 90,
+  "systems_with_runtime_events": 1,
+  "systems_with_incidents": 1,
+  "items": [
+    {
+      "ai_system_id": "sys-quiet-001",
+      "ai_system_name": "QuietSvc",
+      "supplier_label_de": "Manuell / Custom",
+      "event_source": "manual_import",
+      "incident_total_90d": 2,
+      "incident_count_by_category": {
+        "safety": 0,
+        "availability": 1,
+        "other": 1
+      },
+      "weighted_incident_share_safety": 0.34,
+      "weighted_incident_share_availability": 0.33,
+      "weighted_incident_share_other": 0.33,
+      "oami_local_hint_de": "Wenige klassifizierte Incidents; Einordnung mit Vorsicht nutzen."
+    }
+  ]
+}

--- a/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_assertions.json
+++ b/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_assertions.json
@@ -1,0 +1,26 @@
+{
+  "brief_after_alignment": {
+    "governance_maturity_summary_overall_level": "medium",
+    "recommended_focus_areas_0": "Sicherheitsrelevante Incidents und Post-Market-Monitoring (OAMI, Eskalation, Nachweise).",
+    "client_ready_paragraph_de": "Im Fokus stehen aktuell vor allem die Systeme „Acme Claims Assistant“ und „Batch Scoring API“ (Safety-Signalen)."
+  },
+  "full_markdown_must_contain": [
+    "## Governance-Reife – Kurzüberblick",
+    "Post-Market-Monitoring",
+    "Acme Claims Assistant",
+    "Laststufe **hoch**",
+    "### System- und Lieferanten-Drilldown",
+    "Governance-Kurzbriefs wider",
+    "**Batch Scoring API**",
+    "Verfügbarkeits-/Performance-Incidents",
+    "## Profil",
+    "## EU AI Act"
+  ],
+  "section_order": [
+    "## Governance-Reife – Kurzüberblick",
+    "## Risiko- und Incident-Lage (NIS2/KRITIS)",
+    "### System- und Lieferanten-Drilldown",
+    "## Profil",
+    "## EU AI Act"
+  ]
+}

--- a/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_drilldown_fragment.md
+++ b/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_drilldown_fragment.md
@@ -1,0 +1,10 @@
+### System- und Lieferanten-Drilldown
+
+*Überblick zu den KI-Systemen und Lieferanten, die die Incident- und OAMI-Lage im Berichtszeitraum prägen.*
+
+*Die nachfolgenden Systeme und Lieferanten spiegeln die oben genannten Schwerpunkte des Governance-Kurzbriefs wider.*
+
+Die folgende Einordnung basiert auf aggregierten Laufzeit-Incidents (ohne Einzelfall-Inhalte) und der mandantenweiten OAMI-Gewichtung. Priorisiert sind die Systeme mit dem höchsten Incident-Volumen beziehungsweise dem stärksten Sicherheitsbezug gemäß OAMI-Logik.
+
+- **Acme Claims Assistant** (Lieferant: SAP AI Core) zeigt im Berichtszeitraum ein erhöhtes Volumen überwiegend sicherheitsrelevanter Laufzeit-Incidents; diese tragen überproportional zum OAMI bei. *Kurz:* Schwerpunkt: sicherheitsrelevante Laufzeit-Incidents (OAMI-Gewichtung).
+- **Batch Scoring API** (Lieferant: SAP BTP Event Mesh) verursacht vor allem Verfügbarkeits-/Performance-Incidents; Fokus auf Betriebsstabilität und Service-Recovery. *Kurz:* Schwerpunkt: Verfügbarkeits-Incidents (Betriebsstabilität).

--- a/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_risiko_fragment.md
+++ b/tests/fixtures/advisor-report-e2e/safety_dominant_case/expected_risiko_fragment.md
@@ -1,0 +1,14 @@
+## Risiko- und Incident-Lage (NIS2/KRITIS)
+
+**NIS2-Einordnung:** Der Mandant ist als wichtige Einrichtung im Sinne von NIS2 eingestuft (Stammdaten).
+
+**KRITIS-Sektor:** Energie.
+
+**Vorfälle (90 Tage, aggregiert):** 9 erfasst, davon **3** mit Schweregrad „hoch“; Laststufe **hoch**. Keine Inhalte oder Personen aus Einzelfällen.
+
+**Offene/laufende Vorfälle (Register):** 2.
+
+### Kurzbeobachtungen
+
+- Engere Nachverfolgung der offenen Vorfälle ist sinnvoll (Nachweise, interne Fristen, ggf. Vorstandsinformation gemäß Policies).
+- Erhöhte Incident-Aktivität: Melde- und Dokumentationspflichten nach NIS2 sowie Anforderungen aus dem KRITIS-Dachgesetz im Blick behalten.

--- a/tests/fixtures/advisor-report-e2e/safety_dominant_case/governance_maturity_snapshot.json
+++ b/tests/fixtures/advisor-report-e2e/safety_dominant_case/governance_maturity_snapshot.json
@@ -1,0 +1,27 @@
+{
+  "tenant_id": "e2e-golden-safety-tenant",
+  "computed_at": "2025-06-01T12:00:00+00:00",
+  "readiness": {
+    "score": 72,
+    "level": "managed",
+    "interpretation": "Etablierte Registerbasis; fokussiert Lücken schließen."
+  },
+  "governance_activity": {
+    "index": 52,
+    "level": "medium",
+    "window_days": 90,
+    "last_computed_at": "2025-06-01T12:00:00+00:00",
+    "components": null
+  },
+  "operational_ai_monitoring": {
+    "status": "active",
+    "index": 58,
+    "level": "medium",
+    "window_days": 90,
+    "message_de": "Operatives Monitoring mit Schwerpunkt sicherheitsnaher Laufzeitereignisse.",
+    "drivers_de": ["Safety-Subtype-Incidents", "KPI-Stabilität"],
+    "safety_related_runtime_incident_count": 6,
+    "availability_runtime_incident_count": 2,
+    "operational_subtype_hint_de": "Sicherheitsnahe Signale prägen den Index stärker als Verfügbarkeit."
+  }
+}

--- a/tests/fixtures/advisor-report-e2e/safety_dominant_case/incident_drilldown.json
+++ b/tests/fixtures/advisor-report-e2e/safety_dominant_case/incident_drilldown.json
@@ -1,0 +1,40 @@
+{
+  "tenant_id": "e2e-golden-safety-tenant",
+  "window_days": 90,
+  "systems_with_runtime_events": 2,
+  "systems_with_incidents": 2,
+  "items": [
+    {
+      "ai_system_id": "sys-claims-001",
+      "ai_system_name": "Acme Claims Assistant",
+      "supplier_label_de": "SAP AI Core",
+      "event_source": "sap_ai_core",
+      "incident_total_90d": 14,
+      "incident_count_by_category": {
+        "safety": 9,
+        "availability": 3,
+        "other": 2
+      },
+      "weighted_incident_share_safety": 0.58,
+      "weighted_incident_share_availability": 0.22,
+      "weighted_incident_share_other": 0.2,
+      "oami_local_hint_de": "Schwerpunkt: sicherheitsrelevante Laufzeit-Incidents (OAMI-Gewichtung)."
+    },
+    {
+      "ai_system_id": "sys-batch-002",
+      "ai_system_name": "Batch Scoring API",
+      "supplier_label_de": "SAP BTP Event Mesh",
+      "event_source": "sap_btp_event_mesh",
+      "incident_total_90d": 8,
+      "incident_count_by_category": {
+        "safety": 1,
+        "availability": 5,
+        "other": 2
+      },
+      "weighted_incident_share_safety": 0.18,
+      "weighted_incident_share_availability": 0.55,
+      "weighted_incident_share_other": 0.27,
+      "oami_local_hint_de": "Schwerpunkt: Verfügbarkeits-Incidents (Betriebsstabilität)."
+    }
+  ]
+}

--- a/tests/test_advisor_report_e2e_safety_dominant.py
+++ b/tests/test_advisor_report_e2e_safety_dominant.py
@@ -1,0 +1,202 @@
+"""
+E2E-Golden: Advisor-Tenant-Report (Brief ↔ Drilldown ↔ Risiko ↔ Markdown).
+
+Fixtures: tests/fixtures/advisor-report-e2e/
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+from app.advisor_governance_maturity_brief_models import AdvisorGovernanceMaturityBrief
+from app.advisor_models import AdvisorTenantReport, TenantReportCriticalRequirementItem
+from app.governance_maturity_models import GovernanceMaturityResponse
+from app.incident_drilldown_models import TenantIncidentDrilldownOut
+from app.services.advisor_brief_drilldown_alignment import (
+    FOCUS_MONITORING_COVERAGE_DE,
+    apply_drilldown_alignment_to_brief,
+)
+from app.services.advisor_governance_maturity_brief_parse import (
+    build_fallback_advisor_governance_maturity_brief_parse_result,
+)
+from app.services.advisor_tenant_report_incident_drilldown_md import (
+    build_incident_system_supplier_drilldown_section,
+)
+from app.services.advisor_tenant_report_markdown import (
+    render_risiko_incident_lage_markdown_section,
+    render_tenant_report_markdown,
+)
+from app.services.advisor_tenant_report_risiko import nis2_entity_category_report_label_de
+from app.services.incident_drilldown_signal_utils import drilldown_mandate_pattern
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "advisor-report-e2e"
+
+
+def _norm_md(text: str) -> str:
+    lines = [line.rstrip() for line in text.strip().splitlines()]
+    return "\n".join(lines).strip() + "\n"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _safety_aligned_brief_and_drilldown() -> tuple[
+    GovernanceMaturityResponse,
+    TenantIncidentDrilldownOut,
+    dict,
+    AdvisorGovernanceMaturityBrief,
+]:
+    case = _FIXTURES / "safety_dominant_case"
+    snap = GovernanceMaturityResponse.model_validate_json(
+        (case / "governance_maturity_snapshot.json").read_text(encoding="utf-8"),
+    )
+    dd = TenantIncidentDrilldownOut.model_validate_json(
+        (case / "incident_drilldown.json").read_text(encoding="utf-8"),
+    )
+    exp = _load_json(case / "expected_assertions.json")
+    base = build_fallback_advisor_governance_maturity_brief_parse_result(snap).brief
+    aligned = apply_drilldown_alignment_to_brief(base, dd)
+    return snap, dd, exp, aligned
+
+
+def test_e2e_safety_dominant_brief_alignment_matches_golden() -> None:
+    _, dd, exp, aligned = _safety_aligned_brief_and_drilldown()
+    want = exp["brief_after_alignment"]
+    assert (
+        aligned.governance_maturity_summary.overall_assessment.level
+        == want["governance_maturity_summary_overall_level"]
+    )
+    assert aligned.recommended_focus_areas[0] == want["recommended_focus_areas_0"]
+    assert aligned.client_ready_paragraph_de == want["client_ready_paragraph_de"]
+    assert "Acme Claims Assistant" in (aligned.client_ready_paragraph_de or "")
+    assert "Batch Scoring API" in (aligned.client_ready_paragraph_de or "")
+    assert drilldown_mandate_pattern(dd.items) == "safety"
+
+
+def test_e2e_safety_dominant_risiko_and_drilldown_fragments_match_golden_files() -> None:
+    case = _FIXTURES / "safety_dominant_case"
+    _, dd, _, aligned = _safety_aligned_brief_and_drilldown()
+    report = _safety_domain_report(aligned, dd)
+    risiko_md = render_risiko_incident_lage_markdown_section(report)
+    expected_risiko = (case / "expected_risiko_fragment.md").read_text(encoding="utf-8")
+    assert _norm_md(risiko_md) == _norm_md(expected_risiko)
+
+    drill_md = build_incident_system_supplier_drilldown_section(
+        dd,
+        include_governance_brief_bridge=True,
+    )
+    expected_drill = (case / "expected_drilldown_fragment.md").read_text(encoding="utf-8")
+    assert _norm_md(drill_md or "") == _norm_md(expected_drill)
+
+
+def _safety_domain_report(
+    brief: AdvisorGovernanceMaturityBrief,
+    dd: TenantIncidentDrilldownOut,
+) -> AdvisorTenantReport:
+    fixed = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+    return AdvisorTenantReport(
+        tenant_id="e2e-golden-safety-tenant",
+        tenant_name="E2E Golden Mandant",
+        industry="IT",
+        country="DE",
+        generated_at_utc=fixed,
+        ai_systems_total=5,
+        high_risk_systems_count=2,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.72,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=400,
+        nis2_incident_readiness_percent=70.0,
+        nis2_supplier_risk_coverage_percent=65.0,
+        nis2_ot_it_segregation_mean_percent=55.0,
+        nis2_critical_focus_systems_count=1,
+        governance_open_actions_count=3,
+        governance_overdue_actions_count=1,
+        top_critical_requirements=[
+            TenantReportCriticalRequirementItem(code="X1", name="Gap", affected_systems_count=2),
+        ],
+        setup_completed_steps=5,
+        setup_total_steps=7,
+        setup_open_step_labels=[],
+        governance_maturity_advisor_brief=brief,
+        incident_drilldown_snapshot=dd,
+        risiko_nis2_scope_label_de=nis2_entity_category_report_label_de("important_entity"),
+        risiko_kritis_sector_label_de="Energie",
+        risiko_incidents_90d_count=9,
+        risiko_incidents_90d_high_severity=3,
+        risiko_incident_burden_level="high",
+        risiko_open_incidents_count=2,
+        risiko_regulatory_priority_note_de=None,
+        risiko_nis2_entity_category="important_entity",
+    )
+
+
+def test_e2e_safety_dominant_full_markdown_structure_and_alignment() -> None:
+    _, dd, exp, aligned = _safety_aligned_brief_and_drilldown()
+    report = _safety_domain_report(aligned, dd)
+    md = render_tenant_report_markdown(report)
+    for needle in exp["full_markdown_must_contain"]:
+        assert needle in md, f"missing fragment: {needle!r}"
+    order = exp["section_order"]
+    positions = [md.index(marker) for marker in order]
+    assert positions == sorted(positions)
+
+
+def test_e2e_benign_low_monitoring_focus_and_wenige_drilldown_text() -> None:
+    case = _FIXTURES / "benign_low_case"
+    snap = GovernanceMaturityResponse.model_validate_json(
+        (case / "governance_maturity_snapshot.json").read_text(encoding="utf-8"),
+    )
+    dd = TenantIncidentDrilldownOut.model_validate_json(
+        (case / "incident_drilldown.json").read_text(encoding="utf-8"),
+    )
+    exp = _load_json(case / "expected_assertions.json")
+    base = build_fallback_advisor_governance_maturity_brief_parse_result(snap).brief
+    aligned = apply_drilldown_alignment_to_brief(base, dd)
+    want = exp["brief_after_alignment"]
+    assert aligned.recommended_focus_areas[0] == want["recommended_focus_areas_0"]
+    assert aligned.recommended_focus_areas[0] == FOCUS_MONITORING_COVERAGE_DE
+    assert aligned.client_ready_paragraph_de == want["client_ready_paragraph_de"]
+
+    fixed = datetime(2025, 6, 1, 12, 0, 0, tzinfo=UTC)
+    report = AdvisorTenantReport(
+        tenant_id="e2e-golden-benign-tenant",
+        tenant_name="E2E Benign Mandant",
+        industry="IT",
+        country="DE",
+        generated_at_utc=fixed,
+        ai_systems_total=3,
+        high_risk_systems_count=0,
+        high_risk_with_full_controls_count=0,
+        eu_ai_act_readiness_score=0.42,
+        eu_ai_act_deadline="2026-08-02",
+        eu_ai_act_days_remaining=400,
+        nis2_incident_readiness_percent=50.0,
+        nis2_supplier_risk_coverage_percent=40.0,
+        nis2_ot_it_segregation_mean_percent=None,
+        nis2_critical_focus_systems_count=0,
+        governance_open_actions_count=1,
+        governance_overdue_actions_count=0,
+        top_critical_requirements=[],
+        setup_completed_steps=2,
+        setup_total_steps=7,
+        setup_open_step_labels=["KI-Inventar"],
+        governance_maturity_advisor_brief=aligned,
+        incident_drilldown_snapshot=dd,
+        risiko_nis2_scope_label_de=nis2_entity_category_report_label_de("none"),
+        risiko_kritis_sector_label_de=None,
+        risiko_incidents_90d_count=2,
+        risiko_incidents_90d_high_severity=0,
+        risiko_incident_burden_level="low",
+        risiko_open_incidents_count=0,
+        risiko_regulatory_priority_note_de=None,
+        risiko_nis2_entity_category="none",
+    )
+    md = render_tenant_report_markdown(report)
+    for needle in exp["full_markdown_must_contain"]:
+        assert needle in md, f"missing: {needle!r}"
+    for forbidden in exp["full_markdown_must_not_contain"]:
+        assert forbidden not in md


### PR DESCRIPTION
Add safety-dominant and benign-low scenarios under tests/fixtures/advisor-report-e2e with JSON snapshots, drilldown data, expected assertions, and Markdown goldens for Risiko and drilldown blocks. Add test_advisor_report_e2e_safety_dominant.py covering brief alignment, fragment equality, full Markdown order, and benign monitoring focus. Document in advisor-governance-maturity-brief and incidents docs.

Made-with: Cursor