### PR TITLE
feat(rag): harden Wave 3 advisor BM25 pilot for production

### DIFF
--- a/app/rag/confidence.py
+++ b/app/rag/confidence.py
@@ -1,0 +1,43 @@
+"""Heuristic confidence for BM25-based regulatory RAG (advisory, not legal certainty)."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ConfidenceLevel = Literal["high", "medium", "low"]
+
+
+def compute_confidence_level(
+    scores: list[float],
+    *,
+    min_score_for_answer: float,
+    high_score_min: float,
+    score_gap_min: float,
+) -> tuple[ConfidenceLevel, str | None]:
+    """
+    Derive a coarse confidence label from retrieval scores.
+
+    - ``high``: strong top score and clear separation from the runner-up.
+    - ``medium``: usable hit but ambiguous ranking or moderate scores.
+    - ``low``: weak or no evidence; caller may skip LLM or attach ``notes_de``.
+    """
+    if not scores:
+        return "low", (
+            "Keine ausreichenden Treffer in der Wissensbasis. "
+            "Bitte inhaltlich durch eine Fachperson prüfen lassen."
+        )
+    s_desc = sorted(scores, reverse=True)
+    best = s_desc[0]
+    second = s_desc[1] if len(s_desc) > 1 else 0.0
+    if best < min_score_for_answer:
+        return "low", (
+            "Für diese Frage liegen uns in der EU-AI-Act/NIS2-Wissensbasis aktuell keine "
+            "eindeutigen Textstellen vor. Bitte ziehen Sie bei Bedarf eine menschliche "
+            "Fachexpertin bzw. einen Fachexperten hinzu."
+        )
+    if best >= high_score_min and (len(s_desc) == 1 or (best - second) >= score_gap_min):
+        return "high", None
+    return "medium", (
+        "Mehrere mögliche Textstellen oder mittlere Treffersicherheit — bitte Fundstellen "
+        "sorgfältig gegenprüfen."
+    )

--- a/app/rag/generation.py
+++ b/app/rag/generation.py
@@ -1,0 +1,51 @@
+"""Guardrailed LLM generation step for EU regulatory RAG."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from app.llm.client_wrapped import safe_llm_call_sync
+from app.llm.context import LlmCallContext
+from app.llm_models import LLMTaskType
+from app.rag.models import EuRegRagLlmOutput
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+
+def generate_eu_reg_rag_llm_output(
+    prompt: str,
+    *,
+    tenant_id: str,
+    user_role: str,
+    session: Session | None,
+) -> EuRegRagLlmOutput:
+    ctx = LlmCallContext(
+        tenant_id=tenant_id.strip(),
+        user_role=(user_role or "").strip(),
+        action_name="advisor_rag_eu_ai_act_nis2_query",
+    )
+    try:
+        return safe_llm_call_sync(
+            prompt,
+            EuRegRagLlmOutput,
+            context=ctx,
+            session=session,
+            task_type=LLMTaskType.ADVISOR_REGULATORY_RAG,
+        )
+    except Exception as exc:
+        logger.exception(
+            "eu_reg_rag_generator_failed tenant=%s err=%s",
+            tenant_id,
+            type(exc).__name__,
+        )
+        return EuRegRagLlmOutput(
+            answer_de=(
+                "Die KI-Antwort konnte nicht verlässlich erzeugt werden. "
+                "Bitte LLM-Konfiguration prüfen."
+            ),
+            citations=[],
+        )

--- a/app/rag/haystack_config.py
+++ b/app/rag/haystack_config.py
@@ -23,10 +23,62 @@ def rag_embedding_model_id() -> str:
     ).strip()
 
 
-def rag_retriever_top_k() -> int:
-    raw = os.getenv("COMPLIANCEHUB_RAG_TOP_K", "5").strip()
+def rag_merged_top_k() -> int:
+    """Max documents passed to the prompt after merging global + tenant hits (cap 10)."""
+    raw = os.getenv(
+        "COMPLIANCEHUB_RAG_MERGED_TOP_K",
+        os.getenv("COMPLIANCEHUB_RAG_TOP_K", "5"),
+    ).strip()
     try:
         k = int(raw)
     except ValueError:
         return 5
-    return max(1, min(k, 20))
+    return max(1, min(k, 10))
+
+
+def rag_global_top_k() -> int:
+    raw = os.getenv("COMPLIANCEHUB_RAG_GLOBAL_TOP_K", "5").strip()
+    try:
+        k = int(raw)
+    except ValueError:
+        return 5
+    return max(1, min(k, 10))
+
+
+def rag_tenant_overlay_top_k() -> int:
+    raw = os.getenv("COMPLIANCEHUB_RAG_TENANT_TOP_K", "3").strip()
+    try:
+        k = int(raw)
+    except ValueError:
+        return 3
+    return max(1, min(k, 10))
+
+
+def rag_bm25_min_score() -> float:
+    """Drop hits below this BM25 score before LLM (Haystack-normalized scores)."""
+    raw = os.getenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.08").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.08
+
+
+def rag_confidence_high_score_min() -> float:
+    raw = os.getenv("COMPLIANCEHUB_RAG_CONFIDENCE_HIGH_MIN_SCORE", "0.28").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.28
+
+
+def rag_confidence_gap_min() -> float:
+    raw = os.getenv("COMPLIANCEHUB_RAG_CONFIDENCE_GAP_MIN", "0.06").strip()
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return 0.06
+
+
+def rag_retriever_top_k() -> int:
+    """Backward-compatible alias for merged cap."""
+    return rag_merged_top_k()

--- a/app/rag/ingestion.py
+++ b/app/rag/ingestion.py
@@ -50,6 +50,7 @@ def documents_from_markdown_files(
                 "source": source_hint,
                 "section": title_line[:200],
                 "article": slug,
+                "rag_scope": "global",
             }
             out.append(Document(id=doc_id, content=chunk, meta=meta))
     return out

--- a/app/rag/models.py
+++ b/app/rag/models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, Field
 
 
@@ -19,9 +21,20 @@ class EuAiActNis2RagRequest(BaseModel):
 
 
 class EuAiActNis2RagCitation(BaseModel):
-    doc_id: str
-    source: str
+    """Belegzeile; ältere Clients nutzen weiter ``doc_id``/``source``/``section``."""
+
+    doc_id: str = Field(description="Stabile Chunk-ID (Haystack Document.id).")
+    source_id: str = Field(
+        default="",
+        description="Identisch mit doc_id, falls nicht anders vergeben.",
+    )
+    title: str = Field(default="", description="Kurztitel, typisch Abschnittsüberschrift.")
     section: str
+    source: str = Field(description="Quellenbezeichnung / Dateiname.")
+    is_tenant_specific: bool = Field(
+        default=False,
+        description="True bei Mandanten-Leitfaden (tenant_guidance), sonst globaler Kurpus.",
+    )
 
 
 class EuAiActNis2RagResponse(BaseModel):
@@ -29,6 +42,13 @@ class EuAiActNis2RagResponse(BaseModel):
     citations: list[EuAiActNis2RagCitation] = Field(
         default_factory=list,
         description="Bis zu drei wichtigste Belege aus dem Kurpus.",
+    )
+    confidence_level: Literal["high", "medium", "low"] = Field(
+        description="Heuristik aus BM25-Scores (keine Rechtssicherheit).",
+    )
+    notes_de: str | None = Field(
+        default=None,
+        description="Hinweis bei niedriger/mittlerer Konfidenz oder fehlenden Treffern.",
     )
 
 

--- a/app/rag/observability.py
+++ b/app/rag/observability.py
@@ -1,0 +1,107 @@
+"""Structured RAG observability (hashed queries, no raw PII in logs)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import time
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+RagQueryPhase = Literal["retrieval_complete", "response_complete"]
+
+
+def query_sha256_hex(question_de: str) -> str:
+    return hashlib.sha256(question_de.strip().encode("utf-8")).hexdigest()
+
+
+def redacted_query_preview(question_de: str, *, max_len: int = 120) -> str:
+    """Short preview with long digit runs masked (IBANs, IDs)."""
+    s = question_de.strip().replace("\n", " ")[:max_len]
+    return re.sub(r"\d{4,}", "[#]", s)
+
+
+def log_rag_query_event(
+    *,
+    phase: RagQueryPhase,
+    tenant_id: str,
+    user_role: str,
+    advisor_id: str | None,
+    query_sha256: str,
+    query_length_chars: int,
+    query_redacted_preview: str,
+    top_k_effective: int,
+    retrieved_doc_ids: list[str],
+    retrieval_scores: list[float],
+    latency_ms_retrieval: float | None = None,
+    latency_ms_llm: float | None = None,
+    latency_ms_total: float | None = None,
+    confidence_level: str | None = None,
+    llm_action_name: str = "advisor_rag_eu_ai_act_nis2_query",
+    extra: dict[str, Any] | None = None,
+) -> None:
+    """
+    One normalized log line per phase (retrieval vs full response).
+
+    Does not log raw ``question_de``; only hash, length, and redacted preview.
+    """
+    record: dict[str, Any] = {
+        "event": "rag_query",
+        "phase": phase,
+        "tenant_id": tenant_id,
+        "user_role": user_role,
+        "advisor_id": advisor_id,
+        "query_sha256": query_sha256,
+        "query_length_chars": query_length_chars,
+        "query_redacted_preview": query_redacted_preview,
+        "top_k_effective": top_k_effective,
+        "retrieved_doc_ids": retrieved_doc_ids,
+        "retrieval_scores": [round(x, 6) for x in retrieval_scores],
+        "llm_context": {
+            "action_name": llm_action_name,
+        },
+    }
+    if latency_ms_retrieval is not None:
+        record["latency_ms_retrieval"] = round(latency_ms_retrieval, 2)
+    if latency_ms_llm is not None:
+        record["latency_ms_llm"] = round(latency_ms_llm, 2)
+    if latency_ms_total is not None:
+        record["latency_ms_total"] = round(latency_ms_total, 2)
+    if confidence_level is not None:
+        record["confidence_level"] = confidence_level
+    if extra:
+        record["extra"] = extra
+    logger.info("rag_query_event %s", json.dumps(record, ensure_ascii=False))
+
+
+class RagTimingSpan:
+    """Simple perf counter slice for retrieval vs LLM."""
+
+    def __init__(self) -> None:
+        self._t0 = time.perf_counter()
+        self.retrieval_end: float | None = None
+        self.llm_end: float | None = None
+
+    def mark_retrieval_end(self) -> None:
+        self.retrieval_end = time.perf_counter()
+
+    def mark_llm_end(self) -> None:
+        self.llm_end = time.perf_counter()
+
+    def ms_retrieval(self) -> float | None:
+        if self.retrieval_end is None:
+            return None
+        return (self.retrieval_end - self._t0) * 1000.0
+
+    def ms_llm(self) -> float | None:
+        if self.retrieval_end is None or self.llm_end is None:
+            return None
+        return (self.llm_end - self.retrieval_end) * 1000.0
+
+    def ms_total(self) -> float | None:
+        if self.llm_end is None:
+            return None
+        return (self.llm_end - self._t0) * 1000.0

--- a/app/rag/pipelines/eu_ai_act_nis2_pipeline.py
+++ b/app/rag/pipelines/eu_ai_act_nis2_pipeline.py
@@ -1,127 +1,69 @@
 """
-EU AI Act / NIS2 / ISO 42001 advisor RAG — explicit Haystack 2 graph.
+EU AI Act / NIS2 / ISO 42001 advisor RAG — explicit execution graph (BM25 pilot).
 
-Graph (BM25 pilot):
-  ``query`` → Retriever → PromptBuilder → Guardrailed Generator → structured JSON
+Steps (auditable, no hidden lambdas):
+  1. ``merged_bm25_retrieve`` — global corpus + optional tenant guidance (metadata filters).
+  2. ``filter_documents_by_min_score`` — quality gate.
+  3. ``compute_confidence_level`` — heuristic label from scores.
+  4. ``build_eu_reg_rag_prompt`` — German prompt + source catalog.
+  5. ``generate_eu_reg_rag_llm_output`` — ``safe_llm_call_sync`` + ``LlmCallContext``.
 
-All nodes are dedicated component classes (no hidden lambdas). The generator uses
-``safe_llm_call_sync`` + ``LlmCallContext`` so guardrails and task routing match the rest
-of ComplianceHub.
+Haystack ``Pipeline`` is not required for this wave; the sequence above is fixed in code
+so logs and tests can hook each stage.
 """
 
 from __future__ import annotations
 
-import json
-import logging
+import time
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from haystack import Pipeline, component
-from haystack.components.retrievers import InMemoryBM25Retriever
 from haystack.dataclasses import Document
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
-from app.llm.client_wrapped import safe_llm_call_sync
-from app.llm.context import LlmCallContext
-from app.llm_models import LLMTaskType
-from app.rag.haystack_config import rag_retriever_top_k
+from app.rag.confidence import compute_confidence_level
+from app.rag.generation import generate_eu_reg_rag_llm_output
+from app.rag.haystack_config import (
+    rag_bm25_min_score,
+    rag_confidence_gap_min,
+    rag_confidence_high_score_min,
+    rag_merged_top_k,
+)
 from app.rag.models import EuRegRagLlmOutput
+from app.rag.observability import (
+    log_rag_query_event,
+    query_sha256_hex,
+    redacted_query_preview,
+)
+from app.rag.prompting import build_eu_reg_rag_prompt
+from app.rag.retrieval import (
+    documents_scores_and_ids,
+    filter_documents_by_min_score,
+    merged_bm25_retrieve,
+)
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-logger = logging.getLogger(__name__)
 
-_SYSTEM_DE = (
-    "Du bist ein Compliance-Assistent für Berater im DACH-Raum. Antworte auf Deutsch, sachlich, "
-    "ohne Rechtsberatung. Nutze ausschließlich die unten nummerierten Kurzfragmente; keine "
-    "externen Fakten. Wenn der Kurpus nicht reicht, sage das klar.\n\n"
-    "Gib die Antwort als ein JSON-Objekt mit genau diesen Schlüsseln:\n"
-    '- "answer_de": string (Markdown erlaubt, max. knapp)\n'
-    '- "citations": Liste von Objekten mit "doc_id", "source", "section" '
-    "(höchstens 5 Einträge; doc_id exakt wie im Katalog).\n\n"
+@dataclass(frozen=True)
+class EuRegRagPipelineResult:
+    """Structured outcome for API mapping and tests."""
+
+    structured: dict
+    documents_for_prompt: list[Document]
+    merged_documents: list[Document]
+    merged_scores: list[float]
+    confidence_level: str
+    notes_de: str | None
+    used_llm: bool
+
+
+_FALLBACK_NO_HIT_DE = (
+    "Für diese Frage liegen uns in der EU-AI-Act/NIS2-Wissensbasis aktuell keine eindeutigen "
+    "Textstellen vor. Bitte ziehen Sie bei Bedarf eine menschliche Fachexpertin bzw. einen "
+    "Fachexperten hinzu."
 )
-
-
-@component
-class EuAiActNis2PromptBuilder:
-    """Builds the LLM prompt and a machine-readable source catalog from retrieved docs."""
-
-    @component.output_types(prompt=str, retrieved_documents=list)
-    def run(self, query: str, documents: list[Document]) -> dict[str, object]:
-        catalog_lines: list[str] = []
-        for i, doc in enumerate(documents, start=1):
-            did = str(doc.id or f"doc-{i}")
-            meta = doc.meta or {}
-            source = str(meta.get("source", ""))
-            section = str(meta.get("section", ""))
-            body = (doc.content or "").strip()
-            catalog_lines.append(
-                f"[{i}] doc_id={did!r} source={source!r} section={section!r}\n{body}\n",
-            )
-        catalog = "\n".join(catalog_lines) if catalog_lines else "(Keine Treffer im Kurpus.)"
-        prompt = (
-            f"{_SYSTEM_DE}--- Kurpus ---\n{catalog}\n--- Frage ---\n{query.strip()}\n--- JSON ---\n"
-        )
-        return {"prompt": prompt, "retrieved_documents": documents}
-
-
-@component
-class GuardrailedEuRegRagGenerator:
-    """LLM step: guardrailed structured JSON via existing ComplianceHub client."""
-
-    def __init__(self, session: Session | None = None) -> None:
-        self._session = session
-
-    @component.output_types(structured=dict)
-    def run(self, prompt: str, tenant_id: str, user_role: str) -> dict[str, object]:
-        ctx = LlmCallContext(
-            tenant_id=tenant_id.strip(),
-            user_role=(user_role or "").strip(),
-            action_name="advisor_rag_eu_ai_act_nis2_query",
-        )
-        try:
-            parsed = safe_llm_call_sync(
-                prompt,
-                EuRegRagLlmOutput,
-                context=ctx,
-                session=self._session,
-                task_type=LLMTaskType.ADVISOR_REGULATORY_RAG,
-            )
-            payload = parsed.model_dump(mode="json")
-        except Exception as exc:
-            logger.exception(
-                "eu_reg_rag_generator_failed tenant=%s err=%s",
-                tenant_id,
-                type(exc).__name__,
-            )
-            payload = EuRegRagLlmOutput(
-                answer_de=(
-                    "Die KI-Antwort konnte nicht verlässlich erzeugt werden. "
-                    "Bitte LLM-Konfiguration prüfen."
-                ),
-                citations=[],
-            ).model_dump(mode="json")
-        return {"structured": payload}
-
-
-def build_eu_ai_act_nis2_pipeline(
-    document_store: InMemoryDocumentStore,
-    *,
-    session: Session | None = None,
-    top_k: int | None = None,
-) -> Pipeline:
-    k = top_k if top_k is not None else rag_retriever_top_k()
-    retriever = InMemoryBM25Retriever(document_store=document_store, top_k=k)
-    prompt_builder = EuAiActNis2PromptBuilder()
-    generator = GuardrailedEuRegRagGenerator(session=session)
-
-    pipeline = Pipeline()
-    pipeline.add_component("retriever", retriever)
-    pipeline.add_component("prompt_builder", prompt_builder)
-    pipeline.add_component("generator", generator)
-    pipeline.connect("retriever.documents", "prompt_builder.documents")
-    pipeline.connect("prompt_builder.prompt", "generator.prompt")
-    return pipeline
 
 
 def run_eu_ai_act_nis2_pipeline(
@@ -131,26 +73,113 @@ def run_eu_ai_act_nis2_pipeline(
     user_role: str,
     document_store: InMemoryDocumentStore,
     session: Session | None = None,
-    top_k: int | None = None,
-) -> tuple[dict, list[Document]]:
-    """
-    Execute the full graph. Returns (generator structured dict, retrieved documents).
-    """
-    pipe = build_eu_ai_act_nis2_pipeline(
-        document_store,
-        session=session,
-        top_k=top_k,
-    )
+    advisor_id: str | None = None,
+) -> EuRegRagPipelineResult:
+    t0 = time.perf_counter()
     q = question_de.strip()
-    out = pipe.run(
-        {
-            "retriever": {"query": q},
-            "prompt_builder": {"query": q},
-            "generator": {"tenant_id": tenant_id, "user_role": user_role},
-        },
+    q_hash = query_sha256_hex(q)
+    q_prev = redacted_query_preview(q)
+    q_len = len(q)
+
+    merged = merged_bm25_retrieve(document_store, query=q, tenant_id=tenant_id)
+    merged_scores, merged_ids = documents_scores_and_ids(merged)
+    t_after_retrieval = time.perf_counter()
+    latency_retrieval_ms = (t_after_retrieval - t0) * 1000.0
+
+    log_rag_query_event(
+        phase="retrieval_complete",
+        tenant_id=tenant_id,
+        user_role=user_role,
+        advisor_id=advisor_id,
+        query_sha256=q_hash,
+        query_length_chars=q_len,
+        query_redacted_preview=q_prev,
+        top_k_effective=rag_merged_top_k(),
+        retrieved_doc_ids=merged_ids,
+        retrieval_scores=merged_scores,
+        latency_ms_retrieval=latency_retrieval_ms,
+        extra={"merged_hits": len(merged)},
     )
-    structured = out["generator"]["structured"]
-    documents = out["prompt_builder"]["retrieved_documents"]
-    if isinstance(structured, str):
-        structured = json.loads(structured)
-    return structured, documents
+
+    min_s = rag_bm25_min_score()
+    filtered = filter_documents_by_min_score(merged, min_s)
+    conf_scores = documents_scores_and_ids(filtered)[0] if filtered else merged_scores
+    confidence_level, conf_notes = compute_confidence_level(
+        conf_scores,
+        min_score_for_answer=min_s,
+        high_score_min=rag_confidence_high_score_min(),
+        score_gap_min=rag_confidence_gap_min(),
+    )
+
+    if not filtered:
+        payload = EuRegRagLlmOutput(
+            answer_de=_FALLBACK_NO_HIT_DE,
+            citations=[],
+        ).model_dump(mode="json")
+        t_end = time.perf_counter()
+        log_rag_query_event(
+            phase="response_complete",
+            tenant_id=tenant_id,
+            user_role=user_role,
+            advisor_id=advisor_id,
+            query_sha256=q_hash,
+            query_length_chars=q_len,
+            query_redacted_preview=q_prev,
+            top_k_effective=rag_merged_top_k(),
+            retrieved_doc_ids=merged_ids,
+            retrieval_scores=merged_scores,
+            latency_ms_retrieval=latency_retrieval_ms,
+            latency_ms_llm=0.0,
+            latency_ms_total=(t_end - t0) * 1000.0,
+            confidence_level="low",
+            extra={"used_llm": False, "filtered_hits": 0},
+        )
+        return EuRegRagPipelineResult(
+            structured=payload,
+            documents_for_prompt=[],
+            merged_documents=merged,
+            merged_scores=merged_scores,
+            confidence_level="low",
+            notes_de=conf_notes,
+            used_llm=False,
+        )
+
+    prompt = build_eu_reg_rag_prompt(q, filtered)
+    t_before_llm = time.perf_counter()
+    parsed = generate_eu_reg_rag_llm_output(
+        prompt,
+        tenant_id=tenant_id,
+        user_role=user_role,
+        session=session,
+    )
+    t_end = time.perf_counter()
+    latency_llm_ms = (t_end - t_before_llm) * 1000.0
+    notes = conf_notes if confidence_level in ("low", "medium") else None
+
+    log_rag_query_event(
+        phase="response_complete",
+        tenant_id=tenant_id,
+        user_role=user_role,
+        advisor_id=advisor_id,
+        query_sha256=q_hash,
+        query_length_chars=q_len,
+        query_redacted_preview=q_prev,
+        top_k_effective=rag_merged_top_k(),
+        retrieved_doc_ids=merged_ids,
+        retrieval_scores=merged_scores,
+        latency_ms_retrieval=latency_retrieval_ms,
+        latency_ms_llm=latency_llm_ms,
+        latency_ms_total=(t_end - t0) * 1000.0,
+        confidence_level=confidence_level,
+        extra={"used_llm": True, "filtered_hits": len(filtered)},
+    )
+
+    return EuRegRagPipelineResult(
+        structured=parsed.model_dump(mode="json"),
+        documents_for_prompt=filtered,
+        merged_documents=merged,
+        merged_scores=merged_scores,
+        confidence_level=confidence_level,
+        notes_de=notes,
+        used_llm=True,
+    )

--- a/app/rag/prompting.py
+++ b/app/rag/prompting.py
@@ -1,0 +1,35 @@
+"""German compliance prompt construction for EU regulatory RAG (explicit, auditable)."""
+
+from __future__ import annotations
+
+from haystack.dataclasses import Document
+
+from app.rag.retrieval import is_tenant_guidance_document
+
+_SYSTEM_DE = (
+    "Du bist ein Compliance-Assistent für Berater im DACH-Raum. Antworte auf Deutsch, sachlich, "
+    "ohne Rechtsberatung. Nutze ausschließlich die unten nummerierten Kurzfragmente; keine "
+    "externen Fakten. Wenn der Kurpus nicht reicht, sage das klar.\n"
+    "Fragmente mit „Mandanten-Leitfaden“ sind interne Mandanten-Hinweise; "
+    "„EU/NIS2/ISO-Korpus“ bezieht sich auf den globalen Pilot-Kurpus.\n\n"
+    "Gib die Antwort als ein JSON-Objekt mit genau diesen Schlüsseln:\n"
+    '- "answer_de": string (Markdown erlaubt, max. knapp)\n'
+    '- "citations": Liste von Objekten mit "doc_id", "source", "section" '
+    "(höchstens 5 Einträge; doc_id exakt wie im Katalog).\n\n"
+)
+
+
+def build_eu_reg_rag_prompt(query: str, documents: list[Document]) -> str:
+    catalog_lines: list[str] = []
+    for i, doc in enumerate(documents, start=1):
+        did = str(doc.id or f"doc-{i}")
+        meta = doc.meta or {}
+        source = str(meta.get("source", ""))
+        section = str(meta.get("section", ""))
+        body = (doc.content or "").strip()
+        kind = "Mandanten-Leitfaden" if is_tenant_guidance_document(doc) else "EU/NIS2/ISO-Korpus"
+        catalog_lines.append(
+            f"[{i}] doc_id={did!r} kind={kind!r} source={source!r} section={section!r}\n{body}\n",
+        )
+    catalog = "\n".join(catalog_lines) if catalog_lines else "(Keine Treffer im Kurpus.)"
+    return f"{_SYSTEM_DE}--- Kurpus ---\n{catalog}\n--- Frage ---\n{query.strip()}\n--- JSON ---\n"

--- a/app/rag/retrieval.py
+++ b/app/rag/retrieval.py
@@ -1,0 +1,97 @@
+"""Merged BM25 retrieval: global regulatory corpus + optional tenant guidance overlays."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+from haystack import Document
+from haystack.components.retrievers import InMemoryBM25Retriever
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+from app.rag.haystack_config import rag_global_top_k, rag_merged_top_k, rag_tenant_overlay_top_k
+
+logger = logging.getLogger(__name__)
+
+_GLOBAL_SCOPE = "global"
+_TENANT_SCOPE = "tenant_guidance"
+
+
+def _filter_global() -> dict:
+    return {"field": "rag_scope", "operator": "==", "value": _GLOBAL_SCOPE}
+
+
+def _filter_tenant(tenant_id: str) -> dict:
+    return {
+        "operator": "AND",
+        "conditions": [
+            {"field": "tenant_id", "operator": "==", "value": tenant_id},
+            {"field": "rag_scope", "operator": "==", "value": _TENANT_SCOPE},
+        ],
+    }
+
+
+def merged_bm25_retrieve(
+    document_store: InMemoryDocumentStore,
+    *,
+    query: str,
+    tenant_id: str,
+) -> list[Document]:
+    """
+    Retrieve global law snippets always; add tenant-specific guidance when present.
+
+    Documents are returned with ``score`` set (Haystack BM25). Deduplicated by ``id``,
+    highest score kept, then truncated to merged top-k.
+    """
+    q = query.strip()
+    kg = rag_global_top_k()
+    kt = rag_tenant_overlay_top_k()
+    cap = rag_merged_top_k()
+
+    gr = InMemoryBM25Retriever(document_store=document_store, top_k=kg)
+    g_out = gr.run(query=q, filters=_filter_global())
+    g_docs = list(g_out.get("documents") or [])
+
+    tr = InMemoryBM25Retriever(document_store=document_store, top_k=kt)
+    t_out = tr.run(query=q, filters=_filter_tenant(tenant_id.strip()))
+    t_docs = list(t_out.get("documents") or [])
+
+    by_id: dict[str, Document] = {}
+    for d in g_docs + t_docs:
+        did = str(d.id or "")
+        if not did:
+            continue
+        score = float(getattr(d, "score", 0.0) or 0.0)
+        prev = by_id.get(did)
+        if prev is None or float(getattr(prev, "score", 0.0) or 0.0) < score:
+            by_id[did] = replace(d, score=score)
+
+    merged = sorted(
+        by_id.values(),
+        key=lambda x: float(getattr(x, "score", 0.0) or 0.0),
+        reverse=True,
+    )
+    merged = merged[:cap]
+    logger.debug(
+        "rag_merged_retrieval tenant=%s global_hits=%s tenant_hits=%s merged=%s",
+        tenant_id,
+        len(g_docs),
+        len(t_docs),
+        len(merged),
+    )
+    return merged
+
+
+def documents_scores_and_ids(documents: list[Document]) -> tuple[list[float], list[str]]:
+    scores = [float(getattr(d, "score", 0.0) or 0.0) for d in documents]
+    ids = [str(d.id or "") for d in documents]
+    return scores, ids
+
+
+def filter_documents_by_min_score(documents: list[Document], min_score: float) -> list[Document]:
+    return [d for d in documents if float(getattr(d, "score", 0.0) or 0.0) >= min_score]
+
+
+def is_tenant_guidance_document(doc: Document) -> bool:
+    meta = doc.meta or {}
+    return str(meta.get("rag_scope", "")).strip() == _TENANT_SCOPE

--- a/app/rag/service.py
+++ b/app/rag/service.py
@@ -3,18 +3,45 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, cast
 
+from haystack.dataclasses import Document
 from haystack.document_stores.in_memory import InMemoryDocumentStore
 
 from app.rag.models import EuAiActNis2RagCitation, EuAiActNis2RagResponse, EuRegRagLlmOutput
 from app.rag.pipelines.eu_ai_act_nis2_pipeline import run_eu_ai_act_nis2_pipeline
+from app.rag.retrieval import is_tenant_guidance_document
 from app.rag.store import get_eu_reg_document_store
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+def _build_api_citations(
+    parsed: EuRegRagLlmOutput,
+    documents_for_prompt: list[Document],
+    *,
+    max_citations: int = 3,
+) -> list[EuAiActNis2RagCitation]:
+    by_id = {str(d.id): d for d in documents_for_prompt if d.id}
+    out: list[EuAiActNis2RagCitation] = []
+    for c in (parsed.citations or [])[:max_citations]:
+        doc = by_id.get(c.doc_id)
+        is_tenant = is_tenant_guidance_document(doc) if doc is not None else False
+        title = str((doc.meta or {}).get("section", c.section)) if doc is not None else c.section
+        out.append(
+            EuAiActNis2RagCitation(
+                doc_id=c.doc_id,
+                source_id=c.doc_id,
+                title=title,
+                section=c.section,
+                source=c.source,
+                is_tenant_specific=is_tenant,
+            ),
+        )
+    return out
 
 
 def run_advisor_eu_reg_rag(
@@ -27,22 +54,28 @@ def run_advisor_eu_reg_rag(
     document_store: InMemoryDocumentStore | None = None,
 ) -> EuAiActNis2RagResponse:
     store = document_store or get_eu_reg_document_store()
-    structured, _docs = run_eu_ai_act_nis2_pipeline(
+    pr = run_eu_ai_act_nis2_pipeline(
         question_de=question_de,
         tenant_id=tenant_id,
         user_role=user_role,
         document_store=store,
         session=session,
+        advisor_id=advisor_id,
     )
-    parsed = EuRegRagLlmOutput.model_validate(structured)
-    citations = [
-        EuAiActNis2RagCitation(doc_id=c.doc_id, source=c.source, section=c.section)
-        for c in (parsed.citations or [])[:3]
-    ]
+    parsed = EuRegRagLlmOutput.model_validate(pr.structured)
+    citations = _build_api_citations(parsed, pr.documents_for_prompt)
     logger.info(
-        "advisor_eu_reg_rag_done advisor_id=%s tenant_id=%s citation_count=%s",
+        "advisor_eu_reg_rag_done advisor_id=%s tenant_id=%s citation_count=%s confidence=%s llm=%s",
         advisor_id,
         tenant_id,
         len(citations),
+        pr.confidence_level,
+        pr.used_llm,
     )
-    return EuAiActNis2RagResponse(answer_de=parsed.answer_de, citations=citations)
+    conf = cast(Literal["high", "medium", "low"], pr.confidence_level)
+    return EuAiActNis2RagResponse(
+        answer_de=parsed.answer_de,
+        citations=citations,
+        confidence_level=conf,
+        notes_de=pr.notes_de,
+    )

--- a/app/rag/store.py
+++ b/app/rag/store.py
@@ -36,3 +36,22 @@ def replace_eu_reg_document_store_for_tests(store: InMemoryDocumentStore) -> Non
     global _store
     with _lock:
         _store = store
+
+
+def register_tenant_guidance_documents(tenant_id: str, documents: list) -> None:
+    """
+    Append mandanten-spezifische Leitfaden-Fragmente (metadata: rag_scope=tenant_guidance).
+
+    ``documents`` are Haystack ``Document`` instances; ``meta`` wird ergänzt, nicht überschrieben.
+    """
+    from haystack import Document
+
+    store = get_eu_reg_document_store()
+    to_write: list[Document] = []
+    for d in documents:
+        meta = dict(d.meta or {})
+        meta["tenant_id"] = tenant_id.strip()
+        meta["rag_scope"] = "tenant_guidance"
+        to_write.append(Document(id=d.id, content=d.content, meta=meta))
+    if to_write:
+        store.write_documents(to_write)

--- a/docs/architecture/wave3-haystack-rag.md
+++ b/docs/architecture/wave3-haystack-rag.md
@@ -11,30 +11,58 @@ ComplianceHub needs **retrieval-augmented** answers that are **explainable in au
 ## Pilot scope
 
 - **Use case:** Advisors ask **German** questions about **EU AI Act**, **NIS2**, and **ISO 42001** using a **small curated corpus** under `app/rag/corpus/` (markdown snippets, not full legal texts).
-- **Retriever (v1):** `InMemoryBM25Retriever` over `InMemoryDocumentStore` — fast, deterministic in CI, no embedding download.
-- **Generator:** `GuardrailedEuRegRagGenerator` calls **`safe_llm_call_sync`** with a Pydantic JSON contract (`EuRegRagLlmOutput`) so **guardrails + LLMRouter** stay aligned with the rest of the platform.
-- **API:** `POST /api/v1/advisor/rag/eu-ai-act-nis2-query` with OPA action **`advisor_rag_eu_ai_act_nis2_query`**, headers `x-api-key` + **`x-advisor-id`**, feature flag **`COMPLIANCEHUB_FEATURE_COMPLIANCE_RAG_KNOWLEDGE_HUB`**.
+- **Retriever (v1):** **BM25** (`InMemoryBM25Retriever`) over `InMemoryDocumentStore` — fast, deterministic in CI.
+- **Generator:** `generate_eu_reg_rag_llm_output` → **`safe_llm_call_sync`** with `EuRegRagLlmOutput` (JSON) and **`LlmCallContext`** (`action_name=advisor_rag_eu_ai_act_nis2_query`).
+- **API:** `POST /api/v1/advisor/rag/eu-ai-act-nis2-query` with OPA **`advisor_rag_eu_ai_act_nis2_query`**, headers `x-api-key` + **`x-advisor-id`**, feature flag **`COMPLIANCEHUB_FEATURE_COMPLIANCE_RAG_KNOWLEDGE_HUB`**.
 
-Configuration hints live in `app/rag/haystack_config.py` (e.g. future `COMPLIANCEHUB_RAG_RETRIEVER=embedding` + multilingual sentence-transformers).
+Configuration: `app/rag/haystack_config.py`.
 
-## Pipeline graph
+## Execution graph (explicit, auditable)
 
-Defined in `app/rag/pipelines/eu_ai_act_nis2_pipeline.py`:
+Implemented as a **fixed sequence** in `app/rag/pipelines/eu_ai_act_nis2_pipeline.py` (no hidden lambdas):
 
-1. **Retriever** — BM25 over the in-memory store.
-2. **`EuAiActNis2PromptBuilder`** — builds the German compliance prompt and passes through **`retrieved_documents`** (Haystack only returns leaf outputs; this preserves audit context).
-3. **`GuardrailedEuRegRagGenerator`** — structured LLM answer + citations.
+1. **`merged_bm25_retrieve`** (`app/rag/retrieval.py`) — always queries **global** snippets (`meta.rag_scope == global`); optionally **tenant guidance** (`rag_scope == tenant_guidance` + `meta.tenant_id`).
+2. **`filter_documents_by_min_score`** — drops weak BM25 hits (`COMPLIANCEHUB_RAG_BM25_MIN_SCORE`, default `0.08`).
+3. **`compute_confidence_level`** (`app/rag/confidence.py`) — coarse **high / medium / low** from best score and top-1 vs top-2 gap (`COMPLIANCEHUB_RAG_CONFIDENCE_*`).
+4. If nothing passes the threshold: **no LLM call**; returns a **safe German** stock answer and `confidence_level=low` plus `notes_de`.
+5. **`build_eu_reg_rag_prompt`** (`app/rag/prompting.py`) — catalog labels **EU/NIS2/ISO-Korpus** vs **Mandanten-Leitfaden**.
+6. **`generate_eu_reg_rag_llm_output`** (`app/rag/generation.py`) — guardrailed structured answer.
+
+Top-k caps (each max 10): `COMPLIANCEHUB_RAG_GLOBAL_TOP_K`, `COMPLIANCEHUB_RAG_TENANT_TOP_K`, merged cap `COMPLIANCEHUB_RAG_MERGED_TOP_K` (alias: legacy `COMPLIANCEHUB_RAG_TOP_K`).
+
+## Observability
+
+`log_rag_query_event` in `app/rag/observability.py` emits **two** JSON log lines per request:
+
+- **`retrieval_complete`:** `query_sha256`, length, **redacted** preview (long digit runs masked), `retrieved_doc_ids`, `retrieval_scores`, `top_k_effective`, retrieval latency.
+- **`response_complete`:** same hash/preview identifiers, optional LLM latency, total latency, `confidence_level`, `extra.used_llm` / hit counts.
+
+Raw `question_de` is **not** logged.
+
+## Tenant-scoping
+
+- **Global law / norm pilot text:** `meta.rag_scope = "global"` (set automatically in `documents_from_markdown_files`).
+- **Tenant overlays:** documents with `meta.rag_scope = "tenant_guidance"` and `meta.tenant_id = "<tenant>"`. Helper: `register_tenant_guidance_documents` in `app/rag/store.py`.
+- API citations include **`is_tenant_specific`** (true for tenant guidance). Legacy fields **`doc_id`**, **`source`**, **`section`** remain; added **`source_id`** (defaults to `doc_id`) and **`title`**.
+
+## API response (advisory)
+
+`EuAiActNis2RagResponse` includes:
+
+- `answer_de`, `citations`, **`confidence_level`**, optional **`notes_de`**.
+
+**Advisory notice:** RAG output is **not legal advice**. For **`low`** or **`medium`** confidence, `notes_de` prompts human review. Operators should treat the feature as **decision support** only.
 
 ## Ingestion
 
-`scripts/ingest_eu_ai_act_nis2_corpus.py` loads `.md` files, splits into paragraph chunks with metadata (`source`, `section`, `article`), and writes to an in-memory store (stdout logging). Point `--corpus-dir` at additional curated files when expanding the pilot.
+`scripts/ingest_eu_ai_act_nis2_corpus.py` loads `.md` files; chunks get `rag_scope=global` unless extended for tenant uploads.
 
 ## Integration outlook
 
-- **Temporal (Wave 2):** Long-running advisor or board workflows can call this RAG as an **activity** (same guardrailed generator, same OPA action or a derived one) to pre-answer recurring regulatory questions and attach citations to workflow artefacts.
-- **Advisor / board flows:** Responses can be merged into tenant reports or snapshot exports once tenant–advisor linkage and retention policies are applied.
+- **Temporal (Wave 2):** RAG can run inside an activity with the same guardrails and logging hooks.
+- **Advisor / board flows:** attach `query_sha256`, doc ids, and `confidence_level` to workflow artefacts for audit.
 
 ## Operational notes
 
 - Default feature flag for RAG is **off** until operators enable keys and policies.
-- Corpus is **global** for the pilot; tenant-specific indexes can follow via metadata filters on the document store and OPA-scoped actions.
+- Without LLM keys, generation fails gracefully; observability logs still record retrieval.

--- a/tests/test_eu_ai_act_nis2_rag.py
+++ b/tests/test_eu_ai_act_nis2_rag.py
@@ -1,4 +1,4 @@
-"""Wave 3: EU regulatory RAG — retriever, pipeline (mock LLM), API + OPA."""
+"""Wave 3: EU regulatory RAG — retriever, pipeline, API + OPA + observability."""
 
 from __future__ import annotations
 
@@ -45,6 +45,7 @@ def synthetic_reg_store() -> InMemoryDocumentStore:
                     "source": "EU AI Act (Pilot)",
                     "section": "Art. 9 Risikomanagement",
                     "article": "9",
+                    "rag_scope": "global",
                 },
             ),
             Document(
@@ -57,6 +58,7 @@ def synthetic_reg_store() -> InMemoryDocumentStore:
                     "source": "NIS2 (Pilot)",
                     "section": "Meldung von Vorfällen",
                     "article": "21",
+                    "rag_scope": "global",
                 },
             ),
         ],
@@ -65,7 +67,11 @@ def synthetic_reg_store() -> InMemoryDocumentStore:
 
 
 def test_bm25_retriever_returns_nis2_doc(synthetic_reg_store: InMemoryDocumentStore) -> None:
-    retriever = InMemoryBM25Retriever(document_store=synthetic_reg_store, top_k=3)
+    retriever = InMemoryBM25Retriever(
+        document_store=synthetic_reg_store,
+        top_k=3,
+        filters={"field": "rag_scope", "operator": "==", "value": "global"},
+    )
     out = retriever.run(query="NIS2 Meldung Behörden Vorfall")
     ids = [d.id for d in out["documents"]]
     assert "nis2-meldung-chunk-0" in ids
@@ -86,19 +92,147 @@ def test_pipeline_mock_llm_includes_expected_citation(
     )
 
     with patch(
-        "app.rag.pipelines.eu_ai_act_nis2_pipeline.safe_llm_call_sync",
+        "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output",
         return_value=fixed,
     ):
-        structured, docs = run_eu_ai_act_nis2_pipeline(
+        pr = run_eu_ai_act_nis2_pipeline(
             question_de="NIS2 Meldung Behörden Vorfall unverzüglich",
             tenant_id="tenant-rag-1",
             user_role="advisor",
             document_store=synthetic_reg_store,
             session=None,
+            advisor_id="adv-1",
         )
-    assert structured["answer_de"]
-    assert structured["citations"][0]["doc_id"] == "nis2-meldung-chunk-0"
-    assert any(d.id == "nis2-meldung-chunk-0" for d in docs)
+    assert pr.structured["answer_de"]
+    assert pr.structured["citations"][0]["doc_id"] == "nis2-meldung-chunk-0"
+    assert any(d.id == "nis2-meldung-chunk-0" for d in pr.documents_for_prompt)
+
+
+def test_log_rag_query_event_called_twice(
+    synthetic_reg_store: InMemoryDocumentStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_HIGH_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_GAP_MIN", "0.0")
+    fixed = EuRegRagLlmOutput(answer_de="ok", citations=[])
+    phases: list[str] = []
+
+    def _capture(**kwargs: object) -> None:
+        phases.append(str(kwargs.get("phase")))
+
+    with (
+        patch(
+            "app.rag.pipelines.eu_ai_act_nis2_pipeline.log_rag_query_event",
+            side_effect=_capture,
+        ),
+        patch(
+            "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output",
+            return_value=fixed,
+        ),
+    ):
+        run_eu_ai_act_nis2_pipeline(
+            question_de="NIS2 Meldung Behörden Vorfall unverzüglich",
+            tenant_id="t1",
+            user_role="advisor",
+            document_store=synthetic_reg_store,
+            session=None,
+            advisor_id="adv-x",
+        )
+    assert phases == ["retrieval_complete", "response_complete"]
+
+
+def test_tenant_overlay_citation_flag(
+    synthetic_reg_store: InMemoryDocumentStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.01")
+    tid = "tenant-overlay-1"
+    synthetic_reg_store.write_documents(
+        [
+            Document(
+                id="acme-nis2-note-chunk-0",
+                content="Mandant ACME: Bei NIS2-Meldungen zuerst internen Krisenstab informieren.",
+                meta={
+                    "source": "ACME intern",
+                    "section": "Playbook",
+                    "rag_scope": "tenant_guidance",
+                    "tenant_id": tid,
+                },
+            ),
+        ],
+    )
+    fixed = EuRegRagLlmOutput(
+        answer_de="Zuerst Krisenstab laut Mandantenleitfaden.",
+        citations=[
+            EuRegRagLlmCitation(
+                doc_id="acme-nis2-note-chunk-0",
+                source="ACME intern",
+                section="Playbook",
+            ),
+        ],
+    )
+    gen = "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output"
+    with patch(gen, return_value=fixed):
+        pr = run_eu_ai_act_nis2_pipeline(
+            question_de="NIS2 Meldung Krisenstab ACME",
+            tenant_id=tid,
+            user_role="advisor",
+            document_store=synthetic_reg_store,
+            session=None,
+        )
+    assert any(d.id == "acme-nis2-note-chunk-0" for d in pr.documents_for_prompt)
+    from app.rag.service import run_advisor_eu_reg_rag
+
+    with patch(gen, return_value=fixed):
+        out = run_advisor_eu_reg_rag(
+            question_de="NIS2 Meldung Krisenstab ACME",
+            tenant_id=tid,
+            user_role="advisor",
+            advisor_id="adv",
+            session=None,
+            document_store=synthetic_reg_store,
+        )
+    assert out.citations
+    assert out.citations[0].is_tenant_specific is True
+
+
+def test_confidence_high_when_strong_hit(
+    synthetic_reg_store: InMemoryDocumentStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_HIGH_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_GAP_MIN", "0.0")
+    fixed = EuRegRagLlmOutput(answer_de="Antwort", citations=[])
+    with patch("app.rag.generation.generate_eu_reg_rag_llm_output", return_value=fixed):
+        pr = run_eu_ai_act_nis2_pipeline(
+            question_de="NIS2 Meldung Behörden Vorfall unverzüglich",
+            tenant_id="t-high",
+            user_role="advisor",
+            document_store=synthetic_reg_store,
+            session=None,
+        )
+    assert pr.confidence_level == "high"
+
+
+def test_confidence_low_safe_answer_without_llm() -> None:
+    empty_store = InMemoryDocumentStore()
+    with patch(
+        "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output",
+    ) as mock_llm:
+        pr = run_eu_ai_act_nis2_pipeline(
+            question_de="NIS2 Meldung Behörden Vorfall unverzüglich",
+            tenant_id="t-low",
+            user_role="advisor",
+            document_store=empty_store,
+            session=None,
+        )
+    mock_llm.assert_not_called()
+    assert pr.used_llm is False
+    assert pr.confidence_level == "low"
+    assert "keine eindeutigen" in pr.structured["answer_de"].lower()
+    assert pr.notes_de
 
 
 def test_advisor_rag_api_opa_denies_no_pipeline(
@@ -139,6 +273,9 @@ def test_advisor_rag_api_happy_path_mock_llm(
 ) -> None:
     monkeypatch.setenv("COMPLIANCEHUB_FEATURE_COMPLIANCE_RAG_KNOWLEDGE_HUB", "true")
     monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_HIGH_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_GAP_MIN", "0.0")
     tid = f"rag-tenant-{uuid.uuid4().hex[:8]}"
     replace_eu_reg_document_store_for_tests(synthetic_reg_store)
     fixed = EuRegRagLlmOutput(
@@ -158,7 +295,7 @@ def test_advisor_rag_api_happy_path_mock_llm(
                 return_value=PolicyDecision(allowed=True, reason="ok"),
             ),
             patch(
-                "app.rag.pipelines.eu_ai_act_nis2_pipeline.safe_llm_call_sync",
+                "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output",
                 return_value=fixed,
             ),
         ):
@@ -177,3 +314,6 @@ def test_advisor_rag_api_happy_path_mock_llm(
     assert "Risiko" in body["answer_de"] or "risiko" in body["answer_de"].lower()
     assert body["citations"]
     assert body["citations"][0]["doc_id"] == "eu-ai-act-art9-chunk-0"
+    assert body["citations"][0]["source_id"] == "eu-ai-act-art9-chunk-0"
+    assert body["confidence_level"] == "high"
+    assert "notes_de" in body


### PR DESCRIPTION
Add structured RAG observability (log_rag_query_event, query hash, no raw PII), confidence heuristics and BM25 min-score fallback, global plus tenant_guidance retrieval merge, extended API citations and response fields, and tests. Update wave3 Haystack architecture doc with advisory disclaimer.

Made-with: Cursor