### PR TITLE
feat(wave9.1): enterprise-ready advisor presets — tenant/GRC/contracts

### DIFF
--- a/app/advisor/enterprise_context.py
+++ b/app/advisor/enterprise_context.py
@@ -1,0 +1,59 @@
+"""Enterprise tenant/mandant context for advisor presets.
+
+Separates:
+- SaaS tenant (our platform customer)
+- Client / Mandant (Kanzlei's end client in DATEV context)
+- AI system reference (for EU AI Act / ISO 42001 scoping)
+
+All fields are additive and backward compatible — callers that
+don't supply client_id or system_id get the same behaviour as before.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class EnterpriseContext(BaseModel):
+    """Identifies the organisational context for a preset invocation.
+
+    Example (DATEV Kanzlei):
+        tenant_id="kanzlei-mueller"
+        client_id="mandant-12345"
+        system_id=None
+
+    Example (SAP S/4HANA):
+        tenant_id="acme-gmbh"
+        client_id=None
+        system_id="HR-AI-Recruiting-01"
+    """
+
+    tenant_id: str = Field(
+        default="",
+        description="ComplianceHub SaaS tenant identifier",
+    )
+    client_id: str = Field(
+        default="",
+        description=(
+            "Mandant / client identifier within the tenant "
+            "(e.g. DATEV Mandantennummer, SAP Buchungskreis)"
+        ),
+    )
+    system_id: str = Field(
+        default="",
+        description=(
+            "Reference to a specific AI system or use case "
+            "(e.g. EU AI Act Anhang-III ID, internal asset ID)"
+        ),
+    )
+
+    def evidence_dict(self) -> dict[str, str]:
+        """Return non-empty context fields for evidence payloads."""
+        d: dict[str, str] = {}
+        if self.tenant_id:
+            d["tenant_id"] = self.tenant_id
+        if self.client_id:
+            d["client_id"] = self.client_id
+        if self.system_id:
+            d["system_id"] = self.system_id
+        return d

--- a/app/advisor/metrics.py
+++ b/app/advisor/metrics.py
@@ -44,6 +44,7 @@ class AdvisorMetricsResponse(BaseModel):
     agent_decision_distribution: dict[str, int] = Field(default_factory=dict)
     channel_distribution: dict[str, int] = Field(default_factory=dict)
     flow_type_distribution: dict[str, int] = Field(default_factory=dict)
+    client_id_distribution: dict[str, int] = Field(default_factory=dict)
     latency_p50_ms: float | None = None
     latency_p95_ms: float | None = None
     daily: list[AdvisorDailyMetrics] = Field(default_factory=list)
@@ -83,6 +84,7 @@ def aggregate_advisor_metrics(
     daily_map: dict[tuple[str, str], AdvisorDailyMetrics] = {}
     channel_counts: dict[str, int] = defaultdict(int)
     flow_type_counts: dict[str, int] = defaultdict(int)
+    client_id_counts: dict[str, int] = defaultdict(int)
     latencies: list[float] = []
 
     for tid in tenants:
@@ -95,6 +97,7 @@ def aggregate_advisor_metrics(
             limit,
             channel_counts=channel_counts,
             flow_type_counts=flow_type_counts,
+            client_id_counts=client_id_counts,
             latencies=latencies,
         )
 
@@ -103,6 +106,7 @@ def aggregate_advisor_metrics(
     totals = _compute_totals(daily)
     totals["channel_distribution"] = dict(channel_counts)
     totals["flow_type_distribution"] = dict(flow_type_counts)
+    totals["client_id_distribution"] = dict(client_id_counts)
 
     if latencies:
         latencies.sort()
@@ -176,6 +180,7 @@ def _aggregate_agent_events(
     *,
     channel_counts: dict[str, int] | None = None,
     flow_type_counts: dict[str, int] | None = None,
+    client_id_counts: dict[str, int] | None = None,
     latencies: list[float] | None = None,
 ) -> None:
     events = list_advisor_agent_events(tenant_id, limit=limit)
@@ -207,6 +212,10 @@ def _aggregate_agent_events(
         ft = extra.get("flow_type")
         if ft and flow_type_counts is not None:
             flow_type_counts[ft] = flow_type_counts.get(ft, 0) + 1
+
+        cid = extra.get("client_id")
+        if cid and client_id_counts is not None:
+            client_id_counts[cid] = client_id_counts.get(cid, 0) + 1
 
         lat = extra.get("latency_ms")
         if lat is not None and latencies is not None:

--- a/app/advisor/preset_models.py
+++ b/app/advisor/preset_models.py
@@ -1,0 +1,255 @@
+"""Enterprise preset input/output models with GRC alignment.
+
+Each preset has:
+- A typed input with enterprise context (tenant, client, system)
+- A typed result separating human-readable and machine-readable fields
+- GRC-specific fields that downstream ISMS/GRC modules can consume
+
+Response contract version: v1 — callers can rely on field stability.
+
+Example consumption (SAP BTP adapter):
+
+    resp = call_preset("/api/v1/advisor/presets/eu-ai-act-risk-assessment", body)
+    if resp.grc.high_risk_likelihood == "likely":
+        create_sap_grc_finding(
+            risk_category=resp.grc.risk_category,
+            use_case_type=resp.grc.use_case_type,
+            recommendation=resp.machine.suggested_next_steps[0],
+        )
+
+Example consumption (DATEV DMS adapter):
+
+    resp = call_preset("/api/v1/advisor/presets/nis2-obligations", body)
+    create_datev_aufgabe(
+        mandant=resp.context.client_id,
+        pflichten=resp.grc.obligation_tags,
+        hinweis=resp.human.answer_de,
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+from app.advisor.enterprise_context import EnterpriseContext
+from app.advisor.errors import AdvisorError
+
+RESPONSE_CONTRACT_VERSION = "v1"
+
+
+# ---------------------------------------------------------------------------
+# Shared base for all preset inputs
+# ---------------------------------------------------------------------------
+
+
+class PresetInputBase(BaseModel):
+    """Fields shared across all preset input schemas."""
+
+    context: EnterpriseContext = Field(default_factory=EnterpriseContext)
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+
+    # Legacy compat: callers can still set tenant_id at top level
+    tenant_id: str = ""
+
+    def effective_tenant_id(self) -> str:
+        return self.context.tenant_id or self.tenant_id
+
+
+# ---------------------------------------------------------------------------
+# Preset 1: EU AI Act Risk Assessment
+# ---------------------------------------------------------------------------
+
+
+class AiActRiskPresetInput(PresetInputBase):
+    """Input for EU AI Act high-risk classification assessment.
+
+    Example:
+        {
+            "context": {"tenant_id": "kanzlei-mueller", "client_id": "mandant-12345"},
+            "use_case_description": "KI-gestützte Kreditwürdigkeitsprüfung",
+            "industry_sector": "Finanzdienstleistungen",
+            "intended_purpose": "Bonitätsbewertung natürlicher Personen",
+            "channel": "datev"
+        }
+    """
+
+    use_case_description: str = Field(
+        ...,
+        min_length=10,
+        max_length=4000,
+    )
+    industry_sector: str = ""
+    intended_purpose: str = ""
+
+
+class AiActRiskGrc(BaseModel):
+    """GRC fields for EU AI Act risk assessment results."""
+
+    risk_category: str = Field(
+        default="unclassified",
+        description="high_risk | limited_risk | minimal_risk | unclassified",
+    )
+    use_case_type: str = Field(
+        default="",
+        description="E.g. 'credit_scoring', 'recruitment', 'biometric_identification'",
+    )
+    high_risk_likelihood: str = Field(
+        default="unknown",
+        description="likely | unlikely | unclear | unknown",
+    )
+    annex_iii_category: str = Field(
+        default="",
+        description="Annex III category if applicable (e.g. '1(a) biometrics')",
+    )
+    conformity_assessment_required: bool | None = None
+
+
+# ---------------------------------------------------------------------------
+# Preset 2: NIS2 Obligations
+# ---------------------------------------------------------------------------
+
+
+class Nis2ObligationsPresetInput(PresetInputBase):
+    """Input for NIS2 obligation mapping.
+
+    Example:
+        {
+            "context": {"tenant_id": "acme-gmbh", "system_id": "WERK-SUED"},
+            "entity_role": "KRITIS-naher Zulieferer",
+            "sector": "Energie",
+            "employee_count": "250+",
+            "channel": "sap"
+        }
+    """
+
+    entity_role: str = Field(..., min_length=3, max_length=500)
+    sector: str = ""
+    employee_count: str = ""
+
+
+class Nis2ObligationsGrc(BaseModel):
+    """GRC fields for NIS2 obligation results."""
+
+    nis2_entity_type: str = Field(
+        default="",
+        description="essential | important | out_of_scope",
+    )
+    obligation_tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "E.g. ['incident_reporting', 'risk_management', 'supply_chain', "
+            "'bcm', 'governance', 'registration']"
+        ),
+    )
+    reporting_deadlines: list[str] = Field(
+        default_factory=list,
+        description="E.g. ['24h_early_warning', '72h_notification']",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Preset 3: ISO 42001 Gap Check
+# ---------------------------------------------------------------------------
+
+
+class Iso42001GapCheckPresetInput(PresetInputBase):
+    """Input for ISO 42001 gap analysis.
+
+    Example:
+        {
+            "context": {"tenant_id": "tech-ag", "client_id": "", "system_id": "AI-PLATFORM-01"},
+            "current_measures": "ISMS nach ISO 27001 zertifiziert, kein formales KI-Governance",
+            "ai_system_count": "12",
+            "channel": "web"
+        }
+    """
+
+    current_measures: str = Field(..., min_length=10, max_length=4000)
+    ai_system_count: str = ""
+
+
+class Iso42001GapGrc(BaseModel):
+    """GRC fields for ISO 42001 gap check results."""
+
+    control_families: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Affected control families: governance, risk, data, monitoring, lifecycle, transparency"
+        ),
+    )
+    gap_severity: str = Field(
+        default="unknown",
+        description="critical | major | minor | none | unknown",
+    )
+    iso27001_overlap: bool | None = Field(
+        default=None,
+        description="Whether existing ISO 27001 controls partially cover the gap",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unified preset response
+# ---------------------------------------------------------------------------
+
+
+class PresetHumanReadable(BaseModel):
+    """Human-readable portion of the preset response (for advisors/UI)."""
+
+    answer_de: str = ""
+    is_escalated: bool = False
+    escalation_reason: str = ""
+    confidence_level: str = "low"
+
+
+class PresetMachineReadable(BaseModel):
+    """Machine-readable portion for downstream systems (SAP/DATEV/GRC)."""
+
+    tags: list[str] = Field(default_factory=list)
+    suggested_next_steps: list[str] = Field(default_factory=list)
+    ref_ids: dict[str, str] = Field(default_factory=dict)
+    intent: str = ""
+
+
+class PresetResponseMeta(BaseModel):
+    """Response metadata for tracing, caching, and versioning."""
+
+    version: str = RESPONSE_CONTRACT_VERSION
+    flow_type: str = ""
+    channel: AdvisorChannel = AdvisorChannel.web
+    channel_metadata: ChannelMetadata | None = None
+    request_id: str | None = None
+    trace_id: str | None = None
+    latency_ms: float | None = None
+    is_cached: bool = False
+    context: EnterpriseContext = Field(default_factory=EnterpriseContext)
+
+
+class PresetResult(BaseModel):
+    """Enterprise-ready preset response with separated concerns.
+
+    - ``human``: text answer for advisors and UIs
+    - ``machine``: structured tags, steps, references for integrations
+    - ``grc``: domain-specific GRC fields (varies per preset type)
+    - ``meta``: tracing, versioning, caching metadata
+    - ``error``: non-None on failure
+
+    Contract version: v1. Fields are additive; no removals without
+    version bump.
+    """
+
+    human: PresetHumanReadable = Field(default_factory=PresetHumanReadable)
+    machine: PresetMachineReadable = Field(default_factory=PresetMachineReadable)
+    grc: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Preset-specific GRC fields (AiActRiskGrc, Nis2ObligationsGrc, etc.)",
+    )
+    meta: PresetResponseMeta = Field(default_factory=PresetResponseMeta)
+    error: AdvisorError | None = None
+    needs_manual_followup: bool = False
+    agent_trace: list[dict[str, Any]] = Field(default_factory=list)

--- a/app/advisor/preset_service.py
+++ b/app/advisor/preset_service.py
@@ -1,0 +1,423 @@
+"""Preset service layer — anti-corruption boundary for enterprise callers.
+
+This module is the single entry point for all preset invocations. It:
+- Maps external preset inputs to internal AdvisorRequest
+- Runs the generic advisor agent via run_advisor()
+- Derives GRC-specific fields from the advisor response
+- Builds the enterprise PresetResult with separated human/machine/grc
+- Tags evidence events with flow_type, client_id, system_id
+- Enforces per-preset SLA timeouts
+
+REST controllers, Temporal workflows, and future SAP/DATEV connectors
+should all call these functions — never the raw advisor agent directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from app.advisor.channels import ChannelMetadata
+from app.advisor.errors import ADVISOR_SLA_TIMEOUT_SECONDS
+from app.advisor.preset_models import (
+    RESPONSE_CONTRACT_VERSION,
+    AiActRiskGrc,
+    AiActRiskPresetInput,
+    Iso42001GapCheckPresetInput,
+    Iso42001GapGrc,
+    Nis2ObligationsGrc,
+    Nis2ObligationsPresetInput,
+    PresetHumanReadable,
+    PresetInputBase,
+    PresetMachineReadable,
+    PresetResponseMeta,
+    PresetResult,
+)
+from app.advisor.presets import (
+    EU_AI_ACT_RISK_EXTRA_TAGS,
+    ISO42001_GAP_EXTRA_TAGS,
+    NIS2_OBLIGATIONS_EXTRA_TAGS,
+    FlowType,
+    build_eu_ai_act_risk_query,
+    build_iso42001_gap_query,
+    build_nis2_obligations_query,
+)
+from app.advisor.response_models import AdvisorStructuredResponse
+from app.advisor.service import AdvisorRequest, run_advisor
+
+logger = logging.getLogger(__name__)
+
+PRESET_SLA_TIMEOUTS: dict[FlowType, float] = {
+    FlowType.eu_ai_act_risk_assessment: 45.0,
+    FlowType.nis2_obligations: ADVISOR_SLA_TIMEOUT_SECONDS,
+    FlowType.iso42001_gap_check: 45.0,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API — one function per preset
+# ---------------------------------------------------------------------------
+
+
+def run_eu_ai_act_risk_preset(
+    inp: AiActRiskPresetInput,
+    agent: Any = None,
+) -> PresetResult:
+    """EU AI Act high-risk classification preset.
+
+    Builds a German-language query from the structured input, runs it
+    through the advisor agent, then derives GRC risk fields from the
+    response.
+    """
+    from app.advisor.presets import EuAiActRiskAssessmentInput
+
+    legacy = EuAiActRiskAssessmentInput(
+        use_case_description=inp.use_case_description,
+        industry_sector=inp.industry_sector,
+        intended_purpose=inp.intended_purpose,
+    )
+    query = build_eu_ai_act_risk_query(legacy)
+
+    raw = _run_preset_core(
+        flow_type=FlowType.eu_ai_act_risk_assessment,
+        query=query,
+        inp=inp,
+        extra_tags=EU_AI_ACT_RISK_EXTRA_TAGS,
+        agent=agent,
+    )
+
+    grc = _derive_ai_act_risk_grc(raw, inp)
+    return _build_preset_result(
+        raw,
+        inp,
+        FlowType.eu_ai_act_risk_assessment,
+        grc.model_dump(),
+    )
+
+
+def run_nis2_obligations_preset(
+    inp: Nis2ObligationsPresetInput,
+    agent: Any = None,
+) -> PresetResult:
+    """NIS2 obligation mapping preset."""
+    from app.advisor.presets import Nis2ObligationsInput
+
+    legacy = Nis2ObligationsInput(
+        entity_role=inp.entity_role,
+        sector=inp.sector,
+        employee_count=inp.employee_count,
+    )
+    query = build_nis2_obligations_query(legacy)
+
+    raw = _run_preset_core(
+        flow_type=FlowType.nis2_obligations,
+        query=query,
+        inp=inp,
+        extra_tags=NIS2_OBLIGATIONS_EXTRA_TAGS,
+        agent=agent,
+    )
+
+    grc = _derive_nis2_grc(raw, inp)
+    return _build_preset_result(
+        raw,
+        inp,
+        FlowType.nis2_obligations,
+        grc.model_dump(),
+    )
+
+
+def run_iso42001_gap_preset(
+    inp: Iso42001GapCheckPresetInput,
+    agent: Any = None,
+) -> PresetResult:
+    """ISO 42001 gap analysis preset."""
+    from app.advisor.presets import Iso42001GapCheckInput
+
+    legacy = Iso42001GapCheckInput(
+        current_measures=inp.current_measures,
+        ai_system_count=inp.ai_system_count,
+    )
+    query = build_iso42001_gap_query(legacy)
+
+    raw = _run_preset_core(
+        flow_type=FlowType.iso42001_gap_check,
+        query=query,
+        inp=inp,
+        extra_tags=ISO42001_GAP_EXTRA_TAGS,
+        agent=agent,
+    )
+
+    grc = _derive_iso42001_grc(raw, inp)
+    return _build_preset_result(
+        raw,
+        inp,
+        FlowType.iso42001_gap_check,
+        grc.model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_or_create_agent(agent: Any) -> Any:
+    if agent is not None:
+        return agent
+    from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+    from app.services.rag.config import RAGConfig
+    from app.services.rag.corpus_loader import load_advisor_corpus
+    from app.services.rag.hybrid_retriever import HybridRetriever
+
+    corpus = load_advisor_corpus()
+    config = RAGConfig()
+    retriever = HybridRetriever(corpus, config)
+    return AdvisorComplianceAgent(retriever=retriever)
+
+
+def _run_preset_core(
+    *,
+    flow_type: FlowType,
+    query: str,
+    inp: PresetInputBase,
+    extra_tags: list[str],
+    agent: Any = None,
+) -> AdvisorStructuredResponse:
+    """Map preset input → AdvisorRequest → run_advisor()."""
+    ctx = inp.context
+    if not ctx.tenant_id and inp.tenant_id:
+        ctx.tenant_id = inp.tenant_id
+    cm = inp.channel_metadata or ChannelMetadata()
+    if ctx.client_id and not cm.datev_client_number:
+        cm.datev_client_number = ctx.client_id
+
+    request = AdvisorRequest(
+        query=query,
+        tenant_id=inp.effective_tenant_id(),
+        channel=inp.channel,
+        channel_metadata=cm,
+        request_id=inp.request_id,
+        trace_id=inp.trace_id,
+        flow_type=flow_type.value,
+        extra_tags=extra_tags,
+        client_id=ctx.client_id,
+        system_id=ctx.system_id,
+    )
+
+    resolved_agent = _get_or_create_agent(agent)
+    timeout = PRESET_SLA_TIMEOUTS.get(flow_type, ADVISOR_SLA_TIMEOUT_SECONDS)
+    return run_advisor(request, resolved_agent, timeout_seconds=timeout)
+
+
+def _build_preset_result(
+    raw: AdvisorStructuredResponse,
+    inp: PresetInputBase,
+    flow_type: FlowType,
+    grc_fields: dict[str, Any],
+) -> PresetResult:
+    ref_ids = dict(raw.ref_ids)
+    ctx = inp.context
+    if ctx.client_id:
+        ref_ids["client_id"] = ctx.client_id
+    if ctx.system_id:
+        ref_ids["system_id"] = ctx.system_id
+
+    return PresetResult(
+        human=PresetHumanReadable(
+            answer_de=raw.answer,
+            is_escalated=raw.is_escalated,
+            escalation_reason=raw.escalation_reason,
+            confidence_level=raw.confidence_level,
+        ),
+        machine=PresetMachineReadable(
+            tags=raw.tags,
+            suggested_next_steps=raw.suggested_next_steps,
+            ref_ids=ref_ids,
+            intent=raw.intent,
+        ),
+        grc=grc_fields,
+        meta=PresetResponseMeta(
+            version=RESPONSE_CONTRACT_VERSION,
+            flow_type=flow_type.value,
+            channel=inp.channel,
+            channel_metadata=inp.channel_metadata,
+            request_id=inp.request_id,
+            trace_id=inp.trace_id,
+            latency_ms=raw.meta.latency_ms,
+            is_cached=raw.meta.is_cached,
+            context=ctx,
+        ),
+        error=raw.error,
+        needs_manual_followup=raw.needs_manual_followup,
+        agent_trace=raw.agent_trace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GRC field derivation (heuristic, from answer text + tags)
+# ---------------------------------------------------------------------------
+
+_HIGH_RISK_SIGNALS = re.compile(
+    r"hochrisiko|high.risk|anhang\s*iii|annex\s*iii",
+    re.IGNORECASE,
+)
+_LIMITED_RISK_SIGNALS = re.compile(
+    r"begrenztes\s*risiko|limited.risk|transparenzpflicht",
+    re.IGNORECASE,
+)
+_MINIMAL_RISK_SIGNALS = re.compile(
+    r"minimales?\s*risiko|minimal.risk|kein\s*hochrisiko|nicht.*hochrisiko",
+    re.IGNORECASE,
+)
+
+_USE_CASE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"kredit|bonität|scoring", re.IGNORECASE), "credit_scoring"),
+    (re.compile(r"recruit|personal|bewerbung", re.IGNORECASE), "recruitment"),
+    (re.compile(r"biometr", re.IGNORECASE), "biometric_identification"),
+    (re.compile(r"medizin|diagnos|gesundheit", re.IGNORECASE), "medical_device"),
+    (re.compile(r"autonom|fahrzeug|vehicle", re.IGNORECASE), "autonomous_systems"),
+    (re.compile(r"überwach|surveillance|monitor", re.IGNORECASE), "surveillance"),
+]
+
+_ANNEX_III_PATTERN = re.compile(
+    r"anhang\s*iii[^.]{0,80}(?:nr\.?\s*|kategorie\s*)(\d+)",
+    re.IGNORECASE,
+)
+
+
+def _derive_ai_act_risk_grc(
+    raw: AdvisorStructuredResponse,
+    inp: AiActRiskPresetInput,
+) -> AiActRiskGrc:
+    combined = f"{inp.use_case_description} {raw.answer}"
+
+    if _HIGH_RISK_SIGNALS.search(raw.answer):
+        likelihood = "likely"
+        risk_cat = "high_risk"
+    elif _MINIMAL_RISK_SIGNALS.search(raw.answer):
+        likelihood = "unlikely"
+        risk_cat = "minimal_risk"
+    elif _LIMITED_RISK_SIGNALS.search(raw.answer):
+        likelihood = "unclear"
+        risk_cat = "limited_risk"
+    else:
+        likelihood = "unknown"
+        risk_cat = "unclassified"
+
+    use_case_type = ""
+    for pat, uct in _USE_CASE_PATTERNS:
+        if pat.search(combined):
+            use_case_type = uct
+            break
+
+    annex_match = _ANNEX_III_PATTERN.search(raw.answer)
+    annex_cat = annex_match.group(0).strip() if annex_match else ""
+
+    conformity = None
+    if risk_cat == "high_risk":
+        conformity = True
+    elif risk_cat in ("minimal_risk", "limited_risk"):
+        conformity = False
+
+    return AiActRiskGrc(
+        risk_category=risk_cat,
+        use_case_type=use_case_type,
+        high_risk_likelihood=likelihood,
+        annex_iii_category=annex_cat,
+        conformity_assessment_required=conformity,
+    )
+
+
+_ENTITY_TYPE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"wesentlich|essential", re.IGNORECASE), "essential"),
+    (re.compile(r"wichtig|important", re.IGNORECASE), "important"),
+]
+
+_OBLIGATION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"meldepflicht|incident.report|frühwarnung", re.IGNORECASE), "incident_reporting"),
+    (re.compile(r"risikomanagement|risk.management", re.IGNORECASE), "risk_management"),
+    (re.compile(r"lieferkette|supply.chain", re.IGNORECASE), "supply_chain"),
+    (re.compile(r"bcm|business.continuity|kontinuität", re.IGNORECASE), "bcm"),
+    (re.compile(r"governance|leitungsorgan", re.IGNORECASE), "governance"),
+    (re.compile(r"registrierung|registration", re.IGNORECASE), "registration"),
+]
+
+_DEADLINE_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"24\s*(?:stunden|h).*(?:früh|early)", re.IGNORECASE), "24h_early_warning"),
+    (re.compile(r"72\s*(?:stunden|h)", re.IGNORECASE), "72h_notification"),
+    (re.compile(r"abschlussbericht|final.report", re.IGNORECASE), "final_report"),
+]
+
+
+def _derive_nis2_grc(
+    raw: AdvisorStructuredResponse,
+    inp: Nis2ObligationsPresetInput,
+) -> Nis2ObligationsGrc:
+    combined = f"{inp.entity_role} {raw.answer}"
+
+    entity_type = ""
+    for pat, et in _ENTITY_TYPE_PATTERNS:
+        if pat.search(combined):
+            entity_type = et
+            break
+
+    obligations: list[str] = []
+    for pat, tag in _OBLIGATION_PATTERNS:
+        if pat.search(combined):
+            obligations.append(tag)
+
+    deadlines: list[str] = []
+    for pat, dl in _DEADLINE_PATTERNS:
+        if pat.search(raw.answer):
+            deadlines.append(dl)
+
+    return Nis2ObligationsGrc(
+        nis2_entity_type=entity_type,
+        obligation_tags=sorted(set(obligations)),
+        reporting_deadlines=sorted(set(deadlines)),
+    )
+
+
+_CONTROL_FAMILY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"governance|verantwort|leitung", re.IGNORECASE), "governance"),
+    (re.compile(r"risiko|risk", re.IGNORECASE), "risk"),
+    (re.compile(r"daten|data", re.IGNORECASE), "data"),
+    (re.compile(r"monitor|überwach", re.IGNORECASE), "monitoring"),
+    (re.compile(r"lebenszyklus|lifecycle", re.IGNORECASE), "lifecycle"),
+    (re.compile(r"transparenz|transparency|erklär", re.IGNORECASE), "transparency"),
+]
+
+_GAP_SEVERITY_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"kritisch|critical|schwerwiegend", re.IGNORECASE), "critical"),
+    (re.compile(r"erheblich|major|wesentlich", re.IGNORECASE), "major"),
+    (re.compile(r"gering|minor|klein", re.IGNORECASE), "minor"),
+]
+
+
+def _derive_iso42001_grc(
+    raw: AdvisorStructuredResponse,
+    inp: Iso42001GapCheckPresetInput,
+) -> Iso42001GapGrc:
+    combined = f"{inp.current_measures} {raw.answer}"
+
+    families: list[str] = []
+    for pat, fam in _CONTROL_FAMILY_PATTERNS:
+        if pat.search(raw.answer):
+            families.append(fam)
+
+    severity = "unknown"
+    for pat, sev in _GAP_SEVERITY_PATTERNS:
+        if pat.search(raw.answer):
+            severity = sev
+            break
+
+    iso27001_overlap = None
+    if re.search(r"iso\s*27001", combined, re.IGNORECASE):
+        iso27001_overlap = True
+
+    return Iso42001GapGrc(
+        control_families=sorted(set(families)),
+        gap_severity=severity,
+        iso27001_overlap=iso27001_overlap,
+    )

--- a/app/advisor/service.py
+++ b/app/advisor/service.py
@@ -59,6 +59,8 @@ class AdvisorRequest:
         "trace_id",
         "flow_type",
         "extra_tags",
+        "client_id",
+        "system_id",
     )
 
     def __init__(
@@ -71,6 +73,8 @@ class AdvisorRequest:
         trace_id: str | None = None,
         flow_type: str | None = None,
         extra_tags: list[str] | None = None,
+        client_id: str = "",
+        system_id: str = "",
     ) -> None:
         self.query = query
         self.tenant_id = tenant_id
@@ -80,6 +84,8 @@ class AdvisorRequest:
         self.trace_id = trace_id
         self.flow_type = flow_type
         self.extra_tags = extra_tags
+        self.client_id = client_id
+        self.system_id = system_id
 
 
 def run_advisor(
@@ -233,6 +239,10 @@ def _log_invocation(
     }
     if request.flow_type:
         extra["flow_type"] = request.flow_type
+    if request.client_id:
+        extra["client_id"] = request.client_id
+    if request.system_id:
+        extra["system_id"] = request.system_id
     if response.error:
         extra["error_category"] = response.error.category.value
 

--- a/app/main.py
+++ b/app/main.py
@@ -32,15 +32,13 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from app.advisor.metrics import AdvisorMetricsResponse, aggregate_advisor_metrics
-from app.advisor.presets import (
-    PRESET_REGISTRY,
-    EuAiActRiskAssessmentInput,
-    FlowType,
-    Iso42001GapCheckInput,
-    Nis2ObligationsInput,
+from app.advisor.preset_models import (
+    AiActRiskPresetInput,
+    Iso42001GapCheckPresetInput,
+    Nis2ObligationsPresetInput,
+    PresetResult,
 )
-from app.advisor.response_models import AdvisorStructuredResponse
-from app.advisor.service import AdvisorRequest, run_advisor
+from app.advisor.presets import FlowType
 from app.advisor_client_snapshot_models import (
     AdvisorClientGovernanceSnapshotResponse,
     AdvisorGovernanceSnapshotMarkdownResponse,
@@ -4652,28 +4650,16 @@ def get_advisor_metrics(
 
 
 # ---------------------------------------------------------------------------
-# Advisor Preset Micro-Flows (Wave 9)
+# Advisor Preset Micro-Flows (Wave 9 / 9.1 enterprise)
 # ---------------------------------------------------------------------------
 
 
-def _make_advisor_agent() -> Any:
-    """Create a default AdvisorComplianceAgent from the global corpus."""
-    from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
-
-    corpus = load_advisor_corpus()
-    config = RAGConfig()
-    retriever = HybridRetriever(corpus, config)
-    return AdvisorComplianceAgent(retriever=retriever)
-
-
-def _run_preset(
+def _enforce_preset_opa(
     flow_type: FlowType,
-    query: str,
-    body: EuAiActRiskAssessmentInput | Nis2ObligationsInput | Iso42001GapCheckInput,
+    tenant_id: str,
     auth: AuthContext,
     opa_role_header: str | None,
-) -> AdvisorStructuredResponse:
-    """Shared logic for all preset endpoints."""
+) -> None:
     opa_role = resolve_opa_role_for_policy(
         header_value=opa_role_header,
         env_var_name="COMPLIANCEHUB_OPA_ROLE_ADVISOR_PRESET",
@@ -4682,92 +4668,80 @@ def _run_preset(
     enforce_action_policy(
         f"advisor_preset_{flow_type.value}",
         UserPolicyContext(
-            tenant_id=body.tenant_id or auth.tenant_id,
+            tenant_id=tenant_id or auth.tenant_id,
             user_role=opa_role,
         ),
         risk_score=0.6,
     )
 
-    preset_info = PRESET_REGISTRY[flow_type]
-    request = AdvisorRequest(
-        query=query,
-        tenant_id=body.tenant_id or auth.tenant_id,
-        channel=body.channel,
-        channel_metadata=body.channel_metadata,
-        request_id=body.request_id,
-        trace_id=body.trace_id,
-        flow_type=flow_type.value,
-        extra_tags=preset_info["extra_tags"],
-    )
-
-    agent = _make_advisor_agent()
-    return run_advisor(request, agent)
-
 
 @app.post(
     "/api/v1/advisor/presets/eu-ai-act-risk-assessment",
-    response_model=AdvisorStructuredResponse,
+    response_model=PresetResult,
     tags=["advisor", "presets"],
 )
 def preset_eu_ai_act_risk_assessment(
-    body: EuAiActRiskAssessmentInput,
+    body: AiActRiskPresetInput,
     auth: Annotated[AuthContext, Depends(get_auth_context)],
     opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
-) -> AdvisorStructuredResponse:
-    """Preset: Is my planned AI use case likely high-risk under EU AI Act?"""
-    from app.advisor.presets import build_eu_ai_act_risk_query
+) -> PresetResult:
+    """Preset: EU AI Act high-risk classification assessment."""
+    from app.advisor.preset_service import run_eu_ai_act_risk_preset
 
-    query = build_eu_ai_act_risk_query(body)
-    return _run_preset(
+    _enforce_preset_opa(
         FlowType.eu_ai_act_risk_assessment,
-        query,
-        body,
+        body.effective_tenant_id(),
         auth,
         opa_role_header,
     )
+    if not body.context.tenant_id and not body.tenant_id:
+        body.context.tenant_id = auth.tenant_id
+    return run_eu_ai_act_risk_preset(body)
 
 
 @app.post(
     "/api/v1/advisor/presets/nis2-obligations",
-    response_model=AdvisorStructuredResponse,
+    response_model=PresetResult,
     tags=["advisor", "presets"],
 )
 def preset_nis2_obligations(
-    body: Nis2ObligationsInput,
+    body: Nis2ObligationsPresetInput,
     auth: Annotated[AuthContext, Depends(get_auth_context)],
     opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
-) -> AdvisorStructuredResponse:
-    """Preset: What NIS2 obligations apply to an entity with a given role?"""
-    from app.advisor.presets import build_nis2_obligations_query
+) -> PresetResult:
+    """Preset: NIS2 obligation mapping for a given entity role."""
+    from app.advisor.preset_service import run_nis2_obligations_preset
 
-    query = build_nis2_obligations_query(body)
-    return _run_preset(
+    _enforce_preset_opa(
         FlowType.nis2_obligations,
-        query,
-        body,
+        body.effective_tenant_id(),
         auth,
         opa_role_header,
     )
+    if not body.context.tenant_id and not body.tenant_id:
+        body.context.tenant_id = auth.tenant_id
+    return run_nis2_obligations_preset(body)
 
 
 @app.post(
     "/api/v1/advisor/presets/iso42001-gap-check",
-    response_model=AdvisorStructuredResponse,
+    response_model=PresetResult,
     tags=["advisor", "presets"],
 )
 def preset_iso42001_gap_check(
-    body: Iso42001GapCheckInput,
+    body: Iso42001GapCheckPresetInput,
     auth: Annotated[AuthContext, Depends(get_auth_context)],
     opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
-) -> AdvisorStructuredResponse:
-    """Preset: ISO 42001 gap check for current AI governance measures."""
-    from app.advisor.presets import build_iso42001_gap_query
+) -> PresetResult:
+    """Preset: ISO 42001 gap analysis for current governance measures."""
+    from app.advisor.preset_service import run_iso42001_gap_preset
 
-    query = build_iso42001_gap_query(body)
-    return _run_preset(
+    _enforce_preset_opa(
         FlowType.iso42001_gap_check,
-        query,
-        body,
+        body.effective_tenant_id(),
         auth,
         opa_role_header,
     )
+    if not body.context.tenant_id and not body.tenant_id:
+        body.context.tenant_id = auth.tenant_id
+    return run_iso42001_gap_preset(body)

--- a/docs/architecture/wave9.1-advisor-presets-enterprise.md
+++ b/docs/architecture/wave9.1-advisor-presets-enterprise.md
@@ -1,0 +1,272 @@
+# Wave 9.1 — Advisor Presets Enterprise Readiness
+
+## Overview
+
+Wave 9.1 evolves the advisor presets from "micro-flow prototypes" (Wave 9) into an **enterprise-ready capability** with:
+
+- Clean tenant / Mandant / system separation
+- GRC-aligned structured output per preset
+- Anti-corruption boundary (`preset_service.py`) as the single integration surface
+- Per-preset SLA timeouts
+- Integration-friendly response contracts (human + machine + grc)
+
+## Tenant / Mandant / System Separation
+
+### The Three Levels
+
+```
+┌──────────────────────────────────────────┐
+│ SaaS Tenant (tenant_id)                  │
+│  = ComplianceHub-Kunde                   │
+│  z.B. "kanzlei-mueller", "acme-gmbh"    │
+│                                          │
+│  ┌─────────────────────────────────────┐ │
+│  │ Client / Mandant (client_id)        │ │
+│  │  = Endkunde der Kanzlei / BK       │ │
+│  │  z.B. "mandant-12345"              │ │
+│  └─────────────────────────────────────┘ │
+│                                          │
+│  ┌─────────────────────────────────────┐ │
+│  │ AI System (system_id)               │ │
+│  │  = Konkretes KI-System / Use Case   │ │
+│  │  z.B. "HR-AI-Recruiting-01"        │ │
+│  └─────────────────────────────────────┘ │
+└──────────────────────────────────────────┘
+```
+
+| Level | Field | Who sets it | Purpose |
+|---|---|---|---|
+| Tenant | `context.tenant_id` | Platform / Auth | SaaS isolation, billing, OPA |
+| Client | `context.client_id` | Kanzlei-User / DATEV | Per-Mandant reporting, audit trail |
+| System | `context.system_id` | User / SAP | EU AI Act Art. 49 register, ISMS asset link |
+
+### Backward Compatibility
+
+Callers can still set `tenant_id` at the top level (without `context`). The preset service merges it: `effective_tenant_id = context.tenant_id || tenant_id`.
+
+### Evidence & Metrics
+
+All three levels are propagated into:
+- Agent evidence events (`extra.client_id`, `extra.system_id`)
+- Metrics aggregation (`client_id_distribution` in `AdvisorMetricsResponse`)
+- Response `ref_ids` and `meta.context`
+
+## GRC Alignment
+
+Each preset derives domain-specific GRC fields from the advisor response:
+
+### EU AI Act Risk Assessment → `AiActRiskGrc`
+
+| Field | Type | Values | GRC Purpose |
+|---|---|---|---|
+| `risk_category` | string | high_risk, limited_risk, minimal_risk, unclassified | Art. 6 classification |
+| `use_case_type` | string | credit_scoring, recruitment, ... | Annex III mapping |
+| `high_risk_likelihood` | string | likely, unlikely, unclear, unknown | Decision support |
+| `annex_iii_category` | string | Raw Annex III reference | Audit trail |
+| `conformity_assessment_required` | bool? | true/false/null | Art. 43 trigger |
+
+### NIS2 Obligations → `Nis2ObligationsGrc`
+
+| Field | Type | Values | GRC Purpose |
+|---|---|---|---|
+| `nis2_entity_type` | string | essential, important, out_of_scope | Entity classification |
+| `obligation_tags` | list[str] | incident_reporting, risk_management, ... | Pflichtenkatalog |
+| `reporting_deadlines` | list[str] | 24h_early_warning, 72h_notification, ... | Fristenverwaltung |
+
+### ISO 42001 Gap Check → `Iso42001GapGrc`
+
+| Field | Type | Values | GRC Purpose |
+|---|---|---|---|
+| `control_families` | list[str] | governance, risk, data, monitoring, ... | Gap-Matrix |
+| `gap_severity` | string | critical, major, minor, none, unknown | Priorisierung |
+| `iso27001_overlap` | bool? | Whether ISO 27001 partially covers gaps | Migration path |
+
+## Anti-Corruption Boundary: `preset_service.py`
+
+```
+External Caller (REST / SAP / DATEV / Temporal)
+        │
+        ▼
+┌─────────────────────────────────┐
+│   preset_service.py             │
+│   run_eu_ai_act_risk_preset()   │
+│   run_nis2_obligations_preset() │
+│   run_iso42001_gap_preset()     │
+│                                 │
+│   • Maps enterprise input       │
+│   • Builds advisor query        │
+│   • Runs generic advisor agent  │
+│   • Derives GRC fields          │
+│   • Builds PresetResult         │
+│   • Tags evidence               │
+└─────────┬───────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────┐
+│   service.py (run_advisor)      │
+│   • SLA timeout                 │
+│   • Idempotency                 │
+│   • Error handling              │
+│   • Metrics logging             │
+└─────────┬───────────────────────┘
+          │
+          ▼
+┌─────────────────────────────────┐
+│   AdvisorComplianceAgent        │
+│   • RAG + LangGraph             │
+│   • Policies & guardrails       │
+│   • Sensitive topic detection   │
+└─────────────────────────────────┘
+```
+
+The `preset_service` is the **only** entry point for preset invocations. REST controllers, Temporal workflows, and future connectors call it — never the raw agent.
+
+## Per-Preset SLA Timeouts
+
+| Preset | Timeout | Rationale |
+|---|---|---|
+| EU AI Act Risk Assessment | 45s | Complex classification, more RAG context needed |
+| NIS2 Obligations | 30s | Shorter obligation-mapping query |
+| ISO 42001 Gap Check | 45s | Detailed gap analysis, more synthesis |
+
+## Response Contract (v1)
+
+```json
+{
+  "human": {
+    "answer_de": "Basierend auf Art. 6 und Anhang III ...",
+    "is_escalated": false,
+    "escalation_reason": "",
+    "confidence_level": "high"
+  },
+  "machine": {
+    "tags": ["eu_ai_act", "high_risk", "conformity_assessment"],
+    "suggested_next_steps": ["EU AI Act Konformitätsbewertung prüfen"],
+    "ref_ids": {
+      "flow_type": "eu_ai_act_risk_assessment",
+      "client_id": "mandant-12345",
+      "system_id": "HR-AI-01"
+    },
+    "intent": "compliance_query"
+  },
+  "grc": {
+    "risk_category": "high_risk",
+    "use_case_type": "recruitment",
+    "high_risk_likelihood": "likely",
+    "annex_iii_category": "",
+    "conformity_assessment_required": true
+  },
+  "meta": {
+    "version": "v1",
+    "flow_type": "eu_ai_act_risk_assessment",
+    "channel": "datev",
+    "request_id": "REQ-001",
+    "latency_ms": 1234.5,
+    "is_cached": false,
+    "context": {
+      "tenant_id": "kanzlei-mueller",
+      "client_id": "mandant-12345",
+      "system_id": "HR-AI-01"
+    }
+  },
+  "error": null,
+  "needs_manual_followup": false
+}
+```
+
+Contract rules:
+- Version is `"v1"` — fields are additive, no removals without version bump
+- `human.answer_de` is always present (even on errors, contains German error message)
+- `grc` fields vary by preset type but are always a dict
+- `machine.ref_ids` always contains `flow_type`
+
+## Example Flows
+
+### Flow 1: DATEV-Kanzlei ruft EU AI Act Risk-Preset für Mandant X auf
+
+```
+1. Kanzlei-Berater öffnet ComplianceHub DATEV-Plugin
+2. Wählt Mandant "12345" (Autohaus Müller GmbH)
+3. Fragt: "Ist die geplante KI-Schadensbewertung hochrisiko?"
+
+→ DATEV-Plugin sendet POST /api/v1/advisor/presets/eu-ai-act-risk-assessment
+  {
+    "context": {
+      "tenant_id": "kanzlei-schmidt",
+      "client_id": "mandant-12345"
+    },
+    "use_case_description": "KI-gestützte Kfz-Schadensbewertung ...",
+    "channel": "datev",
+    "channel_metadata": { "datev_client_number": "12345" },
+    "request_id": "DATEV-REQ-2026-03-31-001"
+  }
+
+→ ComplianceHub:
+  - OPA: advisor_preset_eu_ai_act_risk_assessment (risk=0.6) ✓
+  - preset_service → build query → run_advisor() → agent
+  - Derive GRC: risk_category="high_risk", likelihood="likely"
+  - Format: structured DATEV answer with Kanzlei-Disclaimer
+
+→ Response:
+  human.answer_de: "...Hochrisiko...Schlagworte: eu_ai_act, high_risk..."
+  grc.risk_category: "high_risk"
+  machine.ref_ids: { client_id: "mandant-12345", flow_type: "..." }
+
+→ DATEV-Plugin erstellt Aufgabe für Mandant 12345:
+  "EU AI Act Konformitätsbewertung durchführen"
+```
+
+### Flow 2: SAP S/4HANA Add-on ruft NIS2-Obligations-Preset für Werk Y auf
+
+```
+1. SAP-Compliance-Officer im S/4HANA GRC-Modul
+2. Wählt Buchungskreis "WERK-SUED" (Produktionsstandort)
+3. Fragt: "NIS2-Pflichten für unseren Energiezulieferer-Status?"
+
+→ SAP BTP calls POST /api/v1/advisor/presets/nis2-obligations
+  {
+    "context": {
+      "tenant_id": "acme-industries",
+      "system_id": "WERK-SUED"
+    },
+    "entity_role": "KRITIS-naher Zulieferer",
+    "sector": "Energie",
+    "employee_count": "250+",
+    "channel": "sap",
+    "channel_metadata": { "sap_document_id": "GRC-FINDING-2026-042" },
+    "request_id": "SAP-REQ-WERK-SUED-001"
+  }
+
+→ ComplianceHub:
+  - Derive GRC: nis2_entity_type="essential",
+    obligation_tags=["incident_reporting", "risk_management", "supply_chain"]
+
+→ SAP BTP maps response to GRC Finding:
+  - finding_type: "NIS2_OBLIGATION"
+  - obligations: grc.obligation_tags
+  - deadlines: grc.reporting_deadlines
+  - linked_entity: "WERK-SUED"
+```
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/advisor/enterprise_context.py` | **New** — EnterpriseContext (tenant_id, client_id, system_id) |
+| `app/advisor/preset_models.py` | **New** — Enterprise input schemas, GRC models, PresetResult contract |
+| `app/advisor/preset_service.py` | **New** — Anti-corruption boundary with GRC derivation |
+| `app/advisor/service.py` | Extended AdvisorRequest with client_id, system_id; evidence propagation |
+| `app/advisor/metrics.py` | Added client_id_distribution to aggregation |
+| `app/main.py` | Updated preset endpoints to use preset_service + new models |
+| `tests/test_advisor_presets_enterprise.py` | **New** — 15 tests |
+| `docs/architecture/wave9.1-advisor-presets-enterprise.md` | **New** — This document |
+
+## Test Coverage
+
+15 tests covering:
+- Enterprise context propagation (tenant, client, system → evidence, metrics, ref_ids) (4 tests)
+- GRC field derivation for all 3 presets (3 tests)
+- PresetResult contract shape and version (3 tests)
+- Idempotency at preset level (2 tests)
+- Channel formatting (DATEV structured, SAP with document ID) (2 tests)
+- Flow type in metrics aggregation (1 test)

--- a/tests/test_advisor_presets_enterprise.py
+++ b/tests/test_advisor_presets_enterprise.py
@@ -1,0 +1,438 @@
+"""Tests for Wave 9.1 — Enterprise advisor presets.
+
+Covers:
+- EnterpriseContext (tenant_id, client_id, system_id) propagation
+- GRC field derivation for each preset type
+- Preset service layer (anti-corruption boundary)
+- PresetResult contract shape (human/machine/grc separation)
+- Idempotency at preset-service level
+- Evidence/metrics tagging with client_id, system_id, flow_type
+- Backward compatibility (legacy tenant_id still works)
+"""
+
+from __future__ import annotations
+
+from app.advisor.channels import AdvisorChannel, ChannelMetadata
+from app.advisor.enterprise_context import EnterpriseContext
+from app.advisor.idempotency import clear_for_tests as clear_idem
+from app.advisor.metrics import aggregate_advisor_metrics
+from app.advisor.preset_models import (
+    RESPONSE_CONTRACT_VERSION,
+    AiActRiskPresetInput,
+    Iso42001GapCheckPresetInput,
+    Nis2ObligationsPresetInput,
+    PresetResult,
+)
+from app.advisor.preset_service import (
+    run_eu_ai_act_risk_preset,
+    run_iso42001_gap_preset,
+    run_nis2_obligations_preset,
+)
+from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+from app.services.rag.config import RAGConfig
+from app.services.rag.corpus import Document
+from app.services.rag.evidence_store import (
+    clear_for_tests as clear_evidence,
+)
+from app.services.rag.evidence_store import (
+    list_advisor_agent_events,
+)
+from app.services.rag.hybrid_retriever import HybridRetriever
+from app.services.rag.llm import LlmCallContext, LlmResponse
+
+MOCK_CORPUS = [
+    Document(
+        doc_id="e-1",
+        title="EU AI Act Art. 6 Hochrisiko",
+        content=(
+            "Hochrisiko KI-Systeme nach Art. 6 und Anhang III "
+            "erfordern eine Konformitätsbewertung. Systeme zur "
+            "Kreditwürdigkeitsprüfung fallen unter Anhang III Nr. 5."
+        ),
+        source="EU AI Act",
+        section="Art. 6",
+    ),
+    Document(
+        doc_id="e-2",
+        title="NIS2 Art. 21 Risikomanagement",
+        content=(
+            "Wesentliche Einrichtungen müssen Risikomanagement, "
+            "Meldepflichten (24 Stunden Frühwarnung, 72 Stunden "
+            "Vorfallmeldung) und Governance-Maßnahmen umsetzen. "
+            "KRITIS-nahe Zulieferer in der Lieferkette unterliegen "
+            "besonderen Pflichten."
+        ),
+        source="NIS2",
+        section="Art. 21",
+    ),
+    Document(
+        doc_id="e-3",
+        title="ISO 42001 Governance",
+        content=(
+            "ISO 42001 erfordert Governance, Risikobewertung, "
+            "Datenmanagement, Monitoring und Transparenz. "
+            "Organisationen mit ISO 27001 haben erhebliche "
+            "Überschneidungen, müssen aber KI-spezifische "
+            "Kontrollen ergänzen."
+        ),
+        source="ISO 42001",
+        section="4-10",
+    ),
+]
+
+
+def _mock_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    return LlmResponse(
+        text=(
+            "Basierend auf Art. 6 und Anhang III ist dieses "
+            "Hochrisiko-KI-System konformitätsbewertungspflichtig."
+        ),
+        model_id="mock-model",
+        input_tokens=50,
+        output_tokens=30,
+    )
+
+
+def _make_agent() -> AdvisorComplianceAgent:
+    config = RAGConfig(retrieval_mode="bm25")
+    retriever = HybridRetriever(MOCK_CORPUS, config)
+    return AdvisorComplianceAgent(retriever=retriever, llm_fn=_mock_llm)
+
+
+# ---------------------------------------------------------------------------
+# Enterprise context propagation
+# ---------------------------------------------------------------------------
+
+
+class TestEnterpriseContextPropagation:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_client_id_propagated_to_evidence(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(
+                tenant_id="kanzlei-t",
+                client_id="mandant-42",
+            ),
+            use_case_description=("KI-gestützte Kreditwürdigkeitsprüfung für Privatkunden"),
+            channel=AdvisorChannel.datev,
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert result.meta.context.client_id == "mandant-42"
+        assert result.meta.context.tenant_id == "kanzlei-t"
+        assert result.machine.ref_ids.get("client_id") == "mandant-42"
+
+        events = list_advisor_agent_events("kanzlei-t", limit=10)
+        assert len(events) >= 1
+        svc = events[0]
+        assert svc.get("extra", {}).get("client_id") == "mandant-42"
+
+    def test_system_id_propagated_to_evidence(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(
+                tenant_id="acme-gmbh",
+                system_id="HR-AI-01",
+            ),
+            use_case_description="Automatisierte Personalauswahl",
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert result.meta.context.system_id == "HR-AI-01"
+        assert result.machine.ref_ids.get("system_id") == "HR-AI-01"
+
+        events = list_advisor_agent_events("acme-gmbh", limit=10)
+        svc = events[0]
+        assert svc.get("extra", {}).get("system_id") == "HR-AI-01"
+
+    def test_legacy_tenant_id_still_works(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            tenant_id="legacy-t",
+            use_case_description="Legacy-Format Kreditprüfung",
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+        assert result.meta.context.tenant_id == "legacy-t"
+
+    def test_client_id_in_metrics_aggregation(self) -> None:
+        agent = _make_agent()
+        for cid in ["mandant-1", "mandant-2", "mandant-1"]:
+            inp = AiActRiskPresetInput(
+                context=EnterpriseContext(
+                    tenant_id="metrics-t",
+                    client_id=cid,
+                ),
+                use_case_description="Testfall für Mandantenmetrik",
+            )
+            run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        metrics = aggregate_advisor_metrics(tenant_id="metrics-t")
+        cid_dist = metrics.client_id_distribution
+        assert cid_dist.get("mandant-1", 0) >= 2
+        assert cid_dist.get("mandant-2", 0) >= 1
+
+
+# ---------------------------------------------------------------------------
+# GRC field derivation
+# ---------------------------------------------------------------------------
+
+
+class TestGrcDerivation:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_ai_act_risk_grc_fields(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(tenant_id="grc-t"),
+            use_case_description="KI-Kreditwürdigkeitsprüfung",
+            industry_sector="Finanzdienstleistungen",
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        grc = result.grc
+        assert grc.get("risk_category") in (
+            "high_risk",
+            "limited_risk",
+            "minimal_risk",
+            "unclassified",
+        )
+        assert grc.get("high_risk_likelihood") in (
+            "likely",
+            "unlikely",
+            "unclear",
+            "unknown",
+        )
+        assert isinstance(grc.get("conformity_assessment_required"), (bool, type(None)))
+
+    def test_nis2_grc_fields(self) -> None:
+        agent = _make_agent()
+        inp = Nis2ObligationsPresetInput(
+            context=EnterpriseContext(tenant_id="grc-t"),
+            entity_role="KRITIS-naher Zulieferer",
+            sector="Energie",
+        )
+
+        result = run_nis2_obligations_preset(inp, agent=agent)
+
+        grc = result.grc
+        assert isinstance(grc.get("obligation_tags"), list)
+        assert isinstance(grc.get("reporting_deadlines"), list)
+        assert grc.get("nis2_entity_type") in (
+            "essential",
+            "important",
+            "",
+            "out_of_scope",
+        )
+
+    def test_iso42001_grc_fields(self) -> None:
+        agent = _make_agent()
+        inp = Iso42001GapCheckPresetInput(
+            context=EnterpriseContext(tenant_id="grc-t"),
+            current_measures=("ISO 27001 zertifiziert, kein formales KI-Governance-Framework"),
+        )
+
+        result = run_iso42001_gap_preset(inp, agent=agent)
+
+        grc = result.grc
+        assert isinstance(grc.get("control_families"), list)
+        assert grc.get("gap_severity") in (
+            "critical",
+            "major",
+            "minor",
+            "none",
+            "unknown",
+        )
+        assert grc.get("iso27001_overlap") is True
+
+
+# ---------------------------------------------------------------------------
+# PresetResult contract shape
+# ---------------------------------------------------------------------------
+
+
+class TestPresetResultContract:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_result_has_human_machine_grc_meta(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(tenant_id="shape-t"),
+            use_case_description="Testfall Vertragsstruktur",
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert isinstance(result, PresetResult)
+        assert result.human.answer_de
+        assert isinstance(result.machine.tags, list)
+        assert isinstance(result.machine.suggested_next_steps, list)
+        assert isinstance(result.grc, dict)
+        assert result.meta.version == RESPONSE_CONTRACT_VERSION
+        assert result.meta.flow_type == "eu_ai_act_risk_assessment"
+        assert result.meta.latency_ms is not None
+
+    def test_version_is_v1(self) -> None:
+        assert RESPONSE_CONTRACT_VERSION == "v1"
+
+    def test_ref_ids_contain_flow_type(self) -> None:
+        agent = _make_agent()
+        inp = Nis2ObligationsPresetInput(
+            context=EnterpriseContext(tenant_id="ref-t"),
+            entity_role="Betreiber wesentlicher Dienste",
+        )
+
+        result = run_nis2_obligations_preset(inp, agent=agent)
+
+        assert result.machine.ref_ids.get("flow_type") == "nis2_obligations"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency at preset level
+# ---------------------------------------------------------------------------
+
+
+class TestPresetIdempotency:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_same_request_id_returns_cached(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(tenant_id="idem-t"),
+            use_case_description="Idempotenz-Test KI-System",
+            request_id="REQ-IDEM-001",
+        )
+
+        r1 = run_eu_ai_act_risk_preset(inp, agent=agent)
+        r2 = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert r2.meta.is_cached is True
+        assert r1.human.answer_de == r2.human.answer_de
+
+    def test_no_request_id_no_caching(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(tenant_id="idem-t"),
+            use_case_description="Kein Request-ID Test",
+        )
+
+        r1 = run_eu_ai_act_risk_preset(inp, agent=agent)
+        r2 = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert r1.meta.is_cached is not True
+        assert r2.meta.is_cached is not True
+
+
+# ---------------------------------------------------------------------------
+# Channel + DATEV/SAP formatting
+# ---------------------------------------------------------------------------
+
+
+class TestChannelFormatting:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_datev_channel_passes_structured_answer(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(
+                tenant_id="datev-t",
+                client_id="mandant-99",
+            ),
+            use_case_description="KI-Bilanzanalyse für DATEV",
+            channel=AdvisorChannel.datev,
+            channel_metadata=ChannelMetadata(
+                datev_client_number="99",
+            ),
+        )
+
+        result = run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        assert result.meta.channel == AdvisorChannel.datev
+        assert "Schlagworte:" in result.human.answer_de
+
+    def test_sap_channel_with_document_id(self) -> None:
+        agent = _make_agent()
+        inp = Nis2ObligationsPresetInput(
+            context=EnterpriseContext(
+                tenant_id="sap-t",
+                system_id="WERK-SUED",
+            ),
+            entity_role="KRITIS-naher Zulieferer",
+            channel=AdvisorChannel.sap,
+            channel_metadata=ChannelMetadata(
+                sap_document_id="SAP-DOC-123",
+            ),
+        )
+
+        result = run_nis2_obligations_preset(inp, agent=agent)
+
+        assert result.meta.channel == AdvisorChannel.sap
+        ref = result.machine.ref_ids
+        assert ref.get("sap_document_id") == "SAP-DOC-123"
+        assert ref.get("system_id") == "WERK-SUED"
+
+
+# ---------------------------------------------------------------------------
+# Flow type in metrics
+# ---------------------------------------------------------------------------
+
+
+class TestFlowTypeMetrics:
+    def setup_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def teardown_method(self) -> None:
+        clear_evidence()
+        clear_idem()
+
+    def test_flow_type_tracked_in_metrics(self) -> None:
+        agent = _make_agent()
+        inp = AiActRiskPresetInput(
+            context=EnterpriseContext(tenant_id="ft-t"),
+            use_case_description="Flow-Type Tracking Test",
+        )
+        run_eu_ai_act_risk_preset(inp, agent=agent)
+
+        metrics = aggregate_advisor_metrics(tenant_id="ft-t")
+        assert (
+            metrics.flow_type_distribution.get(
+                "eu_ai_act_risk_assessment",
+                0,
+            )
+            >= 1
+        )


### PR DESCRIPTION
- Add EnterpriseContext model with tenant_id, client_id (Mandant), and system_id (AI system reference) for clean Kanzlei/Industrie separation (app/advisor/enterprise_context.py).
- Add GRC-aligned response models per preset: AiActRiskGrc (risk_category, high_risk_likelihood, conformity_assessment), Nis2ObligationsGrc (entity_type, obligation_tags, deadlines), Iso42001GapGrc (control_families, gap_severity, iso27001_overlap).
- Add PresetResult contract (v1) separating human-readable, machine-readable, and GRC fields for stable SAP/DATEV consumption (app/advisor/preset_models.py).
- Add preset_service.py as anti-corruption boundary — single entry point for REST, Temporal, and future connectors. Includes GRC field derivation from advisor answers and per-preset SLA timeouts (45s risk assessment, 30s NIS2, 45s gap check).
- Extend AdvisorRequest with client_id/system_id; propagate both into evidence events and metrics aggregation.
- Add client_id_distribution to advisor metrics for per-Mandant reporting.
- Update main.py preset endpoints to use preset_service layer with enterprise input models.
- Add 15 tests covering context propagation, GRC derivation, contract shape, idempotency, and channel formatting.
- Add architecture doc (wave9.1-advisor-presets-enterprise.md).

Made-with: Cursor