### PR TITLE
feat(wave12): AI lifecycle & advisory release-gate model

### DIFF
--- a/app/grc/ai_system_readiness.py
+++ b/app/grc/ai_system_readiness.py
@@ -1,0 +1,308 @@
+"""Release-gate readiness evaluation for AiSystems.
+
+Computes per-framework readiness hints and an overall readiness_level
+by inspecting linked GRC records (risks, NIS2 obligations, ISO 42001 gaps)
+and cross-framework mappings.
+
+Rules are deliberately simple, transparent, and documented so they can
+be reviewed by compliance officers.  This is an *advisory* check — it
+never blocks deployments automatically.
+
+Readiness levels:
+  unknown              — no evidence at all for this system
+  insufficient_evidence — some records exist but key areas are missing
+  partially_covered    — core areas have evidence, some gaps remain open
+  ready_for_review     — all key areas covered, suitable for human go/no-go
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from app.grc.framework_mapping import build_system_overview_hints
+from app.grc.models import (
+    AiSystem,
+    AiSystemClassification,
+    GapStatus,
+    ObligationStatus,
+    ReadinessLevel,
+)
+from app.grc.store import (
+    get_ai_system,
+    list_iso42001_gaps,
+    list_nis2_obligations,
+    list_risks,
+    upsert_ai_system,
+)
+from app.services.rag.evidence_store import record_event
+
+logger = logging.getLogger(__name__)
+
+CORE_GAP_FAMILIES = {"governance", "data", "monitoring"}
+
+
+# ---------------------------------------------------------------------------
+# Per-framework hint builders
+# ---------------------------------------------------------------------------
+
+
+def _ai_act_hints(
+    ai_sys: AiSystem,
+    risks: list[Any],
+) -> dict[str, Any]:
+    """EU AI Act readiness hints."""
+    has_risk_assessment = len(risks) > 0
+    classification = ai_sys.ai_act_classification.value
+    is_high_risk_candidate = classification in (
+        AiSystemClassification.high_risk_candidate,
+        AiSystemClassification.high_risk,
+    )
+
+    findings: list[str] = []
+    if not has_risk_assessment:
+        findings.append("Keine Risikobewertung vorhanden")
+    if is_high_risk_candidate:
+        findings.append(
+            f"System als {classification} markiert — Konformitätsbewertung erforderlich"
+        )
+    elif has_risk_assessment:
+        findings.append("Risikobewertung vorhanden")
+
+    return {
+        "framework": "eu_ai_act",
+        "has_risk_assessment": has_risk_assessment,
+        "classification": classification,
+        "is_high_risk_candidate": is_high_risk_candidate,
+        "findings": findings,
+    }
+
+
+def _nis2_hints(
+    ai_sys: AiSystem,
+    nis2_records: list[Any],
+) -> dict[str, Any]:
+    """NIS2 readiness hints."""
+    if not ai_sys.nis2_relevant:
+        return {
+            "framework": "nis2",
+            "relevant": False,
+            "findings": ["System nicht als NIS2-relevant markiert"],
+        }
+
+    total = len(nis2_records)
+    open_count = sum(1 for r in nis2_records if r.status != ObligationStatus.fulfilled)
+
+    findings: list[str] = []
+    if total == 0:
+        findings.append("Keine NIS2-Pflichten erfasst")
+    else:
+        findings.append(f"{total} Pflicht(en) identifiziert, {open_count} offen")
+
+    return {
+        "framework": "nis2",
+        "relevant": True,
+        "total_obligations": total,
+        "open_obligations": open_count,
+        "findings": findings,
+    }
+
+
+def _iso42001_hints(
+    ai_sys: AiSystem,
+    gap_records: list[Any],
+) -> dict[str, Any]:
+    """ISO 42001 readiness hints."""
+    if not ai_sys.iso42001_in_scope:
+        return {
+            "framework": "iso42001",
+            "in_scope": False,
+            "findings": ["System nicht im ISO 42001-Scope"],
+        }
+
+    total = len(gap_records)
+    open_gaps = [g for g in gap_records if g.status == GapStatus.open]
+    open_count = len(open_gaps)
+
+    open_families: set[str] = set()
+    for g in open_gaps:
+        open_families.update(g.control_families)
+    core_open = open_families & CORE_GAP_FAMILIES
+
+    findings: list[str] = []
+    if total == 0:
+        findings.append("Keine Gap-Analyse durchgeführt")
+    else:
+        findings.append(f"{total} Gap(s) erfasst, {open_count} offen")
+    if core_open:
+        findings.append(f"Offene Kern-Gaps: {', '.join(sorted(core_open))}")
+
+    return {
+        "framework": "iso42001",
+        "in_scope": True,
+        "total_gaps": total,
+        "open_gaps": open_count,
+        "open_core_families": sorted(core_open),
+        "findings": findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Overall readiness computation
+# ---------------------------------------------------------------------------
+
+# Rules (kept simple and adjustable):
+#
+# ready_for_review:
+#   - At least one risk assessment exists
+#   - If high_risk_candidate: no open core ISO 42001 gaps
+#     (governance, data, monitoring)
+#   - If NIS2-relevant: all obligations at least in_progress
+#
+# partially_covered:
+#   - Risk assessment exists but some gaps/obligations are still open
+#
+# insufficient_evidence:
+#   - Risk assessment exists but too many key areas are missing
+#
+# unknown:
+#   - No GRC records at all for this system
+
+
+def compute_readiness(
+    ai_sys: AiSystem,
+    *,
+    risks: list[Any] | None = None,
+    nis2_records: list[Any] | None = None,
+    gap_records: list[Any] | None = None,
+) -> dict[str, Any]:
+    """Compute release-gate readiness for an AiSystem.
+
+    Returns a dict with readiness_level, per-framework hints,
+    blocking_items, and framework_coverage.
+    """
+    tid = ai_sys.tenant_id
+    sid = ai_sys.system_id
+
+    if risks is None:
+        risks = list_risks(tenant_id=tid, system_id=sid)
+    if nis2_records is None:
+        all_nis2 = list_nis2_obligations(tenant_id=tid)
+        nis2_records = [r for r in all_nis2 if r.system_id == sid]
+    if gap_records is None:
+        all_gaps = list_iso42001_gaps(tenant_id=tid)
+        gap_records = [g for g in all_gaps if g.system_id == sid]
+
+    ai_act = _ai_act_hints(ai_sys, risks)
+    nis2 = _nis2_hints(ai_sys, nis2_records)
+    iso42001 = _iso42001_hints(ai_sys, gap_records)
+
+    framework_coverage = build_system_overview_hints(
+        risks=risks,
+        nis2_records=nis2_records,
+        gap_records=gap_records,
+    )
+
+    blocking: list[str] = []
+    level = _derive_level(ai_sys, risks, nis2_records, gap_records, blocking)
+
+    return {
+        "system_id": sid,
+        "lifecycle_stage": ai_sys.lifecycle_stage.value,
+        "readiness_level": level.value,
+        "framework_hints": {
+            "eu_ai_act": ai_act,
+            "nis2": nis2,
+            "iso42001": iso42001,
+        },
+        "blocking_items": blocking,
+        "framework_coverage": framework_coverage,
+    }
+
+
+def _derive_level(
+    ai_sys: AiSystem,
+    risks: list[Any],
+    nis2_records: list[Any],
+    gap_records: list[Any],
+    blocking: list[str],
+) -> ReadinessLevel:
+    has_risks = len(risks) > 0
+    if not has_risks:
+        blocking.append("Keine Risikobewertung vorhanden")
+        if not nis2_records and not gap_records:
+            return ReadinessLevel.unknown
+        return ReadinessLevel.insufficient_evidence
+
+    is_hrc = ai_sys.ai_act_classification in (
+        AiSystemClassification.high_risk_candidate,
+        AiSystemClassification.high_risk,
+    )
+
+    open_core_gaps: set[str] = set()
+    for g in gap_records:
+        if g.status == GapStatus.open:
+            open_core_gaps.update(set(g.control_families) & CORE_GAP_FAMILIES)
+
+    if open_core_gaps:
+        blocking.append(f"Offene ISO 42001 Kern-Gaps: {', '.join(sorted(open_core_gaps))}")
+
+    nis2_all_progressing = all(r.status != ObligationStatus.identified for r in nis2_records)
+    if ai_sys.nis2_relevant and not nis2_all_progressing:
+        blocking.append("NIS2-Pflichten noch nicht in Bearbeitung")
+
+    if blocking:
+        if is_hrc and open_core_gaps:
+            return ReadinessLevel.insufficient_evidence
+        return ReadinessLevel.partially_covered
+
+    return ReadinessLevel.ready_for_review
+
+
+# ---------------------------------------------------------------------------
+# Evaluate + persist + log evidence
+# ---------------------------------------------------------------------------
+
+
+def evaluate_and_update(
+    *,
+    tenant_id: str,
+    system_id: str,
+    trace_id: str = "",
+) -> dict[str, Any]:
+    """Run readiness evaluation, update the AiSystem record, and log an
+    evidence event.  Returns the full readiness result."""
+    ai_sys = get_ai_system(tenant_id=tenant_id, system_id=system_id)
+    if ai_sys is None:
+        return {"error": f"AiSystem not found: {tenant_id}:{system_id}"}
+
+    result = compute_readiness(ai_sys)
+    new_level = ReadinessLevel(result["readiness_level"])
+
+    ai_sys.readiness_level = new_level
+    ai_sys.last_reviewed_at = datetime.now(UTC).isoformat()
+    upsert_ai_system(ai_sys)
+
+    _log_readiness_evidence(ai_sys, result, trace_id)
+    return result
+
+
+def _log_readiness_evidence(
+    ai_sys: AiSystem,
+    result: dict[str, Any],
+    trace_id: str,
+) -> None:
+    payload: dict[str, Any] = {
+        "event_type": "readiness_evaluation",
+        "tenant_id": ai_sys.tenant_id,
+        "system_id": ai_sys.system_id,
+        "ai_system_id": ai_sys.id,
+        "lifecycle_stage": ai_sys.lifecycle_stage.value,
+        "readiness_level": result["readiness_level"],
+        "blocking_items_count": len(result["blocking_items"]),
+        "trace_id": trace_id or f"readiness-{uuid.uuid4().hex[:8]}",
+    }
+    record_event(payload)
+    logger.info("readiness_evaluation_logged", extra=payload)

--- a/app/grc/models.py
+++ b/app/grc/models.py
@@ -57,6 +57,23 @@ class AiSystemClassification(StrEnum):
     high_risk = "high_risk"
 
 
+class LifecycleStage(StrEnum):
+    idea = "idea"
+    design = "design"
+    development = "development"
+    testing = "testing"
+    pilot = "pilot"
+    production = "production"
+    retired = "retired"
+
+
+class ReadinessLevel(StrEnum):
+    unknown = "unknown"
+    insufficient_evidence = "insufficient_evidence"
+    partially_covered = "partially_covered"
+    ready_for_review = "ready_for_review"
+
+
 # ---------------------------------------------------------------------------
 # AI System Inventory entity (Wave 11)
 # ---------------------------------------------------------------------------
@@ -87,6 +104,11 @@ class AiSystem(BaseModel):
     ai_act_classification: AiSystemClassification = AiSystemClassification.not_in_scope
     nis2_relevant: bool = False
     iso42001_in_scope: bool = False
+
+    lifecycle_stage: LifecycleStage = LifecycleStage.idea
+    readiness_level: ReadinessLevel = ReadinessLevel.unknown
+    go_live_target_date: str = ""
+    last_reviewed_at: str = ""
 
     auto_created: bool = False
     created_at: str = Field(default_factory=_now_iso)

--- a/app/main.py
+++ b/app/main.py
@@ -4916,3 +4916,29 @@ def get_ai_system_overview(
         "iso42001_gaps": [g.model_dump() for g in gaps_for_sys],
         "framework_coverage": framework_hints,
     }
+
+
+@app.get(
+    "/api/v1/ai-systems/{system_id}/readiness",
+    tags=["ai-systems"],
+)
+def get_ai_system_readiness(
+    system_id: str,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+    tenant_id: str | None = None,
+    trace_id: str | None = None,
+) -> dict[str, Any]:
+    """Release-gate readiness check for an AI system (advisory only)."""
+    from app.grc.ai_system_readiness import evaluate_and_update
+
+    _enforce_grc_opa("view_ai_systems", auth, opa_role_header)
+    tid = tenant_id or auth.tenant_id
+    result = evaluate_and_update(
+        tenant_id=tid,
+        system_id=system_id,
+        trace_id=trace_id or "",
+    )
+    if "error" in result:
+        raise HTTPException(status_code=404, detail=result["error"])
+    return result

--- a/docs/architecture/wave12-ai-lifecycle-and-release-gates.md
+++ b/docs/architecture/wave12-ai-lifecycle-and-release-gates.md
@@ -1,0 +1,173 @@
+# Wave 12 — AI Lifecycle & Release-Gate Model
+
+## Overview
+
+Wave 12 adds a lightweight lifecycle and release-gate layer to `AiSystem`,
+aligned with ISO 42001 lifecycle management ideas and EU AI Act
+pre-deployment readiness expectations.
+
+The model tracks lifecycle stages, computes advisory readiness hints from
+existing GRC records and framework mappings, and exposes this via API —
+without ever auto-blocking or auto-certifying.  Final go/no-go remains a
+human decision.
+
+## Lifecycle Stages
+
+| Stage        | Meaning                                               |
+|--------------|-------------------------------------------------------|
+| `idea`       | Concept/ideation phase, no formal development started |
+| `design`     | Architecture and requirements being defined           |
+| `development`| Active development, model training, integration       |
+| `testing`    | Internal QA, validation, adversarial testing          |
+| `pilot`      | Limited production deployment, controlled scope       |
+| `production` | Full production deployment                            |
+| `retired`    | System decommissioned                                 |
+
+Lifecycle stages are **never auto-advanced** by the platform.  They are
+set by humans (via future UI) or external systems (e.g. CI/CD webhooks).
+
+## Readiness Levels
+
+| Level                    | Meaning                                          |
+|--------------------------|--------------------------------------------------|
+| `unknown`                | No evidence at all for this system               |
+| `insufficient_evidence`  | Some records exist but key areas are missing     |
+| `partially_covered`      | Core areas have evidence, some gaps remain open  |
+| `ready_for_review`       | All key areas covered, suitable for human review |
+
+## Readiness Evaluation Rules
+
+The readiness service (`app/grc/ai_system_readiness.py`) applies simple,
+transparent rules:
+
+### `ready_for_review` requires:
+1. At least one `AiRiskAssessment` exists for the system
+2. If `ai_act_classification` is `high_risk_candidate` or `high_risk`:
+   no open ISO 42001 gaps in core families (governance, data, monitoring)
+3. If `nis2_relevant`: all NIS2 obligations at least `in_progress`
+
+### `partially_covered`:
+- Risk assessment exists but blocking items remain (gaps or obligations)
+
+### `insufficient_evidence`:
+- Risk assessment exists but critical areas are open (e.g. core ISO 42001
+  gaps for a high-risk candidate)
+
+### `unknown`:
+- No GRC records at all
+
+These rules are **advisory and intentionally simple**.  They are documented
+in code comments and can be adjusted as regulations evolve.
+
+## Per-Framework Hints
+
+The readiness API returns structured hints per framework:
+
+```json
+{
+  "eu_ai_act": {
+    "has_risk_assessment": true,
+    "classification": "high_risk_candidate",
+    "findings": ["System als high_risk_candidate markiert"]
+  },
+  "nis2": {
+    "relevant": true,
+    "total_obligations": 2,
+    "open_obligations": 1,
+    "findings": ["2 Pflicht(en) identifiziert, 1 offen"]
+  },
+  "iso42001": {
+    "in_scope": true,
+    "total_gaps": 3,
+    "open_gaps": 1,
+    "open_core_families": ["monitoring"],
+    "findings": ["3 Gap(s) erfasst, 1 offen"]
+  }
+}
+```
+
+## API Endpoint
+
+### `GET /api/v1/ai-systems/{system_id}/readiness`
+
+Returns:
+- `lifecycle_stage`: current stage
+- `readiness_level`: computed level
+- `framework_hints`: per-framework details
+- `blocking_items`: list of blocking findings (German-language)
+- `framework_coverage`: articles/controls with evidence
+
+Secured via OPA (`view_ai_systems`).
+
+Each call also:
+- Updates `readiness_level` and `last_reviewed_at` on the AiSystem record
+- Logs a `readiness_evaluation` evidence event (no PII, only IDs/statuses)
+
+## Evidence Traceability
+
+```
+readiness_evaluation (event)
+  ├── ai_system_id: SYS-abc123
+  ├── system_id: SAP-CREDIT-AI-01
+  ├── readiness_level: partially_covered
+  ├── blocking_items_count: 2
+  └── trace_id → can link to advisor/GRC events
+```
+
+## Example Scenarios
+
+### Scenario 1: New scoring model in „development"
+
+- **System**: `SAP-CREDIT-AI-01`, `lifecycle_stage=development`
+- **GRC records**: One risk assessment (high_risk_candidate), no gaps recorded
+- **Readiness**: `insufficient_evidence`
+- **Blocking**: "Keine ISO 42001 Gap-Analyse durchgeführt"
+- **Action**: Compliance officer triggers ISO 42001 gap check preset
+
+### Scenario 2: Mature system in „pilot" ready for review
+
+- **System**: `HR-SCREENING-01`, `lifecycle_stage=pilot`
+- **GRC records**:
+  - Risk assessment: high_risk_candidate
+  - NIS2 obligations: 2 identified, both `in_progress`
+  - ISO 42001 gaps: governance (closed), data (closed), monitoring (closed)
+- **Readiness**: `ready_for_review`
+- **Blocking**: none
+- **Action**: CISO reviews and confirms classification → `high_risk`
+
+## Temporal / CI Integration (Future)
+
+### Temporal Workflows
+A Temporal workflow (e.g. „deploy-high-risk-model") could call the
+readiness API before executing the deployment step:
+
+```python
+readiness = call_readiness_api(system_id)
+if readiness["readiness_level"] != "ready_for_review":
+    signal_human_review(readiness["blocking_items"])
+    await human_approval_signal()
+```
+
+### CI/CD Gate (e.g. GitHub Actions)
+A pre-merge check could query the readiness API and annotate the PR:
+
+```yaml
+- name: Check AI System Readiness
+  run: |
+    RESULT=$(curl -s .../api/v1/ai-systems/$SYSTEM_ID/readiness)
+    LEVEL=$(echo $RESULT | jq -r .readiness_level)
+    if [ "$LEVEL" != "ready_for_review" ]; then
+      echo "::warning::AI System not ready: $LEVEL"
+    fi
+```
+
+Both patterns are **advisory** — they surface information but do not
+hard-block without human consent.
+
+## Design Principles
+
+- **Advisory, not enforcement**: Gates inform, they don't block
+- **Human-in-the-loop**: Classification upgrades and go-live decisions need explicit human action
+- **Transparent rules**: Every readiness rule is documented and easy to modify
+- **Full traceability**: Every evaluation is logged as an evidence event
+- **Tenant separation**: All queries scoped to `tenant_id` via OPA

--- a/tests/test_ai_system_readiness.py
+++ b/tests/test_ai_system_readiness.py
@@ -1,0 +1,424 @@
+"""Tests for Wave 12 — AI lifecycle & release-gate readiness.
+
+Covers:
+- Readiness computation on synthetic GRC record combinations
+- Lifecycle stage and readiness_level on AiSystem
+- Per-framework hints (AI Act, NIS2, ISO 42001)
+- Blocking items reported correctly
+- Readiness stable for same input (deterministic)
+- Evidence event logged on readiness evaluation
+- API returning expected readiness levels
+"""
+
+from __future__ import annotations
+
+from app.advisor.enterprise_context import EnterpriseContext
+from app.advisor.idempotency import clear_for_tests as clear_idem
+from app.advisor.preset_models import (
+    AiActRiskPresetInput,
+)
+from app.advisor.preset_service import (
+    run_eu_ai_act_risk_preset,
+)
+from app.grc.ai_system_readiness import compute_readiness, evaluate_and_update
+from app.grc.models import (
+    AiRiskAssessment,
+    AiSystem,
+    AiSystemClassification,
+    GapStatus,
+    Iso42001GapRecord,
+    LifecycleStage,
+    Nis2ObligationRecord,
+    ObligationStatus,
+    ReadinessLevel,
+)
+from app.grc.store import (
+    clear_for_tests as clear_grc,
+)
+from app.grc.store import (
+    get_ai_system,
+    upsert_ai_system,
+    upsert_gap,
+    upsert_nis2,
+    upsert_risk,
+)
+from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+from app.services.rag.config import RAGConfig
+from app.services.rag.corpus import Document
+from app.services.rag.evidence_store import (
+    clear_for_tests as clear_evidence,
+)
+from app.services.rag.hybrid_retriever import HybridRetriever
+from app.services.rag.llm import LlmCallContext, LlmResponse
+
+MOCK_CORPUS = [
+    Document(
+        doc_id="w12-1",
+        title="EU AI Act Art. 6 Hochrisiko",
+        content=(
+            "Hochrisiko KI-Systeme nach Art. 6 und Anhang III "
+            "erfordern eine Konformitätsbewertung. Systeme zur "
+            "Kreditwürdigkeitsprüfung fallen unter Anhang III Nr. 5."
+        ),
+        source="EU AI Act",
+        section="Art. 6",
+    ),
+    Document(
+        doc_id="w12-2",
+        title="NIS2 Art. 21 Risikomanagement",
+        content=(
+            "Wesentliche Einrichtungen müssen Risikomanagement, "
+            "Meldepflichten und Governance-Maßnahmen umsetzen."
+        ),
+        source="NIS2",
+        section="Art. 21",
+    ),
+    Document(
+        doc_id="w12-3",
+        title="ISO 42001 Governance",
+        content=(
+            "ISO 42001 erfordert Governance, Risikobewertung, "
+            "Datenmanagement, Monitoring und Transparenz. "
+            "ISO 27001 bietet erhebliche Überschneidungen."
+        ),
+        source="ISO 42001",
+        section="4-10",
+    ),
+]
+
+
+def _mock_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    return LlmResponse(
+        text=(
+            "Basierend auf Art. 6 und Anhang III ist dieses "
+            "Hochrisiko-KI-System konformitätsbewertungspflichtig."
+        ),
+        model_id="mock",
+        input_tokens=50,
+        output_tokens=30,
+    )
+
+
+def _make_agent() -> AdvisorComplianceAgent:
+    config = RAGConfig(retrieval_mode="bm25")
+    retriever = HybridRetriever(MOCK_CORPUS, config)
+    return AdvisorComplianceAgent(retriever=retriever, llm_fn=_mock_llm)
+
+
+def _cleanup() -> None:
+    clear_evidence()
+    clear_idem()
+    clear_grc()
+
+
+# ---------------------------------------------------------------------------
+# Readiness computation on synthetic data
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessComputation:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_no_records_returns_unknown(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="rd-t",
+                system_id="EMPTY-01",
+            )
+        )
+
+        result = compute_readiness(sys)
+
+        assert result["readiness_level"] == "unknown"
+        assert len(result["blocking_items"]) > 0
+
+    def test_risk_only_returns_partially_covered(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="rd-t",
+                system_id="RISK-ONLY",
+                ai_act_classification=AiSystemClassification.high_risk_candidate,
+                iso42001_in_scope=True,
+            )
+        )
+        upsert_risk(
+            AiRiskAssessment(
+                tenant_id="rd-t",
+                system_id="RISK-ONLY",
+                risk_category="high_risk",
+            )
+        )
+        upsert_gap(
+            Iso42001GapRecord(
+                tenant_id="rd-t",
+                system_id="RISK-ONLY",
+                control_families=["governance", "data"],
+                status=GapStatus.open,
+            )
+        )
+
+        result = compute_readiness(sys)
+
+        assert result["readiness_level"] == "insufficient_evidence"
+        assert any("Kern-Gaps" in b for b in result["blocking_items"])
+
+    def test_all_covered_returns_ready_for_review(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="rd-t",
+                system_id="READY-01",
+                ai_act_classification=AiSystemClassification.high_risk_candidate,
+                nis2_relevant=True,
+                iso42001_in_scope=True,
+                lifecycle_stage=LifecycleStage.pilot,
+            )
+        )
+        upsert_risk(
+            AiRiskAssessment(
+                tenant_id="rd-t",
+                system_id="READY-01",
+                risk_category="high_risk",
+            )
+        )
+        upsert_nis2(
+            Nis2ObligationRecord(
+                tenant_id="rd-t",
+                system_id="READY-01",
+                status=ObligationStatus.in_progress,
+            )
+        )
+        upsert_gap(
+            Iso42001GapRecord(
+                tenant_id="rd-t",
+                system_id="READY-01",
+                control_families=["governance"],
+                status=GapStatus.closed,
+            )
+        )
+
+        result = compute_readiness(sys)
+
+        assert result["readiness_level"] == "ready_for_review"
+        assert result["lifecycle_stage"] == "pilot"
+        assert len(result["blocking_items"]) == 0
+
+    def test_nis2_identified_blocks_readiness(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="rd-t",
+                system_id="NIS2-BLOCK",
+                nis2_relevant=True,
+            )
+        )
+        upsert_risk(
+            AiRiskAssessment(
+                tenant_id="rd-t",
+                system_id="NIS2-BLOCK",
+            )
+        )
+        upsert_nis2(
+            Nis2ObligationRecord(
+                tenant_id="rd-t",
+                system_id="NIS2-BLOCK",
+                status=ObligationStatus.identified,
+            )
+        )
+
+        result = compute_readiness(sys)
+
+        assert result["readiness_level"] == "partially_covered"
+        assert any("NIS2" in b for b in result["blocking_items"])
+
+
+# ---------------------------------------------------------------------------
+# Per-framework hints
+# ---------------------------------------------------------------------------
+
+
+class TestFrameworkHints:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_ai_act_hints_no_assessment(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="h-t",
+                system_id="H-01",
+            )
+        )
+        result = compute_readiness(sys)
+        ai_act = result["framework_hints"]["eu_ai_act"]
+        assert ai_act["has_risk_assessment"] is False
+
+    def test_nis2_hints_not_relevant(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="h-t",
+                system_id="H-02",
+            )
+        )
+        result = compute_readiness(sys)
+        nis2 = result["framework_hints"]["nis2"]
+        assert nis2["relevant"] is False
+
+    def test_iso42001_hints_with_open_gaps(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="h-t",
+                system_id="H-03",
+                iso42001_in_scope=True,
+            )
+        )
+        upsert_gap(
+            Iso42001GapRecord(
+                tenant_id="h-t",
+                system_id="H-03",
+                control_families=["governance", "monitoring"],
+                status=GapStatus.open,
+            )
+        )
+
+        result = compute_readiness(sys)
+        iso = result["framework_hints"]["iso42001"]
+        assert iso["in_scope"] is True
+        assert iso["open_gaps"] == 1
+        assert "governance" in iso["open_core_families"]
+
+
+# ---------------------------------------------------------------------------
+# Determinism / stability
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessStability:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_same_input_same_output(self) -> None:
+        sys = upsert_ai_system(
+            AiSystem(
+                tenant_id="st-t",
+                system_id="STABLE-01",
+            )
+        )
+        upsert_risk(
+            AiRiskAssessment(
+                tenant_id="st-t",
+                system_id="STABLE-01",
+            )
+        )
+
+        r1 = compute_readiness(sys)
+        r2 = compute_readiness(sys)
+
+        assert r1["readiness_level"] == r2["readiness_level"]
+        assert r1["blocking_items"] == r2["blocking_items"]
+
+
+# ---------------------------------------------------------------------------
+# Evidence event logging
+# ---------------------------------------------------------------------------
+
+
+class TestReadinessEvidence:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_evaluate_logs_evidence_event(self) -> None:
+        from app.services.rag.evidence_store import _events, _lock
+
+        upsert_ai_system(
+            AiSystem(
+                tenant_id="ev-t",
+                system_id="EV-01",
+            )
+        )
+
+        evaluate_and_update(
+            tenant_id="ev-t",
+            system_id="EV-01",
+            trace_id="TRACE-RD-001",
+        )
+
+        with _lock:
+            rd_events = [e for e in _events if e.get("event_type") == "readiness_evaluation"]
+
+        assert len(rd_events) >= 1
+        ev = rd_events[-1]
+        assert ev["system_id"] == "EV-01"
+        assert ev["trace_id"] == "TRACE-RD-001"
+        assert "readiness_level" in ev
+
+    def test_evaluate_updates_ai_system_readiness(self) -> None:
+        upsert_ai_system(
+            AiSystem(
+                tenant_id="ev-t",
+                system_id="EV-02",
+            )
+        )
+
+        evaluate_and_update(tenant_id="ev-t", system_id="EV-02")
+
+        sys = get_ai_system(tenant_id="ev-t", system_id="EV-02")
+        assert sys is not None
+        assert sys.readiness_level == ReadinessLevel.unknown
+        assert sys.last_reviewed_at != ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: preset → readiness
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEndReadiness:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_preset_creates_system_then_readiness_evaluates(self) -> None:
+        agent = _make_agent()
+        ctx = EnterpriseContext(
+            tenant_id="e2e-t",
+            system_id="E2E-SYS-01",
+        )
+
+        preset_result = run_eu_ai_act_risk_preset(
+            AiActRiskPresetInput(
+                context=ctx,
+                use_case_description="KI-Kreditwürdigkeitsprüfung",
+            ),
+            agent=agent,
+        )
+
+        if preset_result.human.is_escalated:
+            return
+
+        result = evaluate_and_update(
+            tenant_id="e2e-t",
+            system_id="E2E-SYS-01",
+        )
+
+        assert "error" not in result
+        assert result["readiness_level"] in (
+            "unknown",
+            "ready_for_review",
+            "partially_covered",
+            "insufficient_evidence",
+        )
+        assert result["system_id"] == "E2E-SYS-01"
+        assert result["framework_hints"]["eu_ai_act"]["has_risk_assessment"]


### PR DESCRIPTION
- Extend AiSystem with lifecycle_stage enum (idea → production → retired), readiness_level (unknown/insufficient_evidence/partially_covered/ ready_for_review), go_live_target_date, last_reviewed_at.
- Add readiness evaluation service (app/grc/ai_system_readiness.py): per-framework hints (AI Act, NIS2, ISO 42001) and overall readiness computed from linked GRC records with simple, transparent rules. Advisory only — never auto-blocks or auto-certifies.
- Add GET /api/v1/ai-systems/{system_id}/readiness endpoint returning lifecycle_stage, readiness_level, per-framework hints, blocking items, and framework coverage. OPA-secured (view_ai_systems).
- Log readiness_evaluation evidence events on each check (no PII, only system IDs, statuses, and aggregates).
- Add 11 tests covering readiness computation on synthetic GRC combinations, per-framework hints, stability/determinism, evidence logging, and end-to-end preset → readiness flow.
- Add architecture doc (wave12-ai-lifecycle-and-release-gates.md) with lifecycle stages, readiness rules, example scenarios, and Temporal/CI integration outlines.

Made-with: Cursor