### PR TITLE
feat(policy): OPA CI Rego tests, env/header role resolution, Wave 1 g…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
           ruff check app/ tests/
           ruff format --check app/ tests/
 
+      - name: Setup OPA
+        uses: open-policy-agent/setup-opa@v2
+        with:
+          version: v0.70.0
+
+      - name: OPA Rego policy tests
+        run: opa test infra/opa/policies/compliancehub/regos/
+
       - name: Test
         run: python -m pytest tests/ -q
         # DB governance: tests/test_db_schema_alignment.py (ORM vs DB) +

--- a/app/agents/__init__.py
+++ b/app/agents/__init__.py
@@ -1,0 +1,3 @@
+"""Agent workflows (LangGraph PoCs and future orchestration)."""
+
+from __future__ import annotations

--- a/app/agents/langgraph/__init__.py
+++ b/app/agents/langgraph/__init__.py
@@ -1,0 +1,3 @@
+"""LangGraph-based workflows (Wave 1 PoC scope)."""
+
+from __future__ import annotations

--- a/app/agents/langgraph/oami_explain_poc.py
+++ b/app/agents/langgraph/oami_explain_poc.py
@@ -1,0 +1,135 @@
+"""
+Deterministic OAMI explain PoC: load index → LLM JSON (guardrailed) → optional rule fallback.
+
+Synchronous invocation from FastAPI; MemorySaver checkpointer for LangGraph API compatibility.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, TypedDict
+
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph
+
+from app.llm.guardrails import LLMContractViolation
+from app.llm.safe_llm_invoke import safe_llm_json_call
+from app.llm_models import LLMTaskType
+from app.operational_monitoring_models import OamiExplanationOut, SystemMonitoringIndexOut
+from app.services.oami_explanation import explain_system_oami_de
+from app.services.operational_monitoring_index import compute_system_monitoring_index
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+class OamiExplainPocState(TypedDict, total=False):
+    tenant_id: str
+    ai_system_id: str
+    window_days: int
+    index_json: dict[str, object] | None
+    explanation: dict[str, object] | None
+    llm_error: str | None
+
+
+def _build_oami_explain_prompt(index: dict[str, object]) -> str:
+    return (
+        "Du bist ein Compliance-Assistent. Erzeuge ausschließlich ein JSON-Objekt mit den "
+        "Schlüsseln: summary_de (string), drivers_de (Liste von Strings, höchstens 12 kurze "
+        "Sätze), monitoring_gap_de (string oder null). Nutze nur die folgenden OAMI-Fakten; "
+        "erfunde keine neuen Messzahlen außerhalb der Fakten.\n\n"
+        f"{json.dumps(index, ensure_ascii=False)}"
+    )
+
+
+def build_oami_explain_poc_graph(session: Session):
+    """Compile a small graph bound to a DB session (tenant-scoped callers)."""
+
+    def node_load_index(state: OamiExplainPocState) -> dict[str, object]:
+        tid = state["tenant_id"]
+        sid = state["ai_system_id"]
+        wd = int(state.get("window_days") or 90)
+        idx = compute_system_monitoring_index(session, tid, sid, window_days=wd)
+        payload = idx.model_dump(mode="json")
+        payload.pop("explanation", None)
+        return {"index_json": payload, "llm_error": None}
+
+    def node_llm_explain(state: OamiExplainPocState) -> dict[str, object]:
+        tid = state["tenant_id"]
+        raw_index = state.get("index_json") or {}
+        prompt = _build_oami_explain_prompt(raw_index)
+        try:
+            out = safe_llm_json_call(
+                session,
+                tid,
+                LLMTaskType.STRUCTURED_OUTPUT,
+                prompt,
+                OamiExplanationOut,
+                context="langgraph_oami_explain_poc",
+                response_format="json_object",
+            )
+            return {"explanation": out.model_dump(mode="json"), "llm_error": None}
+        except LLMContractViolation as exc:
+            logger.info(
+                "langgraph_oami_explain_llm_contract_failed tenant=%s system=%s err=%s",
+                tid,
+                state.get("ai_system_id"),
+                exc,
+            )
+            return {"explanation": None, "llm_error": str(exc)[:500]}
+
+    def node_fallback(state: OamiExplainPocState) -> dict[str, object]:
+        raw = state.get("index_json")
+        if not raw:
+            raise RuntimeError("oami_explain_poc_missing_index")
+        idx = SystemMonitoringIndexOut.model_validate(raw)
+        out = explain_system_oami_de(idx)
+        return {"explanation": out.model_dump(mode="json"), "llm_error": None}
+
+    def node_finalize(state: OamiExplainPocState) -> dict[str, object]:
+        return {}
+
+    def route_after_llm(state: OamiExplainPocState) -> str:
+        if state.get("explanation"):
+            return "finalize"
+        return "fallback"
+
+    g = StateGraph(OamiExplainPocState)
+    g.add_node("load_index", node_load_index)
+    g.add_node("llm_explain", node_llm_explain)
+    g.add_node("fallback", node_fallback)
+    g.add_node("finalize", node_finalize)
+    g.add_edge(START, "load_index")
+    g.add_edge("load_index", "llm_explain")
+    g.add_conditional_edges(
+        "llm_explain",
+        route_after_llm,
+        {"finalize": "finalize", "fallback": "fallback"},
+    )
+    g.add_edge("fallback", "finalize")
+    g.add_edge("finalize", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+def run_oami_explain_poc(
+    session: Session,
+    *,
+    tenant_id: str,
+    ai_system_id: str,
+    window_days: int = 90,
+) -> OamiExplanationOut:
+    graph = build_oami_explain_poc_graph(session)
+    init: OamiExplainPocState = {
+        "tenant_id": tenant_id,
+        "ai_system_id": ai_system_id,
+        "window_days": window_days,
+    }
+    cfg = {"configurable": {"thread_id": f"{tenant_id}:{ai_system_id}:{window_days}"}}
+    out_state = graph.invoke(init, cfg)
+    expl = out_state.get("explanation")
+    if not expl:
+        raise RuntimeError("oami_explain_poc_empty_explanation")
+    return OamiExplanationOut.model_validate(expl)

--- a/app/auth_dependencies.py
+++ b/app/auth_dependencies.py
@@ -61,6 +61,20 @@ def get_api_key_and_tenant(
     return tid
 
 
+def get_optional_opa_user_role_header(
+    x_opa_user_role: Annotated[str | None, Header(alias="x-opa-user-role")] = None,
+) -> str | None:
+    """
+    Optional role hint for OPA.
+
+    Honored only when COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER is enabled.
+    """
+    if x_opa_user_role is None:
+        return None
+    s = str(x_opa_user_role).strip()
+    return s or None
+
+
 def get_auth_context(
     request: Request,
     session: Annotated[Session, Depends(get_session)],

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,0 +1,3 @@
+"""LLM utilities: guardrails and safe invocation helpers."""
+
+from __future__ import annotations

--- a/app/llm/guardrails.py
+++ b/app/llm/guardrails.py
@@ -1,0 +1,132 @@
+"""Input scanning and structured-output validation for LLM calls."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Literal, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+GuardrailRiskLevel = Literal["low", "medium", "high"]
+
+
+class GuardrailScanResult(BaseModel):
+    risk_level: GuardrailRiskLevel
+    """Heuristic aggregate risk for logging and future hard blocks."""
+
+    flags: list[str] = []
+    matched_patterns: list[str] = []
+
+
+class LLMContractViolation(Exception):
+    """Raised when LLM output does not validate against the expected Pydantic contract."""
+
+
+_EMAIL_RE = re.compile(
+    r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+)
+_PHONE_RE = re.compile(
+    r"(?:\+?\d{1,3}[-.\s]?)?(?:\(?\d{2,4}\)?[-.\s]?)?\d{3,4}[-.\s]?\d{3,4}\b",
+)
+_IBAN_LIKE_RE = re.compile(
+    r"\b[A-Z]{2}\d{2}[A-Z0-9]{1,30}\b",
+    re.IGNORECASE,
+)
+
+_INJECTION_MARKERS = (
+    "ignore previous instructions",
+    "ignore all previous",
+    "disregard the above",
+    "system:",
+    "assistant:",
+    "you are now",
+    "new instructions:",
+    "override",
+    "jailbreak",
+)
+
+
+def scan_input_for_pii_and_injection(text: str) -> GuardrailScanResult:
+    """
+    Lightweight regex heuristics for obvious PII and prompt-injection markers.
+
+    v1: never blocks by itself; callers log and may tighten policy later.
+    """
+    if not text or not str(text).strip():
+        return GuardrailScanResult(risk_level="low")
+
+    t = str(text)
+    lowered = t.lower()
+    flags: list[str] = []
+    matched: list[str] = []
+
+    if _EMAIL_RE.search(t):
+        flags.append("possible_email")
+        matched.append("email")
+    if _IBAN_LIKE_RE.search(t):
+        flags.append("possible_iban")
+        matched.append("iban_like")
+    if _PHONE_RE.search(t) and len(re.sub(r"\D", "", t)) >= 10:
+        flags.append("possible_phone")
+        matched.append("phone_like")
+
+    for marker in _INJECTION_MARKERS:
+        if marker in lowered:
+            flags.append("injection_marker")
+            matched.append(marker)
+            break
+
+    risk: GuardrailRiskLevel = "low"
+    if flags:
+        risk = "medium"
+    if "injection_marker" in flags and ("possible_email" in flags or "possible_iban" in flags):
+        risk = "high"
+    elif "injection_marker" in flags:
+        risk = "high"
+
+    return GuardrailScanResult(risk_level=risk, flags=flags, matched_patterns=matched)
+
+
+def log_input_guardrail_scan(
+    *,
+    context: str,
+    tenant_id: str,
+    scan: GuardrailScanResult,
+) -> None:
+    if scan.risk_level == "high":
+        logger.warning(
+            "llm_guardrail_input_high_risk context=%s tenant=%s flags=%s",
+            context,
+            tenant_id,
+            scan.flags,
+        )
+    elif scan.risk_level == "medium":
+        logger.info(
+            "llm_guardrail_input_medium_risk context=%s tenant=%s flags=%s",
+            context,
+            tenant_id,
+            scan.flags,
+        )
+
+
+def validate_llm_json_output(payload: Any, schema: type[T]) -> T:
+    """
+    Validate parsed JSON (dict) or JSON string against a Pydantic model.
+
+    Raises LLMContractViolation on failure.
+    """
+    try:
+        if isinstance(payload, schema):
+            return payload
+        if isinstance(payload, dict):
+            return schema.model_validate(payload)
+        if isinstance(payload, str):
+            return schema.model_validate_json(payload)
+        return schema.model_validate(payload)
+    except ValidationError as exc:
+        raise LLMContractViolation(str(exc)) from exc

--- a/app/llm/safe_llm_invoke.py
+++ b/app/llm/safe_llm_invoke.py
@@ -1,0 +1,61 @@
+"""Guardrailed LLM invocation for structured JSON contracts."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, TypeVar
+
+from pydantic import BaseModel
+
+from app.llm.guardrails import (
+    LLMContractViolation,
+    log_input_guardrail_scan,
+    scan_input_for_pii_and_injection,
+    validate_llm_json_output,
+)
+from app.llm_models import LLMTaskType
+from app.services.llm_router import LLMRouter
+from app.services.readiness_explain_structured import extract_json_object
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def safe_llm_json_call(
+    session: Session | None,
+    tenant_id: str,
+    task_type: LLMTaskType,
+    prompt: str,
+    schema: type[T],
+    *,
+    context: str,
+    response_format: str | None = "json_object",
+) -> T:
+    """
+    Scan prompt, call router, parse JSON, validate against `schema`.
+
+    On missing/invalid JSON after extraction, raises LLMContractViolation.
+    """
+    scan = scan_input_for_pii_and_injection(prompt)
+    log_input_guardrail_scan(context=context, tenant_id=tenant_id, scan=scan)
+
+    router = LLMRouter(session=session)
+    resp = router.route_and_call(
+        task_type,
+        prompt,
+        tenant_id,
+        response_format=response_format,
+    )
+    raw = resp.text or ""
+    data = extract_json_object(raw)
+    if data is None:
+        raise LLMContractViolation("LLM output did not contain a parseable JSON object")
+    return validate_llm_json_output(data, schema)
+
+
+# Backwards-friendly alias (spec / docs)
+safe_llm_call = safe_llm_json_call

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from app.advisor_client_snapshot_models import (
 )
 from app.advisor_models import AdvisorTenantReport
 from app.advisor_portfolio_models import AdvisorPortfolioResponse
+from app.agents.langgraph.oami_explain_poc import run_oami_explain_poc
 from app.ai_act_doc_models import (
     AIActDoc,
     AIActDocListResponse,
@@ -94,6 +95,7 @@ from app.audit_models import AuditEvent, AuditLog
 from app.auth_dependencies import (
     get_api_key_and_tenant,
     get_auth_context,
+    get_optional_opa_user_role_header,
     require_path_tenant_matches_auth,
 )
 from app.classification_models import (
@@ -169,11 +171,21 @@ from app.nis2_kritis_models import (
     Nis2KritisKpiUpsertRequest,
 )
 from app.operational_monitoring_models import (
+    OamiExplanationOut,
     RuntimeEventsBatchIn,
     RuntimeEventsIngestResult,
     SystemMonitoringIndexOut,
     TenantOperationalMonitoringIndexOut,
 )
+from app.policy.policy_guard import enforce_action_policy
+from app.policy.role_resolution import (
+    ENV_ROLE_ADVISOR_TENANT_REPORT,
+    ENV_ROLE_BOARD_REPORT,
+    ENV_ROLE_LANGGRAPH_OAMI_POC,
+    ENV_ROLE_READINESS_EXPLAIN,
+    resolve_opa_role_for_policy,
+)
+from app.policy.user_context import UserPolicyContext
 from app.policy_models import Violation
 from app.policy_service import evaluate_policies_for_ai_system
 from app.provisioning_models import (
@@ -612,6 +624,18 @@ def _health_payload() -> dict[str, str]:
         "product": "ComplianceHub",
         "region": "DACH",
     }
+
+
+def _langgraph_poc_enabled() -> bool:
+    v = os.getenv("ENABLE_LANGGRAPH_POC", "").strip().lower()
+    return v in ("1", "true", "yes", "on")
+
+
+class OamiExplainPocRequestBody(BaseModel):
+    """Request body for the LangGraph OAMI explain PoC (tenant-scoped)."""
+
+    ai_system_id: str = Field(min_length=1, max_length=256)
+    window_days: int = Field(default=90, ge=1, le=365)
 
 
 @app.get("/api/v1/health")
@@ -2968,9 +2992,20 @@ def get_advisor_tenant_report(
         Depends(get_ai_governance_action_repository),
     ],
     incident_repo: Annotated[IncidentRepository, Depends(get_incident_repository)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
     export_format: Annotated[Literal["json", "markdown"], Query(alias="format")] = "json",
 ) -> AdvisorTenantReport | Response:
     """Mandanten-Steckbrief (JSON oder Markdown) nur bei Zuordnung in advisor_tenants."""
+    advisor_role = resolve_opa_role_for_policy(
+        header_value=opa_role_header,
+        env_var_name=ENV_ROLE_ADVISOR_TENANT_REPORT,
+        default="advisor",
+    )
+    enforce_action_policy(
+        "advisor_tenant_report",
+        UserPolicyContext(tenant_id=tenant_id, user_role=advisor_role),
+        risk_score=0.55,
+    )
     link = advisor_repo.get_link(advisor_id, tenant_id)
     if link is None:
         raise HTTPException(
@@ -3717,8 +3752,19 @@ def post_ai_compliance_board_report(
     session: Annotated[Session, Depends(get_session)],
     audit_repo: Annotated[AuditRepository, Depends(get_audit_repository)],
     _ff: Annotated[None, Depends(create_feature_guard(FeatureFlag.ai_compliance_board_report))],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
 ) -> AiComplianceBoardReportCreateResponse:
     require_path_tenant_matches_auth(tenant_id, auth_context)
+    board_role = resolve_opa_role_for_policy(
+        header_value=opa_role_header,
+        env_var_name=ENV_ROLE_BOARD_REPORT,
+        default="tenant_admin",
+    )
+    enforce_action_policy(
+        "generate_board_report",
+        UserPolicyContext(tenant_id=tenant_id, user_role=board_role),
+        risk_score=0.75,
+    )
     try:
         out = create_ai_compliance_board_report(
             session,
@@ -4062,10 +4108,21 @@ def post_tenant_readiness_score_explain(
     _ff_rs: Annotated[None, Depends(create_feature_guard(FeatureFlag.readiness_score))],
     auth_context: Annotated[AuthContext, Depends(get_auth_context)],
     session: Annotated[Session, Depends(get_session)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
 ) -> ReadinessScoreExplainResponse:
     """KI-Erklärung zum Readiness Score (aggregierte Kennzahlen, LLM_EXPLAIN + LLM_ENABLED)."""
     if tenant_id != auth_context.tenant_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Tenant mismatch")
+    readiness_role = resolve_opa_role_for_policy(
+        header_value=opa_role_header,
+        env_var_name=ENV_ROLE_READINESS_EXPLAIN,
+        default="tenant_user",
+    )
+    enforce_action_policy(
+        "call_llm_explain_readiness",
+        UserPolicyContext(tenant_id=tenant_id, user_role=readiness_role),
+        risk_score=0.45,
+    )
     snapshot = compute_readiness_score(session, tenant_id)
     try:
         return explain_readiness_score(session, tenant_id, snapshot)
@@ -4078,4 +4135,48 @@ def post_tenant_readiness_score_explain(
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Readiness score explanation failed",
+        ) from exc
+
+
+@app.post(
+    "/api/v1/tenants/{tenant_id}/agents/oami-explain-poc",
+    response_model=OamiExplanationOut,
+    tags=["agents"],
+)
+def post_tenant_oami_explain_langgraph_poc(
+    tenant_id: str,
+    body: OamiExplainPocRequestBody,
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> OamiExplanationOut:
+    """
+    LangGraph PoC: OAMI-Kurzerklärung (gleiches JSON-Contract wie deterministische OAMI-Explain).
+
+    Hinter `ENABLE_LANGGRAPH_POC`; außerhalb OPA-Policy `call_langgraph_oami_explain`.
+    """
+    if not _langgraph_poc_enabled():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+    require_path_tenant_matches_auth(tenant_id, auth_context)
+    poc_role = resolve_opa_role_for_policy(
+        header_value=opa_role_header,
+        env_var_name=ENV_ROLE_LANGGRAPH_OAMI_POC,
+        default="tenant_admin",
+    )
+    enforce_action_policy(
+        "call_langgraph_oami_explain",
+        UserPolicyContext(tenant_id=tenant_id, user_role=poc_role),
+        risk_score=0.4,
+    )
+    try:
+        return run_oami_explain_poc(
+            session,
+            tenant_id=tenant_id,
+            ai_system_id=body.ai_system_id,
+            window_days=body.window_days,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="OAMI explain PoC workflow failed",
         ) from exc

--- a/app/policy/__init__.py
+++ b/app/policy/__init__.py
@@ -1,0 +1,3 @@
+"""Central policy integration (OPA-backed action decisions)."""
+
+from __future__ import annotations

--- a/app/policy/opa_client.py
+++ b/app/policy/opa_client.py
@@ -1,0 +1,72 @@
+"""HTTP client for Open Policy Agent (OPA) decision API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+
+class PolicyDecision(BaseModel):
+    allowed: bool
+    reason: str = Field(default="", max_length=2000)
+
+
+def _truthy_env(key: str) -> bool:
+    raw = os.getenv(key)
+    if raw is None or not str(raw).strip():
+        return False
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _opa_url() -> str:
+    return os.getenv("OPA_URL", "").strip()
+
+
+def _opa_policy_path() -> str:
+    raw = os.getenv("OPA_POLICY_PATH", "/v1/data/compliancehub/allow_action").strip()
+    return raw if raw.startswith("/") else f"/{raw}"
+
+
+def evaluate_action_policy(input_payload: dict[str, Any]) -> PolicyDecision:
+    """
+    POST {OPA_URL}{OPA_POLICY_PATH} with body {"input": ...}; expects boolean `result`.
+
+    When OPA_URL is unset, decisions default to allow (local dev / gradual rollout).
+    Set COMPLIANCEHUB_OPA_STRICT_MISSING=1 to deny when OPA is not configured.
+    """
+    base = _opa_url()
+    if not base:
+        if _truthy_env("COMPLIANCEHUB_OPA_STRICT_MISSING"):
+            return PolicyDecision(allowed=False, reason="opa_not_configured")
+        logger.debug("OPA_URL unset; allowing action (opa_disabled)")
+        return PolicyDecision(allowed=True, reason="opa_disabled")
+
+    path = _opa_policy_path()
+    url = f"{base.rstrip('/')}{path}"
+    try:
+        with httpx.Client(timeout=5.0) as client:
+            resp = client.post(url, json={"input": input_payload})
+            resp.raise_for_status()
+            body = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning("opa_request_failed url=%s err=%s", url, exc)
+        return PolicyDecision(allowed=False, reason="opa_unreachable")
+    except ValueError as exc:
+        logger.warning("opa_invalid_json url=%s err=%s", url, exc)
+        return PolicyDecision(allowed=False, reason="opa_invalid_response")
+
+    result = body.get("result")
+    if isinstance(result, dict) and "allow_action" in result:
+        inner = result.get("allow_action")
+        allowed = bool(inner)
+    else:
+        allowed = bool(result)
+    if allowed:
+        return PolicyDecision(allowed=True, reason="opa_allow")
+    return PolicyDecision(allowed=False, reason="opa_deny")

--- a/app/policy/policy_guard.py
+++ b/app/policy/policy_guard.py
@@ -1,0 +1,34 @@
+"""FastAPI-facing helpers: enforce OPA-backed action policies."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+from app.policy.opa_client import evaluate_action_policy
+from app.policy.user_context import UserPolicyContext
+
+
+def enforce_action_policy(
+    action: str,
+    user: UserPolicyContext,
+    *,
+    risk_score: float = 0.5,
+) -> None:
+    """
+    Build OPA input and raise HTTP 403 when the policy denies the action.
+
+    API error text stays English; user-facing product copy remains German elsewhere.
+    """
+    payload = {
+        "tenant_id": user.tenant_id,
+        "user_role": user.user_role,
+        "action": action,
+        "risk_score": float(risk_score),
+    }
+    decision = evaluate_action_policy(payload)
+    if decision.allowed:
+        return
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail="Action denied by policy",
+    )

--- a/app/policy/role_resolution.py
+++ b/app/policy/role_resolution.py
@@ -1,0 +1,59 @@
+"""Resolve OPA `user_role` from optional trusted header, env, or route default."""
+
+from __future__ import annotations
+
+import os
+
+ALLOWED_OPA_ROLES = frozenset(
+    {
+        "advisor",
+        "tenant_admin",
+        "tenant_user",
+        "viewer",
+    },
+)
+
+# Env var names (documented in docs/architecture/wave1-opa-langgraph-guardrails.md)
+ENV_ROLE_BOARD_REPORT = "COMPLIANCEHUB_OPA_ROLE_BOARD_REPORT"
+ENV_ROLE_READINESS_EXPLAIN = "COMPLIANCEHUB_OPA_ROLE_READINESS_EXPLAIN"
+ENV_ROLE_LANGGRAPH_OAMI_POC = "COMPLIANCEHUB_OPA_ROLE_LANGGRAPH_OAMI_POC"
+ENV_ROLE_ADVISOR_TENANT_REPORT = "COMPLIANCEHUB_OPA_ROLE_ADVISOR_TENANT_REPORT"
+
+
+def _env_bool(key: str) -> bool:
+    raw = os.getenv(key, "").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _normalize(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s if s else None
+
+
+def resolve_opa_role_for_policy(
+    *,
+    header_value: str | None,
+    env_var_name: str,
+    default: str,
+) -> str:
+    """
+    Order when ``COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER`` is enabled:
+    ``x-opa-user-role`` header (allowlist only), else env ``env_var_name``, else ``default``.
+
+    When trust is disabled: env, then default. Invalid values are ignored (fall through).
+    """
+    if _env_bool("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER"):
+        hv = _normalize(header_value)
+        if hv in ALLOWED_OPA_ROLES:
+            return hv
+
+    ev = _normalize(os.getenv(env_var_name))
+    if ev in ALLOWED_OPA_ROLES:
+        return ev
+
+    dv = _normalize(default) or "tenant_user"
+    if dv in ALLOWED_OPA_ROLES:
+        return dv
+    return "tenant_user"

--- a/app/policy/user_context.py
+++ b/app/policy/user_context.py
@@ -1,0 +1,15 @@
+"""User / actor context passed into OPA action policies."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class UserPolicyContext(BaseModel):
+    """Minimal actor context for policy evaluation (API-key auth today)."""
+
+    tenant_id: str = Field(min_length=1)
+    user_role: str = Field(
+        min_length=1,
+        description="Logical role for OPA: advisor, tenant_admin, tenant_user, viewer, …",
+    )

--- a/app/services/advisor_governance_maturity_brief_llm.py
+++ b/app/services/advisor_governance_maturity_brief_llm.py
@@ -9,6 +9,7 @@ from app.feature_flags import FeatureFlag, is_feature_enabled
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturitySummary
 from app.incident_drilldown_models import TenantIncidentDrilldownOut
+from app.llm.guardrails import log_input_guardrail_scan, scan_input_for_pii_and_injection
 from app.llm_models import LLMTaskType
 from app.services.advisor_brief_drilldown_alignment import apply_drilldown_alignment_to_brief
 from app.services.advisor_governance_maturity_brief_parse import (
@@ -38,6 +39,12 @@ def render_advisor_governance_maturity_brief(
     prompt = build_advisor_governance_maturity_brief_prompt(
         snapshot,
         board_summary,
+    )
+    scan = scan_input_for_pii_and_injection(prompt)
+    log_input_guardrail_scan(
+        context="advisor_governance_maturity_brief",
+        tenant_id=tenant_id,
+        scan=scan,
     )
     router = LLMRouter(session=session)
     try:

--- a/app/services/advisor_report_llm_enrichment.py
+++ b/app/services/advisor_report_llm_enrichment.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 from app.advisor_models import AdvisorTenantReport
 from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.llm.guardrails import log_input_guardrail_scan, scan_input_for_pii_and_injection
 from app.llm_models import LLMTaskType
 from app.services.advisor_governance_maturity_brief_llm import (
     maybe_build_advisor_governance_maturity_brief_result,
@@ -86,6 +87,12 @@ def maybe_enrich_advisor_report_with_llm_summary(
         "neuen Zahlen, keine neuen regulatorischen Behauptungen und keine Systemnamen, "
         "die nicht in den Fakten stehen.\n\n"
         f"{json.dumps(facts, ensure_ascii=False)}"
+    )
+    scan = scan_input_for_pii_and_injection(prompt)
+    log_input_guardrail_scan(
+        context="advisor_report_executive_summary",
+        tenant_id=tenant_id,
+        scan=scan,
     )
     try:
         router = LLMRouter(session=session)

--- a/app/services/readiness_score_explain.py
+++ b/app/services/readiness_score_explain.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from app.feature_flags import FeatureFlag, is_feature_enabled
+from app.llm.guardrails import log_input_guardrail_scan, scan_input_for_pii_and_injection
 from app.llm_models import LLMTaskType
 from app.readiness_score_models import ReadinessScoreExplainResponse, ReadinessScoreResponse
 from app.services.llm_router import LLMRouter
@@ -101,6 +102,8 @@ def explain_readiness_score(
         "governance_activity": gai_context,
     }
     prompt = build_readiness_explain_prompt(facts_envelope=envelope)
+    scan = scan_input_for_pii_and_injection(prompt)
+    log_input_guardrail_scan(context="readiness_score_explain", tenant_id=tenant_id, scan=scan)
 
     router = LLMRouter(session=session)
     resp = router.route_and_call(

--- a/docs/architecture/wave1-opa-langgraph-guardrails.md
+++ b/docs/architecture/wave1-opa-langgraph-guardrails.md
@@ -1,0 +1,60 @@
+# Wave 1: OPA, LLM-Guardrails, LangGraph-PoC
+
+Kurzüberblick zur Architektur-Erweiterung (ohne Temporal/Haystack).
+
+## Open Policy Agent (OPA)
+
+- **Zweck:** Zentrale, explizite **Aktionsentscheidungen** (welche Rolle darf welche Operation ausführen, Risiko-Schwellen, globale Denylist) entkoppelt vom Anwendungscode.
+- **Python:** `app/policy/opa_client.py` — HTTP-POST gegen `{OPA_URL}{OPA_POLICY_PATH}` mit `{"input": {...}}`; erwartet booleschen `result`.
+- **Rego:** `infra/opa/policies/compliancehub/regos/action_policy.rego` — u. a. `generate_board_report`, `call_llm_explain_readiness`, `advisor_tenant_report`, `call_langgraph_oami_explain`; Deny bei `risk_score >= 0.8` ist in den Regeln über `< 0.8` abgebildet; globale Denylist-Einträge `auto_delete_data`, `auto_approve_dsar`.
+- **FastAPI:** `app/policy/policy_guard.py` — `enforce_action_policy(...)` wirft bei Verweigerung HTTP **403** (englische API-`detail`-Strings).
+- **Hinweis zu `app/security.py`:** Das bestehende Modul `app/security.py` bleibt für API-Key/Tenant-Auth. Policy-Code liegt bewusst unter **`app/policy/`**, um keine Paket-/Modulnamens-Kollision mit `app/security.py` zu erzeugen.
+
+### Umgebungsvariablen
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `OPA_URL` | Basis-URL des OPA (z. B. `http://localhost:8181`). Leer = Entscheidung **allow** mit Grund `opa_disabled` (lokale Entwicklung). |
+| `OPA_POLICY_PATH` | Pfad, Standard `/v1/data/compliancehub/allow_action`. |
+| `COMPLIANCEHUB_OPA_STRICT_MISSING` | Wenn `1`/`true` und `OPA_URL` leer: **deny** (`opa_not_configured`) — für Striktheit in Staging/Prod. |
+| `COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER` | Wenn `1`/`true`: Header `x-opa-user-role` wird (nach Allowlist) für die Policy verwendet. **Standard aus** — nur aktivieren, wenn das Gateway die Rolle vertrauenswürdig setzt. |
+| `COMPLIANCEHUB_OPA_ROLE_BOARD_REPORT` | Logische Rolle für Board-Report-Policy (Allowlist: `advisor`, `tenant_admin`, `tenant_user`, `viewer`). Default im Code: `tenant_admin`. |
+| `COMPLIANCEHUB_OPA_ROLE_READINESS_EXPLAIN` | Rolle für Readiness-Explain. Default: `tenant_user`. |
+| `COMPLIANCEHUB_OPA_ROLE_LANGGRAPH_OAMI_POC` | Rolle für LangGraph-OAMI-PoC. Default: `tenant_admin`. |
+| `COMPLIANCEHUB_OPA_ROLE_ADVISOR_TENANT_REPORT` | Rolle für Advisor-Mandantenreport. Default: `advisor`. |
+
+Auflösung: bei aktivem Trust zuerst **Header** (falls gültig), sonst **Env** (falls gültig), sonst **Default** pro Route (`app/policy/role_resolution.py`).
+
+### CI: Rego-Tests
+
+- Datei `infra/opa/policies/compliancehub/regos/action_policy_test.rego` — `opa test` gegen das Policy-Bundle.
+- GitHub Actions: Job `lint-test` installiert OPA (pinned) und führt `opa test infra/opa/policies/compliancehub/regos/` aus.
+
+### Eingebundene Routen (Beispiele)
+
+- `POST .../board/ai-compliance-report` — Aktion `generate_board_report`, Rolle aus Env/Header/Default (Default `tenant_admin`), Risiko ~0.75.
+- `POST .../readiness-score/explain` — `call_llm_explain_readiness`, Default-Rolle `tenant_user`, Risiko ~0.45.
+- `GET .../advisors/.../tenants/.../report` — `advisor_tenant_report`, Default `advisor`, Risiko ~0.55.
+- `POST .../agents/oami-explain-poc` — `call_langgraph_oami_explain`, Default `tenant_admin`, Risiko ~0.4.
+
+Rollen sind **logische** OPA-Rollen bis echtes User-RBAC (JWT/SSO) angebunden ist.
+
+## LLM-Guardrails
+
+- **Modul:** `app/llm/guardrails.py`
+  - `scan_input_for_pii_and_injection` — heuristische Regex (E-Mail, IBAN-ähnlich, Telefon, einfache Injection-Marker); liefert `GuardrailScanResult` mit `risk_level` low/medium/high.
+  - `validate_llm_json_output` — strikte Pydantic-Validierung; bei Fehler `LLMContractViolation`.
+  - `log_input_guardrail_scan` — Logging bei medium/high.
+- **Sichere strukturierte Calls:** `app/llm/safe_llm_invoke.py` — `safe_llm_json_call` = Scan → `LLMRouter.route_and_call` → JSON extrahieren → `validate_llm_json_output`.
+- **Eingebunden (Logging v1):** Prompts für Readiness-Explain, Advisor-Governance-Maturity-Brief und Advisor-Executive-Summary-Anreicherung werden vor dem LLM-Aufruf gescannt und protokolliert (kein hartes Blocken in dieser Welle).
+
+## LangGraph-PoC (OAMI-Explain)
+
+- **Code:** `app/agents/langgraph/oami_explain_poc.py` — linearer Graph mit bedingtem Zweig: Index laden → guardrailierter LLM-JSON-Call (`OamiExplanationOut`) → bei Vertragsfehler **deterministischer Fallback** (`explain_system_oami_de`).
+- **Checkpointer:** `MemorySaver` (minimal, kein Postgres-Checkpointer in Wave 1).
+- **API:** `POST /api/v1/tenants/{tenant_id}/agents/oami-explain-poc` — gleiches JSON-Contract wie die bestehende OAMI-Erklärung (`OamiExplanationOut`), synchron, mit OPA-Policy `call_langgraph_oami_explain`.
+- **Feature-Flag:** `ENABLE_LANGGRAPH_POC` — wenn nicht `1`/`true`/`yes`/`on`, antwortet der Endpunkt mit **404 Not found** (schrittweise Einführung).
+
+## Nicht in Wave 1
+
+- Temporal, Haystack, Postgres-Checkpointer für LangGraph, vollständiges RBAC aus JWT/SSO.

--- a/infra/opa/policies/compliancehub/regos/action_policy.rego
+++ b/infra/opa/policies/compliancehub/regos/action_policy.rego
@@ -1,0 +1,52 @@
+# ComplianceHub Wave 1 — action allow/deny (OPA).
+# Compatible with common OPA 0.5x/1.x bundles.
+# Query: POST /v1/data/compliancehub/allow_action  body: {"input": {...}}
+
+package compliancehub
+
+default allow_action = false
+
+# Global denylist (mirror in policy docs): auto_delete_data, auto_approve_dsar
+
+denylisted {
+	input.action == "auto_delete_data"
+}
+
+denylisted {
+	input.action == "auto_approve_dsar"
+}
+
+allow_action {
+	not denylisted
+	input.risk_score < 0.8
+	input.user_role == "advisor"
+	input.action == "generate_board_report"
+}
+
+allow_action {
+	not denylisted
+	input.risk_score < 0.8
+	input.user_role == "advisor"
+	input.action == "advisor_tenant_report"
+}
+
+allow_action {
+	not denylisted
+	input.risk_score < 0.8
+	input.user_role == "tenant_admin"
+	input.action == "generate_board_report"
+}
+
+allow_action {
+	not denylisted
+	input.risk_score < 0.8
+	input.user_role == "tenant_user"
+	input.action == "call_llm_explain_readiness"
+}
+
+allow_action {
+	not denylisted
+	input.risk_score < 0.8
+	input.user_role == "tenant_admin"
+	input.action == "call_langgraph_oami_explain"
+}

--- a/infra/opa/policies/compliancehub/regos/action_policy_test.rego
+++ b/infra/opa/policies/compliancehub/regos/action_policy_test.rego
@@ -1,0 +1,77 @@
+# OPA unit tests: `opa test infra/opa/policies/compliancehub/regos/`
+
+package compliancehub_test
+
+import data.compliancehub
+
+test_tenant_admin_board_report_allowed {
+	compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "tenant_admin",
+		"action": "generate_board_report",
+		"risk_score": 0.5,
+	}
+}
+
+test_advisor_board_report_allowed {
+	compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "advisor",
+		"action": "generate_board_report",
+		"risk_score": 0.5,
+	}
+}
+
+test_tenant_user_readiness_explain_allowed {
+	compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "tenant_user",
+		"action": "call_llm_explain_readiness",
+		"risk_score": 0.2,
+	}
+}
+
+test_tenant_admin_langgraph_oami_allowed {
+	compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "tenant_admin",
+		"action": "call_langgraph_oami_explain",
+		"risk_score": 0.4,
+	}
+}
+
+test_advisor_tenant_report_allowed {
+	compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "advisor",
+		"action": "advisor_tenant_report",
+		"risk_score": 0.5,
+	}
+}
+
+test_auto_delete_data_denied {
+	not compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "tenant_admin",
+		"action": "auto_delete_data",
+		"risk_score": 0.1,
+	}
+}
+
+test_high_risk_score_denied {
+	not compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "tenant_admin",
+		"action": "generate_board_report",
+		"risk_score": 0.85,
+	}
+}
+
+test_viewer_readiness_denied {
+	not compliancehub.allow_action with input as {
+		"tenant_id": "t1",
+		"user_role": "viewer",
+		"action": "call_llm_explain_readiness",
+		"risk_score": 0.1,
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
   "pydantic[email]>=2.0",
   "uvicorn[standard]>=0.30",
   "httpx>=0.27",
+  "langgraph>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ai_compliance_board_report_api.py
+++ b/tests/test_ai_compliance_board_report_api.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.llm_models import LLMProvider, LLMResponse
 from app.main import app
+from app.policy.opa_client import PolicyDecision
 
 client = TestClient(app)
 
@@ -26,6 +27,21 @@ def test_board_report_tenant_path_mismatch(monkeypatch: pytest.MonkeyPatch) -> N
         headers=_h(tid),
         json={"audience_type": "board"},
     )
+    assert r.status_code == 403
+
+
+def test_board_report_403_when_opa_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_AI_COMPLIANCE_BOARD_REPORT", "true")
+    tid = f"br-opa-{uuid.uuid4().hex[:10]}"
+    with patch(
+        "app.policy.policy_guard.evaluate_action_policy",
+        return_value=PolicyDecision(allowed=False, reason="deny"),
+    ):
+        r = client.post(
+            f"/api/v1/tenants/{tid}/board/ai-compliance-report",
+            headers=_h(tid),
+            json={"audience_type": "board"},
+        )
     assert r.status_code == 403
 
 

--- a/tests/test_langgraph_oami_explain_poc.py
+++ b/tests/test_langgraph_oami_explain_poc.py
@@ -1,0 +1,171 @@
+"""LangGraph OAMI explain PoC: contract shape, fallback, API + OPA wiring."""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.ai_system_models import (
+    AIActCategory,
+    AISystemCriticality,
+    AISystemRiskLevel,
+    DataSensitivity,
+)
+from app.db import SessionLocal
+from app.llm.guardrails import LLMContractViolation
+from app.main import app
+from app.operational_monitoring_models import OamiExplanationOut
+from app.policy.opa_client import PolicyDecision
+from app.services.oami_explanation import explain_system_oami_de
+from app.services.operational_monitoring_index import compute_system_monitoring_index
+
+
+@pytest.fixture
+def client() -> TestClient:
+    with TestClient(app) as c:
+        yield c
+
+
+def _headers(tenant_id: str) -> dict[str, str]:
+    return {"x-api-key": "test-api-key", "x-tenant-id": tenant_id}
+
+
+def _create_system(client: TestClient, tenant_id: str, system_id: str) -> None:
+    payload = {
+        "id": system_id,
+        "name": "LangGraph PoC System",
+        "description": "Test",
+        "business_unit": "BU",
+        "risk_level": AISystemRiskLevel.high.value,
+        "ai_act_category": AIActCategory.high_risk.value,
+        "gdpr_dpia_required": True,
+        "criticality": AISystemCriticality.high.value,
+        "data_sensitivity": DataSensitivity.internal.value,
+        "has_incident_runbook": True,
+        "has_supplier_risk_register": True,
+        "has_backup_runbook": True,
+    }
+    r = client.post("/api/v1/ai-systems", json=payload, headers=_headers(tenant_id))
+    assert r.status_code == 200, r.text
+
+
+def test_oami_explain_poc_api_404_when_flag_off(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("ENABLE_LANGGRAPH_POC", raising=False)
+    tid = f"lg-poc-{uuid.uuid4().hex[:10]}"
+    r = client.post(
+        f"/api/v1/tenants/{tid}/agents/oami-explain-poc",
+        headers=_headers(tid),
+        json={"ai_system_id": "any", "window_days": 90},
+    )
+    assert r.status_code == 404
+
+
+def test_oami_explain_poc_api_403_when_opa_denies(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENABLE_LANGGRAPH_POC", "true")
+    tid = f"lg-poc-{uuid.uuid4().hex[:10]}"
+    _create_system(client, tid, "sys-lg-1")
+    with patch(
+        "app.policy.policy_guard.evaluate_action_policy",
+        return_value=PolicyDecision(allowed=False, reason="deny"),
+    ):
+        r = client.post(
+            f"/api/v1/tenants/{tid}/agents/oami-explain-poc",
+            headers=_headers(tid),
+            json={"ai_system_id": "sys-lg-1", "window_days": 90},
+        )
+    assert r.status_code == 403
+
+
+def test_oami_explain_poc_graph_fallback_matches_deterministic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.agents.langgraph.oami_explain_poc import run_oami_explain_poc
+
+    def _boom(*_a: object, **_k: object) -> OamiExplanationOut:
+        raise LLMContractViolation("forced")
+
+    monkeypatch.setattr(
+        "app.agents.langgraph.oami_explain_poc.safe_llm_json_call",
+        _boom,
+    )
+    tid = f"lg-graph-{uuid.uuid4().hex[:10]}"
+    sid = f"sys-{uuid.uuid4().hex[:8]}"
+    with SessionLocal() as session:
+        from app.models_db import AISystemTable
+
+        row = AISystemTable(
+            id=sid,
+            tenant_id=tid,
+            name="LG",
+            description="d",
+            business_unit="BU",
+            risk_level="high",
+            ai_act_category="high_risk",
+            gdpr_dpia_required=True,
+            criticality="high",
+            data_sensitivity="internal",
+            has_incident_runbook=True,
+            has_supplier_risk_register=True,
+            has_backup_runbook=True,
+        )
+        session.add(row)
+        session.commit()
+
+        idx = compute_system_monitoring_index(session, tid, sid, window_days=90)
+        expected = explain_system_oami_de(idx.model_copy(update={"explanation": None}))
+
+        out = run_oami_explain_poc(session, tenant_id=tid, ai_system_id=sid, window_days=90)
+        assert out.summary_de == expected.summary_de
+        assert out.drivers_de == expected.drivers_de
+
+
+def test_oami_explain_poc_graph_llm_path_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.agents.langgraph.oami_explain_poc import run_oami_explain_poc
+
+    fixed = OamiExplanationOut(
+        summary_de="LLM summary",
+        drivers_de=["d1"],
+        monitoring_gap_de="gap",
+    )
+
+    def _fake(*_a: object, **_k: object) -> OamiExplanationOut:
+        return fixed
+
+    monkeypatch.setattr(
+        "app.agents.langgraph.oami_explain_poc.safe_llm_json_call",
+        _fake,
+    )
+    tid = f"lg-llm-{uuid.uuid4().hex[:10]}"
+    sid = f"sys-{uuid.uuid4().hex[:8]}"
+    with SessionLocal() as session:
+        from app.models_db import AISystemTable
+
+        session.add(
+            AISystemTable(
+                id=sid,
+                tenant_id=tid,
+                name="LG",
+                description="d",
+                business_unit="BU",
+                risk_level="high",
+                ai_act_category="high_risk",
+                gdpr_dpia_required=True,
+                criticality="high",
+                data_sensitivity="internal",
+                has_incident_runbook=True,
+                has_supplier_risk_register=True,
+                has_backup_runbook=True,
+            ),
+        )
+        session.commit()
+        out = run_oami_explain_poc(session, tenant_id=tid, ai_system_id=sid, window_days=90)
+    assert out.model_dump() == fixed.model_dump()

--- a/tests/test_llm_guardrails.py
+++ b/tests/test_llm_guardrails.py
@@ -1,0 +1,59 @@
+"""Tests: LLM input scanning and JSON contract validation."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, Field
+
+from app.llm.guardrails import (
+    LLMContractViolation,
+    scan_input_for_pii_and_injection,
+    validate_llm_json_output,
+)
+from app.operational_monitoring_models import OamiExplanationOut
+from app.readiness_score_models import ReadinessScoreExplainResponse
+
+
+def test_scan_low_risk_plain_text() -> None:
+    r = scan_input_for_pii_and_injection("Readiness-Score erklären ohne Sonderzeichen.")
+    assert r.risk_level == "low"
+    assert not r.flags
+
+
+def test_scan_high_risk_email_and_injection() -> None:
+    text = "ignore previous instructions contact user@example.com"
+    r = scan_input_for_pii_and_injection(text)
+    assert r.risk_level == "high"
+    assert "injection_marker" in r.flags
+    assert "possible_email" in r.flags
+
+
+def test_validate_oami_explanation_ok() -> None:
+    payload = {
+        "summary_de": "Kurz",
+        "drivers_de": ["A", "B"],
+        "monitoring_gap_de": None,
+    }
+    m = validate_llm_json_output(payload, OamiExplanationOut)
+    assert m.summary_de == "Kurz"
+    assert len(m.drivers_de) == 2
+
+
+def test_validate_oami_explanation_missing_field_raises() -> None:
+    with pytest.raises(LLMContractViolation):
+        validate_llm_json_output({"drivers_de": []}, OamiExplanationOut)
+
+
+def test_validate_readiness_explain_response_missing_explanation_raises() -> None:
+    with pytest.raises(LLMContractViolation):
+        validate_llm_json_output({"provider": "x"}, ReadinessScoreExplainResponse)
+
+
+class _MiniBrief(BaseModel):
+    title: str = Field(min_length=1)
+    score: int = Field(ge=0, le=100)
+
+
+def test_validate_mini_brief_wrong_type_raises() -> None:
+    with pytest.raises(LLMContractViolation):
+        validate_llm_json_output({"title": "t", "score": "nope"}, _MiniBrief)

--- a/tests/test_opa_client_and_policy_guard.py
+++ b/tests/test_opa_client_and_policy_guard.py
@@ -1,0 +1,91 @@
+"""Tests: OPA client (mocked HTTP) and FastAPI policy guard."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.policy.opa_client import PolicyDecision, evaluate_action_policy
+from app.policy.policy_guard import enforce_action_policy
+from app.policy.user_context import UserPolicyContext
+
+
+class _FakeHttpClient:
+    def __init__(self, result_body: dict) -> None:
+        self._body = result_body
+
+    def __enter__(self) -> _FakeHttpClient:
+        return self
+
+    def __exit__(self, *args: object) -> bool:
+        return False
+
+    def post(self, url: str, json: dict | None = None) -> MagicMock:
+        r = MagicMock()
+        r.json.return_value = self._body
+        r.raise_for_status = MagicMock()
+        return r
+
+
+def test_evaluate_action_policy_disabled_allows(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPA_URL", raising=False)
+    d = evaluate_action_policy(
+        {"tenant_id": "t1", "user_role": "tenant_user", "action": "x", "risk_score": 0.1},
+    )
+    assert d.allowed is True
+    assert "disabled" in d.reason.lower() or d.reason == "opa_disabled"
+
+
+def test_evaluate_action_policy_strict_missing_denies(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPA_URL", raising=False)
+    monkeypatch.setenv("COMPLIANCEHUB_OPA_STRICT_MISSING", "1")
+    d = evaluate_action_policy(
+        {"tenant_id": "t1", "user_role": "tenant_user", "action": "x", "risk_score": 0.1},
+    )
+    assert d.allowed is False
+
+
+def test_evaluate_action_policy_opa_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPA_URL", "http://localhost:8181")
+    monkeypatch.setenv("OPA_POLICY_PATH", "/v1/data/compliancehub/allow_action")
+    with patch(
+        "app.policy.opa_client.httpx.Client",
+        return_value=_FakeHttpClient({"result": True}),
+    ):
+        d = evaluate_action_policy(
+            {
+                "tenant_id": "t1",
+                "user_role": "tenant_user",
+                "action": "call_llm_explain_readiness",
+                "risk_score": 0.2,
+            },
+        )
+    assert d.allowed is True
+
+
+def test_evaluate_action_policy_opa_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPA_URL", "http://localhost:8181")
+    with patch(
+        "app.policy.opa_client.httpx.Client",
+        return_value=_FakeHttpClient({"result": False}),
+    ):
+        d = evaluate_action_policy(
+            {"tenant_id": "t1", "user_role": "viewer", "action": "x", "risk_score": 0.1},
+        )
+    assert d.allowed is False
+
+
+def test_enforce_action_policy_raises_403() -> None:
+    with patch(
+        "app.policy.policy_guard.evaluate_action_policy",
+        return_value=PolicyDecision(allowed=False, reason="opa_deny"),
+    ):
+        with pytest.raises(HTTPException) as ei:
+            enforce_action_policy(
+                "generate_board_report",
+                UserPolicyContext(tenant_id="t1", user_role="tenant_admin"),
+                risk_score=0.5,
+            )
+    assert ei.value.status_code == 403

--- a/tests/test_opa_role_resolution.py
+++ b/tests/test_opa_role_resolution.py
@@ -1,0 +1,65 @@
+"""Tests: OPA user_role resolution (env + optional trusted header)."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.policy.role_resolution import (
+    ENV_ROLE_BOARD_REPORT,
+    ENV_ROLE_READINESS_EXPLAIN,
+    resolve_opa_role_for_policy,
+)
+
+
+def test_resolve_prefers_header_when_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER", "true")
+    r = resolve_opa_role_for_policy(
+        header_value="tenant_admin",
+        env_var_name=ENV_ROLE_READINESS_EXPLAIN,
+        default="tenant_user",
+    )
+    assert r == "tenant_admin"
+
+
+def test_resolve_ignores_header_when_not_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER", raising=False)
+    monkeypatch.setenv(ENV_ROLE_READINESS_EXPLAIN, "tenant_user")
+    r = resolve_opa_role_for_policy(
+        header_value="tenant_admin",
+        env_var_name=ENV_ROLE_READINESS_EXPLAIN,
+        default="tenant_user",
+    )
+    assert r == "tenant_user"
+
+
+def test_resolve_env_overrides_default_when_untrusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER", raising=False)
+    monkeypatch.setenv(ENV_ROLE_BOARD_REPORT, "advisor")
+    r = resolve_opa_role_for_policy(
+        header_value=None,
+        env_var_name=ENV_ROLE_BOARD_REPORT,
+        default="tenant_admin",
+    )
+    assert r == "advisor"
+
+
+def test_resolve_invalid_env_falls_back_to_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER", raising=False)
+    monkeypatch.setenv(ENV_ROLE_BOARD_REPORT, "not_a_real_role")
+    r = resolve_opa_role_for_policy(
+        header_value=None,
+        env_var_name=ENV_ROLE_BOARD_REPORT,
+        default="tenant_admin",
+    )
+    assert r == "tenant_admin"
+
+
+def test_resolve_invalid_header_falls_through_when_trusted(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER", "true")
+    monkeypatch.setenv(ENV_ROLE_READINESS_EXPLAIN, "tenant_user")
+    r = resolve_opa_role_for_policy(
+        header_value="superuser",
+        env_var_name=ENV_ROLE_READINESS_EXPLAIN,
+        default="tenant_admin",
+    )
+    assert r == "tenant_user"


### PR DESCRIPTION
…uardrails

- Add app/policy OPA client, policy guard, and role_resolution (env vars per route, optional x-opa-user-role when COMPLIANCEHUB_OPA_TRUST_CLIENT_ROLE_HEADER is set).
- Wire resolved roles into board report, readiness explain, advisor tenant report, and LangGraph OAMI PoC routes; fix advisor report param order for Python syntax.
- Add Rego policy tests and CI step (open-policy-agent/setup-opa + opa test).
- Include LLM guardrails, LangGraph PoC, tests, docs, and langgraph dependency.

Made-with: Cursor