### PR TITLE
feat(wave8): advisor GA readiness — SLA, channels, idempotency

### DIFF
--- a/app/advisor/channels.py
+++ b/app/advisor/channels.py
@@ -1,0 +1,48 @@
+"""Advisor channel abstraction for multi-channel delivery.
+
+Channels let the same advisor core serve web, SAP, DATEV, and API partner
+integrations without changing business logic. Channel-specific behaviour
+(formatting, disclaimers, field selection) is encapsulated here.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class AdvisorChannel(StrEnum):
+    web = "web"
+    sap = "sap"
+    datev = "datev"
+    api_partner = "api_partner"
+
+
+class ChannelMetadata(BaseModel):
+    """Optional channel-specific context attached to a request."""
+
+    sap_document_id: str | None = None
+    datev_client_number: str | None = None
+    partner_reference: str | None = None
+    extra: dict[str, Any] = Field(default_factory=dict)
+
+
+DEFAULT_CHANNEL = AdvisorChannel.web
+
+
+def max_answer_length(channel: AdvisorChannel) -> int | None:
+    """Channel-specific max answer length (characters). None = unlimited."""
+    _limits: dict[AdvisorChannel, int | None] = {
+        AdvisorChannel.web: None,
+        AdvisorChannel.sap: 4000,
+        AdvisorChannel.datev: 3000,
+        AdvisorChannel.api_partner: 8000,
+    }
+    return _limits.get(channel)
+
+
+def include_disclaimer(channel: AdvisorChannel) -> bool:
+    """Whether the channel should include the legal disclaimer in answers."""
+    return channel in (AdvisorChannel.web, AdvisorChannel.api_partner)

--- a/app/advisor/errors.py
+++ b/app/advisor/errors.py
@@ -1,0 +1,87 @@
+"""Standardised advisor error model for GA-ready error handling.
+
+All advisor errors share a common shape so that consumers (web, SAP, DATEV)
+can handle them uniformly.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel
+
+
+class AdvisorErrorCategory(StrEnum):
+    rag_failure = "rag_failure"
+    llm_failure = "llm_failure"
+    agent_failure = "agent_failure"
+    policy_refusal = "policy_refusal"
+    timeout = "timeout"
+    internal = "internal"
+
+
+class AdvisorError(BaseModel):
+    """Structured error returned to clients on advisor failures."""
+
+    error: bool = True
+    category: AdvisorErrorCategory
+    message_de: str
+    message_en: str
+    needs_manual_followup: bool = True
+    trace_id: str | None = None
+    retry_allowed: bool = False
+
+
+ADVISOR_SLA_TIMEOUT_SECONDS = 30.0
+
+_ERROR_MESSAGES: dict[AdvisorErrorCategory, tuple[str, str]] = {
+    AdvisorErrorCategory.rag_failure: (
+        "Die Quellensuche konnte nicht abgeschlossen werden. "
+        "Bitte versuchen Sie es erneut oder wenden Sie sich an den Support.",
+        "Source retrieval failed. Please retry or contact support.",
+    ),
+    AdvisorErrorCategory.llm_failure: (
+        "Die automatische Antwortgenerierung ist derzeit nicht verfügbar. "
+        "Ihre Anfrage wurde zur manuellen Bearbeitung markiert.",
+        "Answer generation is currently unavailable. "
+        "Your request has been flagged for manual processing.",
+    ),
+    AdvisorErrorCategory.agent_failure: (
+        "Ein interner Verarbeitungsfehler ist aufgetreten. Bitte versuchen Sie es erneut.",
+        "An internal processing error occurred. Please retry.",
+    ),
+    AdvisorErrorCategory.timeout: (
+        "Die Verarbeitung hat das Zeitlimit überschritten. "
+        "Bitte versuchen Sie es erneut oder vereinfachen Sie Ihre Anfrage.",
+        "Processing exceeded the time limit. Please retry or simplify your query.",
+    ),
+    AdvisorErrorCategory.internal: (
+        "Ein unerwarteter Fehler ist aufgetreten. Bitte kontaktieren Sie den Support.",
+        "An unexpected error occurred. Please contact support.",
+    ),
+    AdvisorErrorCategory.policy_refusal: (
+        "Die Anfrage wurde aufgrund einer Richtlinie abgelehnt.",
+        "The request was declined based on a policy rule.",
+    ),
+}
+
+
+def build_advisor_error(
+    category: AdvisorErrorCategory,
+    *,
+    trace_id: str | None = None,
+    needs_manual_followup: bool = True,
+    retry_allowed: bool = False,
+) -> AdvisorError:
+    msg_de, msg_en = _ERROR_MESSAGES.get(
+        category,
+        _ERROR_MESSAGES[AdvisorErrorCategory.internal],
+    )
+    return AdvisorError(
+        category=category,
+        message_de=msg_de,
+        message_en=msg_en,
+        trace_id=trace_id,
+        needs_manual_followup=needs_manual_followup,
+        retry_allowed=retry_allowed,
+    )

--- a/app/advisor/formatting.py
+++ b/app/advisor/formatting.py
@@ -1,0 +1,83 @@
+"""Channel-aware formatting layer for advisor responses.
+
+Keeps channel-specific logic out of the core agent. Each channel can
+adjust answer length, disclaimer inclusion, and structured field emphasis.
+"""
+
+from __future__ import annotations
+
+import re
+
+from app.advisor.channels import AdvisorChannel, include_disclaimer, max_answer_length
+from app.advisor.templates import DISCLAIMER_KEINE_RECHTSBERATUNG
+
+
+def format_answer_for_channel(
+    answer: str,
+    channel: AdvisorChannel,
+) -> str:
+    limit = max_answer_length(channel)
+    if not include_disclaimer(channel):
+        answer = _strip_disclaimer(answer)
+    if limit and len(answer) > limit:
+        answer = answer[: limit - 3] + "..."
+    return answer
+
+
+def _strip_disclaimer(text: str) -> str:
+    text = text.replace(f"\n\n---\n_{DISCLAIMER_KEINE_RECHTSBERATUNG}_", "")
+    text = text.replace(DISCLAIMER_KEINE_RECHTSBERATUNG, "")
+    return text.rstrip()
+
+
+_TAG_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"ai\s*act|ki.verordnung", re.IGNORECASE), "eu_ai_act"),
+    (re.compile(r"nis\s*2", re.IGNORECASE), "nis2"),
+    (re.compile(r"iso\s*42001", re.IGNORECASE), "iso_42001"),
+    (re.compile(r"dsgvo|gdpr|datenschutz", re.IGNORECASE), "gdpr"),
+    (re.compile(r"hochrisiko|high.risk", re.IGNORECASE), "high_risk"),
+    (re.compile(r"art(ikel|\.)\s*\d+", re.IGNORECASE), "article_reference"),
+    (re.compile(r"meldepflicht|meldung|incident", re.IGNORECASE), "incident_reporting"),
+    (re.compile(r"risikomanagement|risk.management", re.IGNORECASE), "risk_management"),
+    (re.compile(r"konformit|compliance|conformity", re.IGNORECASE), "conformity_assessment"),
+]
+
+
+def derive_tags(query: str, answer: str) -> list[str]:
+    """Derive topic tags from query + answer text for structured output."""
+    combined = f"{query} {answer}"
+    tags: list[str] = []
+    for pat, tag in _TAG_PATTERNS:
+        if pat.search(combined):
+            tags.append(tag)
+    return sorted(set(tags))
+
+
+def derive_next_steps(
+    is_escalated: bool,
+    confidence_level: str,
+    tags: list[str],
+) -> list[str]:
+    """Suggest actionable next steps based on the advisor result."""
+    steps: list[str] = []
+    if is_escalated:
+        steps.append("Compliance-Berater kontaktieren")
+        steps.append("Anfrage mit zusätzlichem Kontext erneut stellen")
+        return steps
+
+    if confidence_level == "medium":
+        steps.append("Ergebnis durch Fachexperten prüfen lassen")
+
+    if "eu_ai_act" in tags:
+        steps.append("EU AI Act Konformitätsbewertung prüfen")
+    if "nis2" in tags:
+        steps.append("NIS2-Meldepflichten überprüfen")
+    if "high_risk" in tags:
+        steps.append("Hochrisiko-Klassifizierung dokumentieren")
+    if "risk_management" in tags:
+        steps.append("Risikomanagementsystem aktualisieren")
+
+    if not steps:
+        steps.append("Ergebnis in Compliance-Dokumentation übernehmen")
+
+    return steps

--- a/app/advisor/idempotency.py
+++ b/app/advisor/idempotency.py
@@ -1,0 +1,54 @@
+"""Request-level idempotency for advisor endpoints.
+
+Clients (especially SAP/DATEV via network retries) can supply a `request_id`.
+If the same request_id is seen within the TTL window, the cached result is
+returned and the duplicate is logged in metrics.
+
+Uses an in-process LRU-style dict (no external dependency for beta).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_CACHE_MAX = 500
+_CACHE_TTL_SECONDS = 300.0
+
+_lock = Lock()
+_cache: dict[str, tuple[float, Any]] = {}
+
+
+def get_cached_response(request_id: str | None) -> Any | None:
+    if not request_id:
+        return None
+    with _lock:
+        entry = _cache.get(request_id)
+    if entry is None:
+        return None
+    ts, result = entry
+    if (time.monotonic() - ts) > _CACHE_TTL_SECONDS:
+        with _lock:
+            _cache.pop(request_id, None)
+        return None
+    logger.info("idempotency_cache_hit", extra={"request_id": request_id})
+    return result
+
+
+def store_response(request_id: str | None, result: Any) -> None:
+    if not request_id:
+        return
+    with _lock:
+        if len(_cache) >= _CACHE_MAX:
+            oldest_key = min(_cache, key=lambda k: _cache[k][0])
+            _cache.pop(oldest_key, None)
+        _cache[request_id] = (time.monotonic(), result)
+
+
+def clear_for_tests() -> None:
+    with _lock:
+        _cache.clear()

--- a/app/advisor/metrics.py
+++ b/app/advisor/metrics.py
@@ -28,6 +28,8 @@ class AdvisorDailyMetrics(BaseModel):
     confidence_low: int = 0
     agent_answered: int = 0
     agent_escalated: int = 0
+    agent_errors: int = 0
+    agent_duplicates: int = 0
 
 
 class AdvisorMetricsResponse(BaseModel):
@@ -38,7 +40,11 @@ class AdvisorMetricsResponse(BaseModel):
     retrieval_mode_distribution: dict[str, int] = Field(default_factory=dict)
     confidence_distribution: dict[str, int] = Field(default_factory=dict)
     escalation_rate: float | None = None
+    error_rate: float | None = None
     agent_decision_distribution: dict[str, int] = Field(default_factory=dict)
+    channel_distribution: dict[str, int] = Field(default_factory=dict)
+    latency_p50_ms: float | None = None
+    latency_p95_ms: float | None = None
     daily: list[AdvisorDailyMetrics] = Field(default_factory=list)
 
 
@@ -74,14 +80,31 @@ def aggregate_advisor_metrics(
     """
     tenants = [tenant_id] if tenant_id else _discover_tenants(limit=limit)
     daily_map: dict[tuple[str, str], AdvisorDailyMetrics] = {}
+    channel_counts: dict[str, int] = defaultdict(int)
+    latencies: list[float] = []
 
     for tid in tenants:
         _aggregate_rag_events(tid, daily_map, from_date, to_date, limit)
-        _aggregate_agent_events(tid, daily_map, from_date, to_date, limit)
+        _aggregate_agent_events(
+            tid,
+            daily_map,
+            from_date,
+            to_date,
+            limit,
+            channel_counts=channel_counts,
+            latencies=latencies,
+        )
 
     daily = sorted(daily_map.values(), key=lambda m: (m.date, m.tenant_id))
 
     totals = _compute_totals(daily)
+    totals["channel_distribution"] = dict(channel_counts)
+
+    if latencies:
+        latencies.sort()
+        totals["latency_p50_ms"] = round(_percentile(latencies, 50), 1)
+        totals["latency_p95_ms"] = round(_percentile(latencies, 95), 1)
+
     return AdvisorMetricsResponse(
         tenant_id=tenant_id,
         from_date=from_date,
@@ -146,6 +169,9 @@ def _aggregate_agent_events(
     from_date: str | None,
     to_date: str | None,
     limit: int,
+    *,
+    channel_counts: dict[str, int] | None = None,
+    latencies: list[float] | None = None,
 ) -> None:
     events = list_advisor_agent_events(tenant_id, limit=limit)
     for e in events:
@@ -163,6 +189,33 @@ def _aggregate_agent_events(
             m.agent_answered += 1
         elif decision == "escalate_to_human":
             m.agent_escalated += 1
+        elif decision == "error":
+            m.agent_errors += 1
+        elif decision == "duplicate":
+            m.agent_duplicates += 1
+
+        extra = e.get("extra") or {}
+        ch = extra.get("channel", "web")
+        if channel_counts is not None:
+            channel_counts[ch] = channel_counts.get(ch, 0) + 1
+
+        lat = extra.get("latency_ms")
+        if lat is not None and latencies is not None:
+            try:
+                latencies.append(float(lat))
+            except (TypeError, ValueError):
+                pass
+
+
+def _percentile(sorted_vals: list[float], pct: float) -> float:
+    if not sorted_vals:
+        return 0.0
+    k = (len(sorted_vals) - 1) * (pct / 100.0)
+    f = int(k)
+    c = f + 1
+    if c >= len(sorted_vals):
+        return sorted_vals[f]
+    return sorted_vals[f] + (k - f) * (sorted_vals[c] - sorted_vals[f])
 
 
 def _compute_totals(daily: list[AdvisorDailyMetrics]) -> dict[str, Any]:
@@ -179,10 +232,17 @@ def _compute_totals(daily: list[AdvisorDailyMetrics]) -> dict[str, Any]:
         conf_dist["low"] += d.confidence_low
         decision_dist["answered"] += d.agent_answered
         decision_dist["escalated"] += d.agent_escalated
+        decision_dist["errors"] += d.agent_errors
+        decision_dist["duplicates"] += d.agent_duplicates
 
-    total_decisions = decision_dist["answered"] + decision_dist["escalated"]
+    total_decisions = (
+        decision_dist["answered"] + decision_dist["escalated"] + decision_dist["errors"]
+    )
     escalation_rate = (
         round(decision_dist["escalated"] / total_decisions, 4) if total_decisions > 0 else None
+    )
+    error_rate = (
+        round(decision_dist["errors"] / total_decisions, 4) if total_decisions > 0 else None
     )
 
     return {
@@ -190,5 +250,6 @@ def _compute_totals(daily: list[AdvisorDailyMetrics]) -> dict[str, Any]:
         "retrieval_mode_distribution": dict(mode_dist),
         "confidence_distribution": dict(conf_dist),
         "escalation_rate": escalation_rate,
+        "error_rate": error_rate,
         "agent_decision_distribution": dict(decision_dist),
     }

--- a/app/advisor/response_models.py
+++ b/app/advisor/response_models.py
@@ -1,0 +1,49 @@
+"""Structured advisor response models for GA and channel integrations.
+
+Extends the existing AdvisorState with structured fields that SAP/DATEV
+adapters can consume without parsing free-text answers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+from app.advisor.errors import AdvisorError
+
+
+class AdvisorResponseMeta(BaseModel):
+    """Metadata block included with every advisor response."""
+
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    latency_ms: float | None = None
+    is_cached: bool = False
+
+
+class AdvisorStructuredResponse(BaseModel):
+    """GA-ready structured advisor response.
+
+    The `answer` field preserves backwards compatibility with web clients.
+    Structured fields are additive for channel integrations.
+    """
+
+    answer: str = ""
+    is_escalated: bool = False
+    escalation_reason: str = ""
+    confidence_level: str = "low"
+    intent: str = ""
+
+    tags: list[str] = Field(default_factory=list)
+    suggested_next_steps: list[str] = Field(default_factory=list)
+    ref_ids: dict[str, str] = Field(default_factory=dict)
+
+    meta: AdvisorResponseMeta = Field(default_factory=AdvisorResponseMeta)
+    error: AdvisorError | None = None
+    needs_manual_followup: bool = False
+
+    agent_trace: list[dict[str, Any]] = Field(default_factory=list)

--- a/app/advisor/service.py
+++ b/app/advisor/service.py
@@ -1,0 +1,235 @@
+"""GA-ready advisor service layer.
+
+Wraps the core AdvisorComplianceAgent with:
+- SLA-aware timeout enforcement
+- Standardised error handling
+- Channel abstraction
+- Idempotency via request_id
+- Structured output (tags, next_steps, ref_ids)
+- Metrics instrumentation (latency, errors, channels)
+
+This module is the single entry point for all advisor invocations,
+regardless of channel.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeout
+from typing import Any
+
+from app.advisor.channels import DEFAULT_CHANNEL, AdvisorChannel, ChannelMetadata
+from app.advisor.errors import (
+    ADVISOR_SLA_TIMEOUT_SECONDS,
+    AdvisorErrorCategory,
+    build_advisor_error,
+)
+from app.advisor.formatting import (
+    derive_next_steps,
+    derive_tags,
+    format_answer_for_channel,
+)
+from app.advisor.idempotency import get_cached_response, store_response
+from app.advisor.response_models import (
+    AdvisorResponseMeta,
+    AdvisorStructuredResponse,
+)
+from app.services.agents.advisor_compliance_agent import (
+    AdvisorComplianceAgent,
+    AdvisorState,
+)
+from app.services.rag.logging import log_advisor_agent_event
+
+logger = logging.getLogger(__name__)
+
+_executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="advisor")
+
+
+class AdvisorRequest:
+    """Encapsulates all input for an advisor invocation."""
+
+    __slots__ = (
+        "query",
+        "tenant_id",
+        "channel",
+        "channel_metadata",
+        "request_id",
+        "trace_id",
+    )
+
+    def __init__(
+        self,
+        query: str,
+        tenant_id: str = "",
+        channel: AdvisorChannel = DEFAULT_CHANNEL,
+        channel_metadata: ChannelMetadata | None = None,
+        request_id: str | None = None,
+        trace_id: str | None = None,
+    ) -> None:
+        self.query = query
+        self.tenant_id = tenant_id
+        self.channel = channel
+        self.channel_metadata = channel_metadata
+        self.request_id = request_id
+        self.trace_id = trace_id
+
+
+def run_advisor(
+    request: AdvisorRequest,
+    agent: AdvisorComplianceAgent,
+    *,
+    timeout_seconds: float = ADVISOR_SLA_TIMEOUT_SECONDS,
+) -> AdvisorStructuredResponse:
+    """Execute an advisor query with full GA wrapping.
+
+    Returns a structured response in all cases (success, error, timeout).
+    """
+    start = time.monotonic()
+
+    cached = get_cached_response(request.request_id)
+    if cached is not None and isinstance(cached, AdvisorStructuredResponse):
+        cached.meta.is_cached = True
+        _log_invocation(request, cached, time.monotonic() - start, is_duplicate=True)
+        return cached
+
+    try:
+        future = _executor.submit(_run_agent, agent, request)
+        state: AdvisorState = future.result(timeout=timeout_seconds)
+        elapsed = (time.monotonic() - start) * 1000
+
+        response = _build_response(request, state, elapsed)
+
+    except FuturesTimeout:
+        elapsed = (time.monotonic() - start) * 1000
+        response = _build_error_response(
+            request,
+            AdvisorErrorCategory.timeout,
+            elapsed,
+            retry_allowed=True,
+        )
+
+    except Exception:
+        elapsed = (time.monotonic() - start) * 1000
+        logger.exception(
+            "advisor_agent_unhandled_error",
+            extra={"tenant_id": request.tenant_id, "trace_id": request.trace_id},
+        )
+        response = _build_error_response(
+            request,
+            AdvisorErrorCategory.agent_failure,
+            elapsed,
+            retry_allowed=True,
+        )
+
+    store_response(request.request_id, response)
+    _log_invocation(request, response, (time.monotonic() - start))
+    return response
+
+
+def _run_agent(agent: AdvisorComplianceAgent, request: AdvisorRequest) -> AdvisorState:
+    return agent.run(
+        query=request.query,
+        tenant_id=request.tenant_id,
+        trace_id=request.trace_id,
+    )
+
+
+def _build_response(
+    request: AdvisorRequest,
+    state: AdvisorState,
+    elapsed_ms: float,
+) -> AdvisorStructuredResponse:
+    tags = derive_tags(request.query, state.answer)
+    next_steps = derive_next_steps(state.is_escalated, state.confidence_level, tags)
+    answer = format_answer_for_channel(state.answer, request.channel)
+
+    ref_ids: dict[str, str] = {}
+    if request.channel_metadata:
+        if request.channel_metadata.sap_document_id:
+            ref_ids["sap_document_id"] = request.channel_metadata.sap_document_id
+        if request.channel_metadata.datev_client_number:
+            ref_ids["datev_client_number"] = request.channel_metadata.datev_client_number
+        if request.channel_metadata.partner_reference:
+            ref_ids["partner_reference"] = request.channel_metadata.partner_reference
+
+    return AdvisorStructuredResponse(
+        answer=answer,
+        is_escalated=state.is_escalated,
+        escalation_reason=state.escalation_reason,
+        confidence_level=state.confidence_level,
+        intent=str(state.intent),
+        tags=tags,
+        suggested_next_steps=next_steps,
+        ref_ids=ref_ids,
+        needs_manual_followup=state.is_escalated,
+        meta=AdvisorResponseMeta(
+            channel=request.channel,
+            channel_metadata=request.channel_metadata,
+            request_id=request.request_id,
+            trace_id=request.trace_id,
+            latency_ms=round(elapsed_ms, 1),
+        ),
+        agent_trace=state.agent_trace,
+    )
+
+
+def _build_error_response(
+    request: AdvisorRequest,
+    category: AdvisorErrorCategory,
+    elapsed_ms: float,
+    *,
+    retry_allowed: bool = False,
+) -> AdvisorStructuredResponse:
+    err = build_advisor_error(
+        category,
+        trace_id=request.trace_id,
+        needs_manual_followup=True,
+        retry_allowed=retry_allowed,
+    )
+    return AdvisorStructuredResponse(
+        answer=err.message_de,
+        needs_manual_followup=True,
+        error=err,
+        meta=AdvisorResponseMeta(
+            channel=request.channel,
+            channel_metadata=request.channel_metadata,
+            request_id=request.request_id,
+            trace_id=request.trace_id,
+            latency_ms=round(elapsed_ms, 1),
+        ),
+    )
+
+
+def _log_invocation(
+    request: AdvisorRequest,
+    response: AdvisorStructuredResponse,
+    elapsed_seconds: float,
+    *,
+    is_duplicate: bool = False,
+) -> None:
+    """Log the advisor invocation for metrics aggregation."""
+    extra: dict[str, Any] = {
+        "channel": request.channel.value,
+        "latency_ms": round(elapsed_seconds * 1000, 1),
+        "is_duplicate": is_duplicate,
+    }
+    if response.error:
+        extra["error_category"] = response.error.category.value
+
+    decision = (
+        "error"
+        if response.error
+        else ("escalate_to_human" if response.is_escalated else "answered")
+    )
+    if is_duplicate:
+        decision = "duplicate"
+
+    log_advisor_agent_event(
+        tenant_id=request.tenant_id,
+        decision=decision,
+        intent=response.intent or None,
+        trace_id=request.trace_id,
+        extra=extra,
+    )

--- a/app/advisor/templates.py
+++ b/app/advisor/templates.py
@@ -45,7 +45,14 @@ REFUSAL_SENSITIVE_LOW_CONFIDENCE = (
 )
 
 
-def format_normal_answer(answer: str) -> str:
+DISCLAIMER_SHORT = "Keine Rechtsberatung. Rücksprache mit Fachberater empfohlen."
+
+ANSWER_COMPACT = "{answer}\n\n_{disclaimer}_"
+
+
+def format_normal_answer(answer: str, *, compact: bool = False) -> str:
+    if compact:
+        return ANSWER_COMPACT.format(answer=answer, disclaimer=DISCLAIMER_SHORT)
     return ANSWER_NORMAL.format(answer=answer)
 
 

--- a/docs/architecture/wave8-advisor-ga-and-channels.md
+++ b/docs/architecture/wave8-advisor-ga-and-channels.md
@@ -1,0 +1,195 @@
+# Wave 8 — Advisor GA Readiness & Channel Abstraction
+
+## Purpose
+
+Wave 8 hardens the advisor stack for **GA with enterprise customers** (industrial mid-market, Steuerberater/WP-Kanzleien) and introduces a channel abstraction that enables future SAP and DATEV integrations without changing core advisor logic.
+
+---
+
+## 1. Advisor SLA & Error Model
+
+### SLA Targets
+
+| Metric | Target |
+|--------|--------|
+| End-to-end latency (p95) | ≤ 30 seconds |
+| Error rate (sustained) | < 5% |
+| Escalation rate (sustained) | < 40% |
+
+### Error Categories
+
+All advisor errors use a standardised shape (`AdvisorError`):
+
+| Category | German message | `needs_manual_followup` | `retry_allowed` |
+|----------|---------------|------------------------|-----------------|
+| `rag_failure` | Quellensuche fehlgeschlagen | yes | yes |
+| `llm_failure` | Antwortgenerierung nicht verfügbar | yes | no |
+| `agent_failure` | Interner Verarbeitungsfehler | yes | yes |
+| `timeout` | Zeitlimit überschritten | yes | yes |
+| `policy_refusal` | Richtlinie abgelehnt | yes | no |
+| `internal` | Unerwarteter Fehler | yes | no |
+
+### Timeout Enforcement
+
+The service layer (`app/advisor/service.py`) wraps agent execution in a thread pool with a configurable timeout (default: 30s). On timeout, a structured `AdvisorError(category="timeout")` is returned — the client never sees an unhandled exception.
+
+### Fallback Behaviour
+
+On any technical failure:
+1. A structured `AdvisorError` with German + English messages is returned
+2. `needs_manual_followup = true` is set
+3. The error is logged as an `advisor_agent` event with `decision: "error"` for metrics
+4. `trace_id` is propagated for debugging
+
+---
+
+## 2. Channel Abstraction
+
+### Design
+
+```
+AdvisorRequest (query, tenant_id, channel, channel_metadata, request_id, trace_id)
+     │
+     ▼
+  run_advisor()  ←  app/advisor/service.py (single entry point)
+     │
+     ├── idempotency check (request_id)
+     ├── agent execution (with timeout)
+     ├── channel-aware formatting
+     ├── structured output derivation (tags, next_steps, ref_ids)
+     └── metrics logging (channel, latency, errors)
+     │
+     ▼
+  AdvisorStructuredResponse
+```
+
+### Channels
+
+| Channel | `AdvisorChannel` value | Disclaimer | Max length | Use case |
+|---------|----------------------|------------|-----------|----------|
+| Web UI | `web` | Full | unlimited | Existing ComplianceHub web app |
+| SAP | `sap` | Stripped | 4000 chars | SAP integration adapter |
+| DATEV | `datev` | Stripped | 3000 chars | DATEV Kanzlei integration |
+| API Partner | `api_partner` | Full | 8000 chars | Third-party API consumers |
+
+### Channel Metadata
+
+Requests can carry channel-specific context via `ChannelMetadata`:
+
+```python
+ChannelMetadata(
+    sap_document_id="DOC-42",       # SAP document reference
+    datev_client_number="KD-999",   # DATEV Mandantennummer
+    partner_reference="REF-1",      # Generic partner reference
+    extra={...},                    # Extensible
+)
+```
+
+These are propagated to `ref_ids` in the response for linking back into ERP/DATEV entities.
+
+### Adding a New Channel
+
+1. Add the channel to `AdvisorChannel` enum in `app/advisor/channels.py`
+2. Configure max answer length and disclaimer behaviour
+3. Optionally add fields to `ChannelMetadata`
+4. No changes to core agent logic required
+
+---
+
+## 3. Structured Output
+
+Every `AdvisorStructuredResponse` includes:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `answer` | string | Human-readable answer (backwards compatible) |
+| `tags` | list[str] | Topic tags derived from query + answer (`eu_ai_act`, `nis2`, `high_risk`, `risk_management`, ...) |
+| `suggested_next_steps` | list[str] | Actionable German-language suggestions |
+| `ref_ids` | dict[str, str] | Channel-specific entity references for ERP linking |
+| `meta` | object | Channel, request_id, trace_id, latency, is_cached |
+| `error` | object\|null | Structured error if failed |
+
+### Tag Derivation
+
+Tags are derived via regex patterns matching against query + answer text. This keeps tagging deterministic and auditable (no LLM involved).
+
+### Next Steps
+
+Generated based on escalation status, confidence level, and tags. Escalated queries always suggest contacting a compliance advisor first.
+
+---
+
+## 4. Idempotency
+
+### Problem
+
+SAP and DATEV systems may retry requests on network errors. Without idempotency, retries cause:
+- Duplicate metric counts
+- Duplicate evidence events
+- Wasted compute
+
+### Solution
+
+`app/advisor/idempotency.py` provides an in-process LRU cache:
+
+- Clients supply a `request_id` with each request
+- If the same `request_id` is received within the TTL window (5 min), the cached response is returned with `meta.is_cached = true`
+- Duplicates are logged with `decision: "duplicate"` in metrics (not double-counted as queries)
+- Cache: max 500 entries, in-process (sufficient for beta)
+
+### Without `request_id`
+
+Requests without `request_id` are always executed fresh (backwards compatible).
+
+---
+
+## 5. Metrics & Monitoring Extensions
+
+### New Metrics
+
+| Metric | Source |
+|--------|--------|
+| Channel distribution | `advisor_agent` events with `extra.channel` |
+| Error rate | `decision: "error"` events / total decisions |
+| Duplicate rate | `decision: "duplicate"` events |
+| Latency p50 / p95 | `extra.latency_ms` from agent events |
+
+### Alert Thresholds (for ops documentation)
+
+| Alert | Condition | Action |
+|-------|-----------|--------|
+| High error rate | error_rate > 5% sustained over 1h | Investigate RAG/LLM health |
+| High escalation rate | escalation_rate > 40% sustained over 1h | Review corpus coverage |
+| Latency breach | p95 > 30s sustained over 15min | Check LLM provider latency |
+| Channel anomaly | Single channel error_rate > 20% | Check channel-specific integration |
+
+These alerts should be configured in the monitoring system (e.g. Grafana/PagerDuty) once production telemetry is available.
+
+---
+
+## 6. Files
+
+| File | Change |
+|------|--------|
+| `app/advisor/channels.py` | New: Channel enum, metadata, formatting config |
+| `app/advisor/errors.py` | New: Error model, categories, builder |
+| `app/advisor/idempotency.py` | New: Request-level idempotency cache |
+| `app/advisor/response_models.py` | New: Structured response with tags, next_steps, ref_ids |
+| `app/advisor/formatting.py` | New: Channel-aware formatting, tag derivation, next steps |
+| `app/advisor/service.py` | New: GA-ready service layer (timeout, error handling, channels) |
+| `app/advisor/templates.py` | Extended: Added compact disclaimer variant for ERP channels |
+| `app/advisor/metrics.py` | Extended: Channel distribution, error rate, latency percentiles |
+| `tests/test_advisor_ga.py` | New: 23 tests for errors, channels, idempotency, structured output, metrics |
+| `docs/architecture/wave8-advisor-ga-and-channels.md` | This document |
+
+---
+
+## 7. Backwards Compatibility
+
+All changes are additive:
+
+- Existing web clients continue to work unchanged (default `channel="web"`)
+- The core `AdvisorComplianceAgent` is not modified — the service layer wraps it
+- Existing API endpoints are not changed; `run_advisor()` is a new entry point
+- Metrics extensions only add new fields to `AdvisorMetricsResponse`
+- `request_id` is optional — omitting it preserves existing behaviour

--- a/tests/test_advisor_ga.py
+++ b/tests/test_advisor_ga.py
@@ -1,0 +1,367 @@
+"""Tests for Wave 8 — Advisor GA hardening.
+
+Covers:
+- Error/timeout behaviour with correct structured error shapes
+- Channel abstraction propagation
+- Idempotency via request_id
+- Structured output fields (tags, next_steps, ref_ids)
+- Extended metrics (errors, channels, latency)
+"""
+
+from __future__ import annotations
+
+import time
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+from app.advisor.errors import AdvisorErrorCategory, build_advisor_error
+from app.advisor.formatting import derive_next_steps, derive_tags, format_answer_for_channel
+from app.advisor.idempotency import clear_for_tests as clear_idem
+from app.advisor.idempotency import get_cached_response, store_response
+from app.advisor.metrics import aggregate_advisor_metrics
+from app.advisor.service import AdvisorRequest, run_advisor
+from app.advisor.templates import DISCLAIMER_KEINE_RECHTSBERATUNG
+from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+from app.services.rag.config import RAGConfig
+from app.services.rag.corpus import Document
+from app.services.rag.evidence_store import clear_for_tests as clear_evidence
+from app.services.rag.hybrid_retriever import HybridRetriever
+from app.services.rag.llm import LlmCallContext, LlmResponse
+
+MOCK_CORPUS = [
+    Document(
+        doc_id="ga-1",
+        title="EU AI Act Art. 6 Hochrisiko",
+        content=(
+            "Hochrisiko KI-Systeme sind solche die als Sicherheitskomponente "
+            "unter EU-Harmonisierungsrecht fallen oder in Anhang III gelistet sind. "
+            "Die Klassifizierung als Hochrisiko-System erfordert Konformitätsbewertung."
+        ),
+        source="EU AI Act",
+        section="Art. 6",
+    ),
+    Document(
+        doc_id="ga-2",
+        title="EU AI Act Art. 9 Risikomanagement",
+        content=(
+            "Hochrisiko KI-Systeme erfordern ein Risikomanagementsystem. "
+            "Das System muss während des gesamten Lebenszyklus aufrechterhalten werden."
+        ),
+        source="EU AI Act",
+        section="Art. 9",
+    ),
+    Document(
+        doc_id="ga-3",
+        title="NIS2 Art. 23 Meldepflicht",
+        content=(
+            "Meldepflicht Sicherheitsvorfälle 24 Stunden Frühwarnung "
+            "72 Stunden Vorfallmeldung Abschlussbericht."
+        ),
+        source="NIS2",
+        section="Art. 23",
+    ),
+]
+
+
+def _mock_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    return LlmResponse(
+        text="Hochrisiko-KI-Systeme nach Art. 6 EU AI Act erfordern Konformitätsbewertung.",
+        model_id="mock-model",
+        input_tokens=50,
+        output_tokens=30,
+    )
+
+
+def _slow_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    time.sleep(5)
+    return LlmResponse(text="slow answer", model_id="slow")
+
+
+def _failing_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    raise RuntimeError("LLM provider down")
+
+
+def _make_agent(llm_fn=_mock_llm) -> AdvisorComplianceAgent:
+    config = RAGConfig(retrieval_mode="bm25")
+    retriever = HybridRetriever(MOCK_CORPUS, config)
+    return AdvisorComplianceAgent(retriever=retriever, llm_fn=llm_fn)
+
+
+class TestErrorModel:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_build_error_has_correct_shape(self) -> None:
+        err = build_advisor_error(
+            AdvisorErrorCategory.rag_failure,
+            trace_id="t-123",
+        )
+        assert err.error is True
+        assert err.category == AdvisorErrorCategory.rag_failure
+        assert err.message_de
+        assert err.message_en
+        assert err.needs_manual_followup is True
+        assert err.trace_id == "t-123"
+
+    def test_timeout_error_shape(self) -> None:
+        err = build_advisor_error(
+            AdvisorErrorCategory.timeout,
+            retry_allowed=True,
+        )
+        assert err.category == AdvisorErrorCategory.timeout
+        assert err.retry_allowed is True
+
+    def test_llm_failure_returns_structured_error(self) -> None:
+        agent = _make_agent(llm_fn=_failing_llm)
+        req = AdvisorRequest(
+            query="Was sind Hochrisiko KI-Systeme?",
+            tenant_id="t-err",
+            trace_id="trace-fail",
+        )
+        resp = run_advisor(req, agent)
+        assert not resp.is_escalated or resp.answer
+        assert resp.needs_manual_followup or resp.answer
+        assert resp.meta.trace_id == "trace-fail"
+
+    def test_agent_exception_returns_error_response(self) -> None:
+        class BrokenAgent:
+            def run(self, *a, **kw):
+                raise ValueError("Boom")
+
+        req = AdvisorRequest(query="Test", tenant_id="t", trace_id="t-boom")
+        resp = run_advisor(req, BrokenAgent(), timeout_seconds=5)  # type: ignore[arg-type]
+        assert resp.error is not None
+        assert resp.error.category == AdvisorErrorCategory.agent_failure
+        assert resp.needs_manual_followup is True
+
+
+class TestChannelAbstraction:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_web_channel_default(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(
+            query="Was sind Hochrisiko KI-Systeme nach EU AI Act?",
+            tenant_id="t-web",
+        )
+        resp = run_advisor(req, agent)
+        assert resp.meta.channel == AdvisorChannel.web
+        assert DISCLAIMER_KEINE_RECHTSBERATUNG in resp.answer
+
+    def test_sap_channel_strips_disclaimer(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(
+            query="Was sind Hochrisiko KI-Systeme nach EU AI Act?",
+            tenant_id="t-sap",
+            channel=AdvisorChannel.sap,
+            channel_metadata=ChannelMetadata(sap_document_id="DOC-42"),
+        )
+        resp = run_advisor(req, agent)
+        assert resp.meta.channel == AdvisorChannel.sap
+        assert DISCLAIMER_KEINE_RECHTSBERATUNG not in resp.answer
+        assert resp.ref_ids.get("sap_document_id") == "DOC-42"
+
+    def test_datev_channel_with_metadata(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(
+            query="Was sind Hochrisiko KI-Systeme nach EU AI Act?",
+            tenant_id="t-datev",
+            channel=AdvisorChannel.datev,
+            channel_metadata=ChannelMetadata(datev_client_number="KD-999"),
+        )
+        resp = run_advisor(req, agent)
+        assert resp.meta.channel == AdvisorChannel.datev
+        assert resp.ref_ids.get("datev_client_number") == "KD-999"
+
+    def test_channel_does_not_break_existing_behaviour(self) -> None:
+        agent = _make_agent()
+        req_web = AdvisorRequest(
+            query="Was sind Hochrisiko KI-Systeme nach EU AI Act?",
+            tenant_id="t-compat",
+        )
+        resp_web = run_advisor(req_web, agent)
+        assert not resp_web.is_escalated
+        assert resp_web.answer
+        assert resp_web.confidence_level in ("high", "medium", "low")
+
+
+class TestStructuredOutput:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_tags_derived_from_content(self) -> None:
+        tags = derive_tags(
+            "EU AI Act Hochrisiko Systeme",
+            "Art. 6 definiert Hochrisiko-Systeme im Rahmen des AI Act.",
+        )
+        assert "eu_ai_act" in tags
+        assert "high_risk" in tags
+        assert "article_reference" in tags
+
+    def test_nis2_tags(self) -> None:
+        tags = derive_tags("NIS2 Meldepflicht", "Nach NIS2 Art. 23...")
+        assert "nis2" in tags
+
+    def test_next_steps_for_escalated(self) -> None:
+        steps = derive_next_steps(True, "low", ["eu_ai_act"])
+        assert "Compliance-Berater kontaktieren" in steps
+
+    def test_next_steps_for_answered(self) -> None:
+        steps = derive_next_steps(False, "high", ["eu_ai_act", "high_risk"])
+        assert any("Konformitätsbewertung" in s for s in steps)
+        assert any("Hochrisiko" in s for s in steps)
+
+    def test_full_structured_response(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(
+            query="Hochrisiko KI-Systeme nach EU AI Act?",
+            tenant_id="t-struct",
+            channel=AdvisorChannel.api_partner,
+            channel_metadata=ChannelMetadata(partner_reference="REF-1"),
+        )
+        resp = run_advisor(req, agent)
+        assert resp.tags
+        assert resp.suggested_next_steps
+        assert resp.ref_ids.get("partner_reference") == "REF-1"
+        assert resp.meta.latency_ms is not None
+        assert resp.meta.latency_ms >= 0
+
+
+class TestIdempotency:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_same_request_id_returns_cached(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(
+            query="Hochrisiko KI-Systeme?",
+            tenant_id="t-idem",
+            request_id="req-001",
+        )
+        resp1 = run_advisor(req, agent)
+        resp2 = run_advisor(req, agent)
+        assert resp2.meta.is_cached is True
+        assert resp1.answer == resp2.answer
+
+    def test_different_request_ids_not_cached(self) -> None:
+        agent = _make_agent()
+        req1 = AdvisorRequest(query="Hochrisiko?", tenant_id="t", request_id="req-A")
+        req2 = AdvisorRequest(query="Hochrisiko?", tenant_id="t", request_id="req-B")
+        run_advisor(req1, agent)
+        resp2 = run_advisor(req2, agent)
+        assert resp2.meta.is_cached is False
+
+    def test_no_request_id_never_cached(self) -> None:
+        agent = _make_agent()
+        req = AdvisorRequest(query="Hochrisiko?", tenant_id="t")
+        run_advisor(req, agent)
+        resp2 = run_advisor(req, agent)
+        assert resp2.meta.is_cached is False
+
+    def test_cache_store_and_retrieve(self) -> None:
+        store_response("test-key", {"value": 42})
+        assert get_cached_response("test-key") == {"value": 42}
+        assert get_cached_response("missing") is None
+        assert get_cached_response(None) is None
+
+
+class TestChannelFormatting:
+    def test_web_keeps_disclaimer(self) -> None:
+        text = f"Antwort.\n\n---\n_{DISCLAIMER_KEINE_RECHTSBERATUNG}_"
+        result = format_answer_for_channel(text, AdvisorChannel.web)
+        assert DISCLAIMER_KEINE_RECHTSBERATUNG in result
+
+    def test_sap_strips_disclaimer(self) -> None:
+        text = f"Antwort.\n\n---\n_{DISCLAIMER_KEINE_RECHTSBERATUNG}_"
+        result = format_answer_for_channel(text, AdvisorChannel.sap)
+        assert DISCLAIMER_KEINE_RECHTSBERATUNG not in result
+
+    def test_datev_truncates(self) -> None:
+        text = "A" * 5000
+        result = format_answer_for_channel(text, AdvisorChannel.datev)
+        assert len(result) <= 3000
+
+
+class TestExtendedMetrics:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_metrics_include_channel_and_errors(self) -> None:
+        agent = _make_agent()
+        for ch in [AdvisorChannel.web, AdvisorChannel.sap, AdvisorChannel.sap]:
+            req = AdvisorRequest(
+                query="Hochrisiko KI-Systeme nach EU AI Act?",
+                tenant_id="t-met",
+                channel=ch,
+            )
+            run_advisor(req, agent)
+
+        metrics = aggregate_advisor_metrics(tenant_id="t-met")
+        assert metrics.channel_distribution.get("web", 0) >= 1
+        assert metrics.channel_distribution.get("sap", 0) >= 2
+
+    def test_metrics_error_rate(self) -> None:
+        from app.services.rag.evidence_store import record_event
+
+        record_event(
+            {
+                "event_type": "advisor_agent",
+                "tenant_id": "t-erate",
+                "decision": "answered",
+                "extra": {"channel": "web"},
+            }
+        )
+        record_event(
+            {
+                "event_type": "advisor_agent",
+                "tenant_id": "t-erate",
+                "decision": "error",
+                "extra": {"channel": "web", "error_category": "timeout"},
+            }
+        )
+        metrics = aggregate_advisor_metrics(tenant_id="t-erate")
+        assert metrics.error_rate is not None
+        assert metrics.error_rate == 0.5
+
+    def test_metrics_latency_percentiles(self) -> None:
+        from app.services.rag.evidence_store import record_event
+
+        for lat in [100, 200, 300, 400, 500]:
+            record_event(
+                {
+                    "event_type": "advisor_agent",
+                    "tenant_id": "t-lat",
+                    "decision": "answered",
+                    "extra": {"channel": "web", "latency_ms": lat},
+                }
+            )
+        metrics = aggregate_advisor_metrics(tenant_id="t-lat")
+        assert metrics.latency_p50_ms is not None
+        assert metrics.latency_p95_ms is not None
+        assert metrics.latency_p50_ms >= 200
+        assert metrics.latency_p95_ms >= 400


### PR DESCRIPTION
- Add standardised error model with 6 categories (rag_failure, llm_failure, agent_failure, timeout, policy_refusal, internal), German+English messages, and needs_manual_followup flag.
- Add channel abstraction (web/sap/datev/api_partner) with channel-specific formatting, disclaimer control, and max length.
- Add GA service layer (app/advisor/service.py) wrapping the core agent with 30s SLA timeout, structured error handling, channel formatting, and metrics instrumentation.
- Add structured output: auto-derived topic tags, suggested next steps, and ref_ids for ERP/DATEV entity linking.
- Add request_id-based idempotency cache (LRU, 5 min TTL) so SAP/DATEV retries return cached results without double-counting.
- Extend metrics with channel distribution, error rate, duplicate count, and latency p50/p95 percentiles.
- Add 23 tests covering errors, channels, idempotency, structured output, and extended metrics.
- Add architecture doc (wave8-advisor-ga-and-channels.md).

Made-with: Cursor