### PR TITLE
feat(wave9): advisor preset micro-flows for DATEV/SAP alignment

### DIFF
--- a/app/advisor/channels.py
+++ b/app/advisor/channels.py
@@ -46,3 +46,13 @@ def max_answer_length(channel: AdvisorChannel) -> int | None:
 def include_disclaimer(channel: AdvisorChannel) -> bool:
     """Whether the channel should include the legal disclaimer in answers."""
     return channel in (AdvisorChannel.web, AdvisorChannel.api_partner)
+
+
+def use_structured_format(channel: AdvisorChannel) -> bool:
+    """Whether the channel prefers structured answer format with tags/steps."""
+    return channel in (AdvisorChannel.sap, AdvisorChannel.datev)
+
+
+def is_kanzlei_channel(channel: AdvisorChannel) -> bool:
+    """Whether the channel targets Kanzlei users (stronger disclaimers)."""
+    return channel == AdvisorChannel.datev

--- a/app/advisor/formatting.py
+++ b/app/advisor/formatting.py
@@ -8,17 +8,36 @@ from __future__ import annotations
 
 import re
 
-from app.advisor.channels import AdvisorChannel, include_disclaimer, max_answer_length
+from app.advisor.channels import (
+    AdvisorChannel,
+    include_disclaimer,
+    is_kanzlei_channel,
+    max_answer_length,
+    use_structured_format,
+)
 from app.advisor.templates import DISCLAIMER_KEINE_RECHTSBERATUNG
 
 
 def format_answer_for_channel(
     answer: str,
     channel: AdvisorChannel,
+    *,
+    tags: list[str] | None = None,
+    next_steps: list[str] | None = None,
 ) -> str:
-    limit = max_answer_length(channel)
-    if not include_disclaimer(channel):
+    if use_structured_format(channel) and tags is not None:
+        from app.advisor.templates import format_structured_answer
+
+        answer = format_structured_answer(
+            _strip_disclaimer(answer),
+            tags or [],
+            next_steps or [],
+            kanzlei=is_kanzlei_channel(channel),
+        )
+    elif not include_disclaimer(channel):
         answer = _strip_disclaimer(answer)
+
+    limit = max_answer_length(channel)
     if limit and len(answer) > limit:
         answer = answer[: limit - 3] + "..."
     return answer

--- a/app/advisor/metrics.py
+++ b/app/advisor/metrics.py
@@ -43,6 +43,7 @@ class AdvisorMetricsResponse(BaseModel):
     error_rate: float | None = None
     agent_decision_distribution: dict[str, int] = Field(default_factory=dict)
     channel_distribution: dict[str, int] = Field(default_factory=dict)
+    flow_type_distribution: dict[str, int] = Field(default_factory=dict)
     latency_p50_ms: float | None = None
     latency_p95_ms: float | None = None
     daily: list[AdvisorDailyMetrics] = Field(default_factory=list)
@@ -81,6 +82,7 @@ def aggregate_advisor_metrics(
     tenants = [tenant_id] if tenant_id else _discover_tenants(limit=limit)
     daily_map: dict[tuple[str, str], AdvisorDailyMetrics] = {}
     channel_counts: dict[str, int] = defaultdict(int)
+    flow_type_counts: dict[str, int] = defaultdict(int)
     latencies: list[float] = []
 
     for tid in tenants:
@@ -92,6 +94,7 @@ def aggregate_advisor_metrics(
             to_date,
             limit,
             channel_counts=channel_counts,
+            flow_type_counts=flow_type_counts,
             latencies=latencies,
         )
 
@@ -99,6 +102,7 @@ def aggregate_advisor_metrics(
 
     totals = _compute_totals(daily)
     totals["channel_distribution"] = dict(channel_counts)
+    totals["flow_type_distribution"] = dict(flow_type_counts)
 
     if latencies:
         latencies.sort()
@@ -171,6 +175,7 @@ def _aggregate_agent_events(
     limit: int,
     *,
     channel_counts: dict[str, int] | None = None,
+    flow_type_counts: dict[str, int] | None = None,
     latencies: list[float] | None = None,
 ) -> None:
     events = list_advisor_agent_events(tenant_id, limit=limit)
@@ -198,6 +203,10 @@ def _aggregate_agent_events(
         ch = extra.get("channel", "web")
         if channel_counts is not None:
             channel_counts[ch] = channel_counts.get(ch, 0) + 1
+
+        ft = extra.get("flow_type")
+        if ft and flow_type_counts is not None:
+            flow_type_counts[ft] = flow_type_counts.get(ft, 0) + 1
 
         lat = extra.get("latency_ms")
         if lat is not None and latencies is not None:

--- a/app/advisor/presets.py
+++ b/app/advisor/presets.py
@@ -1,0 +1,193 @@
+"""Advisor preset micro-flows for DATEV/SAP-aligned use cases.
+
+Each preset defines:
+- A flow_type identifier for evidence/metrics tagging
+- Input schema with channel-specific metadata
+- Query shaping: builds the natural-language query from structured input
+- Extra tags to force-include in the response
+
+Presets are thin wrappers around the generic advisor service — no separate
+business logic, just prompt/context shaping.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+
+
+class FlowType(StrEnum):
+    eu_ai_act_risk_assessment = "eu_ai_act_risk_assessment"
+    nis2_obligations = "nis2_obligations"
+    iso42001_gap_check = "iso42001_gap_check"
+
+
+# ---------------------------------------------------------------------------
+# Preset 1: EU AI Act Risk Assessment
+# ---------------------------------------------------------------------------
+
+
+class EuAiActRiskAssessmentInput(BaseModel):
+    """Input for the 'Is my AI use case high-risk?' preset."""
+
+    use_case_description: str = Field(
+        ...,
+        min_length=10,
+        max_length=4000,
+        description="Description of the planned AI use case",
+    )
+    industry_sector: str = Field(
+        default="",
+        description="Industry sector (e.g. 'Finanzdienstleistungen', 'Gesundheit')",
+    )
+    intended_purpose: str = Field(
+        default="",
+        description="Intended purpose of the AI system",
+    )
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    tenant_id: str = ""
+
+
+def build_eu_ai_act_risk_query(inp: EuAiActRiskAssessmentInput) -> str:
+    parts = [
+        "Ist der folgende geplante KI-Anwendungsfall voraussichtlich "
+        "hochrisikorelevant nach dem EU AI Act (Verordnung 2024/1689)?",
+        f"\nAnwendungsfall: {inp.use_case_description}",
+    ]
+    if inp.industry_sector:
+        parts.append(f"Branche: {inp.industry_sector}")
+    if inp.intended_purpose:
+        parts.append(f"Zweckbestimmung: {inp.intended_purpose}")
+    parts.append(
+        "\nBitte bewerte anhand Art. 6 und Anhang III, ob eine "
+        "Hochrisiko-Klassifizierung wahrscheinlich ist, und nenne "
+        "die relevanten Kriterien."
+    )
+    return "\n".join(parts)
+
+
+EU_AI_ACT_RISK_EXTRA_TAGS = ["eu_ai_act", "high_risk", "conformity_assessment"]
+
+
+# ---------------------------------------------------------------------------
+# Preset 2: NIS2 Obligations
+# ---------------------------------------------------------------------------
+
+
+class Nis2ObligationsInput(BaseModel):
+    """Input for the 'What NIS2 obligations apply?' preset."""
+
+    entity_role: str = Field(
+        ...,
+        min_length=3,
+        max_length=500,
+        description=(
+            "Role of the entity (e.g. 'KRITIS-naher Zulieferer', "
+            "'Betreiber wesentlicher Dienste', 'Digitaler Dienstleister')"
+        ),
+    )
+    sector: str = Field(
+        default="",
+        description="Sector (e.g. 'Energie', 'Transport', 'Digitale Infrastruktur')",
+    )
+    employee_count: str = Field(
+        default="",
+        description="Approximate size (e.g. '50-249', '250+')",
+    )
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    tenant_id: str = ""
+
+
+def build_nis2_obligations_query(inp: Nis2ObligationsInput) -> str:
+    parts = [
+        "Welche NIS2-Pflichten (Richtlinie 2022/2555) betreffen "
+        f"eine Organisation mit der Rolle '{inp.entity_role}'?",
+    ]
+    if inp.sector:
+        parts.append(f"Sektor: {inp.sector}")
+    if inp.employee_count:
+        parts.append(f"Größenordnung: {inp.employee_count} Mitarbeiter")
+    parts.append(
+        "\nBitte nenne die wesentlichen Pflichten (Meldepflichten, "
+        "Risikomanagement, Governance) und relevante Fristen."
+    )
+    return "\n".join(parts)
+
+
+NIS2_OBLIGATIONS_EXTRA_TAGS = ["nis2", "incident_reporting", "risk_management"]
+
+
+# ---------------------------------------------------------------------------
+# Preset 3: ISO 42001 Gap Check
+# ---------------------------------------------------------------------------
+
+
+class Iso42001GapCheckInput(BaseModel):
+    """Input for the 'ISO 42001 gap check' preset."""
+
+    current_measures: str = Field(
+        ...,
+        min_length=10,
+        max_length=4000,
+        description="Description of current AI governance measures in place",
+    )
+    ai_system_count: str = Field(
+        default="",
+        description="Number of AI systems in scope",
+    )
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    tenant_id: str = ""
+
+
+def build_iso42001_gap_query(inp: Iso42001GapCheckInput) -> str:
+    parts = [
+        "Welche Lücken bestehen voraussichtlich gegenüber "
+        "ISO 42001 (AI Management System) bei folgenden "
+        "aktuellen Governance-Maßnahmen?",
+        f"\nAktuelle Maßnahmen: {inp.current_measures}",
+    ]
+    if inp.ai_system_count:
+        parts.append(f"Anzahl KI-Systeme im Scope: {inp.ai_system_count}")
+    parts.append(
+        "\nBitte identifiziere die wichtigsten Lücken und priorisiere Handlungsempfehlungen."
+    )
+    return "\n".join(parts)
+
+
+ISO42001_GAP_EXTRA_TAGS = ["iso_42001", "risk_management", "conformity_assessment"]
+
+
+# ---------------------------------------------------------------------------
+# Registry for preset resolution
+# ---------------------------------------------------------------------------
+
+PRESET_REGISTRY: dict[FlowType, dict[str, Any]] = {
+    FlowType.eu_ai_act_risk_assessment: {
+        "build_query": build_eu_ai_act_risk_query,
+        "extra_tags": EU_AI_ACT_RISK_EXTRA_TAGS,
+        "input_model": EuAiActRiskAssessmentInput,
+    },
+    FlowType.nis2_obligations: {
+        "build_query": build_nis2_obligations_query,
+        "extra_tags": NIS2_OBLIGATIONS_EXTRA_TAGS,
+        "input_model": Nis2ObligationsInput,
+    },
+    FlowType.iso42001_gap_check: {
+        "build_query": build_iso42001_gap_query,
+        "extra_tags": ISO42001_GAP_EXTRA_TAGS,
+        "input_model": Iso42001GapCheckInput,
+    },
+}

--- a/app/advisor/response_models.py
+++ b/app/advisor/response_models.py
@@ -23,6 +23,7 @@ class AdvisorResponseMeta(BaseModel):
     trace_id: str | None = None
     latency_ms: float | None = None
     is_cached: bool = False
+    flow_type: str | None = None
 
 
 class AdvisorStructuredResponse(BaseModel):

--- a/app/advisor/service.py
+++ b/app/advisor/service.py
@@ -57,6 +57,8 @@ class AdvisorRequest:
         "channel_metadata",
         "request_id",
         "trace_id",
+        "flow_type",
+        "extra_tags",
     )
 
     def __init__(
@@ -67,6 +69,8 @@ class AdvisorRequest:
         channel_metadata: ChannelMetadata | None = None,
         request_id: str | None = None,
         trace_id: str | None = None,
+        flow_type: str | None = None,
+        extra_tags: list[str] | None = None,
     ) -> None:
         self.query = query
         self.tenant_id = tenant_id
@@ -74,6 +78,8 @@ class AdvisorRequest:
         self.channel_metadata = channel_metadata
         self.request_id = request_id
         self.trace_id = trace_id
+        self.flow_type = flow_type
+        self.extra_tags = extra_tags
 
 
 def run_advisor(
@@ -142,10 +148,19 @@ def _build_response(
     elapsed_ms: float,
 ) -> AdvisorStructuredResponse:
     tags = derive_tags(request.query, state.answer)
+    if request.extra_tags:
+        tags = sorted(set(tags) | set(request.extra_tags))
     next_steps = derive_next_steps(state.is_escalated, state.confidence_level, tags)
-    answer = format_answer_for_channel(state.answer, request.channel)
+    answer = format_answer_for_channel(
+        state.answer,
+        request.channel,
+        tags=tags,
+        next_steps=next_steps,
+    )
 
     ref_ids: dict[str, str] = {}
+    if request.flow_type:
+        ref_ids["flow_type"] = request.flow_type
     if request.channel_metadata:
         if request.channel_metadata.sap_document_id:
             ref_ids["sap_document_id"] = request.channel_metadata.sap_document_id
@@ -170,6 +185,7 @@ def _build_response(
             request_id=request.request_id,
             trace_id=request.trace_id,
             latency_ms=round(elapsed_ms, 1),
+            flow_type=request.flow_type,
         ),
         agent_trace=state.agent_trace,
     )
@@ -215,6 +231,8 @@ def _log_invocation(
         "latency_ms": round(elapsed_seconds * 1000, 1),
         "is_duplicate": is_duplicate,
     }
+    if request.flow_type:
+        extra["flow_type"] = request.flow_type
     if response.error:
         extra["error_category"] = response.error.category.value
 

--- a/app/advisor/templates.py
+++ b/app/advisor/templates.py
@@ -47,13 +47,43 @@ REFUSAL_SENSITIVE_LOW_CONFIDENCE = (
 
 DISCLAIMER_SHORT = "Keine Rechtsberatung. Rücksprache mit Fachberater empfohlen."
 
+DISCLAIMER_KANZLEI = (
+    "Wichtiger Hinweis: Diese automatisierte Einschätzung ersetzt keine "
+    "individuelle Rechtsberatung. Die Verantwortung für mandantenbezogene "
+    "Entscheidungen liegt beim beratenden Berufsträger."
+)
+
 ANSWER_COMPACT = "{answer}\n\n_{disclaimer}_"
+
+ANSWER_STRUCTURED = (
+    "{answer}\n\n"
+    "---\n"
+    "Schlagworte: {tags}\n"
+    "Empfohlene nächste Schritte: {next_steps}\n\n"
+    "_{disclaimer}_"
+)
 
 
 def format_normal_answer(answer: str, *, compact: bool = False) -> str:
     if compact:
         return ANSWER_COMPACT.format(answer=answer, disclaimer=DISCLAIMER_SHORT)
     return ANSWER_NORMAL.format(answer=answer)
+
+
+def format_structured_answer(
+    answer: str,
+    tags: list[str],
+    next_steps: list[str],
+    *,
+    kanzlei: bool = False,
+) -> str:
+    disclaimer = DISCLAIMER_KANZLEI if kanzlei else DISCLAIMER_SHORT
+    return ANSWER_STRUCTURED.format(
+        answer=answer,
+        tags=", ".join(tags) if tags else "—",
+        next_steps="; ".join(next_steps) if next_steps else "—",
+        disclaimer=disclaimer,
+    )
 
 
 def format_escalation(reason: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -32,6 +32,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.advisor.metrics import AdvisorMetricsResponse, aggregate_advisor_metrics
+from app.advisor.presets import (
+    PRESET_REGISTRY,
+    EuAiActRiskAssessmentInput,
+    FlowType,
+    Iso42001GapCheckInput,
+    Nis2ObligationsInput,
+)
+from app.advisor.response_models import AdvisorStructuredResponse
+from app.advisor.service import AdvisorRequest, run_advisor
 from app.advisor_client_snapshot_models import (
     AdvisorClientGovernanceSnapshotResponse,
     AdvisorGovernanceSnapshotMarkdownResponse,
@@ -4639,4 +4648,126 @@ def get_advisor_metrics(
         tenant_id=tenant_id,
         from_date=from_date,
         to_date=to_date,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Advisor Preset Micro-Flows (Wave 9)
+# ---------------------------------------------------------------------------
+
+
+def _make_advisor_agent() -> Any:
+    """Create a default AdvisorComplianceAgent from the global corpus."""
+    from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+
+    corpus = load_advisor_corpus()
+    config = RAGConfig()
+    retriever = HybridRetriever(corpus, config)
+    return AdvisorComplianceAgent(retriever=retriever)
+
+
+def _run_preset(
+    flow_type: FlowType,
+    query: str,
+    body: EuAiActRiskAssessmentInput | Nis2ObligationsInput | Iso42001GapCheckInput,
+    auth: AuthContext,
+    opa_role_header: str | None,
+) -> AdvisorStructuredResponse:
+    """Shared logic for all preset endpoints."""
+    opa_role = resolve_opa_role_for_policy(
+        header_value=opa_role_header,
+        env_var_name="COMPLIANCEHUB_OPA_ROLE_ADVISOR_PRESET",
+        default="advisor_user",
+    )
+    enforce_action_policy(
+        f"advisor_preset_{flow_type.value}",
+        UserPolicyContext(
+            tenant_id=body.tenant_id or auth.tenant_id,
+            user_role=opa_role,
+        ),
+        risk_score=0.6,
+    )
+
+    preset_info = PRESET_REGISTRY[flow_type]
+    request = AdvisorRequest(
+        query=query,
+        tenant_id=body.tenant_id or auth.tenant_id,
+        channel=body.channel,
+        channel_metadata=body.channel_metadata,
+        request_id=body.request_id,
+        trace_id=body.trace_id,
+        flow_type=flow_type.value,
+        extra_tags=preset_info["extra_tags"],
+    )
+
+    agent = _make_advisor_agent()
+    return run_advisor(request, agent)
+
+
+@app.post(
+    "/api/v1/advisor/presets/eu-ai-act-risk-assessment",
+    response_model=AdvisorStructuredResponse,
+    tags=["advisor", "presets"],
+)
+def preset_eu_ai_act_risk_assessment(
+    body: EuAiActRiskAssessmentInput,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> AdvisorStructuredResponse:
+    """Preset: Is my planned AI use case likely high-risk under EU AI Act?"""
+    from app.advisor.presets import build_eu_ai_act_risk_query
+
+    query = build_eu_ai_act_risk_query(body)
+    return _run_preset(
+        FlowType.eu_ai_act_risk_assessment,
+        query,
+        body,
+        auth,
+        opa_role_header,
+    )
+
+
+@app.post(
+    "/api/v1/advisor/presets/nis2-obligations",
+    response_model=AdvisorStructuredResponse,
+    tags=["advisor", "presets"],
+)
+def preset_nis2_obligations(
+    body: Nis2ObligationsInput,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> AdvisorStructuredResponse:
+    """Preset: What NIS2 obligations apply to an entity with a given role?"""
+    from app.advisor.presets import build_nis2_obligations_query
+
+    query = build_nis2_obligations_query(body)
+    return _run_preset(
+        FlowType.nis2_obligations,
+        query,
+        body,
+        auth,
+        opa_role_header,
+    )
+
+
+@app.post(
+    "/api/v1/advisor/presets/iso42001-gap-check",
+    response_model=AdvisorStructuredResponse,
+    tags=["advisor", "presets"],
+)
+def preset_iso42001_gap_check(
+    body: Iso42001GapCheckInput,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> AdvisorStructuredResponse:
+    """Preset: ISO 42001 gap check for current AI governance measures."""
+    from app.advisor.presets import build_iso42001_gap_query
+
+    query = build_iso42001_gap_query(body)
+    return _run_preset(
+        FlowType.iso42001_gap_check,
+        query,
+        body,
+        auth,
+        opa_role_header,
     )

--- a/docs/architecture/wave9-advisor-presets-and-datev-sap-alignment.md
+++ b/docs/architecture/wave9-advisor-presets-and-datev-sap-alignment.md
@@ -1,0 +1,192 @@
+# Wave 9 — Advisor Presets & DATEV/SAP Alignment
+
+## Overview
+
+Wave 9 introduces **advisor preset micro-flows** — structured, domain-specific entry points into the generic advisor stack, designed around the questions that Kanzleien (DATEV) and Industrie-Mittelstand (SAP) actually ask.
+
+No direct DATEV/SAP API integration yet, but every preset is designed so a future connector can call it 1:1.
+
+## Chosen Micro-Flows
+
+### 1. EU AI Act Risk Assessment
+
+**Endpoint:** `POST /api/v1/advisor/presets/eu-ai-act-risk-assessment`
+
+**Use case:** A Steuerberater or Compliance-Beauftragter wants to know whether a planned AI use case is likely high-risk under the EU AI Act.
+
+**Why this matters:**
+- Art. 6 + Annex III classification is the single most frequent compliance question for companies deploying AI
+- DATEV-Kanzleien advise mid-market clients on exactly this question
+- SAP customers need to assess their AI modules (predictive analytics, intelligent RPA)
+
+**Input:**
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `use_case_description` | string | yes | The planned AI use case |
+| `industry_sector` | string | no | Industry (e.g. Finanzdienstleistungen) |
+| `intended_purpose` | string | no | Intended purpose of the AI system |
+| `channel` | enum | no | web / sap / datev / api_partner |
+| `channel_metadata` | object | no | DATEV client no., SAP doc ID, etc. |
+
+**Expected tags:** `eu_ai_act`, `high_risk`, `conformity_assessment`
+
+### 2. NIS2 Obligations
+
+**Endpoint:** `POST /api/v1/advisor/presets/nis2-obligations`
+
+**Use case:** A compliance team needs to understand what NIS2 obligations apply to a specific entity role (e.g. KRITIS-naher Zulieferer).
+
+**Why this matters:**
+- NIS2 implementation (NIS2UmsuCG) affects ~30.000 companies in Germany
+- Entity role → obligation mapping is complex and frequently misunderstood
+- Kanzleien need to advise multiple Mandanten with different roles
+
+**Input:**
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `entity_role` | string | yes | Role (e.g. KRITIS-naher Zulieferer) |
+| `sector` | string | no | Sector (e.g. Energie, Transport) |
+| `employee_count` | string | no | Size category (50-249, 250+) |
+| `channel` | enum | no | web / sap / datev / api_partner |
+| `channel_metadata` | object | no | Channel-specific refs |
+
+**Expected tags:** `nis2`, `incident_reporting`, `risk_management`
+
+### 3. ISO 42001 Gap Check
+
+**Endpoint:** `POST /api/v1/advisor/presets/iso42001-gap-check`
+
+**Use case:** A company with existing governance measures wants to understand gaps relative to ISO 42001.
+
+**Why this matters:**
+- ISO 42001 is becoming the standard for AI governance certification
+- Companies with ISO 27001 need to understand what additional measures ISO 42001 requires
+- Gap analysis is a natural starting point for a consulting engagement
+
+**Input:**
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `current_measures` | string | yes | Description of existing governance |
+| `ai_system_count` | string | no | Number of AI systems in scope |
+| `channel` | enum | no | web / sap / datev / api_partner |
+| `channel_metadata` | object | no | Channel-specific refs |
+
+**Expected tags:** `iso_42001`, `risk_management`, `conformity_assessment`
+
+## Architecture
+
+### Thin Wrapper Pattern
+
+Presets are **thin wrappers** around the existing advisor service — no separate business logic:
+
+```
+Preset Endpoint
+  ├─ Validate structured input (Pydantic model)
+  ├─ Build natural-language query from fields
+  ├─ Enforce OPA policy (action = advisor_preset_{flow_type})
+  ├─ Create AdvisorRequest with:
+  │   ├─ channel, channel_metadata (from input)
+  │   ├─ flow_type (from preset definition)
+  │   └─ extra_tags (from preset definition)
+  └─ Call run_advisor() — the generic GA service layer
+        ├─ Idempotency check
+        ├─ Agent execution (with timeout)
+        ├─ Channel-aware formatting
+        ├─ Structured output derivation
+        └─ Evidence & metrics logging (with flow_type)
+```
+
+All existing guardrails, policies, error handling, SLA enforcement, and auditability remain fully active.
+
+### Channel-Specific Formatting
+
+| Channel | Format | Disclaimer | Structured fields |
+|---|---|---|---|
+| `web` | Full text + normal disclaimer | Standard | In response JSON, not in answer text |
+| `datev` | Structured: tags + next steps in answer text | Kanzlei-specific (stronger) | Embedded in answer |
+| `sap` | Structured: tags + next steps in answer text | Short | Embedded in answer |
+| `api_partner` | Full text + normal disclaimer | Standard | In response JSON |
+
+DATEV channel uses `DISCLAIMER_KANZLEI`: stronger wording about professional responsibility, appropriate for Berufsträger advising Mandanten.
+
+### Evidence & Metrics Tagging
+
+Every preset invocation is tagged with:
+- `flow_type` in the agent event `extra` field → appears in metrics as `flow_type_distribution`
+- `channel` in the agent event → appears in `channel_distribution`
+- `flow_type` in `AdvisorResponseMeta` and `ref_ids`
+
+This enables:
+- Per-flow volume, confidence, and escalation rate tracking
+- Identification of which flows have quality/safety issues
+- Channel-specific usage patterns for DATEV vs. SAP vs. web
+
+### OPA Policy Integration
+
+Each preset endpoint enforces an OPA policy with a distinct action name:
+- `advisor_preset_eu_ai_act_risk_assessment` (risk_score: 0.6)
+- `advisor_preset_nis2_obligations` (risk_score: 0.6)
+- `advisor_preset_iso42001_gap_check` (risk_score: 0.6)
+
+This allows fine-grained access control per flow type.
+
+## Preset Registry
+
+All preset definitions live in `app/advisor/presets.py` with a central `PRESET_REGISTRY`:
+
+```python
+PRESET_REGISTRY: dict[FlowType, dict[str, Any]] = {
+    FlowType.eu_ai_act_risk_assessment: {
+        "build_query": build_eu_ai_act_risk_query,
+        "extra_tags": EU_AI_ACT_RISK_EXTRA_TAGS,
+        "input_model": EuAiActRiskAssessmentInput,
+    },
+    # ...
+}
+```
+
+Adding a new preset requires:
+1. Define a `FlowType` enum value
+2. Add input model (Pydantic)
+3. Write a `build_*_query` function
+4. Register in `PRESET_REGISTRY`
+5. Add endpoint in `main.py` (3 lines calling `_run_preset`)
+
+## Path to Real DATEV/SAP Integrations
+
+This wave sets the stage for real integrations:
+
+| Current (Wave 9) | Future (DATEV Integration) | Future (SAP Integration) |
+|---|---|---|
+| `channel=datev` in request | DATEV DMS webhook calls preset endpoint | SAP BTP event calls preset endpoint |
+| `channel_metadata.datev_client_number` | Extracted from DATEV context | — |
+| `channel_metadata.sap_document_id` | — | Extracted from SAP document flow |
+| Structured answer with tags/steps | Mapped to DATEV Aufgaben / Hinweise | Mapped to SAP workflow tasks |
+| `flow_type` in evidence | Links to DATEV audit trail | Links to SAP GRC findings |
+
+The preset endpoints are **the integration surface** — a DATEV connector would POST to the same endpoint with `channel=datev` and the appropriate metadata.
+
+## Test Coverage
+
+21 tests covering:
+- Query building for all 3 presets (6 tests)
+- Request mapping: channel, metadata, flow_type propagation (3 tests)
+- Response shape: structured fields, DATEV vs. web formatting (3 tests)
+- Evidence & metrics: flow_type in events, metrics aggregation (3 tests)
+- Channel formatting: DATEV structured, SAP structured, web default (5 tests)
+- Registry completeness (1 test)
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/advisor/presets.py` | **New** — Preset definitions, input schemas, query builders, registry |
+| `app/advisor/service.py` | Extended `AdvisorRequest` with `flow_type` + `extra_tags`; propagated to response and evidence |
+| `app/advisor/response_models.py` | Added `flow_type` to `AdvisorResponseMeta` |
+| `app/advisor/channels.py` | Added `use_structured_format()` and `is_kanzlei_channel()` |
+| `app/advisor/templates.py` | Added `DISCLAIMER_KANZLEI`, `ANSWER_STRUCTURED`, `format_structured_answer()` |
+| `app/advisor/formatting.py` | Extended `format_answer_for_channel()` with tags/next_steps for structured channels |
+| `app/advisor/metrics.py` | Added `flow_type_distribution` to metrics aggregation |
+| `app/main.py` | Added 3 preset endpoints + `_run_preset` shared handler |
+| `tests/test_advisor_presets.py` | **New** — 21 tests |
+| `docs/architecture/wave9-advisor-presets-and-datev-sap-alignment.md` | **New** — This document |

--- a/tests/test_advisor_presets.py
+++ b/tests/test_advisor_presets.py
@@ -1,0 +1,479 @@
+"""Tests for Wave 9 — Advisor preset micro-flows.
+
+Covers:
+- Preset input → query building (all 3 flows)
+- Preset endpoint → generic advisor request mapping (channel, metadata, flow_type)
+- Structured response shape with expected fields
+- Evidence/metrics tagging with flow_type and channel
+- Channel-specific formatting (DATEV structured, SAP structured, web default)
+- flow_type in metrics aggregation
+"""
+
+from __future__ import annotations
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+from app.advisor.formatting import (
+    derive_next_steps,
+    derive_tags,
+    format_answer_for_channel,
+)
+from app.advisor.metrics import aggregate_advisor_metrics
+from app.advisor.presets import (
+    EU_AI_ACT_RISK_EXTRA_TAGS,
+    ISO42001_GAP_EXTRA_TAGS,
+    NIS2_OBLIGATIONS_EXTRA_TAGS,
+    PRESET_REGISTRY,
+    EuAiActRiskAssessmentInput,
+    FlowType,
+    Iso42001GapCheckInput,
+    Nis2ObligationsInput,
+    build_eu_ai_act_risk_query,
+    build_iso42001_gap_query,
+    build_nis2_obligations_query,
+)
+from app.advisor.service import AdvisorRequest, run_advisor
+from app.advisor.templates import (
+    DISCLAIMER_KANZLEI,
+    DISCLAIMER_KEINE_RECHTSBERATUNG,
+)
+from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+from app.services.rag.config import RAGConfig
+from app.services.rag.corpus import Document
+from app.services.rag.evidence_store import (
+    clear_for_tests as clear_evidence,
+)
+from app.services.rag.evidence_store import (
+    list_advisor_agent_events,
+)
+from app.services.rag.hybrid_retriever import HybridRetriever
+from app.services.rag.llm import LlmCallContext, LlmResponse
+
+MOCK_CORPUS = [
+    Document(
+        doc_id="p-1",
+        title="EU AI Act Art. 6 Hochrisiko",
+        content=(
+            "Hochrisiko KI-Systeme sind solche die als Sicherheitskomponente "
+            "unter EU-Harmonisierungsrecht fallen oder in Anhang III gelistet sind. "
+            "Die Klassifizierung als Hochrisiko-System erfordert eine "
+            "Konformitätsbewertung nach den Verfahren gemäß Art. 43."
+        ),
+        source="EU AI Act",
+        section="Art. 6",
+    ),
+    Document(
+        doc_id="p-2",
+        title="NIS2 Art. 21 Risikomanagement",
+        content=(
+            "Wesentliche und wichtige Einrichtungen müssen technische, "
+            "betriebliche und organisatorische Maßnahmen zum "
+            "Risikomanagement ergreifen. KRITIS-nahe Zulieferer unterliegen "
+            "besonderen Meldepflichten nach Art. 23."
+        ),
+        source="NIS2",
+        section="Art. 21",
+    ),
+    Document(
+        doc_id="p-3",
+        title="ISO 42001 Anforderungen",
+        content=(
+            "ISO 42001 AI Management System erfordert ein KI-Governance-Framework "
+            "mit Risikobewertung, Verantwortlichkeiten und kontinuierlicher "
+            "Verbesserung. Gap-Analyse gegen die Norm identifiziert fehlende "
+            "Prozesse und Kontrollen."
+        ),
+        source="ISO 42001",
+        section="4-10",
+    ),
+]
+
+
+def _mock_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    return LlmResponse(
+        text=(
+            "Basierend auf Art. 6 EU AI Act und Anhang III "
+            "ist Ihr KI-System wahrscheinlich hochrisikorelevant."
+        ),
+        model_id="mock-model",
+        input_tokens=50,
+        output_tokens=30,
+    )
+
+
+def _make_agent(llm_fn=_mock_llm) -> AdvisorComplianceAgent:
+    config = RAGConfig(retrieval_mode="bm25")
+    retriever = HybridRetriever(MOCK_CORPUS, config)
+    return AdvisorComplianceAgent(retriever=retriever, llm_fn=llm_fn)
+
+
+# ---------------------------------------------------------------------------
+# Query building
+# ---------------------------------------------------------------------------
+
+
+class TestQueryBuilding:
+    def test_eu_ai_act_risk_query_contains_use_case(self) -> None:
+        inp = EuAiActRiskAssessmentInput(
+            use_case_description="Automatisierte Kreditwürdigkeitsprüfung",
+            industry_sector="Finanzdienstleistungen",
+            intended_purpose="Bonitätsbewertung natürlicher Personen",
+        )
+        q = build_eu_ai_act_risk_query(inp)
+        assert "hochrisikorelevant" in q
+        assert "Kreditwürdigkeitsprüfung" in q
+        assert "Finanzdienstleistungen" in q
+        assert "Art. 6" in q
+
+    def test_eu_ai_act_risk_query_minimal(self) -> None:
+        inp = EuAiActRiskAssessmentInput(
+            use_case_description="Chatbot für FAQ",
+        )
+        q = build_eu_ai_act_risk_query(inp)
+        assert "Chatbot" in q
+        assert "Branche:" not in q
+
+    def test_nis2_obligations_query_contains_role(self) -> None:
+        inp = Nis2ObligationsInput(
+            entity_role="KRITIS-naher Zulieferer",
+            sector="Energie",
+            employee_count="250+",
+        )
+        q = build_nis2_obligations_query(inp)
+        assert "NIS2" in q
+        assert "KRITIS-naher Zulieferer" in q
+        assert "Energie" in q
+        assert "250+" in q
+
+    def test_nis2_obligations_query_minimal(self) -> None:
+        inp = Nis2ObligationsInput(entity_role="Betreiber wesentlicher Dienste")
+        q = build_nis2_obligations_query(inp)
+        assert "Betreiber wesentlicher Dienste" in q
+        assert "Sektor:" not in q
+
+    def test_iso42001_gap_query_contains_measures(self) -> None:
+        inp = Iso42001GapCheckInput(
+            current_measures="Wir haben ein ISMS nach ISO 27001",
+            ai_system_count="5",
+        )
+        q = build_iso42001_gap_query(inp)
+        assert "ISO 42001" in q
+        assert "ISMS" in q
+        assert "5" in q
+
+    def test_iso42001_gap_query_minimal(self) -> None:
+        inp = Iso42001GapCheckInput(current_measures="Keine formalen KI-Governance-Maßnahmen")
+        q = build_iso42001_gap_query(inp)
+        assert "Lücken" in q
+        assert "Keine formalen" in q
+
+
+# ---------------------------------------------------------------------------
+# Preset → generic AdvisorRequest mapping
+# ---------------------------------------------------------------------------
+
+
+class TestPresetRequestMapping:
+    def setup_method(self) -> None:
+        clear_evidence()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+
+    def test_eu_ai_act_preset_maps_flow_type_and_tags(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_eu_ai_act_risk_query(
+                EuAiActRiskAssessmentInput(
+                    use_case_description="Automatisierte Gesichtserkennung",
+                ),
+            ),
+            tenant_id="test-t",
+            channel=AdvisorChannel.datev,
+            channel_metadata=ChannelMetadata(datev_client_number="12345"),
+            flow_type=FlowType.eu_ai_act_risk_assessment.value,
+            extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert resp.meta.flow_type == "eu_ai_act_risk_assessment"
+        assert "eu_ai_act" in resp.tags
+        assert "high_risk" in resp.tags
+        assert resp.ref_ids.get("flow_type") == "eu_ai_act_risk_assessment"
+        assert resp.ref_ids.get("datev_client_number") == "12345"
+
+    def test_nis2_preset_maps_channel_and_flow_type(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_nis2_obligations_query(
+                Nis2ObligationsInput(entity_role="KRITIS-naher Zulieferer"),
+            ),
+            tenant_id="test-t",
+            channel=AdvisorChannel.sap,
+            channel_metadata=ChannelMetadata(sap_document_id="SAP-001"),
+            flow_type=FlowType.nis2_obligations.value,
+            extra_tags=NIS2_OBLIGATIONS_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert resp.meta.flow_type == "nis2_obligations"
+        assert resp.meta.channel == AdvisorChannel.sap
+        assert "nis2" in resp.tags
+        assert resp.ref_ids.get("sap_document_id") == "SAP-001"
+
+    def test_iso42001_preset_web_channel_defaults(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_iso42001_gap_query(
+                Iso42001GapCheckInput(
+                    current_measures="Wir haben keine formalen KI-Governance-Prozesse",
+                ),
+            ),
+            tenant_id="test-t",
+            flow_type=FlowType.iso42001_gap_check.value,
+            extra_tags=ISO42001_GAP_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert resp.meta.flow_type == "iso42001_gap_check"
+        assert resp.meta.channel == AdvisorChannel.web
+        assert "iso_42001" in resp.tags
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+class TestPresetResponseShape:
+    def setup_method(self) -> None:
+        clear_evidence()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+
+    def test_response_has_structured_fields(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_eu_ai_act_risk_query(
+                EuAiActRiskAssessmentInput(
+                    use_case_description="KI-gestützte Personalauswahl",
+                ),
+            ),
+            tenant_id="test-t",
+            flow_type=FlowType.eu_ai_act_risk_assessment.value,
+            extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert isinstance(resp.tags, list)
+        assert isinstance(resp.suggested_next_steps, list)
+        assert isinstance(resp.ref_ids, dict)
+        assert resp.answer
+        assert resp.meta.latency_ms is not None
+        assert resp.meta.latency_ms > 0
+
+    def test_datev_channel_uses_structured_format(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_eu_ai_act_risk_query(
+                EuAiActRiskAssessmentInput(
+                    use_case_description="Automatisierte Bilanzanalyse mit KI",
+                ),
+            ),
+            tenant_id="test-t",
+            channel=AdvisorChannel.datev,
+            flow_type=FlowType.eu_ai_act_risk_assessment.value,
+            extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert "Schlagworte:" in resp.answer
+        assert "Empfohlene nächste Schritte:" in resp.answer
+        assert DISCLAIMER_KANZLEI in resp.answer
+
+    def test_web_channel_uses_normal_format(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_eu_ai_act_risk_query(
+                EuAiActRiskAssessmentInput(
+                    use_case_description="Automatisierte Bilanzanalyse",
+                ),
+            ),
+            tenant_id="test-t",
+            channel=AdvisorChannel.web,
+            flow_type=FlowType.eu_ai_act_risk_assessment.value,
+            extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        )
+
+        resp = run_advisor(request, agent)
+
+        assert DISCLAIMER_KEINE_RECHTSBERATUNG in resp.answer
+        assert "Schlagworte:" not in resp.answer
+
+
+# ---------------------------------------------------------------------------
+# Evidence & metrics flow_type tagging
+# ---------------------------------------------------------------------------
+
+
+class TestEvidenceAndMetrics:
+    def setup_method(self) -> None:
+        clear_evidence()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+
+    def test_flow_type_logged_in_agent_events(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_eu_ai_act_risk_query(
+                EuAiActRiskAssessmentInput(
+                    use_case_description="KI für Qualitätskontrolle",
+                ),
+            ),
+            tenant_id="preset-t",
+            channel=AdvisorChannel.datev,
+            flow_type=FlowType.eu_ai_act_risk_assessment.value,
+            extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        )
+
+        run_advisor(request, agent)
+
+        events = list_advisor_agent_events("preset-t", limit=10)
+        assert len(events) >= 1
+        service_event = events[0]
+        extra = service_event.get("extra", {})
+        assert extra.get("flow_type") == "eu_ai_act_risk_assessment"
+        assert extra.get("channel") == "datev"
+
+    def test_flow_type_in_metrics_aggregation(self) -> None:
+        agent = _make_agent()
+        for ft, query_fn, inp in [
+            (
+                FlowType.eu_ai_act_risk_assessment,
+                build_eu_ai_act_risk_query,
+                EuAiActRiskAssessmentInput(
+                    use_case_description="KI für Qualitätskontrolle in der Fertigung",
+                ),
+            ),
+            (
+                FlowType.nis2_obligations,
+                build_nis2_obligations_query,
+                Nis2ObligationsInput(entity_role="KRITIS-Betreiber"),
+            ),
+        ]:
+            request = AdvisorRequest(
+                query=query_fn(inp),
+                tenant_id="metrics-t",
+                flow_type=ft.value,
+                extra_tags=PRESET_REGISTRY[ft]["extra_tags"],
+            )
+            run_advisor(request, agent)
+
+        metrics = aggregate_advisor_metrics(tenant_id="metrics-t")
+        ftd = metrics.flow_type_distribution
+        assert ftd.get("eu_ai_act_risk_assessment", 0) >= 1
+        assert ftd.get("nis2_obligations", 0) >= 1
+
+    def test_sap_channel_in_metrics_distribution(self) -> None:
+        agent = _make_agent()
+        request = AdvisorRequest(
+            query=build_nis2_obligations_query(
+                Nis2ObligationsInput(entity_role="Digitaler Dienstleister"),
+            ),
+            tenant_id="sap-metrics-t",
+            channel=AdvisorChannel.sap,
+            flow_type=FlowType.nis2_obligations.value,
+            extra_tags=NIS2_OBLIGATIONS_EXTRA_TAGS,
+        )
+
+        run_advisor(request, agent)
+
+        metrics = aggregate_advisor_metrics(tenant_id="sap-metrics-t")
+        assert metrics.channel_distribution.get("sap", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Channel-specific formatting
+# ---------------------------------------------------------------------------
+
+
+class TestChannelFormatting:
+    def test_datev_structured_format_with_kanzlei_disclaimer(self) -> None:
+        answer = "Dies ist eine Testantwort zum EU AI Act."
+        tags = ["eu_ai_act", "high_risk"]
+        steps = ["Konformitätsbewertung prüfen"]
+
+        formatted = format_answer_for_channel(
+            answer,
+            AdvisorChannel.datev,
+            tags=tags,
+            next_steps=steps,
+        )
+
+        assert "Schlagworte: eu_ai_act, high_risk" in formatted
+        assert "Konformitätsbewertung prüfen" in formatted
+        assert DISCLAIMER_KANZLEI in formatted
+
+    def test_sap_structured_format_with_short_disclaimer(self) -> None:
+        answer = "NIS2-Pflichten für KRITIS-nahe Zulieferer."
+        tags = ["nis2"]
+        steps = ["Meldepflichten prüfen"]
+
+        formatted = format_answer_for_channel(
+            answer,
+            AdvisorChannel.sap,
+            tags=tags,
+            next_steps=steps,
+        )
+
+        assert "Schlagworte: nis2" in formatted
+        assert DISCLAIMER_KANZLEI not in formatted
+
+    def test_web_channel_no_structured_fields_in_answer(self) -> None:
+        answer = "Testantwort."
+        formatted = format_answer_for_channel(
+            answer,
+            AdvisorChannel.web,
+            tags=["eu_ai_act"],
+            next_steps=["prüfen"],
+        )
+        assert "Schlagworte:" not in formatted
+
+    def test_derive_tags_detects_preset_topics(self) -> None:
+        tags = derive_tags(
+            "Hochrisiko KI-System nach EU AI Act",
+            "Art. 6 Konformitätsbewertung erforderlich",
+        )
+        assert "eu_ai_act" in tags
+        assert "high_risk" in tags
+        assert "article_reference" in tags
+
+    def test_derive_next_steps_includes_ai_act_and_nis2(self) -> None:
+        tags = ["eu_ai_act", "nis2", "high_risk"]
+        steps = derive_next_steps(False, "high", tags)
+        assert "EU AI Act Konformitätsbewertung prüfen" in steps
+        assert "NIS2-Meldepflichten überprüfen" in steps
+        assert "Hochrisiko-Klassifizierung dokumentieren" in steps
+
+
+# ---------------------------------------------------------------------------
+# Preset registry completeness
+# ---------------------------------------------------------------------------
+
+
+class TestPresetRegistry:
+    def test_all_flow_types_in_registry(self) -> None:
+        from app.advisor.presets import PRESET_REGISTRY
+
+        for ft in FlowType:
+            assert ft in PRESET_REGISTRY, f"{ft} missing from PRESET_REGISTRY"
+            entry = PRESET_REGISTRY[ft]
+            assert callable(entry["build_query"])
+            assert isinstance(entry["extra_tags"], list)
+            assert len(entry["extra_tags"]) > 0


### PR DESCRIPTION
- Add 3 preset micro-flows: EU AI Act risk assessment, NIS2 obligations, ISO 42001 gap check — each with typed input schema, query builder, and extra tags (app/advisor/presets.py).
- Add thin preset API endpoints at /api/v1/advisor/presets/* that map structured input → generic advisor call with OPA policy enforcement per flow_type.
- Extend channel formatting: DATEV/SAP channels now produce structured answers with tags + next steps embedded in text, DATEV gets stronger Kanzlei-specific disclaimer.
- Propagate flow_type through AdvisorRequest → response meta, ref_ids, and evidence/metrics events for per-flow analytics.
- Add flow_type_distribution to advisor metrics aggregation.
- Add 21 tests covering query building, request mapping, response shape, evidence tagging, channel formatting, and registry.
- Add architecture doc (wave9-advisor-presets-and-datev-sap-alignment.md).

Made-with: Cursor