### PR TITLE
feat(observability): Wave 4 OpenTelemetry traces + RAG/Temporal joins

### DIFF
--- a/app/llm/client_wrapped.py
+++ b/app/llm/client_wrapped.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 from typing import TYPE_CHECKING, TypeVar
 
@@ -18,8 +19,10 @@ from app.llm.guardrails import (
     validate_llm_json_output,
 )
 from app.llm_models import LLMResponse, LLMTaskType
+from app.services import llm_client
 from app.services.llm_router import LLMRouter
 from app.services.readiness_explain_structured import extract_json_object
+from app.telemetry.tracing import start_span
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -27,6 +30,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _prompt_sha256_prefix(prompt: str, n: int = 16) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:n]
 
 
 def _prepare_prompt_after_scan(prompt: str, scan: GuardrailScanResult) -> str:
@@ -71,18 +78,49 @@ async def safe_llm_call(
 
     Underlying router is sync; runs in a thread pool.
     """
-    scan = scan_input_for_pii_and_injection(prompt)
-    log_llm_guardrail_scan(context, scan)
-    effective = _prepare_prompt_after_scan(prompt, scan)
-    return await asyncio.to_thread(
-        _structured_llm_sync,
-        effective,
-        schema,
-        session,
-        context.tenant_id,
-        task_type,
-        response_format=response_format,
-    )
+    with start_span(
+        "llm.guardrailed_call",
+        llm_tenant_id=context.tenant_id,
+        llm_user_role=context.user_role,
+        llm_action_name=context.action_name,
+        llm_task_type=task_type.value,
+        llm_contract_schema=schema.__name__,
+        llm_prompt_length_chars=len(prompt),
+        llm_prompt_sha256_prefix=_prompt_sha256_prefix(prompt),
+    ) as span:
+        try:
+            scan = scan_input_for_pii_and_injection(prompt)
+            log_llm_guardrail_scan(context, scan)
+            effective = _prepare_prompt_after_scan(prompt, scan)
+            out = await asyncio.to_thread(
+                _structured_llm_sync,
+                effective,
+                schema,
+                session,
+                context.tenant_id,
+                task_type,
+                response_format=response_format,
+            )
+            if span.is_recording():
+                span.set_attribute("llm_result", "ok")
+                span.set_attribute("llm_response_json_length", len(out.model_dump_json()))
+            return out
+        except LLMContractViolation:
+            if span.is_recording():
+                span.set_attribute("llm_result", "contract_violation")
+            raise
+        except PermissionError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "guardrail_blocked")
+            raise
+        except llm_client.LLMConfigurationError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "configuration_error")
+            raise
+        except llm_client.LLMProviderHTTPError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "provider_error")
+            raise
 
 
 def safe_llm_call_sync(
@@ -95,17 +133,48 @@ def safe_llm_call_sync(
     response_format: str | None = "json_object",
 ) -> T:
     """Synchronous variant for LangGraph sync nodes and legacy call sites."""
-    scan = scan_input_for_pii_and_injection(prompt)
-    log_llm_guardrail_scan(context, scan)
-    effective = _prepare_prompt_after_scan(prompt, scan)
-    return _structured_llm_sync(
-        effective,
-        schema,
-        session,
-        context.tenant_id,
-        task_type,
-        response_format=response_format,
-    )
+    with start_span(
+        "llm.guardrailed_call",
+        llm_tenant_id=context.tenant_id,
+        llm_user_role=context.user_role,
+        llm_action_name=context.action_name,
+        llm_task_type=task_type.value,
+        llm_contract_schema=schema.__name__,
+        llm_prompt_length_chars=len(prompt),
+        llm_prompt_sha256_prefix=_prompt_sha256_prefix(prompt),
+    ) as span:
+        try:
+            scan = scan_input_for_pii_and_injection(prompt)
+            log_llm_guardrail_scan(context, scan)
+            effective = _prepare_prompt_after_scan(prompt, scan)
+            out = _structured_llm_sync(
+                effective,
+                schema,
+                session,
+                context.tenant_id,
+                task_type,
+                response_format=response_format,
+            )
+            if span.is_recording():
+                span.set_attribute("llm_result", "ok")
+                span.set_attribute("llm_response_json_length", len(out.model_dump_json()))
+            return out
+        except LLMContractViolation:
+            if span.is_recording():
+                span.set_attribute("llm_result", "contract_violation")
+            raise
+        except PermissionError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "guardrail_blocked")
+            raise
+        except llm_client.LLMConfigurationError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "configuration_error")
+            raise
+        except llm_client.LLMProviderHTTPError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "provider_error")
+            raise
 
 
 def guardrailed_route_and_call_sync(
@@ -122,14 +191,44 @@ def guardrailed_route_and_call_sync(
 
     Applies the same input scan, logging, and high-risk redaction before calling the router.
     """
-    scan = scan_input_for_pii_and_injection(prompt)
-    log_llm_guardrail_scan(context, scan)
-    effective = _prepare_prompt_after_scan(prompt, scan)
-    router = LLMRouter(session=session)
-    kwargs: dict[str, str] = {}
-    if response_format is not None:
-        kwargs["response_format"] = response_format
-    return router.route_and_call(task_type, effective, tenant_id, **kwargs)
+    with start_span(
+        "llm.guardrailed_call",
+        llm_tenant_id=context.tenant_id,
+        llm_user_role=context.user_role,
+        llm_action_name=context.action_name,
+        llm_task_type=task_type.value,
+        llm_contract_schema="freeform_markdown",
+        llm_prompt_length_chars=len(prompt),
+        llm_prompt_sha256_prefix=_prompt_sha256_prefix(prompt),
+    ) as span:
+        try:
+            scan = scan_input_for_pii_and_injection(prompt)
+            log_llm_guardrail_scan(context, scan)
+            effective = _prepare_prompt_after_scan(prompt, scan)
+            router = LLMRouter(session=session)
+            kwargs: dict[str, str] = {}
+            if response_format is not None:
+                kwargs["response_format"] = response_format
+            resp = router.route_and_call(task_type, effective, tenant_id, **kwargs)
+            if span.is_recording():
+                span.set_attribute("llm_result", "ok")
+            return resp
+        except LLMContractViolation:
+            if span.is_recording():
+                span.set_attribute("llm_result", "contract_violation")
+            raise
+        except PermissionError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "guardrail_blocked")
+            raise
+        except llm_client.LLMConfigurationError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "configuration_error")
+            raise
+        except llm_client.LLMProviderHTTPError:
+            if span.is_recording():
+                span.set_attribute("llm_result", "provider_error")
+            raise
 
 
 def safe_llm_json_call(

--- a/app/main.py
+++ b/app/main.py
@@ -373,6 +373,8 @@ from app.supplier_risk_models import (
     AISupplierRiskBySystemEntry,
     AISupplierRiskOverview,
 )
+from app.telemetry.middleware import TelemetryMiddleware
+from app.telemetry.tracing import configure_telemetry, inject_trace_carrier, start_span
 from app.temporal_client import get_temporal_client
 from app.tenant_ai_governance_setup_models import (
     TenantAIGovernanceSetupPatch,
@@ -413,6 +415,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Startup phase
     Base.metadata.create_all(bind=engine)
     run_all_db_migrations(engine)
+    configure_telemetry()
     with Session(engine) as seed_session:
         ensure_cross_regulation_catalog_seeded(seed_session)
         ensure_ai_kpi_definitions_seeded(seed_session)
@@ -425,6 +428,7 @@ app = FastAPI(
     version="0.1.0",
     lifespan=lifespan,
 )
+app.add_middleware(TelemetryMiddleware)
 
 logger = logging.getLogger(__name__)
 
@@ -3920,22 +3924,30 @@ async def post_start_board_report_workflow(
     safe = _sanitize_tenant_id_for_temporal_workflow_id(tenant_id)
     workflow_id = f"board-report-{safe}-{uuid.uuid4()}"
     client = await get_temporal_client()
-    handle = await client.start_workflow(
-        BoardReportWorkflow.run,
-        BoardReportWorkflowInput(
-            tenant_id=tenant_id,
-            snapshot_reference=body.snapshot_reference,
-            audience_type=body.audience_type,
-            primary_ai_system_id=body.primary_ai_system_id,
-            focus_frameworks=list(body.focus_frameworks or []),
-            include_ai_act_only=body.include_ai_act_only,
-            language=body.language,
-            user_role_for_opa=wf_role,
-        ),
-        id=workflow_id,
-        task_queue=temporal_task_queue(),
-    )
-    desc = await handle.describe()
+    otel_carrier: dict[str, str] = {}
+    inject_trace_carrier(otel_carrier)
+    with start_span(
+        "temporal.board_report.enqueue",
+        tenant_id=tenant_id,
+        workflow_id=workflow_id,
+    ):
+        handle = await client.start_workflow(
+            BoardReportWorkflow.run,
+            BoardReportWorkflowInput(
+                tenant_id=tenant_id,
+                snapshot_reference=body.snapshot_reference,
+                audience_type=body.audience_type,
+                primary_ai_system_id=body.primary_ai_system_id,
+                focus_frameworks=list(body.focus_frameworks or []),
+                include_ai_act_only=body.include_ai_act_only,
+                language=body.language,
+                user_role_for_opa=wf_role,
+                otel_trace_carrier=otel_carrier,
+            ),
+            id=workflow_id,
+            task_queue=temporal_task_queue(),
+        )
+        desc = await handle.describe()
     audit_repo.log_event(
         tenant_id=tenant_id,
         actor_type="api_key",

--- a/app/rag/observability.py
+++ b/app/rag/observability.py
@@ -9,6 +9,8 @@ import re
 import time
 from typing import Any, Literal
 
+from app.telemetry.tracing import get_trace_context_for_log_fields
+
 logger = logging.getLogger(__name__)
 
 RagQueryPhase = Literal["retrieval_complete", "response_complete"]
@@ -74,6 +76,11 @@ def log_rag_query_event(
         record["confidence_level"] = confidence_level
     if extra:
         record["extra"] = extra
+    otel = get_trace_context_for_log_fields()
+    if otel.get("trace_id"):
+        record["trace_id"] = otel["trace_id"]
+    if otel.get("span_id"):
+        record["span_id"] = otel["span_id"]
     logger.info("rag_query_event %s", json.dumps(record, ensure_ascii=False))
 
 

--- a/app/rag/pipelines/eu_ai_act_nis2_pipeline.py
+++ b/app/rag/pipelines/eu_ai_act_nis2_pipeline.py
@@ -41,6 +41,7 @@ from app.rag.retrieval import (
     filter_documents_by_min_score,
     merged_bm25_retrieve,
 )
+from app.telemetry.tracing import record_event, start_span
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -81,42 +82,89 @@ def run_eu_ai_act_nis2_pipeline(
     q_prev = redacted_query_preview(q)
     q_len = len(q)
 
-    merged = merged_bm25_retrieve(document_store, query=q, tenant_id=tenant_id)
-    merged_scores, merged_ids = documents_scores_and_ids(merged)
-    t_after_retrieval = time.perf_counter()
-    latency_retrieval_ms = (t_after_retrieval - t0) * 1000.0
-
-    log_rag_query_event(
-        phase="retrieval_complete",
+    with start_span(
+        "rag.retrieval",
         tenant_id=tenant_id,
         user_role=user_role,
-        advisor_id=advisor_id,
-        query_sha256=q_hash,
-        query_length_chars=q_len,
-        query_redacted_preview=q_prev,
         top_k_effective=rag_merged_top_k(),
-        retrieved_doc_ids=merged_ids,
-        retrieval_scores=merged_scores,
-        latency_ms_retrieval=latency_retrieval_ms,
-        extra={"merged_hits": len(merged)},
-    )
+    ):
+        merged = merged_bm25_retrieve(document_store, query=q, tenant_id=tenant_id)
+        merged_scores, merged_ids = documents_scores_and_ids(merged)
+        t_after_retrieval = time.perf_counter()
+        latency_retrieval_ms = (t_after_retrieval - t0) * 1000.0
 
-    min_s = rag_bm25_min_score()
-    filtered = filter_documents_by_min_score(merged, min_s)
-    conf_scores = documents_scores_and_ids(filtered)[0] if filtered else merged_scores
-    confidence_level, conf_notes = compute_confidence_level(
-        conf_scores,
-        min_score_for_answer=min_s,
-        high_score_min=rag_confidence_high_score_min(),
-        score_gap_min=rag_confidence_gap_min(),
-    )
+        log_rag_query_event(
+            phase="retrieval_complete",
+            tenant_id=tenant_id,
+            user_role=user_role,
+            advisor_id=advisor_id,
+            query_sha256=q_hash,
+            query_length_chars=q_len,
+            query_redacted_preview=q_prev,
+            top_k_effective=rag_merged_top_k(),
+            retrieved_doc_ids=merged_ids,
+            retrieval_scores=merged_scores,
+            latency_ms_retrieval=latency_retrieval_ms,
+            extra={"merged_hits": len(merged)},
+        )
 
-    if not filtered:
-        payload = EuRegRagLlmOutput(
-            answer_de=_FALLBACK_NO_HIT_DE,
-            citations=[],
-        ).model_dump(mode="json")
+        min_s = rag_bm25_min_score()
+        filtered = filter_documents_by_min_score(merged, min_s)
+        conf_scores = documents_scores_and_ids(filtered)[0] if filtered else merged_scores
+        confidence_level, conf_notes = compute_confidence_level(
+            conf_scores,
+            min_score_for_answer=min_s,
+            high_score_min=rag_confidence_high_score_min(),
+            score_gap_min=rag_confidence_gap_min(),
+        )
+
+        if not filtered:
+            record_event("rag.generation_skipped", reason="no_hits_above_threshold")
+            payload = EuRegRagLlmOutput(
+                answer_de=_FALLBACK_NO_HIT_DE,
+                citations=[],
+            ).model_dump(mode="json")
+            t_end = time.perf_counter()
+            log_rag_query_event(
+                phase="response_complete",
+                tenant_id=tenant_id,
+                user_role=user_role,
+                advisor_id=advisor_id,
+                query_sha256=q_hash,
+                query_length_chars=q_len,
+                query_redacted_preview=q_prev,
+                top_k_effective=rag_merged_top_k(),
+                retrieved_doc_ids=merged_ids,
+                retrieval_scores=merged_scores,
+                latency_ms_retrieval=latency_retrieval_ms,
+                latency_ms_llm=0.0,
+                latency_ms_total=(t_end - t0) * 1000.0,
+                confidence_level="low",
+                extra={"used_llm": False, "filtered_hits": 0},
+            )
+            return EuRegRagPipelineResult(
+                structured=payload,
+                documents_for_prompt=[],
+                merged_documents=merged,
+                merged_scores=merged_scores,
+                confidence_level="low",
+                notes_de=conf_notes,
+                used_llm=False,
+            )
+
+    with start_span("rag.generation", tenant_id=tenant_id, user_role=user_role):
+        prompt = build_eu_reg_rag_prompt(q, filtered)
+        t_before_llm = time.perf_counter()
+        parsed = generate_eu_reg_rag_llm_output(
+            prompt,
+            tenant_id=tenant_id,
+            user_role=user_role,
+            session=session,
+        )
         t_end = time.perf_counter()
+        latency_llm_ms = (t_end - t_before_llm) * 1000.0
+        notes = conf_notes if confidence_level in ("low", "medium") else None
+
         log_rag_query_event(
             phase="response_complete",
             tenant_id=tenant_id,
@@ -129,57 +177,18 @@ def run_eu_ai_act_nis2_pipeline(
             retrieved_doc_ids=merged_ids,
             retrieval_scores=merged_scores,
             latency_ms_retrieval=latency_retrieval_ms,
-            latency_ms_llm=0.0,
+            latency_ms_llm=latency_llm_ms,
             latency_ms_total=(t_end - t0) * 1000.0,
-            confidence_level="low",
-            extra={"used_llm": False, "filtered_hits": 0},
+            confidence_level=confidence_level,
+            extra={"used_llm": True, "filtered_hits": len(filtered)},
         )
+
         return EuRegRagPipelineResult(
-            structured=payload,
-            documents_for_prompt=[],
+            structured=parsed.model_dump(mode="json"),
+            documents_for_prompt=filtered,
             merged_documents=merged,
             merged_scores=merged_scores,
-            confidence_level="low",
-            notes_de=conf_notes,
-            used_llm=False,
+            confidence_level=confidence_level,
+            notes_de=notes,
+            used_llm=True,
         )
-
-    prompt = build_eu_reg_rag_prompt(q, filtered)
-    t_before_llm = time.perf_counter()
-    parsed = generate_eu_reg_rag_llm_output(
-        prompt,
-        tenant_id=tenant_id,
-        user_role=user_role,
-        session=session,
-    )
-    t_end = time.perf_counter()
-    latency_llm_ms = (t_end - t_before_llm) * 1000.0
-    notes = conf_notes if confidence_level in ("low", "medium") else None
-
-    log_rag_query_event(
-        phase="response_complete",
-        tenant_id=tenant_id,
-        user_role=user_role,
-        advisor_id=advisor_id,
-        query_sha256=q_hash,
-        query_length_chars=q_len,
-        query_redacted_preview=q_prev,
-        top_k_effective=rag_merged_top_k(),
-        retrieved_doc_ids=merged_ids,
-        retrieval_scores=merged_scores,
-        latency_ms_retrieval=latency_retrieval_ms,
-        latency_ms_llm=latency_llm_ms,
-        latency_ms_total=(t_end - t0) * 1000.0,
-        confidence_level=confidence_level,
-        extra={"used_llm": True, "filtered_hits": len(filtered)},
-    )
-
-    return EuRegRagPipelineResult(
-        structured=parsed.model_dump(mode="json"),
-        documents_for_prompt=filtered,
-        merged_documents=merged,
-        merged_scores=merged_scores,
-        confidence_level=confidence_level,
-        notes_de=notes,
-        used_llm=True,
-    )

--- a/app/rag/service.py
+++ b/app/rag/service.py
@@ -12,6 +12,7 @@ from app.rag.models import EuAiActNis2RagCitation, EuAiActNis2RagResponse, EuReg
 from app.rag.pipelines.eu_ai_act_nis2_pipeline import run_eu_ai_act_nis2_pipeline
 from app.rag.retrieval import is_tenant_guidance_document
 from app.rag.store import get_eu_reg_document_store
+from app.telemetry.tracing import start_span
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -54,14 +55,20 @@ def run_advisor_eu_reg_rag(
     document_store: InMemoryDocumentStore | None = None,
 ) -> EuAiActNis2RagResponse:
     store = document_store or get_eu_reg_document_store()
-    pr = run_eu_ai_act_nis2_pipeline(
-        question_de=question_de,
+    with start_span(
+        "rag.query_received",
         tenant_id=tenant_id,
         user_role=user_role,
-        document_store=store,
-        session=session,
         advisor_id=advisor_id,
-    )
+    ):
+        pr = run_eu_ai_act_nis2_pipeline(
+            question_de=question_de,
+            tenant_id=tenant_id,
+            user_role=user_role,
+            document_store=store,
+            session=session,
+            advisor_id=advisor_id,
+        )
     parsed = EuRegRagLlmOutput.model_validate(pr.structured)
     citations = _build_api_citations(parsed, pr.documents_for_prompt)
     logger.info(

--- a/app/services/llm_router.py
+++ b/app/services/llm_router.py
@@ -8,6 +8,8 @@ import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+from opentelemetry import trace
+
 from app.llm_models import (
     CostSensitivity,
     DataResidencyPolicy,
@@ -225,6 +227,15 @@ class LLMRouter:
                     in_tok=resp.input_tokens_est,
                     out_tok=resp.output_tokens_est,
                 )
+                span = trace.get_current_span()
+                if span.is_recording():
+                    span.set_attribute("llm_provider", resp.provider.value)
+                    span.set_attribute("llm_model_id", resp.model_id)
+                    span.set_attribute(
+                        "llm_tokens_used_est",
+                        resp.input_tokens_est + resp.output_tokens_est,
+                    )
+                    span.set_attribute("llm_response_length_chars", len(resp.text))
                 return resp
             except Exception as exc:
                 last_err = exc

--- a/app/telemetry/__init__.py
+++ b/app/telemetry/__init__.py
@@ -1,0 +1,19 @@
+"""Cross-cutting observability (OpenTelemetry-style tracing, structured joins with logs)."""
+
+from __future__ import annotations
+
+from app.telemetry.tracing import (
+    configure_telemetry,
+    configure_telemetry_test_memory_exporter,
+    get_trace_context_for_log_fields,
+    record_event,
+    start_span,
+)
+
+__all__ = [
+    "configure_telemetry",
+    "configure_telemetry_test_memory_exporter",
+    "get_trace_context_for_log_fields",
+    "record_event",
+    "start_span",
+]

--- a/app/telemetry/middleware.py
+++ b/app/telemetry/middleware.py
@@ -1,0 +1,53 @@
+"""ASGI middleware: root HTTP span, W3C trace context, correlation id, tenant headers."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from opentelemetry import context
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.telemetry.tracing import extract_trace_from_headers, get_tracer, new_correlation_id
+
+
+class TelemetryMiddleware(BaseHTTPMiddleware):
+    """
+    One root span per request; propagates ``traceparent`` / ``tracestate``; sets
+    ``http.*``, ``tenant_id`` (from ``x-tenant-id`` when present), ``user_role``,
+    ``correlation_id``.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        trace_headers = {k.decode(): v.decode() for k, v in request.scope.get("headers", [])}
+        ctx = extract_trace_from_headers(trace_headers)
+        token = context.attach(ctx)
+        tracer = get_tracer()
+        route_path = request.scope.get("path", "") or ""
+        method = request.method
+        span_name = f"http {method} {route_path}"
+        try:
+            with tracer.start_as_current_span(span_name) as span:
+                corr = request.headers.get("x-correlation-id") or new_correlation_id()
+                if span.is_recording():
+                    span.set_attribute("http.method", method)
+                    span.set_attribute("http.target", route_path)
+                    span.set_attribute("correlation_id", corr)
+                    tid = request.headers.get("x-tenant-id")
+                    if tid:
+                        span.set_attribute("tenant_id", tid)
+                    role = request.headers.get("x-opa-user-role")
+                    if role:
+                        span.set_attribute("user_role", role)
+                response = await call_next(request)
+                if span.is_recording():
+                    span.set_attribute("http.status_code", response.status_code)
+                response.headers["X-Correlation-ID"] = corr
+                return response
+        finally:
+            context.detach(token)

--- a/app/telemetry/tracing.py
+++ b/app/telemetry/tracing.py
@@ -1,0 +1,203 @@
+"""
+Light-weight OpenTelemetry tracing (swappable exporters: console, none, test memory).
+
+Env:
+- COMPLIANCEHUB_OTEL_ENABLED: ``1``/``true`` to register a real TracerProvider (default: enabled).
+- COMPLIANCEHUB_OTEL_SERVICE_NAME: default ``compliancehub-api``.
+- COMPLIANCEHUB_ENVIRONMENT: ``dev`` | ``stage`` | ``prod`` (span resource attribute).
+- COMPLIANCEHUB_OTEL_CONSOLE_EXPORTER: ``1`` to attach ConsoleSpanProcessor (dev only).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from collections.abc import Generator, Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any
+
+from opentelemetry import context, trace
+from opentelemetry.context import Context
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+from opentelemetry.trace import Span, Status, StatusCode
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+logger = logging.getLogger(__name__)
+
+_TRACER_NAME = "compliancehub"
+_CONFIGURED = False
+_TEST_MEMORY_EXPORTER: Any | None = None
+_TEXTMAP = TraceContextTextMapPropagator()
+
+
+def _parse_env_bool(key: str, default: bool = False) -> bool:
+    raw = os.getenv(key)
+    if raw is None or not str(raw).strip():
+        return default
+    return str(raw).strip().lower() in ("1", "true", "yes", "on")
+
+
+def service_name() -> str:
+    return os.getenv("COMPLIANCEHUB_OTEL_SERVICE_NAME", "compliancehub-api").strip()
+
+
+def deployment_environment() -> str:
+    return os.getenv("COMPLIANCEHUB_ENVIRONMENT", "dev").strip().lower()
+
+
+def configure_telemetry(*, force: bool = False) -> None:
+    """Idempotent SDK registration; noop provider when disabled."""
+    global _CONFIGURED
+    if _CONFIGURED and not force:
+        return
+    _CONFIGURED = True
+    if not _parse_env_bool("COMPLIANCEHUB_OTEL_ENABLED", True):
+        logger.info("OpenTelemetry tracing disabled (COMPLIANCEHUB_OTEL_ENABLED=false)")
+        return
+    resource = Resource.create(
+        {
+            "service.name": service_name(),
+            "deployment.environment": deployment_environment(),
+        },
+    )
+    provider = TracerProvider(resource=resource)
+    trace.set_tracer_provider(provider)
+    if _parse_env_bool("COMPLIANCEHUB_OTEL_CONSOLE_EXPORTER"):
+        provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+        logger.info("OpenTelemetry console span exporter enabled")
+    logger.info(
+        "OpenTelemetry TracerProvider configured service=%s env=%s",
+        service_name(),
+        deployment_environment(),
+    )
+
+
+def configure_telemetry_test_memory_exporter() -> Any:
+    """
+    Attach in-memory export to the active SDK ``TracerProvider`` (singleton).
+
+    OpenTelemetry forbids replacing ``TracerProvider`` after startup; tests that import
+    ``app.main`` first rely on ``configure_telemetry()`` in lifespan, then we add a
+    ``SimpleSpanProcessor`` here. Returns the shared ``InMemorySpanExporter``.
+    """
+    global _CONFIGURED, _TEST_MEMORY_EXPORTER
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    if _TEST_MEMORY_EXPORTER is not None:
+        _TEST_MEMORY_EXPORTER.clear()
+        return _TEST_MEMORY_EXPORTER
+
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    current = trace.get_tracer_provider()
+    if isinstance(current, TracerProvider):
+        current.add_span_processor(processor)
+        _TEST_MEMORY_EXPORTER = exporter
+        _CONFIGURED = True
+        return exporter
+
+    resource = Resource.create(
+        {
+            "service.name": "compliancehub-api-test",
+            "deployment.environment": "test",
+        },
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(processor)
+    trace.set_tracer_provider(provider)
+    _TEST_MEMORY_EXPORTER = exporter
+    _CONFIGURED = True
+    return exporter
+
+
+def get_tracer() -> trace.Tracer:
+    return trace.get_tracer(_TRACER_NAME)
+
+
+def get_trace_context_for_log_fields() -> dict[str, str]:
+    """Hex trace_id / span_id for joining structured logs to traces (no PII)."""
+    span = trace.get_current_span()
+    sc = span.get_span_context()
+    if not sc.is_valid:
+        return {}
+    return {
+        "trace_id": format(sc.trace_id, "032x"),
+        "span_id": format(sc.span_id, "016x"),
+    }
+
+
+def _norm_attrs(attrs: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k, v in attrs.items():
+        if v is None:
+            continue
+        if isinstance(v, (bool, int, float, str)):
+            out[k] = v
+        else:
+            out[k] = str(v)
+    return out
+
+
+@contextmanager
+def start_span(name: str, **attrs: Any) -> Generator[Span, None, None]:
+    """Start a span; records exceptions; no-op-like when tracer is not recording."""
+    tracer = get_tracer()
+    with tracer.start_as_current_span(name, attributes=_norm_attrs(attrs)) as span:
+        try:
+            yield span
+        except Exception as exc:
+            if span.is_recording():
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+                span.record_exception(exc)
+            raise
+
+
+def record_event(name: str, **attrs: Any) -> None:
+    """Add a named event on the current span (OTel ``add_event``)."""
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return
+    span.add_event(name, attributes=_norm_attrs(attrs))
+
+
+def inject_trace_carrier(carrier: dict[str, str]) -> None:
+    """Inject W3C traceparent into ``carrier`` (mutates dict)."""
+    _TEXTMAP.inject(carrier)
+
+
+@contextmanager
+def attach_trace_carrier(carrier: Mapping[str, str] | None) -> Iterator[None]:
+    """
+    Context manager: continue trace from W3C ``traceparent`` in carrier (Temporal worker).
+    """
+    if not carrier or not str(carrier.get("traceparent", "")).strip():
+        yield
+        return
+    cap = {k: str(v) for k, v in carrier.items() if v is not None}
+    ctx = _TEXTMAP.extract(cap, context=context.get_current())
+    token = context.attach(ctx)
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
+def extract_trace_from_headers(headers: Mapping[str, str]) -> Context:
+    """Build a Context from incoming HTTP headers (lowercase keys ok)."""
+    carrier = {k.lower(): v for k, v in headers.items()}
+    return _TEXTMAP.extract(carrier, context=context.get_current())
+
+
+def attach_context(ctx: Context) -> object:
+    return context.attach(ctx)
+
+
+def detach_context(token: object) -> None:
+    context.detach(token)
+
+
+def new_correlation_id() -> str:
+    return str(uuid.uuid4())

--- a/app/workflows/board_report.py
+++ b/app/workflows/board_report.py
@@ -22,6 +22,8 @@ class BoardReportWorkflowInput:
     include_ai_act_only: bool = False
     language: str = "de"
     user_role_for_opa: str = ""
+    # W3C trace context (traceparent / tracestate) from API for worker span stitching.
+    otel_trace_carrier: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -50,6 +52,7 @@ class BoardReportWorkflow:
                     "tenant_id": inp.tenant_id,
                     "ai_system_id": str(primary_id),
                     "user_role": inp.user_role_for_opa or "",
+                    "otel_trace_carrier": dict(inp.otel_trace_carrier or {}),
                 },
                 start_to_close_timeout=timedelta(minutes=15),
             )

--- a/app/workflows/board_report_activities.py
+++ b/app/workflows/board_report_activities.py
@@ -12,16 +12,26 @@ from app.services.temporal_board_report import (
     load_tenant_snapshot_for_board_report,
     persist_versioned_board_report_from_workflow,
 )
+from app.telemetry.tracing import attach_trace_carrier, start_span
 from app.workflows.board_report import BoardReportWorkflowInput
+
+
+def _carrier_from_mapping(raw: object) -> dict[str, str] | None:
+    if not isinstance(raw, dict) or not raw:
+        return None
+    return {str(k): str(v) for k, v in raw.items() if v is not None}
 
 
 @activity.defn
 def load_tenant_board_snapshot_activity(inp: BoardReportWorkflowInput) -> dict:
-    session = SessionLocal()
-    try:
-        return load_tenant_snapshot_for_board_report(session, inp)
-    finally:
-        session.close()
+    carrier = _carrier_from_mapping(inp.otel_trace_carrier)
+    with attach_trace_carrier(carrier):
+        with start_span("activity.load_snapshot", tenant_id=inp.tenant_id):
+            session = SessionLocal()
+            try:
+                return load_tenant_snapshot_for_board_report(session, inp)
+            finally:
+                session.close()
 
 
 @activity.defn
@@ -29,48 +39,57 @@ def generate_explanations_with_langgraph_activity(params: dict) -> dict:
     tenant_id = str(params["tenant_id"])
     ai_system_id = str(params["ai_system_id"])
     user_role = str(params.get("user_role") or "")
-    decision = evaluate_action_policy(
-        {
-            "tenant_id": tenant_id,
-            "user_role": user_role or "tenant_admin",
-            "action": "call_langgraph_oami_explain",
-            "risk_score": 0.4,
-        },
-    )
-    if not decision.allowed:
-        raise ApplicationError(
-            "OPA denied call_langgraph_oami_explain",
-            non_retryable=True,
-        )
-    session = SessionLocal()
-    try:
-        out = run_oami_explain_poc(
-            session,
-            tenant_id=tenant_id,
-            ai_system_id=ai_system_id,
-            window_days=90,
-            user_role=user_role,
-        )
-        return out.model_dump(mode="json")
-    finally:
-        session.close()
+    carrier = _carrier_from_mapping(params.get("otel_trace_carrier"))
+    with attach_trace_carrier(carrier):
+        with start_span("activity.langgraph_explain", tenant_id=tenant_id):
+            decision = evaluate_action_policy(
+                {
+                    "tenant_id": tenant_id,
+                    "user_role": user_role or "tenant_admin",
+                    "action": "call_langgraph_oami_explain",
+                    "risk_score": 0.4,
+                },
+            )
+            if not decision.allowed:
+                raise ApplicationError(
+                    "OPA denied call_langgraph_oami_explain",
+                    non_retryable=True,
+                )
+            session = SessionLocal()
+            try:
+                out = run_oami_explain_poc(
+                    session,
+                    tenant_id=tenant_id,
+                    ai_system_id=ai_system_id,
+                    window_days=90,
+                    user_role=user_role,
+                )
+                return out.model_dump(mode="json")
+            finally:
+                session.close()
 
 
 @activity.defn
 def persist_board_report_activity(params: dict) -> str:
-    session = SessionLocal()
-    try:
-        return persist_versioned_board_report_from_workflow(
-            session,
-            tenant_id=str(params["tenant_id"]),
-            user_role=str(params.get("user_role") or ""),
-            workflow_input_dict=dict(params["workflow_input"]),
-            snapshot=dict(params["snapshot"]),
-            oami_explanation=dict(params.get("oami_explanation") or {}),
-            temporal_workflow_id=str(params["temporal_workflow_id"]),
-            temporal_run_id=str(params.get("temporal_run_id") or ""),
-        )
-    except PermissionError as exc:
-        raise ApplicationError(str(exc), non_retryable=True) from exc
-    finally:
-        session.close()
+    wf_in = params.get("workflow_input")
+    carrier = _carrier_from_mapping(
+        wf_in.get("otel_trace_carrier") if isinstance(wf_in, dict) else None,
+    )
+    with attach_trace_carrier(carrier):
+        with start_span("activity.persist_board_report", tenant_id=str(params["tenant_id"])):
+            session = SessionLocal()
+            try:
+                return persist_versioned_board_report_from_workflow(
+                    session,
+                    tenant_id=str(params["tenant_id"]),
+                    user_role=str(params.get("user_role") or ""),
+                    workflow_input_dict=dict(params["workflow_input"]),
+                    snapshot=dict(params["snapshot"]),
+                    oami_explanation=dict(params.get("oami_explanation") or {}),
+                    temporal_workflow_id=str(params["temporal_workflow_id"]),
+                    temporal_run_id=str(params.get("temporal_run_id") or ""),
+                )
+            except PermissionError as exc:
+                raise ApplicationError(str(exc), non_retryable=True) from exc
+            finally:
+                session.close()

--- a/docs/architecture/wave4-observability.md
+++ b/docs/architecture/wave4-observability.md
@@ -1,0 +1,59 @@
+# Wave 4: Cross-cutting observability (OpenTelemetry traces + structured logs)
+
+## Goals
+
+- **End-to-end traceability** from HTTP through advisor RAG, Temporal board-report flows, and guardrailed LLM calls.
+- **Audit-friendly signals** for EU AI Act, ISO 42001, and NIS2 logging and monitoring (who/what/when, model metadata, outcomes — **no** raw prompts or completions in traces).
+- **Join logs and traces** via `trace_id` / `span_id` on normalized events (e.g. `rag_query_event`).
+
+## Components
+
+| Piece | Location | Role |
+|--------|-----------|------|
+| Tracer setup | `app/telemetry/tracing.py` | `configure_telemetry()`, `start_span`, `record_event`, W3C `inject` / `attach_trace_carrier` |
+| HTTP root span | `app/telemetry/middleware.py` | `TelemetryMiddleware`: reads `traceparent`, sets `http.*`, `tenant_id` (from `x-tenant-id`), `user_role`, `correlation_id`; echoes `X-Correlation-ID` |
+| RAG | `app/rag/service.py`, `app/rag/pipelines/eu_ai_act_nis2_pipeline.py` | Spans: `rag.query_received`, `rag.retrieval`, `rag.generation`; `log_rag_query_event` adds `trace_id` / `span_id` when a span is active |
+| LLM | `app/llm/client_wrapped.py`, `app/services/llm_router.py` | Span `llm.guardrailed_call` with `llm_*` attributes; router adds provider/model/tokens/response length on success |
+| Temporal board report | `app/main.py`, `app/workflows/board_report.py`, `app/workflows/board_report_activities.py` | API injects `otel_trace_carrier` into `BoardReportWorkflowInput`; activities `attach_trace_carrier` and emit `activity.load_snapshot`, `activity.langgraph_explain`, `activity.persist_board_report` |
+
+## Trace model (how requests stitch)
+
+1. **Browser / API gateway** may send W3C `traceparent` (optional). Middleware continues that trace or starts a new one.
+2. **Advisor RAG** (`POST /api/v1/advisor/rag/eu-ai-act-nis2-query`): HTTP span → `rag.query_received` → `rag.retrieval` → (optional) `rag.generation` → nested `llm.guardrailed_call` when the LLM runs.
+3. **Board report workflow start** (`POST .../board-report/workflows/start`): HTTP span → `temporal.board_report.enqueue` → `inject_trace_carrier` captures the **current** span context into `otel_trace_carrier` passed to Temporal. Worker activities **extract** that context so their spans share the **same `trace_id`** as the API call.
+4. **Workflow body** (`BoardReportWorkflow`) intentionally has **no** OpenTelemetry calls (Temporal replay / determinism). Logical “workflow” visibility is covered by the enqueue span plus activity spans.
+
+## Environment
+
+| Variable | Purpose |
+|----------|---------|
+| `COMPLIANCEHUB_OTEL_ENABLED` | Default on; set `false` to skip registering `TracerProvider` (no-op tracing). |
+| `COMPLIANCEHUB_OTEL_SERVICE_NAME` | Default `compliancehub-api`. |
+| `COMPLIANCEHUB_ENVIRONMENT` | `dev` / `stage` / `prod` (resource attribute). |
+| `COMPLIANCEHUB_OTEL_CONSOLE_EXPORTER` | `1` enables `ConsoleSpanExporter` (local debugging only). |
+
+Production typically attaches an OTLP exporter via the OpenTelemetry SDK (not hard-coded here) so Jaeger / Grafana / the OTEL Collector can be swapped without app changes.
+
+## Example analytics queries (conceptual)
+
+These are **documentation targets** for your log/trace backend (not shipped SQL).
+
+1. **Low-confidence RAG answers for a tenant (last 7 days)**  
+   Filter structured logs: `event=rag_query`, `phase=response_complete`, `confidence_level=low`, `tenant_id=<id>`, time range. Use `trace_id` to open the full trace (retrieval scores, LLM span outcome).
+
+2. **Board report workflows with LLM contract violations**  
+   Filter traces/spans where `llm_result=contract_violation` and parent or linked attributes include `workflow_id` / `tenant_id` (from enqueue or activity spans). Correlate with Temporal workflow ID from audit logs.
+
+3. **End-to-end latency**  
+   Trace: `http ...` → `rag.*` → `llm.guardrailed_call` or `temporal.board_report.enqueue` → `activity.*` → `llm.guardrailed_call`.
+
+## EU AI Act / ISO 42001 / NIS2 alignment (high level)
+
+- **Technical documentation and logs** of high-risk AI operations benefit from consistent **trace identifiers** and **outcome metadata** (e.g. `llm_result`, RAG `confidence_level`) without storing **content** of prompts or answers in traces.
+- **Human oversight**: low-confidence RAG paths remain explicit in logs (`confidence_level`, `notes_de` in the API); traces link to the same request for incident review.
+- **Monitoring**: rate of `guardrail_blocked`, `contract_violation`, and provider errors supports operational and governance KPIs.
+
+## Privacy
+
+- **Never** log full prompts or completions in span attributes or `record_event` payloads; use **lengths**, **hashes** (e.g. `llm_prompt_sha256_prefix`), and **enumerated results** only.
+- RAG logs keep **query SHA-256** and **redacted previews** (existing Wave 3 behavior); trace IDs are appended for correlation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ authors = [
 
 dependencies = [
   "fastapi>=0.115",
+  "opentelemetry-api>=1.27",
+  "opentelemetry-sdk>=1.27",
   "openpyxl>=3.1",
   "python-multipart>=0.0.9",
   "sqlalchemy>=2.0",

--- a/tests/test_wave4_telemetry.py
+++ b/tests/test_wave4_telemetry.py
@@ -1,0 +1,155 @@
+"""Wave 4: OpenTelemetry spans align with RAG logs; Temporal activity carrier stitching."""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from unittest.mock import patch
+
+import pytest
+from haystack import Document
+from haystack.document_stores.in_memory import InMemoryDocumentStore
+from opentelemetry import trace
+
+from app.policy.opa_client import PolicyDecision
+from app.rag.models import EuRegRagLlmCitation, EuRegRagLlmOutput
+from app.rag.store import (
+    replace_eu_reg_document_store_for_tests,
+    reset_eu_reg_document_store_for_tests,
+)
+from app.telemetry.tracing import configure_telemetry_test_memory_exporter, inject_trace_carrier
+from app.workflows.board_report import BoardReportWorkflowInput
+from app.workflows.board_report_activities import load_tenant_board_snapshot_activity
+
+
+@pytest.fixture
+def otel_exporter() -> object:
+    exporter = configure_telemetry_test_memory_exporter()
+    yield exporter
+    exporter.clear()
+
+
+def _minimal_rag_store() -> InMemoryDocumentStore:
+    store = InMemoryDocumentStore()
+    store.write_documents(
+        [
+            Document(
+                id="eu-ai-act-art9-chunk-0",
+                content=(
+                    "Anbieter von Hochrisiko-KI-Systemen müssen ein Risikomanagementsystem "
+                    "einrichten und dokumentieren."
+                ),
+                meta={
+                    "source": "EU AI Act (Pilot)",
+                    "section": "Art. 9 Risikomanagement",
+                    "rag_scope": "global",
+                },
+            ),
+        ],
+    )
+    return store
+
+
+def _rag_headers() -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-advisor-id": "advisor-otel-test",
+    }
+
+
+def test_rag_http_spans_and_log_share_trace_id(
+    otel_exporter: object,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from fastapi.testclient import TestClient
+
+    from app.main import app
+
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_COMPLIANCE_RAG_KNOWLEDGE_HUB", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_FEATURE_LLM_ENABLED", "true")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_BM25_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_HIGH_MIN_SCORE", "0.01")
+    monkeypatch.setenv("COMPLIANCEHUB_RAG_CONFIDENCE_GAP_MIN", "0.0")
+
+    store = _minimal_rag_store()
+    tid = f"otel-rag-{uuid.uuid4().hex[:8]}"
+    replace_eu_reg_document_store_for_tests(store)
+    fixed = EuRegRagLlmOutput(
+        answer_de="Antwort mit Spur.",
+        citations=[
+            EuRegRagLlmCitation(
+                doc_id="eu-ai-act-art9-chunk-0",
+                source="EU AI Act (Pilot)",
+                section="Art. 9",
+            ),
+        ],
+    )
+    caplog.set_level(logging.INFO)
+
+    try:
+        with (
+            patch(
+                "app.policy.policy_guard.evaluate_action_policy",
+                return_value=PolicyDecision(allowed=True, reason="ok"),
+            ),
+            patch(
+                "app.rag.pipelines.eu_ai_act_nis2_pipeline.generate_eu_reg_rag_llm_output",
+                return_value=fixed,
+            ),
+            TestClient(app) as client,
+        ):
+            r = client.post(
+                "/api/v1/advisor/rag/eu-ai-act-nis2-query",
+                headers=_rag_headers(),
+                json={"question_de": "Risikomanagement Hochrisiko KI?", "tenant_id": tid},
+            )
+    finally:
+        reset_eu_reg_document_store_for_tests()
+
+    assert r.status_code == 200
+    spans = otel_exporter.get_finished_spans()
+    names = sorted({s.name for s in spans})
+    assert "rag.generation" in names
+    assert "rag.query_received" in names
+    assert "rag.retrieval" in names
+    assert any(n.startswith("http ") for n in names)
+    # LLM span appears when ``generate_eu_reg_rag_llm_output`` calls ``safe_llm_call_sync``;
+    # this test mocks generation, so we only assert RAG + HTTP spans and log correlation.
+
+    log_lines = [r.getMessage() for r in caplog.records if "rag_query_event" in r.getMessage()]
+    assert len(log_lines) >= 2
+    payload = json.loads(log_lines[-1].split("rag_query_event ", 1)[1])
+    log_tid = payload.get("trace_id")
+    assert log_tid
+    span_trace_ids = {format(s.context.trace_id, "032x") for s in spans}
+    assert log_tid in span_trace_ids
+
+
+def test_activity_load_snapshot_continues_api_trace_carrier(
+    otel_exporter: object,
+) -> None:
+    tracer = trace.get_tracer("test.manual")
+    carrier: dict[str, str] = {}
+    with tracer.start_as_current_span("synthetic_http_board_report"):
+        inject_trace_carrier(carrier)
+    assert carrier.get("traceparent")
+
+    wf_in = BoardReportWorkflowInput(
+        tenant_id="otel-wf-tenant",
+        user_role_for_opa="tenant_admin",
+        otel_trace_carrier=carrier,
+    )
+    with patch(
+        "app.workflows.board_report_activities.load_tenant_snapshot_for_board_report",
+        return_value={"primary_ai_system_id": None},
+    ):
+        load_tenant_board_snapshot_activity(wf_in)
+
+    spans = otel_exporter.get_finished_spans()
+    names = [s.name for s in spans]
+    assert "synthetic_http_board_report" in names
+    assert "activity.load_snapshot" in names
+    trace_ids = {format(s.context.trace_id, "032x") for s in spans}
+    assert len(trace_ids) == 1


### PR DESCRIPTION
Add app/telemetry (tracing, HTTP middleware, W3C propagation), wire FastAPI lifespan and board-report workflow carrier. Instrument RAG spans and trace_id in rag_query_event logs; guardrailed LLM spans and router metadata; Temporal activities under propagated trace context. Document wave4 model and queries; add tests with in-memory span export.

Made-with: Cursor