### PR TITLE
feat(wave17): product packaging — tiers, bundles, capability enforcement

### DIFF
--- a/app/demo_models.py
+++ b/app/demo_models.py
@@ -96,3 +96,15 @@ class TenantWorkspaceMetaResponse(BaseModel):
             "COMPLIANCEHUB_OPA_ROLE_AI_EVIDENCE wie die Evidence-API."
         ),
     )
+    plan_tier: str = Field(
+        default="starter",
+        description="Product tier (starter | pro | enterprise).",
+    )
+    plan_display: str = Field(
+        default="",
+        description="Human-readable plan label for UI shell.",
+    )
+    plan_capabilities: list[str] = Field(
+        default_factory=list,
+        description="List of capability flags enabled for this tenant.",
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -220,6 +220,7 @@ from app.policy.role_resolution import (
 from app.policy.user_context import UserPolicyContext
 from app.policy_models import Violation
 from app.policy_service import evaluate_policies_for_ai_system
+from app.product.models import Capability
 from app.provisioning_models import (
     ProvisionTenantRequest,
     ProvisionTenantResponse,
@@ -3230,6 +3231,9 @@ def get_workspace_tenant_meta(
             "risk_score": 0.4,
         },
     )
+    from app.product.plan_store import get_tenant_plan
+
+    plan = get_tenant_plan(tid)
     return TenantWorkspaceMetaResponse(
         tenant_id=row.id,
         display_name=row.display_name,
@@ -3242,6 +3246,9 @@ def get_workspace_tenant_meta(
         demo_mode_feature_enabled=is_feature_enabled(FeatureFlag.demo_mode),
         feature_ai_act_evidence_views=ai_evidence_ff,
         can_view_ai_evidence=bool(evidence_decision.allowed),
+        plan_tier=plan.tier.value,
+        plan_display=plan.plan_display(),
+        plan_capabilities=sorted(c.value for c in plan.capabilities()),
     )
 
 
@@ -4765,8 +4772,10 @@ def list_grc_ai_risks(
 ) -> list[dict[str, Any]]:
     """List AI risk assessment records (read-only)."""
     from app.grc.store import list_risks
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("view_grc_records", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.grc_records)
     tid = tenant_id or auth.tenant_id
     records = list_risks(tenant_id=tid, client_id=client_id, system_id=system_id)
     return [r.model_dump() for r in records]
@@ -4785,8 +4794,10 @@ def list_grc_nis2_obligations(
 ) -> list[dict[str, Any]]:
     """List NIS2 obligation records (read-only)."""
     from app.grc.store import list_nis2_obligations
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("view_grc_records", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.grc_records)
     tid = tenant_id or auth.tenant_id
     records = list_nis2_obligations(
         tenant_id=tid,
@@ -4809,8 +4820,10 @@ def list_grc_iso42001_gaps(
 ) -> list[dict[str, Any]]:
     """List ISO 42001 gap records (read-only)."""
     from app.grc.store import list_iso42001_gaps
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("view_grc_records", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.grc_records)
     tid = tenant_id or auth.tenant_id
     records = list_iso42001_gaps(
         tenant_id=tid,
@@ -4856,8 +4869,10 @@ def list_ai_systems_endpoint(
 ) -> list[dict[str, Any]]:
     """List AI systems registered for a tenant."""
     from app.grc.store import list_ai_systems
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("view_ai_systems", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.ai_system_inventory)
     tid = tenant_id or auth.tenant_id
     systems = list_ai_systems(
         tenant_id=tid,
@@ -4996,8 +5011,10 @@ def start_client_board_report(
 ) -> dict[str, Any]:
     """Start a Mandant-level AI compliance board report workflow."""
     from app.grc.client_board_report_service import run_client_board_report
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("start_client_board_report", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.kanzlei_reports)
     tid = auth.tenant_id
 
     sf = [s.strip() for s in system_filter.split(",") if s.strip()] if system_filter else None
@@ -5104,8 +5121,10 @@ def list_integration_jobs(
 ) -> list[dict[str, Any]]:
     """List outbox integration jobs (internal/admin)."""
     from app.integrations.store import list_jobs
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("view_integration_jobs", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.enterprise_integrations)
     tid = tenant_id or auth.tenant_id
     jobs = list_jobs(
         tenant_id=tid,
@@ -5140,8 +5159,10 @@ def create_integration_job(
     """Manually enqueue an integration job for a source entity."""
     from app.integrations.models import IntegrationTarget
     from app.integrations.outbox import enqueue_for_entity
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("manage_integrations", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.enterprise_integrations)
     try:
         tgt = IntegrationTarget(body.target)
     except ValueError:
@@ -5250,8 +5271,10 @@ def create_mandant_export(
 ) -> dict[str, Any]:
     """Enqueue a Mandanten-Compliance-Dossier export job."""
     from app.integrations.outbox import enqueue_mandant_dossier
+    from app.product.plan_store import require_capability
 
     _enforce_grc_opa("manage_integrations", auth, opa_role_header)
+    require_capability(auth.tenant_id, Capability.kanzlei_reports)
     job = enqueue_mandant_dossier(
         tenant_id=auth.tenant_id,
         client_id=body.client_id,
@@ -5292,6 +5315,9 @@ def receive_sap_ai_system_event(
         process_sap_ai_system_event,
         validate_sap_envelope,
     )
+    from app.product.plan_store import require_capability
+
+    require_capability(auth.tenant_id, Capability.enterprise_integrations)
 
     if not body.get("tenantid"):
         body["tenantid"] = auth.tenant_id
@@ -5304,3 +5330,96 @@ def receive_sap_ai_system_event(
         )
     result = process_sap_ai_system_event(body)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Product Packaging APIs (Wave 17)
+# ---------------------------------------------------------------------------
+
+
+@app.get(
+    "/api/internal/product/plan",
+    tags=["product"],
+)
+def get_tenant_plan_api(
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+) -> dict[str, Any]:
+    """Return the product plan for the authenticated tenant."""
+    from app.product.plan_store import get_tenant_plan
+
+    plan = get_tenant_plan(auth.tenant_id)
+    return {
+        "tenant_id": auth.tenant_id,
+        "tier": plan.tier.value,
+        "bundles": sorted(b.value for b in plan.effective_bundles()),
+        "capabilities": sorted(c.value for c in plan.capabilities()),
+        "plan_display": plan.plan_display(),
+        "label": plan.label,
+    }
+
+
+class SetTenantPlanRequest(BaseModel):
+    tier: str = "starter"
+    bundles: list[str] = []
+    label: str = ""
+
+
+@app.put(
+    "/api/internal/product/plan/{tenant_id}",
+    tags=["product"],
+)
+def set_tenant_plan_api(
+    tenant_id: str,
+    body: SetTenantPlanRequest,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+) -> dict[str, Any]:
+    """Set the product plan for a tenant (admin-only)."""
+    from app.product.models import ProductTier, TenantPlanConfig
+    from app.product.plan_store import set_tenant_plan
+
+    _enforce_grc_opa("manage_integrations", auth, opa_role_header)
+    try:
+        tier = ProductTier(body.tier)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Unknown tier: {body.tier}")
+    plan = TenantPlanConfig(
+        tenant_id=tenant_id,
+        tier=tier,
+        bundles=set(body.bundles),
+        label=body.label,
+    )
+    saved = set_tenant_plan(plan)
+    return {
+        "tenant_id": tenant_id,
+        "tier": saved.tier.value,
+        "bundles": sorted(b.value for b in saved.effective_bundles()),
+        "capabilities": sorted(c.value for c in saved.capabilities()),
+        "plan_display": saved.plan_display(),
+    }
+
+
+@app.post(
+    "/api/internal/product/demo-seed/{tenant_id}",
+    tags=["product"],
+)
+def seed_demo_plan_api(
+    tenant_id: str,
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    opa_role_header: Annotated[str | None, Depends(get_optional_opa_user_role_header)],
+    profile: str = Query(..., description="Demo profile: kanzlei_demo, sap_demo, sme_demo"),
+) -> dict[str, Any]:
+    """Apply a demo plan profile to a tenant."""
+    from app.product.demo_plans import seed_demo_plan
+
+    _enforce_grc_opa("manage_integrations", auth, opa_role_header)
+    plan = seed_demo_plan(tenant_id, profile)
+    if plan is None:
+        raise HTTPException(status_code=400, detail=f"Unknown profile: {profile}")
+    return {
+        "tenant_id": tenant_id,
+        "profile": profile,
+        "tier": plan.tier.value,
+        "bundles": sorted(b.value for b in plan.effective_bundles()),
+        "capabilities": sorted(c.value for c in plan.capabilities()),
+    }

--- a/app/product/__init__.py
+++ b/app/product/__init__.py
@@ -1,0 +1,1 @@
+"""Product packaging — tiers, bundles, and capability checks."""

--- a/app/product/demo_plans.py
+++ b/app/product/demo_plans.py
@@ -1,0 +1,53 @@
+"""Pre-configured demo tenant plans for sales/demo environments.
+
+Each plan profile represents a typical DACH customer segment:
+- Kanzlei Demo: Pro tier with governance + evidence bundles
+- SAP Demo: Enterprise with full integrations
+- SME Demo: Starter with AI Act Readiness only
+"""
+
+from __future__ import annotations
+
+from app.product.models import ProductBundle, ProductTier, TenantPlanConfig
+from app.product.plan_store import set_tenant_plan
+
+DEMO_PLAN_PROFILES: dict[str, TenantPlanConfig] = {
+    "kanzlei_demo": TenantPlanConfig(
+        tenant_id="",
+        tier=ProductTier.pro,
+        bundles={
+            ProductBundle.ai_act_readiness,
+            ProductBundle.ai_governance_evidence,
+        },
+        label="Kanzlei Demo (Pro)",
+    ),
+    "sap_demo": TenantPlanConfig(
+        tenant_id="",
+        tier=ProductTier.enterprise,
+        bundles={
+            ProductBundle.ai_act_readiness,
+            ProductBundle.ai_governance_evidence,
+            ProductBundle.enterprise_integrations,
+        },
+        label="SAP Enterprise Demo",
+    ),
+    "sme_demo": TenantPlanConfig(
+        tenant_id="",
+        tier=ProductTier.starter,
+        bundles={ProductBundle.ai_act_readiness},
+        label="SME Demo (Starter)",
+    ),
+}
+
+
+def seed_demo_plan(tenant_id: str, profile: str) -> TenantPlanConfig | None:
+    """Apply a demo plan profile to a tenant. Returns None if profile unknown."""
+    template = DEMO_PLAN_PROFILES.get(profile)
+    if template is None:
+        return None
+    plan = template.model_copy(update={"tenant_id": tenant_id})
+    return set_tenant_plan(plan)
+
+
+def list_profiles() -> list[str]:
+    return sorted(DEMO_PLAN_PROFILES.keys())

--- a/app/product/models.py
+++ b/app/product/models.py
@@ -1,0 +1,150 @@
+"""Product packaging domain model.
+
+Defines tiers, bundles, capabilities, and the mapping between them.
+These are the building blocks for DACH-market product packages:
+- Starter: AI Act Readiness (Einstieg für KMU)
+- Pro: AI Governance + Evidence (Wachstumsphase Kanzlei/Mittelstand)
+- Enterprise: Full platform + SAP/DATEV connectors
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class ProductTier(StrEnum):
+    starter = "starter"
+    pro = "pro"
+    enterprise = "enterprise"
+
+
+class ProductBundle(StrEnum):
+    ai_act_readiness = "ai_act_readiness"
+    ai_governance_evidence = "ai_governance_evidence"
+    enterprise_integrations = "enterprise_integrations"
+
+
+class Capability(StrEnum):
+    ai_advisor_basic = "cap_ai_advisor_basic"
+    ai_evidence_basic = "cap_ai_evidence_basic"
+    grc_records = "cap_grc_records"
+    ai_system_inventory = "cap_ai_system_inventory"
+    kanzlei_reports = "cap_kanzlei_reports"
+    enterprise_integrations = "cap_enterprise_integrations"
+
+
+BUNDLE_CAPABILITIES: dict[ProductBundle, frozenset[Capability]] = {
+    ProductBundle.ai_act_readiness: frozenset(
+        {
+            Capability.ai_advisor_basic,
+            Capability.ai_evidence_basic,
+        }
+    ),
+    ProductBundle.ai_governance_evidence: frozenset(
+        {
+            Capability.ai_advisor_basic,
+            Capability.ai_evidence_basic,
+            Capability.grc_records,
+            Capability.ai_system_inventory,
+            Capability.kanzlei_reports,
+        }
+    ),
+    ProductBundle.enterprise_integrations: frozenset(
+        {
+            Capability.enterprise_integrations,
+            Capability.kanzlei_reports,
+        }
+    ),
+}
+
+TIER_DEFAULT_BUNDLES: dict[ProductTier, frozenset[ProductBundle]] = {
+    ProductTier.starter: frozenset({ProductBundle.ai_act_readiness}),
+    ProductTier.pro: frozenset(
+        {
+            ProductBundle.ai_act_readiness,
+            ProductBundle.ai_governance_evidence,
+        }
+    ),
+    ProductTier.enterprise: frozenset(
+        {
+            ProductBundle.ai_act_readiness,
+            ProductBundle.ai_governance_evidence,
+            ProductBundle.enterprise_integrations,
+        }
+    ),
+}
+
+
+class TenantPlanConfig(BaseModel):
+    """Product plan assigned to a tenant."""
+
+    tenant_id: str
+    tier: ProductTier = ProductTier.starter
+    bundles: set[str] = Field(default_factory=set)
+    label: str = ""
+
+    def effective_bundles(self) -> set[ProductBundle]:
+        """Bundles from tier defaults merged with explicit overrides."""
+        result = set(TIER_DEFAULT_BUNDLES.get(self.tier, set()))
+        for b in self.bundles:
+            try:
+                result.add(ProductBundle(b))
+            except ValueError:
+                pass
+        return result
+
+    def capabilities(self) -> set[Capability]:
+        """All capabilities granted by the effective bundle set."""
+        caps: set[Capability] = set()
+        for bundle in self.effective_bundles():
+            caps |= BUNDLE_CAPABILITIES.get(bundle, frozenset())
+        return caps
+
+    def has_capability(self, cap: Capability) -> bool:
+        return cap in self.capabilities()
+
+    def plan_display(self) -> str:
+        """Human-readable plan string for UI."""
+        tier_labels = {
+            ProductTier.starter: "Starter",
+            ProductTier.pro: "Professional",
+            ProductTier.enterprise: "Enterprise",
+        }
+        bundle_labels = {
+            ProductBundle.ai_act_readiness: "AI Act Readiness",
+            ProductBundle.ai_governance_evidence: "AI Governance & Evidence",
+            ProductBundle.enterprise_integrations: "Enterprise Connectors",
+        }
+        tier_label = tier_labels.get(self.tier, self.tier.value)
+        bundle_names = sorted(bundle_labels.get(b, b.value) for b in self.effective_bundles())
+        return f"{tier_label} – {', '.join(bundle_names)}"
+
+
+CAPABILITY_LABELS: dict[Capability, dict[str, str]] = {
+    Capability.ai_advisor_basic: {
+        "de": "AI Act Advisor (Basis)",
+        "en": "AI Act Advisor (Basic)",
+    },
+    Capability.ai_evidence_basic: {
+        "de": "AI Act Evidence & Nachweise",
+        "en": "AI Act Evidence & Documentation",
+    },
+    Capability.grc_records: {
+        "de": "GRC-Einträge (Risiko, NIS2, ISO 42001)",
+        "en": "GRC Records (Risk, NIS2, ISO 42001)",
+    },
+    Capability.ai_system_inventory: {
+        "de": "AI-System-Inventar & Lifecycle",
+        "en": "AI System Inventory & Lifecycle",
+    },
+    Capability.kanzlei_reports: {
+        "de": "Mandanten-Board-Reports & Dossiers",
+        "en": "Client Board Reports & Dossiers",
+    },
+    Capability.enterprise_integrations: {
+        "de": "Enterprise-Integrationen (SAP/DATEV)",
+        "en": "Enterprise Integrations (SAP/DATEV)",
+    },
+}

--- a/app/product/plan_store.py
+++ b/app/product/plan_store.py
@@ -1,0 +1,136 @@
+"""In-memory tenant plan store and capability resolution.
+
+Fast, cache-friendly lookups for capability checks at API and UI level.
+Tenants without an explicit plan config get a default starter tier.
+"""
+
+from __future__ import annotations
+
+import logging
+from threading import Lock
+
+from app.product.models import (
+    CAPABILITY_LABELS,
+    Capability,
+    ProductTier,
+    TenantPlanConfig,
+)
+from app.services.rag.evidence_store import record_event
+
+logger = logging.getLogger(__name__)
+
+_lock = Lock()
+_plans: dict[str, TenantPlanConfig] = {}
+
+_DEFAULT_PLAN = TenantPlanConfig(tenant_id="__default__", tier=ProductTier.starter)
+
+
+def set_tenant_plan(plan: TenantPlanConfig) -> TenantPlanConfig:
+    """Assign or update a tenant's product plan."""
+    with _lock:
+        _plans[plan.tenant_id] = plan
+    logger.info(
+        "tenant_plan_set",
+        extra={
+            "tenant_id": plan.tenant_id,
+            "tier": plan.tier.value,
+            "bundles": sorted(plan.bundles),
+        },
+    )
+    return plan
+
+
+def get_tenant_plan(tenant_id: str) -> TenantPlanConfig:
+    """Return the plan for a tenant, defaulting to starter if unset."""
+    with _lock:
+        plan = _plans.get(tenant_id)
+    if plan is not None:
+        return plan
+    return TenantPlanConfig(tenant_id=tenant_id, tier=ProductTier.starter)
+
+
+def has_capability(tenant_id: str, cap: Capability) -> bool:
+    """Check if a tenant has a specific capability. Fast path."""
+    return get_tenant_plan(tenant_id).has_capability(cap)
+
+
+def list_tenant_plans() -> list[TenantPlanConfig]:
+    """List all explicitly configured tenant plans (internal/admin)."""
+    with _lock:
+        return list(_plans.values())
+
+
+def clear_for_tests() -> None:
+    with _lock:
+        _plans.clear()
+
+
+# ---------------------------------------------------------------------------
+# Capability enforcement helper (raises HTTPException)
+# ---------------------------------------------------------------------------
+
+from fastapi import HTTPException, status  # noqa: E402
+
+
+def require_capability(tenant_id: str, cap: Capability) -> None:
+    """Raise 403 if the tenant lacks the required capability."""
+    if has_capability(tenant_id, cap):
+        return
+    labels = CAPABILITY_LABELS.get(cap, {})
+    label_de = labels.get("de", cap.value)
+    label_en = labels.get("en", cap.value)
+    raise HTTPException(
+        status_code=status.HTTP_403_FORBIDDEN,
+        detail={
+            "error": "feature_not_enabled",
+            "message_en": (
+                f"This feature ({label_en}) is not included in your current plan. "
+                f"Contact your ComplianceHub representative to upgrade."
+            ),
+            "message_de": (
+                f"Diese Funktion ({label_de}) ist in Ihrem aktuellen Paket nicht enthalten. "
+                f"Kontaktieren Sie Ihren ComplianceHub-Ansprechpartner für ein Upgrade."
+            ),
+            "capability": cap.value,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Usage metrics
+# ---------------------------------------------------------------------------
+
+
+def log_capability_usage(
+    *,
+    tenant_id: str,
+    capability: str,
+    action: str,
+    bundle: str = "",
+) -> None:
+    """Record a feature usage event for packaging analytics."""
+    plan = get_tenant_plan(tenant_id)
+    record_event(
+        {
+            "event_type": "capability_usage",
+            "tenant_id": tenant_id,
+            "capability": capability,
+            "action": action,
+            "tier": plan.tier.value,
+            "bundle": bundle or _primary_bundle_for_cap(plan, capability),
+        }
+    )
+
+
+def _primary_bundle_for_cap(plan: TenantPlanConfig, cap_value: str) -> str:
+    """Best-effort: find the first bundle that grants this capability."""
+    try:
+        cap = Capability(cap_value)
+    except ValueError:
+        return ""
+    for bundle in plan.effective_bundles():
+        from app.product.models import BUNDLE_CAPABILITIES
+
+        if cap in BUNDLE_CAPABILITIES.get(bundle, frozenset()):
+            return bundle.value
+    return ""

--- a/docs/architecture/wave17-product-packaging-and-feature-flags.md
+++ b/docs/architecture/wave17-product-packaging-and-feature-flags.md
@@ -1,0 +1,214 @@
+# Wave 17 — Product Packaging & Feature-Flag Model
+
+## Overview
+
+Wave 17 introduces ComplianceHub's internal product packaging model: tiers,
+bundles, capabilities, and enforcement — so the platform can be sold in
+coherent packages for DACH enterprise and Kanzlei customers.
+
+**Key principle:** capabilities are enforced on the backend (not just hidden in
+the UI). No billing integration in this wave — pure feature gating.
+
+---
+
+## 1. Tier / Bundle / Capability Model
+
+### Product Tiers
+
+| Tier | Target Segment | Default Bundles |
+|---|---|---|
+| **Starter** | KMU-Einstieg | AI Act Readiness |
+| **Professional** | Kanzlei / wachsender Mittelstand | AI Act Readiness + AI Governance & Evidence |
+| **Enterprise** | SAP-Mittelstand / Konzern | All bundles |
+
+### Product Bundles
+
+| Bundle | Capabilities Included |
+|---|---|
+| `ai_act_readiness` | `cap_ai_advisor_basic`, `cap_ai_evidence_basic` |
+| `ai_governance_evidence` | `cap_ai_advisor_basic`, `cap_ai_evidence_basic`, `cap_grc_records`, `cap_ai_system_inventory`, `cap_kanzlei_reports` |
+| `enterprise_integrations` | `cap_enterprise_integrations`, `cap_kanzlei_reports` |
+
+### Capability Flags
+
+| Capability | Description |
+|---|---|
+| `cap_ai_advisor_basic` | AI Act Advisor (RAG + presets) |
+| `cap_ai_evidence_basic` | AI Act Evidence & Nachweise |
+| `cap_grc_records` | GRC records (Risk, NIS2, ISO 42001) |
+| `cap_ai_system_inventory` | AI system inventory & lifecycle |
+| `cap_kanzlei_reports` | Mandanten-Board-Reports & Dossiers |
+| `cap_enterprise_integrations` | Enterprise connectors (SAP/DATEV) |
+
+### Resolution
+
+```
+Tenant → TenantPlanConfig (tier + optional extra bundles)
+  → effective_bundles() = tier defaults ∪ explicit overrides
+  → capabilities() = union of all bundle capabilities
+  → has_capability(cap) = cap ∈ capabilities()
+```
+
+---
+
+## 2. Example SKUs
+
+### AI Act Readiness (Starter)
+
+- Advisor basics (RAG, presets for AI Act risk assessment)
+- Evidence views (AI Act documentation tracking)
+- No GRC entities, no integrations, no board reports
+- **Target:** KMU / SME starting their AI Act journey
+
+### AI Governance Suite (Professional)
+
+- Everything in Starter
+- GRC records (AiRiskAssessment, NIS2, ISO 42001 gaps)
+- AI system inventory with lifecycle & readiness
+- Mandanten-Board-Reports & Kanzlei-Dossiers
+- **Target:** Steuerberater/WP-Kanzleien, growing Mittelstand
+
+### Enterprise Connectors (Enterprise add-on)
+
+- Everything in Professional
+- DATEV export artifacts & SAP BTP envelopes
+- Integration job management (outbox, dispatcher, retry)
+- SAP S/4 inbound endpoint
+- **Target:** SAP-centric enterprises, large Kanzleien with system integrations
+
+---
+
+## 3. API Enforcement
+
+Capability checks are enforced **on the backend** at the endpoint level,
+after OPA role checks:
+
+```python
+require_capability(auth.tenant_id, Capability.grc_records)
+```
+
+### Protected Endpoints
+
+| Endpoint Group | Required Capability |
+|---|---|
+| GRC APIs (`/api/v1/grc/*`) | `cap_grc_records` |
+| AI System Inventory (`/api/v1/ai-systems`) | `cap_ai_system_inventory` |
+| Client Board Reports | `cap_kanzlei_reports` |
+| Mandant-Dossier Export | `cap_kanzlei_reports` |
+| Integration Jobs | `cap_enterprise_integrations` |
+| SAP Inbound Endpoint | `cap_enterprise_integrations` |
+
+### Error Response
+
+When a capability is missing, the API returns HTTP 403 with a standardized
+bilingual error:
+
+```json
+{
+  "error": "feature_not_enabled",
+  "message_en": "This feature (GRC Records) is not included in your current plan. Contact your ComplianceHub representative to upgrade.",
+  "message_de": "Diese Funktion (GRC-Einträge) ist in Ihrem aktuellen Paket nicht enthalten. Kontaktieren Sie Ihren ComplianceHub-Ansprechpartner für ein Upgrade.",
+  "capability": "cap_grc_records"
+}
+```
+
+---
+
+## 4. UI Integration
+
+The workspace meta endpoint (`/api/v1/workspace/tenant-meta`) now includes:
+
+```json
+{
+  "plan_tier": "pro",
+  "plan_display": "Professional – AI Act Readiness, AI Governance & Evidence",
+  "plan_capabilities": [
+    "cap_ai_advisor_basic",
+    "cap_ai_evidence_basic",
+    "cap_ai_system_inventory",
+    "cap_grc_records",
+    "cap_kanzlei_reports"
+  ]
+}
+```
+
+The frontend can use `plan_capabilities` to:
+- Show/hide navigation items
+- Enable/disable workflow buttons
+- Display "In Ihrem aktuellen Paket nicht enthalten" tooltips
+
+---
+
+## 5. Demo Tenant Profiles
+
+Pre-configured profiles for sales demos:
+
+| Profile | Tier | Use Case |
+|---|---|---|
+| `kanzlei_demo` | Professional | Kanzlei with governance + evidence |
+| `sap_demo` | Enterprise | Full platform including integrations |
+| `sme_demo` | Starter | SME with AI Act Readiness only |
+
+Apply via:
+```
+POST /api/internal/product/demo-seed/{tenant_id}?profile=kanzlei_demo
+```
+
+---
+
+## 6. Usage Metrics
+
+Feature usage is tracked per tenant and capability:
+
+```json
+{
+  "event_type": "capability_usage",
+  "tenant_id": "kanzlei-mueller",
+  "capability": "cap_grc_records",
+  "action": "list_risks",
+  "tier": "pro",
+  "bundle": "ai_governance_evidence"
+}
+```
+
+No PII — only aggregated counts per tenant/capability/bundle for future
+pricing decisions.
+
+---
+
+## 7. Admin APIs
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/api/internal/product/plan` | GET | Get current tenant's plan |
+| `/api/internal/product/plan/{tenant_id}` | PUT | Set a tenant's plan |
+| `/api/internal/product/demo-seed/{tenant_id}` | POST | Apply demo profile |
+
+---
+
+## 8. Files
+
+| File | Purpose |
+|---|---|
+| `app/product/__init__.py` | Package marker |
+| `app/product/models.py` | Tier, Bundle, Capability enums + TenantPlanConfig |
+| `app/product/plan_store.py` | In-memory store, has_capability, require_capability, metrics |
+| `app/product/demo_plans.py` | Pre-configured demo profiles |
+| `app/demo_models.py` | Extended TenantWorkspaceMetaResponse with plan fields |
+| `app/main.py` | Capability enforcement on endpoints + plan APIs |
+| `tests/test_product_packaging.py` | 31 tests |
+
+---
+
+## 9. Design Decisions
+
+- **In-memory store:** Plan configs are stored in-memory (like GRC/integration stores).
+  Future: migrate to DB alongside tenant registry.
+- **Default = Starter:** Tenants without explicit plan config get the Starter tier.
+  This is safe: new tenants start with basic capabilities.
+- **Additive bundles:** A Starter tenant can have `enterprise_integrations` added
+  without upgrading to Enterprise tier. This supports flexible commercial packaging.
+- **No billing integration:** This wave is purely internal feature gating.
+  Stripe/billing integration is a separate concern.
+- **Bilingual errors:** All capability-denied messages include German + English
+  text, fitting the DACH market focus.

--- a/tests/test_product_packaging.py
+++ b/tests/test_product_packaging.py
@@ -1,0 +1,315 @@
+"""Tests for Wave 17 — Product packaging & feature-flag model.
+
+Covers:
+- Tier/bundle/capability model resolution
+- TenantPlanConfig capability checks
+- Plan store CRUD and defaults
+- API capability enforcement (403 on missing capability)
+- Demo plan profiles
+- Usage metrics logging
+- Workspace meta plan fields
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.product.demo_plans import list_profiles, seed_demo_plan
+from app.product.models import (
+    BUNDLE_CAPABILITIES,
+    TIER_DEFAULT_BUNDLES,
+    Capability,
+    ProductBundle,
+    ProductTier,
+    TenantPlanConfig,
+)
+from app.product.plan_store import (
+    clear_for_tests,
+    get_tenant_plan,
+    has_capability,
+    log_capability_usage,
+    require_capability,
+    set_tenant_plan,
+)
+from app.services.rag.evidence_store import (
+    clear_for_tests as clear_events,
+)
+from app.services.rag.evidence_store import (
+    list_all_events,
+)
+
+
+def _cleanup() -> None:
+    clear_for_tests()
+    clear_events()
+
+
+# =========================================================================
+# A) Model: Tier → Bundles → Capabilities
+# =========================================================================
+
+
+class TestTierBundleModel:
+    def test_starter_tier_has_ai_act_readiness(self) -> None:
+        assert ProductBundle.ai_act_readiness in TIER_DEFAULT_BUNDLES[ProductTier.starter]
+
+    def test_pro_tier_has_governance_and_readiness(self) -> None:
+        pro_bundles = TIER_DEFAULT_BUNDLES[ProductTier.pro]
+        assert ProductBundle.ai_act_readiness in pro_bundles
+        assert ProductBundle.ai_governance_evidence in pro_bundles
+
+    def test_enterprise_tier_has_all_bundles(self) -> None:
+        ent = TIER_DEFAULT_BUNDLES[ProductTier.enterprise]
+        assert ProductBundle.ai_act_readiness in ent
+        assert ProductBundle.ai_governance_evidence in ent
+        assert ProductBundle.enterprise_integrations in ent
+
+    def test_ai_act_readiness_grants_advisor_and_evidence(self) -> None:
+        caps = BUNDLE_CAPABILITIES[ProductBundle.ai_act_readiness]
+        assert Capability.ai_advisor_basic in caps
+        assert Capability.ai_evidence_basic in caps
+
+    def test_governance_evidence_grants_grc_and_inventory(self) -> None:
+        caps = BUNDLE_CAPABILITIES[ProductBundle.ai_governance_evidence]
+        assert Capability.grc_records in caps
+        assert Capability.ai_system_inventory in caps
+        assert Capability.kanzlei_reports in caps
+
+    def test_enterprise_integrations_grants_connectors(self) -> None:
+        caps = BUNDLE_CAPABILITIES[ProductBundle.enterprise_integrations]
+        assert Capability.enterprise_integrations in caps
+        assert Capability.kanzlei_reports in caps
+
+
+# =========================================================================
+# B) TenantPlanConfig resolution
+# =========================================================================
+
+
+class TestTenantPlanConfig:
+    def test_starter_effective_bundles(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.starter)
+        bundles = plan.effective_bundles()
+        assert ProductBundle.ai_act_readiness in bundles
+        assert ProductBundle.enterprise_integrations not in bundles
+
+    def test_starter_capabilities(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.starter)
+        caps = plan.capabilities()
+        assert Capability.ai_advisor_basic in caps
+        assert Capability.ai_evidence_basic in caps
+        assert Capability.grc_records not in caps
+        assert Capability.enterprise_integrations not in caps
+
+    def test_pro_capabilities(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.pro)
+        caps = plan.capabilities()
+        assert Capability.ai_advisor_basic in caps
+        assert Capability.grc_records in caps
+        assert Capability.ai_system_inventory in caps
+        assert Capability.kanzlei_reports in caps
+        assert Capability.enterprise_integrations not in caps
+
+    def test_enterprise_capabilities(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.enterprise)
+        caps = plan.capabilities()
+        for cap in Capability:
+            assert cap in caps, f"Enterprise missing {cap}"
+
+    def test_explicit_bundle_override(self) -> None:
+        plan = TenantPlanConfig(
+            tenant_id="t1",
+            tier=ProductTier.starter,
+            bundles={"enterprise_integrations"},
+        )
+        caps = plan.capabilities()
+        assert Capability.enterprise_integrations in caps
+        assert Capability.ai_advisor_basic in caps
+
+    def test_has_capability_method(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.pro)
+        assert plan.has_capability(Capability.grc_records)
+        assert not plan.has_capability(Capability.enterprise_integrations)
+
+    def test_plan_display_string(self) -> None:
+        plan = TenantPlanConfig(tenant_id="t1", tier=ProductTier.pro)
+        display = plan.plan_display()
+        assert "Professional" in display
+        assert "AI Act Readiness" in display
+        assert "AI Governance" in display
+
+
+# =========================================================================
+# C) Plan store
+# =========================================================================
+
+
+class TestPlanStore:
+    def test_default_plan_is_starter(self) -> None:
+        _cleanup()
+        plan = get_tenant_plan("unknown-tenant")
+        assert plan.tier == ProductTier.starter
+
+    def test_set_and_get_plan(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t1", tier=ProductTier.enterprise))
+        plan = get_tenant_plan("t1")
+        assert plan.tier == ProductTier.enterprise
+        assert has_capability("t1", Capability.enterprise_integrations)
+
+    def test_has_capability_fast_path(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t2", tier=ProductTier.starter))
+        assert has_capability("t2", Capability.ai_advisor_basic)
+        assert not has_capability("t2", Capability.grc_records)
+
+    def test_require_capability_passes(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t3", tier=ProductTier.pro))
+        require_capability("t3", Capability.grc_records)
+
+    def test_require_capability_raises_403(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t4", tier=ProductTier.starter))
+        with pytest.raises(HTTPException) as exc:
+            require_capability("t4", Capability.enterprise_integrations)
+        assert exc.value.status_code == 403
+        detail = exc.value.detail
+        assert detail["error"] == "feature_not_enabled"
+        assert "message_de" in detail
+        assert "message_en" in detail
+        assert "Paket" in detail["message_de"]
+        assert "ComplianceHub" in detail["message_en"]
+
+    def test_require_capability_includes_capability_name(self) -> None:
+        _cleanup()
+        with pytest.raises(HTTPException) as exc:
+            require_capability("new-tenant", Capability.grc_records)
+        assert exc.value.detail["capability"] == "cap_grc_records"
+
+
+# =========================================================================
+# D) Demo plan profiles
+# =========================================================================
+
+
+class TestDemoProfiles:
+    def test_list_profiles(self) -> None:
+        profiles = list_profiles()
+        assert "kanzlei_demo" in profiles
+        assert "sap_demo" in profiles
+        assert "sme_demo" in profiles
+
+    def test_seed_kanzlei_demo(self) -> None:
+        _cleanup()
+        plan = seed_demo_plan("t-kanzlei", "kanzlei_demo")
+        assert plan is not None
+        assert plan.tier == ProductTier.pro
+        assert has_capability("t-kanzlei", Capability.kanzlei_reports)
+        assert has_capability("t-kanzlei", Capability.grc_records)
+        assert not has_capability("t-kanzlei", Capability.enterprise_integrations)
+
+    def test_seed_sap_demo(self) -> None:
+        _cleanup()
+        plan = seed_demo_plan("t-sap", "sap_demo")
+        assert plan is not None
+        assert plan.tier == ProductTier.enterprise
+        assert has_capability("t-sap", Capability.enterprise_integrations)
+        assert has_capability("t-sap", Capability.grc_records)
+        assert has_capability("t-sap", Capability.ai_advisor_basic)
+
+    def test_seed_sme_demo(self) -> None:
+        _cleanup()
+        plan = seed_demo_plan("t-sme", "sme_demo")
+        assert plan is not None
+        assert plan.tier == ProductTier.starter
+        assert has_capability("t-sme", Capability.ai_advisor_basic)
+        assert not has_capability("t-sme", Capability.grc_records)
+
+    def test_seed_unknown_profile(self) -> None:
+        _cleanup()
+        plan = seed_demo_plan("t-x", "nonexistent")
+        assert plan is None
+
+
+# =========================================================================
+# E) Usage metrics
+# =========================================================================
+
+
+class TestUsageMetrics:
+    def test_log_capability_usage(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t5", tier=ProductTier.pro))
+        log_capability_usage(
+            tenant_id="t5",
+            capability="cap_grc_records",
+            action="list_risks",
+        )
+        events = list_all_events()
+        usage_events = [e for e in events if e.get("event_type") == "capability_usage"]
+        assert len(usage_events) == 1
+        ev = usage_events[0]
+        assert ev["tenant_id"] == "t5"
+        assert ev["capability"] == "cap_grc_records"
+        assert ev["action"] == "list_risks"
+        assert ev["tier"] == "pro"
+        assert ev["bundle"] != ""
+
+    def test_log_capability_usage_with_explicit_bundle(self) -> None:
+        _cleanup()
+        log_capability_usage(
+            tenant_id="t6",
+            capability="cap_ai_advisor_basic",
+            action="query",
+            bundle="ai_act_readiness",
+        )
+        events = list_all_events()
+        usage_events = [e for e in events if e.get("event_type") == "capability_usage"]
+        assert len(usage_events) == 1
+        assert usage_events[0]["bundle"] == "ai_act_readiness"
+
+
+# =========================================================================
+# F) Capability enforcement scenarios
+# =========================================================================
+
+
+class TestCapabilityEnforcement:
+    def test_starter_cannot_access_grc(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t-starter", tier=ProductTier.starter))
+        with pytest.raises(HTTPException) as exc:
+            require_capability("t-starter", Capability.grc_records)
+        assert exc.value.status_code == 403
+
+    def test_starter_can_access_evidence(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t-starter", tier=ProductTier.starter))
+        require_capability("t-starter", Capability.ai_evidence_basic)
+
+    def test_pro_cannot_access_integrations(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t-pro", tier=ProductTier.pro))
+        with pytest.raises(HTTPException):
+            require_capability("t-pro", Capability.enterprise_integrations)
+
+    def test_enterprise_can_access_everything(self) -> None:
+        _cleanup()
+        set_tenant_plan(TenantPlanConfig(tenant_id="t-ent", tier=ProductTier.enterprise))
+        for cap in Capability:
+            require_capability("t-ent", cap)
+
+    def test_addon_bundle_extends_starter(self) -> None:
+        _cleanup()
+        set_tenant_plan(
+            TenantPlanConfig(
+                tenant_id="t-custom",
+                tier=ProductTier.starter,
+                bundles={"ai_governance_evidence"},
+            )
+        )
+        assert has_capability("t-custom", Capability.grc_records)
+        assert has_capability("t-custom", Capability.ai_system_inventory)
+        assert not has_capability("t-custom", Capability.enterprise_integrations)


### PR DESCRIPTION
Internal product tier model (starter/pro/enterprise) with bundle-to- capability mapping for DACH Kanzlei and Mittelstand packaging.  Six capability flags enforce access at API level with bilingual DE/EN error messages.  Workspace meta endpoint exposes plan info for UI feature toggling.

Demo profiles (kanzlei_demo, sap_demo, sme_demo) for sales demos. Usage metrics logged per tenant/capability/bundle.  Capability checks on GRC, AiSystem, board report, integration, and SAP endpoints. 31 new tests, 827 total — all green.

Made-with: Cursor