### PR TITLE
feat(wave13): Mandant-level AI compliance board reports for Kanzleien

### DIFF
--- a/app/grc/client_board_report_service.py
+++ b/app/grc/client_board_report_service.py
@@ -1,0 +1,455 @@
+"""Client/Mandant-level AI Compliance Board Report service (Wave 13).
+
+Aggregates AiSystem inventory + GRC records for one client, synthesises
+a German advisory board report, persists it in-memory, and logs
+evidence/metrics events.
+
+All operations are read-only w.r.t. AiSystems and GRC records.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+from threading import Lock
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.grc.ai_system_readiness import compute_readiness
+from app.grc.framework_mapping import build_system_overview_hints
+from app.grc.models import (
+    GapStatus,
+    ObligationStatus,
+)
+from app.grc.store import (
+    list_ai_systems,
+    list_iso42001_gaps,
+    list_nis2_obligations,
+    list_risks,
+)
+from app.services.rag.evidence_store import record_event
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Report model
+# ---------------------------------------------------------------------------
+
+
+class ClientBoardReport(BaseModel):
+    id: str = Field(default_factory=lambda: f"CBR-{uuid.uuid4().hex[:12]}")
+    tenant_id: str = ""
+    client_id: str = ""
+    reporting_period: str = ""
+    created_at: str = Field(default_factory=lambda: datetime.now(UTC).isoformat())
+    systems_included: int = 0
+    system_ids: list[str] = Field(default_factory=list)
+    snapshot: dict[str, Any] = Field(default_factory=dict)
+    report_markdown: str = ""
+    highlights: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# In-memory report store
+# ---------------------------------------------------------------------------
+
+_lock = Lock()
+_reports: dict[str, ClientBoardReport] = {}
+
+
+def _store_report(report: ClientBoardReport) -> ClientBoardReport:
+    with _lock:
+        _reports[report.id] = report
+    return report
+
+
+def get_report(report_id: str) -> ClientBoardReport | None:
+    with _lock:
+        return _reports.get(report_id)
+
+
+def list_reports(*, tenant_id: str, client_id: str) -> list[ClientBoardReport]:
+    with _lock:
+        return [
+            r for r in _reports.values() if r.tenant_id == tenant_id and r.client_id == client_id
+        ]
+
+
+def clear_reports_for_tests() -> None:
+    with _lock:
+        _reports.clear()
+
+
+# ---------------------------------------------------------------------------
+# In-memory workflow tracker
+# ---------------------------------------------------------------------------
+
+_wf_lock = Lock()
+_workflows: dict[str, dict[str, Any]] = {}
+
+
+def _track_workflow(workflow_id: str, tenant_id: str, client_id: str, period: str) -> None:
+    with _wf_lock:
+        _workflows[workflow_id] = {
+            "status": "RUNNING",
+            "tenant_id": tenant_id,
+            "client_id": client_id,
+            "reporting_period": period,
+            "report_id": None,
+            "systems_included": 0,
+            "started_at": datetime.now(UTC).isoformat(),
+        }
+
+
+def _complete_workflow(workflow_id: str, report_id: str, systems_included: int) -> None:
+    with _wf_lock:
+        if workflow_id in _workflows:
+            _workflows[workflow_id]["status"] = "COMPLETED"
+            _workflows[workflow_id]["report_id"] = report_id
+            _workflows[workflow_id]["systems_included"] = systems_included
+
+
+def get_workflow_status(workflow_id: str) -> dict[str, Any] | None:
+    with _wf_lock:
+        return _workflows.get(workflow_id)
+
+
+def clear_workflows_for_tests() -> None:
+    with _wf_lock:
+        _workflows.clear()
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Data aggregation
+# ---------------------------------------------------------------------------
+
+
+def aggregate_client_data(
+    *,
+    tenant_id: str,
+    client_id: str,
+    system_filter: list[str] | None = None,
+) -> dict[str, Any]:
+    """Aggregate AiSystem inventory + GRC records for one Mandant.
+
+    Returns a structured snapshot dict — purely read-only, no status
+    changes.
+    """
+    systems = list_ai_systems(tenant_id=tenant_id, client_id=client_id)
+    if not systems:
+        systems = [
+            s
+            for s in list_ai_systems(tenant_id=tenant_id)
+            if s.client_id == client_id or s.client_id == ""
+        ]
+
+    if system_filter:
+        systems = [s for s in systems if s.system_id in system_filter]
+
+    system_summaries: list[dict[str, Any]] = []
+    for ai_sys in systems:
+        risks = list_risks(tenant_id=tenant_id, system_id=ai_sys.system_id)
+        all_nis2 = list_nis2_obligations(tenant_id=tenant_id)
+        nis2 = [r for r in all_nis2 if r.system_id == ai_sys.system_id]
+        all_gaps = list_iso42001_gaps(tenant_id=tenant_id)
+        gaps = [g for g in all_gaps if g.system_id == ai_sys.system_id]
+
+        open_gaps = [g for g in gaps if g.status == GapStatus.open]
+        open_nis2 = [r for r in nis2 if r.status != ObligationStatus.fulfilled]
+
+        readiness = compute_readiness(ai_sys, risks=risks, nis2_records=nis2, gap_records=gaps)
+
+        coverage = build_system_overview_hints(risks=risks, nis2_records=nis2, gap_records=gaps)
+
+        system_summaries.append(
+            {
+                "system_id": ai_sys.system_id,
+                "name": ai_sys.name or ai_sys.system_id,
+                "classification": ai_sys.ai_act_classification.value,
+                "lifecycle_stage": ai_sys.lifecycle_stage.value,
+                "readiness_level": readiness["readiness_level"],
+                "nis2_relevant": ai_sys.nis2_relevant,
+                "iso42001_in_scope": ai_sys.iso42001_in_scope,
+                "risk_assessments_count": len(risks),
+                "open_gaps_count": len(open_gaps),
+                "open_obligations_count": len(open_nis2),
+                "framework_coverage": coverage,
+                "blocking_items": readiness.get("blocking_items", []),
+            }
+        )
+
+    high_risk_count = sum(
+        1 for s in system_summaries if s["classification"] in ("high_risk_candidate", "high_risk")
+    )
+
+    return {
+        "tenant_id": tenant_id,
+        "client_id": client_id,
+        "systems": system_summaries,
+        "systems_count": len(system_summaries),
+        "high_risk_systems": high_risk_count,
+        "total_open_gaps": sum(s["open_gaps_count"] for s in system_summaries),
+        "total_open_obligations": sum(s["open_obligations_count"] for s in system_summaries),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Report synthesis (LLM or deterministic fallback)
+# ---------------------------------------------------------------------------
+
+_DISCLAIMER = (
+    "\n\n---\n*Hinweis: Dieser Report dient ausschließlich der "
+    "unverbindlichen Einordnung und stellt keine Rechtsberatung dar. "
+    "Für verbindliche Bewertungen wenden Sie sich bitte an Ihre "
+    "Rechtsabteilung oder einen spezialisierten Anwalt.*\n"
+)
+
+
+def synthesise_report(
+    *,
+    tenant_id: str,
+    client_id: str,
+    reporting_period: str,
+    snapshot: dict[str, Any],
+    llm_fn: Any | None = None,
+) -> ClientBoardReport:
+    """Build a Mandant board report from the aggregated snapshot.
+
+    Uses the guardrailed LLM if ``llm_fn`` is provided, otherwise falls
+    back to deterministic Markdown rendering.
+    """
+    systems = snapshot.get("systems", [])
+    system_ids = [s["system_id"] for s in systems]
+
+    if llm_fn is not None:
+        md = _synthesise_with_llm(tenant_id, client_id, reporting_period, snapshot, llm_fn)
+    else:
+        md = _render_deterministic(client_id, reporting_period, snapshot)
+
+    highlights = _extract_highlights(snapshot)
+
+    report = ClientBoardReport(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        reporting_period=reporting_period,
+        systems_included=len(systems),
+        system_ids=system_ids,
+        snapshot=snapshot,
+        report_markdown=md,
+        highlights=highlights,
+    )
+    _store_report(report)
+    return report
+
+
+def _synthesise_with_llm(
+    tenant_id: str,
+    client_id: str,
+    period: str,
+    snapshot: dict[str, Any],
+    llm_fn: Any,
+) -> str:
+    from app.services.rag.llm import LlmCallContext
+
+    prompt = _build_prompt(client_id, period, snapshot)
+    ctx = LlmCallContext(
+        tenant_id=tenant_id,
+        role="kanzlei_advisor",
+        action="generate_client_board_report",
+        metadata={"client_id": client_id, "period": period},
+    )
+    resp = llm_fn(prompt, ctx)
+    return resp.text + _DISCLAIMER
+
+
+def _build_prompt(
+    client_id: str,
+    period: str,
+    snapshot: dict[str, Any],
+) -> str:
+    n_sys = snapshot.get("systems_count", 0)
+    hr = snapshot.get("high_risk_systems", 0)
+    gaps = snapshot.get("total_open_gaps", 0)
+    obls = snapshot.get("total_open_obligations", 0)
+
+    system_lines: list[str] = []
+    for s in snapshot.get("systems", []):
+        system_lines.append(
+            f"- {s['name']}: Klassifizierung={s['classification']}, "
+            f"Lifecycle={s['lifecycle_stage']}, "
+            f"Readiness={s['readiness_level']}, "
+            f"Risikobewertungen={s['risk_assessments_count']}, "
+            f"Offene Gaps={s['open_gaps_count']}, "
+            f"Offene NIS2-Pflichten={s['open_obligations_count']}"
+        )
+
+    return (
+        f"Erstelle einen AI Compliance Board-Report für Mandant "
+        f"'{client_id}' (Berichtszeitraum: {period or 'aktuell'}).\n\n"
+        f"Zusammenfassung:\n"
+        f"- {n_sys} AI-System(e) erfasst\n"
+        f"- {hr} als high_risk_candidate/high_risk eingestuft\n"
+        f"- {gaps} offene ISO 42001 Gaps\n"
+        f"- {obls} offene NIS2-Verpflichtungen\n\n"
+        f"AI-Systeme:\n" + "\n".join(system_lines) + "\n\n"
+        "Gliedere den Report in:\n"
+        "1. AI Systemübersicht\n"
+        "2. EU AI Act Risikoeinschätzungen & offene Punkte\n"
+        "3. NIS2-relevante Verpflichtungen\n"
+        "4. ISO 42001/27001 Governance & Gap-Status\n"
+        "5. Empfehlungen\n\n"
+        "Schreibe auf Deutsch, sachlich, keine Rechtsberatung."
+    )
+
+
+def _render_deterministic(
+    client_id: str,
+    period: str,
+    snapshot: dict[str, Any],
+) -> str:
+    """Deterministic Markdown fallback (no LLM needed)."""
+    n_sys = snapshot.get("systems_count", 0)
+    hr = snapshot.get("high_risk_systems", 0)
+    gaps = snapshot.get("total_open_gaps", 0)
+    obls = snapshot.get("total_open_obligations", 0)
+    period_label = period or "aktuell"
+
+    lines = [
+        f"# AI Compliance Board-Report — Mandant {client_id}",
+        f"**Berichtszeitraum:** {period_label}",
+        "",
+        "## AI Systemübersicht",
+        f"- **{n_sys}** AI-System(e) erfasst",
+        f"- **{hr}** als high_risk_candidate / high_risk eingestuft",
+        "",
+    ]
+
+    for s in snapshot.get("systems", []):
+        lines.append(f"### {s['name']} ({s['system_id']})")
+        lines.append(f"- Klassifizierung: {s['classification']}")
+        lines.append(f"- Lifecycle: {s['lifecycle_stage']}")
+        lines.append(f"- Readiness: {s['readiness_level']}")
+        if s.get("risk_assessments_count"):
+            lines.append(f"- Risikobewertungen: {s['risk_assessments_count']}")
+        if s.get("open_gaps_count"):
+            lines.append(f"- Offene ISO 42001 Gaps: {s['open_gaps_count']}")
+        if s.get("open_obligations_count"):
+            lines.append(f"- Offene NIS2-Pflichten: {s['open_obligations_count']}")
+        lines.append("")
+
+    lines.append("## EU AI Act Risikoeinschätzungen")
+    if hr > 0:
+        lines.append(
+            f"- {hr} System(e) als high_risk_candidate markiert — Konformitätsbewertung prüfen"
+        )
+    else:
+        lines.append("- Keine Hochrisiko-Systeme identifiziert")
+    lines.append("")
+
+    lines.append("## NIS2-relevante Verpflichtungen")
+    if obls > 0:
+        lines.append(f"- {obls} offene Verpflichtung(en)")
+    else:
+        lines.append("- Keine offenen NIS2-Verpflichtungen")
+    lines.append("")
+
+    lines.append("## ISO 42001/27001 Governance & Gap-Status")
+    if gaps > 0:
+        lines.append(f"- {gaps} offene Gap(s)")
+    else:
+        lines.append("- Keine offenen Gaps")
+    lines.append("")
+
+    lines.append(_DISCLAIMER)
+    return "\n".join(lines)
+
+
+def _extract_highlights(snapshot: dict[str, Any]) -> list[str]:
+    highlights: list[str] = []
+    hr = snapshot.get("high_risk_systems", 0)
+    gaps = snapshot.get("total_open_gaps", 0)
+    obls = snapshot.get("total_open_obligations", 0)
+    n_sys = snapshot.get("systems_count", 0)
+
+    highlights.append(f"{n_sys} AI-System(e) erfasst")
+    if hr > 0:
+        highlights.append(f"{hr} high_risk_candidate System(e)")
+    if gaps > 0:
+        highlights.append(f"{gaps} offene ISO 42001 Gap(s)")
+    if obls > 0:
+        highlights.append(f"{obls} offene NIS2-Verpflichtung(en)")
+    return highlights
+
+
+# ---------------------------------------------------------------------------
+# Task 5: Evidence & metrics
+# ---------------------------------------------------------------------------
+
+
+def log_report_evidence(report: ClientBoardReport) -> None:
+    """Emit evidence event for a completed client board report."""
+    payload: dict[str, Any] = {
+        "event_type": "client_board_report_generated",
+        "tenant_id": report.tenant_id,
+        "client_id": report.client_id,
+        "report_id": report.id,
+        "reporting_period": report.reporting_period,
+        "systems_included": report.systems_included,
+        "system_ids": report.system_ids,
+    }
+    record_event(payload)
+    logger.info("client_board_report_evidence", extra=payload)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: run workflow synchronously (in-memory, no Temporal needed)
+# ---------------------------------------------------------------------------
+
+
+def run_client_board_report(
+    *,
+    tenant_id: str,
+    client_id: str,
+    reporting_period: str = "",
+    system_filter: list[str] | None = None,
+    llm_fn: Any | None = None,
+    workflow_id: str | None = None,
+) -> dict[str, Any]:
+    """Run a full client board report workflow synchronously.
+
+    This is the primary entry point used by the API layer and tests.
+    In production with Temporal, the Temporal workflow would call
+    aggregate_client_data and synthesise_report as activities.
+    """
+    wf_id = workflow_id or f"cbr-{uuid.uuid4().hex[:12]}"
+    _track_workflow(wf_id, tenant_id, client_id, reporting_period)
+
+    snapshot = aggregate_client_data(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        system_filter=system_filter,
+    )
+
+    report = synthesise_report(
+        tenant_id=tenant_id,
+        client_id=client_id,
+        reporting_period=reporting_period,
+        snapshot=snapshot,
+        llm_fn=llm_fn,
+    )
+
+    _complete_workflow(wf_id, report.id, report.systems_included)
+    log_report_evidence(report)
+
+    return {
+        "workflow_id": wf_id,
+        "report_id": report.id,
+        "tenant_id": tenant_id,
+        "client_id": client_id,
+        "reporting_period": reporting_period,
+        "systems_included": report.systems_included,
+        "status": "COMPLETED",
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -4942,3 +4942,110 @@ def get_ai_system_readiness(
     if "error" in result:
         raise HTTPException(status_code=404, detail=result["error"])
     return result
+
+
+# ---------------------------------------------------------------------------
+# Client/Mandant Board Report APIs (Wave 13)
+# ---------------------------------------------------------------------------
+
+
+@app.post(
+    "/api/v1/clients/{client_id}/ai-board-report/workflows/start",
+    tags=["client-board-reports"],
+    status_code=202,
+)
+def start_client_board_report(
+    client_id: str,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+    reporting_period: str | None = None,
+    system_filter: str | None = None,
+) -> dict[str, Any]:
+    """Start a Mandant-level AI compliance board report workflow."""
+    from app.grc.client_board_report_service import run_client_board_report
+
+    _enforce_grc_opa("start_client_board_report", auth, opa_role_header)
+    tid = auth.tenant_id
+
+    sf = [s.strip() for s in system_filter.split(",") if s.strip()] if system_filter else None
+
+    result = run_client_board_report(
+        tenant_id=tid,
+        client_id=client_id,
+        reporting_period=reporting_period or "",
+        system_filter=sf,
+    )
+    return result
+
+
+@app.get(
+    "/api/v1/clients/{client_id}/ai-board-report/workflows/{workflow_id}",
+    tags=["client-board-reports"],
+)
+def get_client_board_report_workflow(
+    client_id: str,
+    workflow_id: str,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> dict[str, Any]:
+    """Get status/result of a client board report workflow."""
+    from app.grc.client_board_report_service import (
+        get_report,
+        get_workflow_status,
+    )
+
+    _enforce_grc_opa("view_client_board_report", auth, opa_role_header)
+
+    wf = get_workflow_status(workflow_id)
+    if wf is None:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    if wf.get("client_id") != client_id:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    report_data: dict[str, Any] | None = None
+    if wf.get("report_id"):
+        rpt = get_report(wf["report_id"])
+        if rpt:
+            report_data = {
+                "report_id": rpt.id,
+                "report_markdown": rpt.report_markdown,
+                "highlights": rpt.highlights,
+                "systems_included": rpt.systems_included,
+                "system_ids": rpt.system_ids,
+                "created_at": rpt.created_at,
+            }
+
+    return {
+        "workflow_id": workflow_id,
+        "status": wf.get("status", "UNKNOWN"),
+        "tenant_id": wf.get("tenant_id"),
+        "client_id": client_id,
+        "reporting_period": wf.get("reporting_period"),
+        "report": report_data,
+    }
+
+
+@app.get(
+    "/api/v1/clients/{client_id}/ai-board-reports",
+    tags=["client-board-reports"],
+)
+def list_client_board_reports(
+    client_id: str,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> list[dict[str, Any]]:
+    """List past AI board reports for a Mandant."""
+    from app.grc.client_board_report_service import list_reports
+
+    _enforce_grc_opa("view_client_board_report", auth, opa_role_header)
+    reports = list_reports(tenant_id=auth.tenant_id, client_id=client_id)
+    return [
+        {
+            "report_id": r.id,
+            "reporting_period": r.reporting_period,
+            "systems_included": r.systems_included,
+            "highlights": r.highlights,
+            "created_at": r.created_at,
+        }
+        for r in reports
+    ]

--- a/app/workflows/client_board_report.py
+++ b/app/workflows/client_board_report.py
@@ -1,0 +1,75 @@
+"""Client/Mandant-level AI Compliance Board Report workflow (Wave 13).
+
+Mirrors the tenant-level BoardReportWorkflow but scoped to a single
+client_id (Mandant) within a Kanzlei-tenant.  Aggregates AiSystem
+inventory + GRC records and synthesises a German advisory board report.
+
+LLM and I/O live in activities / service layer, not in the workflow body.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+from temporalio import workflow
+
+
+@dataclass
+class ClientBoardReportInput:
+    tenant_id: str
+    client_id: str
+    reporting_period: str = ""
+    system_filter: list[str] = field(default_factory=list)
+    language: str = "de"
+    user_role_for_opa: str = ""
+    otel_trace_carrier: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class ClientBoardReportResult:
+    report_id: str
+    workflow_id: str
+    tenant_id: str
+    client_id: str
+    reporting_period: str
+    systems_included: int
+
+
+@workflow.defn(name="ClientBoardReportWorkflow")
+class ClientBoardReportWorkflow:
+    @workflow.run
+    async def run(self, inp: ClientBoardReportInput) -> ClientBoardReportResult:
+        snapshot = await workflow.execute_activity(
+            "aggregate_client_board_data_activity",
+            {
+                "tenant_id": inp.tenant_id,
+                "client_id": inp.client_id,
+                "reporting_period": inp.reporting_period,
+                "system_filter": inp.system_filter,
+            },
+            start_to_close_timeout=timedelta(minutes=10),
+        )
+
+        report = await workflow.execute_activity(
+            "synthesise_client_board_report_activity",
+            {
+                "tenant_id": inp.tenant_id,
+                "client_id": inp.client_id,
+                "reporting_period": inp.reporting_period,
+                "snapshot": snapshot,
+                "language": inp.language,
+                "user_role": inp.user_role_for_opa,
+            },
+            start_to_close_timeout=timedelta(minutes=15),
+        )
+
+        info = workflow.info()
+        return ClientBoardReportResult(
+            report_id=report.get("report_id", ""),
+            workflow_id=info.workflow_id,
+            tenant_id=inp.tenant_id,
+            client_id=inp.client_id,
+            reporting_period=inp.reporting_period,
+            systems_included=report.get("systems_included", 0),
+        )

--- a/docs/architecture/wave13-client-board-reports-for-firms.md
+++ b/docs/architecture/wave13-client-board-reports-for-firms.md
@@ -1,0 +1,156 @@
+# Wave 13 — Client/Mandant-Level AI Compliance Board Reports
+
+## Overview
+
+Wave 13 introduces **Mandant-level AI Compliance Board Reports** for
+Steuerberater-/WP-Kanzleien.  These reports aggregate AiSystem inventory
+and GRC artefacts per Mandant (`client_id`) into a structured, advisory
+summary — ready for recurring compliance reporting.
+
+```
+Kanzlei (tenant)
+  └── Mandant A (client_id)
+        ├── AiSystem: CREDIT-AI-01 (high_risk_candidate, pilot)
+        │     ├── AiRiskAssessment: high_risk
+        │     ├── Nis2ObligationRecord: in_progress
+        │     └── Iso42001GapRecord: governance/monitoring open
+        ├── AiSystem: CHATBOT-02 (limited, production)
+        │     └── AiRiskAssessment: limited_risk
+        └── → Board Report (Markdown + highlights)
+```
+
+## Tenant-Level vs. Client-Level Reports
+
+| Aspect           | Tenant-Level (Wave 8+)              | Client-Level (Wave 13)                    |
+|------------------|--------------------------------------|-------------------------------------------|
+| Scope            | All AI systems in tenant             | AI systems for one Mandant                |
+| Use case         | Internal governance overview         | Kanzlei → Mandant advisory report         |
+| Triggered by     | Compliance Officer                   | Kanzlei-Berater for specific Mandant      |
+| EnterpriseContext| `tenant_id` only                     | `tenant_id` + `client_id`                 |
+| Temporal support | Full workflow                        | Workflow-ready, sync fallback for MVP     |
+
+## Workflow
+
+### ClientBoardReportWorkflow
+
+**Input:**
+- `tenant_id` — Kanzlei as SaaS tenant
+- `client_id` — Mandant
+- `reporting_period` — e.g. "Q1 2026"
+- `system_filter` — optional subset of system_ids
+- `language` — default "de"
+
+**Steps:**
+1. **Aggregate** — Load AiSystems + GRC records for this Mandant
+2. **Synthesise** — Generate Markdown report (LLM or deterministic fallback)
+3. **Persist** — Store report in-memory (DB later)
+4. **Evidence** — Log `client_board_report_generated` event
+
+**Output:**
+- `report_id`, `workflow_id`, `systems_included`, `status`
+
+## Data Aggregation
+
+Per AiSystem for the Mandant:
+- Classification, lifecycle stage, readiness level
+- Count of risk assessments
+- Open/in-progress NIS2 obligations
+- Open/remediation-planned ISO 42001 gaps
+- Framework coverage hints
+
+Aggregated totals:
+- Number of high-risk systems
+- Total open gaps
+- Total open obligations
+
+All operations are **read-only** — no GRC record status changes.
+
+## Report Synthesis
+
+### Sections
+1. **AI Systemübersicht Mandant X** — list with classification/lifecycle/readiness
+2. **EU AI Act Risikoeinschätzungen & offene Punkte** — high-risk candidates, conformity
+3. **NIS2-relevante Verpflichtungen** — open obligations, deadlines
+4. **ISO 42001/27001 Governance & Gap-Status** — open gaps by control family
+5. **Empfehlungen** (LLM path only)
+6. **Disclaimer** — "keine Rechtsberatung, nur unverbindliche Einordnung"
+
+### Two Paths
+- **LLM path**: Guardrailed LLM call with `LlmCallContext(action="generate_client_board_report")`
+- **Deterministic fallback**: Template-based Markdown (no LLM needed, always available)
+
+## API Endpoints
+
+### `POST /api/v1/clients/{client_id}/ai-board-report/workflows/start`
+Start a Mandant board report.  OPA: `start_client_board_report`.
+Returns `202 Accepted` with workflow_id, report_id, status.
+
+### `GET /api/v1/clients/{client_id}/ai-board-report/workflows/{workflow_id}`
+Check workflow status and retrieve report when complete.
+OPA: `view_client_board_report`.
+
+### `GET /api/v1/clients/{client_id}/ai-board-reports`
+List past reports for a Mandant.
+OPA: `view_client_board_report`.
+
+## Evidence & Metrics
+
+Each completed report emits:
+```json
+{
+  "event_type": "client_board_report_generated",
+  "tenant_id": "kanzlei-mueller",
+  "client_id": "mandant-42",
+  "report_id": "CBR-abc123",
+  "reporting_period": "Q1 2026",
+  "systems_included": 3,
+  "system_ids": ["CREDIT-AI-01", "CHATBOT-02", "HR-SCREEN-03"]
+}
+```
+
+Enables:
+- Kanzlei-internes Reporting (wie viele Mandanten-Reports pro Quartal?)
+- AI-Act-Audit trail (wann wurde welcher Mandant zuletzt bewertet?)
+
+## DATEV Integration Outlook
+
+These reports are designed for future DATEV-nahe integration:
+
+1. **DATEV DMS Export**: Report Markdown → PDF → upload to DATEV Dokumentenmanagement per Mandantennummer
+2. **DATEV Schnittstelle**: Structured `snapshot` payload → DATEV comfort letter / Prüfungsdokumentation
+3. **DATEV Online**: Mandant-portal view showing latest AI compliance status
+
+The `client_id` maps directly to DATEV Mandantennummer, making the
+data model ready for these integrations.
+
+## Example: Kanzlei Mueller, Mandant Acme GmbH
+
+1. Kanzlei-Berater starts report: `POST .../clients/mandant-42/ai-board-report/workflows/start?reporting_period=Q1 2026`
+2. System aggregates: 2 AiSystems, 1 high_risk_candidate, 1 open ISO gap
+3. Report generated:
+
+```markdown
+# AI Compliance Board-Report — Mandant mandant-42
+**Berichtszeitraum:** Q1 2026
+
+## AI Systemübersicht
+- **2** AI-System(e) erfasst
+- **1** als high_risk_candidate eingestuft
+
+### KI-Kreditprüfung (CREDIT-AI-01)
+- Klassifizierung: high_risk_candidate
+- Lifecycle: pilot
+- Readiness: insufficient_evidence
+- Offene ISO 42001 Gaps: 1
+
+### Mandanten-Chatbot (CHATBOT-02)
+- Klassifizierung: limited
+- Lifecycle: production
+...
+
+*Hinweis: Dieser Report dient ausschließlich der unverbindlichen
+Einordnung und stellt keine Rechtsberatung dar.*
+```
+
+4. Evidence event logged with all system_ids and report_id
+5. Report available via list/status API for future reference

--- a/tests/test_client_board_reports.py
+++ b/tests/test_client_board_reports.py
@@ -1,0 +1,437 @@
+"""Tests for Wave 13 — Client/Mandant-level AI Compliance Board Reports.
+
+Covers:
+- Data aggregation for a Mandant with multiple AiSystems + GRC records
+- Report synthesis (deterministic fallback + LLM path)
+- Workflow start → status → completed flow
+- Evidence events including tenant_id, client_id, system_ids
+- OPA enforcement on API endpoints
+- EnterpriseContext propagation (Kanzlei tenant + Mandant client)
+- System filter restricting included systems
+"""
+
+from __future__ import annotations
+
+from app.advisor.enterprise_context import EnterpriseContext
+from app.advisor.idempotency import clear_for_tests as clear_idem
+from app.advisor.preset_models import (
+    AiActRiskPresetInput,
+)
+from app.advisor.preset_service import (
+    run_eu_ai_act_risk_preset,
+)
+from app.grc.client_board_report_service import (
+    aggregate_client_data,
+    clear_reports_for_tests,
+    clear_workflows_for_tests,
+    get_report,
+    get_workflow_status,
+    list_reports,
+    run_client_board_report,
+    synthesise_report,
+)
+from app.grc.models import (
+    AiRiskAssessment,
+    AiSystem,
+    AiSystemClassification,
+    GapStatus,
+    Iso42001GapRecord,
+    LifecycleStage,
+    Nis2ObligationRecord,
+    ObligationStatus,
+)
+from app.grc.store import (
+    clear_for_tests as clear_grc,
+)
+from app.grc.store import (
+    upsert_ai_system,
+    upsert_gap,
+    upsert_nis2,
+    upsert_risk,
+)
+from app.services.agents.advisor_compliance_agent import AdvisorComplianceAgent
+from app.services.rag.config import RAGConfig
+from app.services.rag.corpus import Document
+from app.services.rag.evidence_store import clear_for_tests as clear_evidence
+from app.services.rag.hybrid_retriever import HybridRetriever
+from app.services.rag.llm import LlmCallContext, LlmResponse
+
+MOCK_CORPUS = [
+    Document(
+        doc_id="w13-1",
+        title="EU AI Act Art. 6",
+        content=(
+            "Hochrisiko KI-Systeme nach Art. 6 und Anhang III "
+            "erfordern eine Konformitätsbewertung. Systeme zur "
+            "Kreditwürdigkeitsprüfung fallen unter Anhang III Nr. 5."
+        ),
+        source="EU AI Act",
+        section="Art. 6",
+    ),
+    Document(
+        doc_id="w13-2",
+        title="NIS2 Art. 21",
+        content=(
+            "Wesentliche Einrichtungen müssen Risikomanagement, "
+            "Meldepflichten und Governance-Maßnahmen umsetzen."
+        ),
+        source="NIS2",
+        section="Art. 21",
+    ),
+    Document(
+        doc_id="w13-3",
+        title="ISO 42001 Governance",
+        content=(
+            "ISO 42001 erfordert Governance, Risikobewertung, "
+            "Datenmanagement, Monitoring und Transparenz. "
+            "ISO 27001 bietet erhebliche Überschneidungen."
+        ),
+        source="ISO 42001",
+        section="4-10",
+    ),
+]
+
+
+def _mock_llm(prompt: str, context: LlmCallContext) -> LlmResponse:
+    return LlmResponse(
+        text=(
+            "Basierend auf Art. 6 und Anhang III ist dieses "
+            "Hochrisiko-KI-System konformitätsbewertungspflichtig."
+        ),
+        model_id="mock",
+        input_tokens=50,
+        output_tokens=30,
+    )
+
+
+def _make_agent() -> AdvisorComplianceAgent:
+    config = RAGConfig(retrieval_mode="bm25")
+    retriever = HybridRetriever(MOCK_CORPUS, config)
+    return AdvisorComplianceAgent(retriever=retriever, llm_fn=_mock_llm)
+
+
+def _cleanup() -> None:
+    clear_evidence()
+    clear_idem()
+    clear_grc()
+    clear_reports_for_tests()
+    clear_workflows_for_tests()
+
+
+def _seed_mandant_data(
+    tenant_id: str = "kanzlei-t",
+    client_id: str = "mandant-42",
+) -> None:
+    """Seed synthetic AiSystems + GRC records for a Mandant."""
+    upsert_ai_system(
+        AiSystem(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            system_id="CREDIT-AI-01",
+            name="KI-Kreditprüfung",
+            ai_act_classification=AiSystemClassification.high_risk_candidate,
+            nis2_relevant=True,
+            iso42001_in_scope=True,
+            lifecycle_stage=LifecycleStage.pilot,
+        )
+    )
+    upsert_ai_system(
+        AiSystem(
+            tenant_id=tenant_id,
+            client_id=client_id,
+            system_id="CHATBOT-02",
+            name="Mandanten-Chatbot",
+            ai_act_classification=AiSystemClassification.limited,
+            lifecycle_stage=LifecycleStage.production,
+        )
+    )
+
+    upsert_risk(
+        AiRiskAssessment(
+            tenant_id=tenant_id,
+            system_id="CREDIT-AI-01",
+            risk_category="high_risk",
+        )
+    )
+    upsert_risk(
+        AiRiskAssessment(
+            tenant_id=tenant_id,
+            system_id="CHATBOT-02",
+            risk_category="limited_risk",
+        )
+    )
+
+    upsert_nis2(
+        Nis2ObligationRecord(
+            tenant_id=tenant_id,
+            system_id="CREDIT-AI-01",
+            status=ObligationStatus.in_progress,
+            obligation_tags=["risk_management", "incident_reporting"],
+        )
+    )
+
+    upsert_gap(
+        Iso42001GapRecord(
+            tenant_id=tenant_id,
+            system_id="CREDIT-AI-01",
+            control_families=["governance", "monitoring"],
+            status=GapStatus.open,
+            gap_severity="major",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestDataAggregation:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_aggregate_returns_system_summaries(self) -> None:
+        _seed_mandant_data()
+        result = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+        )
+
+        assert result["systems_count"] == 2
+        assert result["high_risk_systems"] == 1
+        assert result["total_open_gaps"] == 1
+        assert result["total_open_obligations"] == 1
+
+        sys_ids = [s["system_id"] for s in result["systems"]]
+        assert "CREDIT-AI-01" in sys_ids
+        assert "CHATBOT-02" in sys_ids
+
+    def test_aggregate_empty_mandant(self) -> None:
+        result = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="unknown",
+        )
+        assert result["systems_count"] == 0
+
+    def test_system_filter(self) -> None:
+        _seed_mandant_data()
+        result = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            system_filter=["CREDIT-AI-01"],
+        )
+        assert result["systems_count"] == 1
+        assert result["systems"][0]["system_id"] == "CREDIT-AI-01"
+
+
+# ---------------------------------------------------------------------------
+# Report synthesis
+# ---------------------------------------------------------------------------
+
+
+class TestReportSynthesis:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_deterministic_report(self) -> None:
+        _seed_mandant_data()
+        snapshot = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+        )
+        report = synthesise_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+            snapshot=snapshot,
+        )
+
+        assert "mandant-42" in report.report_markdown
+        assert "Rechtsberatung" in report.report_markdown
+        assert report.systems_included == 2
+        assert len(report.highlights) >= 1
+
+    def test_llm_report(self) -> None:
+        _seed_mandant_data()
+        snapshot = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+        )
+
+        def mock_llm(prompt: str, ctx: LlmCallContext) -> LlmResponse:
+            assert ctx.tenant_id == "kanzlei-t"
+            assert ctx.action == "generate_client_board_report"
+            return LlmResponse(
+                text="## LLM-generierter Report\nTest-Inhalt.",
+                model_id="mock",
+            )
+
+        report = synthesise_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+            snapshot=snapshot,
+            llm_fn=mock_llm,
+        )
+
+        assert "LLM-generierter Report" in report.report_markdown
+        assert "Rechtsberatung" in report.report_markdown
+
+    def test_report_persisted(self) -> None:
+        _seed_mandant_data()
+        snapshot = aggregate_client_data(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+        )
+        report = synthesise_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+            snapshot=snapshot,
+        )
+
+        stored = get_report(report.id)
+        assert stored is not None
+        assert stored.id == report.id
+
+
+# ---------------------------------------------------------------------------
+# Workflow orchestration
+# ---------------------------------------------------------------------------
+
+
+class TestWorkflowOrchestration:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_full_workflow_run(self) -> None:
+        _seed_mandant_data()
+        result = run_client_board_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+        )
+
+        assert result["status"] == "COMPLETED"
+        assert result["systems_included"] == 2
+        assert result["report_id"].startswith("CBR-")
+        assert result["client_id"] == "mandant-42"
+
+    def test_workflow_status_tracked(self) -> None:
+        _seed_mandant_data()
+        result = run_client_board_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            workflow_id="cbr-test-001",
+        )
+
+        wf = get_workflow_status("cbr-test-001")
+        assert wf is not None
+        assert wf["status"] == "COMPLETED"
+        assert wf["report_id"] == result["report_id"]
+
+    def test_list_reports_for_mandant(self) -> None:
+        _seed_mandant_data()
+        run_client_board_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+        )
+        run_client_board_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q2 2026",
+        )
+
+        reports = list_reports(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+        )
+        assert len(reports) == 2
+
+
+# ---------------------------------------------------------------------------
+# Evidence events
+# ---------------------------------------------------------------------------
+
+
+class TestReportEvidence:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_evidence_event_emitted(self) -> None:
+        from app.services.rag.evidence_store import _events, _lock
+
+        _seed_mandant_data()
+        run_client_board_report(
+            tenant_id="kanzlei-t",
+            client_id="mandant-42",
+            reporting_period="Q1 2026",
+        )
+
+        with _lock:
+            cbr_events = [
+                e for e in _events if e.get("event_type") == "client_board_report_generated"
+            ]
+
+        assert len(cbr_events) >= 1
+        ev = cbr_events[-1]
+        assert ev["tenant_id"] == "kanzlei-t"
+        assert ev["client_id"] == "mandant-42"
+        assert ev["reporting_period"] == "Q1 2026"
+        assert ev["systems_included"] == 2
+        assert len(ev["system_ids"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: presets → GRC → board report
+# ---------------------------------------------------------------------------
+
+
+class TestEndToEnd:
+    def setup_method(self) -> None:
+        _cleanup()
+
+    def teardown_method(self) -> None:
+        _cleanup()
+
+    def test_presets_then_board_report(self) -> None:
+        agent = _make_agent()
+        ctx = EnterpriseContext(
+            tenant_id="e2e-kanzlei",
+            client_id="mandant-99",
+            system_id="E2E-SYS",
+        )
+
+        run_eu_ai_act_risk_preset(
+            AiActRiskPresetInput(
+                context=ctx,
+                use_case_description="KI-Kreditprüfung",
+            ),
+            agent=agent,
+        )
+
+        result = run_client_board_report(
+            tenant_id="e2e-kanzlei",
+            client_id="mandant-99",
+        )
+
+        assert result["status"] == "COMPLETED"
+        assert result["systems_included"] >= 0
+
+        if result["report_id"]:
+            report = get_report(result["report_id"])
+            assert report is not None
+            assert "Rechtsberatung" in report.report_markdown


### PR DESCRIPTION
- Add ClientBoardReportWorkflow (Temporal-ready) with input model: tenant_id, client_id, reporting_period, system_filter, language.
- Add client board report service (app/grc/client_board_report_service.py):
  - Data aggregation: loads AiSystems + GRC records per Mandant, computes per-system classification/lifecycle/readiness/gaps/obligations summary.
  - Report synthesis: guardrailed LLM path + deterministic Markdown fallback, German sections (Systemübersicht, AI Act, NIS2, ISO 42001, Disclaimer).
  - In-memory report + workflow store with list/get/status operations.
  - Evidence: logs client_board_report_generated events with tenant_id, client_id, system_ids, reporting_period.
- Add 3 API endpoints: POST /api/v1/clients/{client_id}/ai-board-report/workflows/start (202), GET  .../workflows/{workflow_id} (status + report payload), GET  /api/v1/clients/{client_id}/ai-board-reports (list past reports). All OPA-secured (start_client_board_report / view_client_board_report).
- Add 11 tests covering data aggregation, deterministic + LLM synthesis, workflow orchestration, evidence events, system filter, and end-to-end preset → GRC → board report flow.
- Add architecture doc (wave13-client-board-reports-for-firms.md) with tenant vs. client comparison, DATEV integration outlook, and example.

Made-with: Cursor