### PR TITLE
docs(wave19): internal pricing structure, sales playbook, GTM assets

### DIFF
--- a/app/product/copy_de.py
+++ b/app/product/copy_de.py
@@ -67,36 +67,51 @@ BUNDLE_DESCRIPTIONS_DE: dict[str, str] = {
 VALUE_HINTS_DE: dict[str, str] = {
     "ai_advisor": (
         "Teil Ihres Pakets: Der AI Act Advisor unterstützt Sie bei der "
-        "strukturierten Einschätzung Ihrer KI-Systeme gemäß EU-KI-Verordnung."
+        "strukturierten Einschätzung Ihrer KI-Systeme gemäß EU-KI-Verordnung. "
+        "Dieses Modul ist typischerweise Bestandteil von „AI Act Readiness“ "
+        "(Starter-Tier)."
     ),
     "evidence_views": (
         "Teil Ihres Pakets: AI-Evidence & Audit-Trail — dokumentieren Sie "
-        "Nachweise, Prüfschritte und Entscheidungen nachvollziehbar."
+        "Nachweise, Prüfschritte und Entscheidungen nachvollziehbar. "
+        "Typischerweise Teil von „AI Act Readiness“ (Starter-Tier) oder "
+        "erweitert in „AI Governance & Evidence“ (Professional-Tier)."
     ),
     "grc_records": (
-        "Teil Ihres Pakets 'AI Governance & Evidence': Risikobewertungen, "
-        "NIS2-Pflichten und ISO 42001-Gaps zentral verwalten."
+        "Teil Ihres Pakets „AI Governance & Evidence“: Risikobewertungen, "
+        "NIS2-Pflichten und ISO 42001-Gaps zentral verwalten. "
+        "Dieses Modul ist typischerweise Teil des Professional-Tiers "
+        "(Paket „AI Governance & Evidence“), nicht des reinen Starter-Pakets."
     ),
     "ai_system_inventory": (
-        "Teil Ihres Pakets 'AI Governance & Evidence': Übersicht aller "
-        "KI-Systeme mit AI-Act-/NIS2-/ISO-42001-Bezug und Lifecycle-Status."
+        "Teil Ihres Pakets „AI Governance & Evidence“: Übersicht aller "
+        "KI-Systeme mit AI-Act-/NIS2-/ISO-42001-Bezug und Lifecycle-Status. "
+        "Typischerweise Professional-Tier; für Kanzleien und Mittelstand der "
+        "Kern vor optionalen Enterprise-Connectors."
     ),
     "kanzlei_reports": (
         "Teil Ihres Kanzlei-Pakets: Mandanten-Board-Reports fassen den "
-        "KI-Compliance-Status eines Mandanten für Beirat oder Vorstand zusammen."
+        "KI-Compliance-Status eines Mandanten für Beirat oder Vorstand zusammen. "
+        "Typischerweise Paket „AI Governance & Evidence“ (Professional-Tier)."
     ),
     "kanzlei_dossier": (
         "Teil Ihres Kanzlei-Pakets: Mandanten-Compliance-Dossiers eignen sich "
         "als Anlage zur Verfahrensdokumentation oder als strukturierter "
-        "Compliance-Nachweis im DATEV-Umfeld."
+        "Compliance-Nachweis im DATEV-Umfeld. "
+        "Ebenfalls typischerweise „AI Governance & Evidence“ (Professional-Tier); "
+        "DATEV-nahe Exporte stärker mit Enterprise Connectors kombinierbar."
     ),
     "enterprise_integrations": (
         "Teil Ihres Enterprise-Pakets: Nahtlose Integration in SAP- und "
-        "DATEV-Ökosysteme für automatisierte Compliance-Synchronisation."
+        "DATEV-Ökosysteme für automatisierte Compliance-Synchronisation. "
+        "Enterprise Connectors sind als Zusatzpaket im Enterprise-Tier für "
+        "SAP-/DATEV-Integrationen vorgesehen — sinnvoll auf Basis von "
+        "Governance & Evidence."
     ),
     "deployment_check": (
         "Deployment-Prüfung: Automatische Prüfung der Compliance-Readiness "
-        "eines KI-Systems vor dem Go-live."
+        "eines KI-Systems vor dem Go-live. "
+        "Häufig im Umfeld von Governance & Evidence (Professional-Tier) im Einsatz."
     ),
 }
 
@@ -121,12 +136,14 @@ FEATURE_NOT_ENABLED_DISCLAIMER_DE = (
 )
 
 CAPABILITY_UPGRADE_HINTS_DE: dict[Capability, str] = {
-    Capability.ai_advisor_basic: "AI Act Readiness (Starter)",
-    Capability.ai_evidence_basic: "AI Act Readiness (Starter)",
-    Capability.grc_records: "AI Governance & Evidence (Professional)",
-    Capability.ai_system_inventory: "AI Governance & Evidence (Professional)",
-    Capability.kanzlei_reports: "AI Governance & Evidence (Professional)",
-    Capability.enterprise_integrations: "Enterprise Connectors",
+    Capability.ai_advisor_basic: "AI Act Readiness (Starter-Tier)",
+    Capability.ai_evidence_basic: "AI Act Readiness (Starter-Tier)",
+    Capability.grc_records: "AI Governance & Evidence (Professional-Tier)",
+    Capability.ai_system_inventory: "AI Governance & Evidence (Professional-Tier)",
+    Capability.kanzlei_reports: "AI Governance & Evidence (Professional-Tier)",
+    Capability.enterprise_integrations: (
+        "Enterprise Connectors (Zusatzpaket, Enterprise-Tier; SAP-/DATEV-Integrationen)"
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/docs/gtm/lead_to_package_heuristics.json
+++ b/docs/gtm/lead_to_package_heuristics.json
@@ -1,0 +1,109 @@
+{
+  "meta": {
+    "version": "1",
+    "purpose": "Konzeptionelles Lead-Routing für CRM, Discovery-Calls und Playbooks. Keine automatische Preislogik im Produkt.",
+    "language": "de"
+  },
+  "qualification_questions": [
+    {
+      "id": "isms_iso27001",
+      "question_de": "Betreiben Sie bereits ein ISMS (z. B. ISO 27001) und planen oder führen Sie ein AI-Management-System (ISO 42001) ein?",
+      "follow_up_de": "Wer ist für KI-Risiko und Dokumentation zuständig — CISO, Datenschutz, Fachbereich?"
+    },
+    {
+      "id": "datev_primary",
+      "question_de": "Ist DATEV (oder vergleichbare Kanzlei-Software) das führende System für Mandanten- und Belegprozesse?",
+      "follow_up_de": "Exportieren Sie Compliance-Nachweise heute manuell oder über Schnittstellen?"
+    },
+    {
+      "id": "high_risk_ai",
+      "question_de": "Setzen Sie eigene oder eingekaufte Hochrisiko-KI ein (z. B. Kredit-Scoring, Personalauswahl, biometrische Systeme)?",
+      "follow_up_de": "Werden diese Systeme schon im Inventar geführt und gegen AI Act / interne Policy geprüft?"
+    },
+    {
+      "id": "sap_landscape",
+      "question_de": "Läuft Ihr Kerngeschäft über SAP (S/4HANA, BTP) oder planen Sie Event-getriebene Integrationen?",
+      "follow_up_de": "Gibt es ein zentrales AI- oder Innovation-Office mit ERP-Bezug?"
+    },
+    {
+      "id": "mandanten_count",
+      "question_de": "Wie viele relevante Mandanten bzw. rechtliche Einheiten sollen abgedeckt werden?",
+      "follow_up_de": "Brauchen Sie pro Mandant getrennte Nachweise (Kanzlei) oder ein konzernweites Tenant-Modell?"
+    },
+    {
+      "id": "audit_pressure",
+      "question_de": "Steht eine externe Prüfung, NIS2-Meldepflicht oder Konzern-Audit in den nächsten 12 Monaten an?",
+      "follow_up_de": "Welche Nachweise werden explizit eingefordert?"
+    }
+  ],
+  "routing_heuristics": [
+    {
+      "id": "route_starter_light",
+      "if_signals_de": [
+        "Wenige KI-Anwendungen, noch kein formales Inventar",
+        "Fokus: erst Verständnis und erste AI-Act-Einschätzung",
+        "Kein kurzfristiger Integrationsbedarf SAP/DATEV"
+      ],
+      "suggested_entry_package": "SKU_AI_ACT_STARTER",
+      "tier_hint": "starter",
+      "notes_de": "Demo: sme_demo oder schlanke Umgebung; Upsell-Pfad zu Governance-Pro klar benennen."
+    },
+    {
+      "id": "route_pro_kanzlei",
+      "if_signals_de": [
+        "DATEV oder stark mandantenbezogene Arbeit",
+        "Bedarf an Board-Reports, Dossiers, wiederholbarer Mandanten-Dokumentation"
+      ],
+      "suggested_entry_package": "SKU_GOVERNANCE_PRO",
+      "tier_hint": "pro",
+      "notes_de": "Demo: kanzlei_demo; Argument: Honorar-Pakete und Verfahrensdokumentation."
+    },
+    {
+      "id": "route_pro_industrie",
+      "if_signals_de": [
+        "Mehrere KI-Systeme, NIS2/ISO-42001-Relevanz",
+        "CISO/Leiter Informationssicherheit involviert",
+        "ISMS vorhanden oder geplant"
+      ],
+      "suggested_entry_package": "SKU_GOVERNANCE_PRO",
+      "tier_hint": "pro",
+      "notes_de": "Demo: industrie_mittelstand_demo; Fokus Inventar + GRC + Evidence."
+    },
+    {
+      "id": "route_enterprise_connect",
+      "if_signals_de": [
+        "SAP BTP / S/4 oder DATEV-Exporte als Muss",
+        "KI-Events aus ERP oder verpflichtende Schnittstellen-Roadmap"
+      ],
+      "suggested_entry_package": "SKU_ENTERPRISE_CONNECT",
+      "tier_hint": "enterprise",
+      "notes_de": "Nur zusammen mit Governance-Basis verkaufen; Demo: sap_enterprise_demo. Prüfen, ob Pro bereits live oder parallel beschlossen."
+    }
+  ],
+  "answer_hints_to_packages": [
+    {
+      "question_id": "high_risk_ai",
+      "answer_pattern": "ja_mehrere_kritische",
+      "lean_toward": "SKU_GOVERNANCE_PRO",
+      "rationale_de": "Inventar + GRC + Evidence werden schnell Pflicht; Starter reicht selten."
+    },
+    {
+      "question_id": "datev_primary",
+      "answer_pattern": "ja",
+      "lean_toward": "SKU_GOVERNANCE_PRO",
+      "rationale_de": "Mandanten-Reports und Dossiers sind das natürliche Kernprodukt; Connectors optional als Upsell."
+    },
+    {
+      "question_id": "sap_landscape",
+      "answer_pattern": "ja_event_mesh",
+      "lean_toward": "SKU_ENTERPRISE_CONNECT",
+      "rationale_de": "Enterprise-Tier mit Integrationspaket; Governance-Pro als fachliche Basis."
+    },
+    {
+      "question_id": "isms_iso27001",
+      "answer_pattern": "noch_nicht",
+      "lean_toward": "SKU_AI_ACT_STARTER",
+      "rationale_de": "Einstieg über Readiness und Evidence; spätere Ausweitung auf ISO-42001-Gaps im Pro-Paket."
+    }
+  ]
+}

--- a/docs/gtm/pricing_internal.yaml
+++ b/docs/gtm/pricing_internal.yaml
@@ -1,0 +1,83 @@
+# ComplianceHub — interne Preis- & Lizenzstruktur (Wave 19)
+#
+# HINWEIS: Arbeitsdokument. Keine EUR-Beträge. Nur relative Positionierung
+# und Abrechnungslogik-Hinweise für Sales/Finance vor Go-Live abstimmen.
+#
+# Felder:
+#   sku: interne SKU-ID (siehe app/product/offerings.py)
+#   segment: kmu_industrie_mittelstand | kanzlei | enterprise_sap
+#   positioning: entry | core | premium_addon
+#   relative_price: Vergleichsfaktor zum Basispaket (1x = Referenz)
+#   price_band_hint: qualitative Spanne (low / mid / high) je Segment
+#   billing_model_hint: typische Abrechnungsdimension (ohne konkrete Staffel)
+
+version: "1"
+reference_sku: SKU_AI_ACT_STARTER
+reference_relative_price: "1x"
+
+entries:
+  # --- AI Act Readiness (Starter-SKU) ---
+  - sku: SKU_AI_ACT_STARTER
+    segment: kmu_industrie_mittelstand
+    positioning: entry
+    relative_price: "1x"
+    price_band_hint: low_to_mid
+    billing_model_hint: "pro Mandant/Tenant; Nutzerpool nach Vereinbarung; optional nach registrierten KI-Systemen staffelbar"
+
+  - sku: SKU_AI_ACT_STARTER
+    segment: kanzlei
+    positioning: entry
+    relative_price: "1x"
+    price_band_hint: low_to_mid
+    billing_model_hint: "pro Kanzlei-Mandant (Tenant oder Mandanten-Workspace); Staffel nach Mandantenanzahl üblich"
+
+  - sku: SKU_AI_ACT_STARTER
+    segment: enterprise_sap
+    positioning: entry
+    relative_price: "1x"
+    price_band_hint: mid
+    billing_model_hint: "selten allein; eher Pilot- oder Tochtergesellschaft; pro Geschäftseinheit/Tenant"
+
+  # --- AI Governance & Evidence (Pro-SKU) ---
+  - sku: SKU_GOVERNANCE_PRO
+    segment: kmu_industrie_mittelstand
+    positioning: core
+    relative_price: "2x bis 3x"
+    price_band_hint: mid_to_high
+    billing_model_hint: "pro Tenant; häufig Jahreslizenz; optionale Staffel nach KI-Systemen für Inventar/GRC-Umfang"
+
+  - sku: SKU_GOVERNANCE_PRO
+    segment: kanzlei
+    positioning: core
+    relative_price: "2x bis 4x"
+    price_band_hint: mid_to_high
+    billing_model_hint: "pro Mandant oder Mandantenpaket; Honorar-/Beratungspakete kombinierbar; Staffel nach Mandanten"
+
+  - sku: SKU_GOVERNANCE_PRO
+    segment: enterprise_sap
+    positioning: core
+    relative_price: "2x bis 3x"
+    price_band_hint: high
+    billing_model_hint: "pro Tenant/Konzernbereich; oft Rahmenvertrag; Zusatz nach KI-Systemen oder Nutzergruppen"
+
+  # --- Enterprise Connectors ---
+  - sku: SKU_ENTERPRISE_CONNECT
+    segment: kmu_industrie_mittelstand
+    positioning: premium_addon
+    relative_price: "+1x bis +2x auf Governance-Pro-Basis"
+    price_band_hint: high
+    billing_model_hint: "Zusatzmodul zum Pro-/Enterprise-Tier; oft Setup-Fee + laufende Anbindung; pro Tenant"
+
+  - sku: SKU_ENTERPRISE_CONNECT
+    segment: kanzlei
+    positioning: premium_addon
+    relative_price: "+1x bis +2x"
+    price_band_hint: high
+    billing_model_hint: "Zusatz zu Governance & Evidence; DATEV-/Export-Pfade; pro Kanzlei oder Mandantencluster"
+
+  - sku: SKU_ENTERPRISE_CONNECT
+    segment: enterprise_sap
+    positioning: premium_addon
+    relative_price: "+2x bis +4x auf Governance-Pro-Basis"
+    price_band_hint: high
+    billing_model_hint: "Zusatzpaket; SAP BTP/Event Mesh; oft Projektlizenz + Betrieb; pro Tenant oder Integrationsumfang"

--- a/docs/gtm/sales_arguments_by_segment.json
+++ b/docs/gtm/sales_arguments_by_segment.json
@@ -1,0 +1,94 @@
+{
+  "meta": {
+    "version": "1",
+    "language": "de",
+    "disclaimer": "Argumente für Readiness, Governance und Evidence — keine Garantie auf Rechtskonformität. Individuelle Prüfung und ggf. Rechtsberatung bleiben erforderlich."
+  },
+  "SKU_AI_ACT_STARTER": {
+    "kmu_industrie_mittelstand": {
+      "arguments_de": [
+        "Schneller Überblick, welche KI-Anwendungen im Unternehmen die EU-KI-Verordnung berühren — ohne zuerst externe Tagessätze zu binden.",
+        "Strukturierte Ersteinschätzung (Advisor) und nachvollziehbare Dokumentation (Evidence) für interne Audits und Management-Reports.",
+        "Unterstützung bei der Vorbereitung auf ISO-42001- und NIS2-Themen, bevor ein volles GRC-Programm ansteht.",
+        "Geringerer Einstiegsaufwand für CISO/Leiter Informationssicherheit und Fachbereichsverantwortliche.",
+        "Skalierbar später hin zu Inventar und GRC, wenn die KI-Landschaft wächst."
+      ]
+    },
+    "kanzlei": {
+      "arguments_de": [
+        "Einstiegspaket für Mandanten mit wenigen KI-Tools: Risiko-Scan und Evidence als Baustein für die Beratungsdokumentation.",
+        "Wiederkehrende, standardisierte AI-Act-Readiness-Checks statt jedes Mal neue Excel-Vorlagen.",
+        "Grundlage für Honorar-Pakete („AI-Act-Check“, „Ersteinschätzung pro Mandant“) ohne sofort die volle Governance-Suite zu verkaufen.",
+        "GoBD-taugliche Spuren: Nachweise und Entscheidungen dokumentieren, ohne Voll-Dossier zu versprechen.",
+        "Klare Upgrade-Perspektive zu Mandanten-Board-Reports und Dossiers, wenn der Mandant reift."
+      ]
+    },
+    "enterprise_sap": {
+      "arguments_de": [
+        "Pilotierbar für einzelne Geschäftseinheiten oder Tochtergesellschaften vor Konzern-Rollout.",
+        "Abgestimmt auf spätere Anbindung an SAP/DATEV über Enterprise Connectors — ohne Big-Bang.",
+        "Gleiche Begriffswelt wie in späteren Integrationen (KI-System, Evidence, Mandant), damit Playbooks übertragbar sind.",
+        "Readiness-Nachweise für interne Revision und Konzern-Governance vorbereiten.",
+        "Typischerweise Zwischenstufe: Zielbild bleibt Governance-Pro oder Enterprise mit Integration."
+      ]
+    }
+  },
+  "SKU_GOVERNANCE_PRO": {
+    "kmu_industrie_mittelstand": {
+      "arguments_de": [
+        "Zentrales AI-System-Inventar mit Lifecycle und Bezug zu AI Act, NIS2 und ISO 42001 — eine Quelle für IT, Security und Fachbereiche.",
+        "GRC-Einträge (Risiken, Pflichten, Gaps) unterstützen Nachweise gegenüber Aufsicht, Auditoren und Konzernmutter.",
+        "Weniger Streuverlust zwischen Werkzeugen: Board-Reports und Evidence hängen an denselben Systemdaten.",
+        "Unterstützung bei NIS2- und Kritis-Themen, wo KI-Systeme die Lieferkette oder kritische Prozesse berühren.",
+        "Positionierung als „Betriebssystem“ für KI-Governance im Mittelstand — vor Enterprise-Integration."
+      ]
+    },
+    "kanzlei": {
+      "arguments_de": [
+        "Mandanten-Board-Reports und Compliance-Dossiers als verkaufbare Leistung: strukturierte KI-Compliance-Darstellung für Geschäftsführung oder Beirat.",
+        "AI-Evidence und GRC-Daten als Grundlage für Honorarmodelle (Pakete pro Mandant, Jahresbetreuung, Vorstands-Updates).",
+        "Differenzierung gegenüber reinen Checklisten: Mandanten sehen Inventar, Risiko und Maßnahmen an einem Ort.",
+        "Anknüpfung an Verfahrensdokumentation und DATEV-nahe Exporte (ohne rechtliche Vollständigkeit zu behaupten).",
+        "Skalierung über viele Mandanten mit wiederkehrenden Workflows statt Einzelprojekte."
+      ]
+    },
+    "enterprise_sap": {
+      "arguments_de": [
+        "Einheitliche Governance-Sicht vor SAP-BTP- und Event-Mesh-Anbindung: erst Datenqualität, dann Automation.",
+        "Vorbereitung auf konzernweite Reporting-Linien (Risk, Compliance, AI-Office).",
+        "Nachvollziehbare Entscheidungs- und Prüfpfade für interne und externe Prüfer.",
+        "Klare Trennung: Governance & Evidence als Kern; Connectors als darauf aufsetzendes Zusatzpaket.",
+        "Reduziert Doppelarbeit zwischen Fachbereich und IT bei Hochrisiko-KI (z. B. Scoring, Personalauswahl)."
+      ]
+    }
+  },
+  "SKU_ENTERPRISE_CONNECT": {
+    "kmu_industrie_mittelstand": {
+      "arguments_de": [
+        "Automatisierte Übergabe von Dossiers und Jobs in DATEV-nahe Prozesse — weniger Copy-Paste, mehr Wiederholbarkeit.",
+        "Vorbereitung auf SAP-S/4- und BTP-Landschaften, wenn KI-Events aus dem ERP kommen sollen.",
+        "Auditierbare Integrationsjobs statt manueller Schnittstellen.",
+        "Passt zu Unternehmen, die bereits ERP-zentriert denken und KI-Governance dort verankern wollen.",
+        "Premium-Add-on: nur sinnvoll, wenn Governance-Pro im Einsatz ist oder gleichzeitig beschlossen wird."
+      ]
+    },
+    "kanzlei": {
+      "arguments_de": [
+        "DATEV-Ökosystem: strukturierte Mandanten-Dossiers als Anhang zu bestehenden Kanzlei-Workflows.",
+        "Weniger Medienbruch zwischen ComplianceHub und Kanzlei-Dokumentation.",
+        "Argument für Premium-Mandate oder Konzernmandanten mit eigener SAP-Welt.",
+        "Professioneller Auftritt: „wir liefern nicht nur Beratung, sondern auch maschinenlesbare Nachweise“.",
+        "Typischerweise Zusatz zu Governance & Evidence, nicht allein verkauft."
+      ]
+    },
+    "enterprise_sap": {
+      "arguments_de": [
+        "CloudEvents-fähige Anbindung (Referenz: BTP Event Mesh) — KI-Systeme aus SAP-Landschaft werden erkannt und im Inventar geführt.",
+        "Konzernweite Skalierung: gleiche Integrationsmuster für mehrere Werke oder Regionen.",
+        "Reduziert manuelle Abstimmung zwischen SAP-Team und AI-Governance-Team.",
+        "Grundlage für Betrieb und Monitoring von Schnittstellen-Jobs (Outbox-Pattern, Wiederholung).",
+        "Positionierung als strategisches Add-on für SAP-Bestandskunden mit KI in kritischen Prozessen."
+      ]
+    }
+  }
+}

--- a/docs/gtm/sales_enablement_cheat_sheet.md
+++ b/docs/gtm/sales_enablement_cheat_sheet.md
@@ -1,0 +1,83 @@
+# Sales Enablement — Cheat Sheet (Deck-Bausteine)
+
+**Sprache:** Deutsch · **Ziel:** Slides / Gesprächsführung · **Stand:** Wave 19 (Entwurf)
+
+**Disclaimer:** Keine Preise, keine Rechtsberatung, keine Konformitätsgarantie. ComplianceHub unterstützt bei Readiness, Governance und Evidence.
+
+---
+
+## Slide-Struktur (für alle drei Tracks)
+
+1. **Problem** — Regulatorik + Komplexität + fehlende Nachweise  
+2. **Lösung** — Eine Plattform: Inventar, GRC, Evidence, Reports (je nach Paket)  
+3. **Modul-Übersicht** — Advisor · Evidence · GRC · AiSystem · Board Reports · Dossiers · Integrationen  
+4. **Pakete** — AI Act Readiness (Starter) · Governance & Evidence (Pro) · Enterprise Connectors (Add-on)  
+5. **Beispiel-Use-Cases** — 2 konkrete Szenen aus dem Segment  
+6. **Nächste Schritte** — Discovery, Demo-Profil, Pilot-Tenant, Abstimmung Legal/Finance
+
+---
+
+## Track A — KMU / Industrie-Mittelstand (AI Act / NIS2)
+
+| Slide | Inhalt (Stichpunkte) |
+|-------|----------------------|
+| Problem | Viele Schatten-KI-Tools; NIS2/AI Act; Audit erwartet Nachweise; Excel reicht nicht. |
+| Lösung | Inventar + Risiko + Evidence; eine Quelle für CISO und Fachbereich. |
+| Module | Starter: Advisor + Evidence. Pro: + GRC + Inventar + Board Reports. |
+| Pakete | Einstieg Readiness → Ausbau Governance-Pro vor Enterprise-Integration. |
+| Use-Case 1 | Predictive Maintenance: Risikoklasse, NIS2-Hinweis, Maßnahmen dokumentiert. |
+| Use-Case 2 | HR-Scoring-Pilot: Advisor-Ersteinschätzung, Evidence für interne Freigabe. |
+| Nächste Schritte | `industrie_mittelstand_demo` · Fragenkatalog ISMS/KI-Anzahl · Angebot Pro-Tier skizzieren. |
+
+**Kernbotschaft:** Readiness ohne Overhead; skalierbar bis Konzern-Governance.
+
+---
+
+## Track B — Kanzlei (Mandanten, GoBD, AI Act)
+
+| Slide | Inhalt (Stichpunkte) |
+|-------|----------------------|
+| Problem | Mandanten mit KI; Erwartung an dokumentierte Beratung; DATEV/GoBD-Kontext. |
+| Lösung | Mandantenbezogene Reports, Dossiers, Evidence — Honorar-Pakete möglich. |
+| Module | Pro: Board Reports, Dossiers, Inventar, GRC, Evidence. Connectors optional. |
+| Pakete | Governance & Evidence als Kern; Starter nur für Mini-Mandanten. |
+| Use-Case 1 | Mandanten-Chatbot: Risiko, Report für GF, Dossier-Anlage Verfahrensdokumentation. |
+| Use-Case 2 | Steuerrisiko-Scoring beim Mandanten: Gaps + Beratungspfad dokumentiert. |
+| Nächste Schritte | `kanzlei_demo` · Mandantenanzahl · DATEV-Export als Upsell besprechen. |
+
+**Kernbotschaft:** Wiederholbare Mandanten-Compliance-Leistung, nicht nur Projekt.
+
+---
+
+## Track C — Enterprise / SAP (KI über SAP-Landschaft)
+
+| Slide | Inhalt (Stichpunkte) |
+|-------|----------------------|
+| Problem | KI in SAP/ERP; Event-getriebene Welt; manuelle CSV-Exports skalieren nicht. |
+| Lösung | Governance-Pro als Daten- und Prozesskern + Enterprise Connectors (BTP/DATEV). |
+| Module | Inventar aus Events; Jobs; Dossiers; volle Evidence-Linie. |
+| Pakete | Enterprise-Tier; Connectors als **Zusatzpaket** zum Governance-Kern. |
+| Use-Case 1 | Kredit-Scoring in S/4: Event → Inventar-Update → GRC → Report. |
+| Use-Case 2 | Konzernweiter Rollout: gleiche Integrationsmuster, mandantenfähig. |
+| Nächste Schritte | `sap_enterprise_demo` · SAP-Team einbinden · Integrations-Roadmap ohne Festpreis. |
+
+**Kernbotschaft:** SAP-nah, auditierbar, ohne Big-Bang — Pilot zuerst.
+
+---
+
+## Einzeiler für Elevator Pitch
+
+- **Industrie:** „Wir geben Mittelständlern ein Inventar, Risiko und Nachweise für KI — von AI Act bis NIS2.“  
+- **Kanzlei:** „Wir helfen Kanzleien, Mandanten-KI strukturiert zu dokumentieren — Reports, Dossiers, Evidence.“  
+- **SAP:** „Wir verbinden SAP-KI-Events mit Governance — damit IT und Compliance dieselbe Wahrheit haben.“
+
+---
+
+## Verweise auf Konfiguration
+
+| Artefakt | Pfad |
+|----------|------|
+| Relative Preis-Positionierung | `docs/gtm/pricing_internal.yaml` |
+| Argumente je SKU & Segment | `docs/gtm/sales_arguments_by_segment.json` |
+| Lead-Routing | `docs/gtm/lead_to_package_heuristics.json` |
+| Gesamt-Playbook | `docs/gtm/wave19-internal-pricing-and-sales-playbook.md` |

--- a/docs/gtm/wave19-internal-pricing-and-sales-playbook.md
+++ b/docs/gtm/wave19-internal-pricing-and-sales-playbook.md
@@ -1,0 +1,150 @@
+# Wave 19 — Internes Pricing & Sales Playbook (Entwurf)
+
+> **Status:** Arbeitsdokument für Produkt, Vertrieb und Marketing.  
+> **Pflicht vor Go-Live:** Abstimmung mit Legal und Finance; keine verbindlichen Preise oder Zusicherungen aus diesem Dokument.
+
+---
+
+## 1. Zweck
+
+Dieses Playbook verbindet **technische Capabilities** (Tiers, Bundles, SKUs) mit **Vertriebslogik**:
+
+- relative Preis- und Lizenzlogik (ohne EUR),
+- Argumentation pro Segment,
+- Demo-Empfehlungen,
+- Qualifizierungsfragen und Paket-Routing.
+
+---
+
+## 2. Produktüberblick (Reminder)
+
+| Tier | Typische SKU | Bundles (Kurz) |
+|------|----------------|----------------|
+| **Starter** | AI Act Readiness | AI Act Readiness |
+| **Professional** | AI Governance & Evidence | Readiness + Governance & Evidence |
+| **Enterprise** | + Enterprise Connectors | alle Bundles inkl. Integrationen |
+
+**SKUs (Kundensprache):**
+
+- `SKU_AI_ACT_STARTER` — AI Act Readiness  
+- `SKU_GOVERNANCE_PRO` — AI Governance & Evidence Suite  
+- `SKU_ENTERPRISE_CONNECT` — Enterprise Connectors (SAP/DATEV)
+
+Technische Details: `app/product/offerings.py`, `app/product/models.py`, Wave-17/18-Dokumentation unter `docs/architecture/`.
+
+---
+
+## 3. Relative Preis-Positionierung
+
+**Quelle der Wahrheit:** `docs/gtm/pricing_internal.yaml`
+
+**Prinzipien:**
+
+- **1x** = Referenz (`SKU_AI_ACT_STARTER`), qualitative Bänder (`low_to_mid`, `mid_to_high`, `high`).
+- **Governance-Pro** typisch **2x–4x** relativ, abhängig von Segment (Kanzlei oft höhere Mandanten-Streuung).
+- **Enterprise Connectors** = **Premium-Add-on** (`+1x` bis `+4x` relativ zur Governance-Basis), nicht als Alleinstellungsmerkmal ohne Governance-Kern.
+
+**Abrechnungsdimensionen (Hinweise, nicht Vertragstext):**
+
+| Dimension | Wann relevant |
+|-----------|----------------|
+| Pro Tenant / Mandant | Mandantenfähige Kanzlei, Konzern-Tenants |
+| Pro KI-System (Staffel) | großes Inventar, faire Verteilung |
+| Setup + Betrieb (Connectors) | SAP BTP, DATEV-Pfade, Projektstart |
+
+Keine Euro-Beträge in Repo-Konfiguration — nur relative und qualitative Angaben.
+
+---
+
+## 4. Vertriebsargumente pro SKU & Segment
+
+**Quelle:** `docs/gtm/sales_arguments_by_segment.json`
+
+Kurzfassung:
+
+- **AI Act Readiness + KMU:** Schneller Überblick, Evidence für interne Audits, geringer Einstieg, später Upgrade.  
+- **AI Act Readiness + Kanzlei:** Einstiegs-Honorar-Pakete, Standardisierung, Pfad zu Dossiers.  
+- **Governance & Evidence + Kanzlei:** Board Reports, Dossiers, Mandanten-Skalierung, DATEV-Nähe.  
+- **Governance & Evidence + Industrie:** Inventar + NIS2/ISO-42001-Bezug, eine Quelle für Security und Fachbereich.  
+- **Enterprise Connectors + SAP:** Event Mesh, weniger Medienbruch, Konzern-Skalierung — immer mit Governance-Basis.
+
+Formulierung in Gesprächen: **„unterstützt bei Readiness / Governance / Nachweisen“** — nie **„garantiert compliant“**.
+
+---
+
+## 5. In-App-Hinweise (ohne Preise)
+
+Die UI nutzt deutsche **Value Hints** und **Upgrade-Hinweise** (`app/product/copy_de.py`):
+
+- Zuordnung zu **Paketnamen** und **Tier** (z. B. „Professional-Tier“, „Zusatzpaket Enterprise Connectors“).
+- **Keine** Euro-Preise, **keine** Rabattversprechen.
+
+API für gefilterte Hints: `GET /api/internal/product/value-hints` (Wave 18).
+
+---
+
+## 6. Demo-Empfehlungen pro Segment
+
+| Segment | Demo-Profil (intern) | Fokus in 20–30 Min |
+|---------|----------------------|---------------------|
+| Industrie-Mittelstand | `industrie_mittelstand_demo` | Inventar → GRC → Evidence → Board Report |
+| Kanzlei | `kanzlei_demo` | Mandanten-Systeme → Advisor → Report → Dossier |
+| Enterprise SAP | `sap_enterprise_demo` | Inventar + Integrations-/Jobs-Sicht + Governance |
+
+Ausführliche Skripte: `docs/architecture/wave18-offerings-and-gtm-alignment.md`.
+
+---
+
+## 7. Lead-Qualifizierung & Paket-Mapping
+
+**Quelle:** `docs/gtm/lead_to_package_heuristics.json`
+
+**Beispielfragen:**
+
+1. ISMS / ISO 27001 und geplantes ISO-42001-AI-MS?  
+2. DATEV als Leit-system für Mandanten?  
+3. Hochrisiko-KI (Scoring, Personal, Biometrie)?  
+4. SAP S/4 oder BTP / Event-getriebene Architektur?  
+5. Wie viele Mandanten bzw. Einheiten?  
+6. Audit- oder Meldedruck in den nächsten 12 Monaten?
+
+**Heuristik (vereinfacht):**
+
+| Signal | Tendenz |
+|--------|---------|
+| Wenig KI, kein Integrationszwang | Starter / AI Act Readiness |
+| DATEV, Mandanten-Reports, Dossiers | Pro / Governance & Evidence |
+| Viele Systeme, NIS2, CISO involviert | Pro / Governance & Evidence |
+| SAP Events, konzernweite Anbindung | Enterprise + Connectors (mit Pro-Basis) |
+
+CRM/Playbooks können die JSON-Struktur 1:1 importieren oder in Notion/HubSpot übernehmen.
+
+---
+
+## 8. Sales-Deck-Bausteine
+
+**Quelle:** `docs/gtm/sales_enablement_cheat_sheet.md`
+
+Struktur pro Track: Problem → Lösung → Module → Pakete → Use-Cases → Nächste Schritte.
+
+---
+
+## 9. Nächste Schritte (Produkt & GTM)
+
+1. Finance: EUR-Bänder und Staffeln festlegen (außerhalb dieses Repos).  
+2. Legal: Claims-Review Website und Angebots-PDFs.  
+3. Marketing: Website-Segmente (Industrie / Kanzlei / SAP) an Cheat Sheet anbinden.  
+4. CRM: Qualifizierungsfelder aus `lead_to_package_heuristics.json` mappen.
+
+---
+
+## 10. Dateiindex Wave 19
+
+| Datei | Inhalt |
+|-------|--------|
+| `docs/gtm/pricing_internal.yaml` | SKU × Segment × relative Preis × Billing-Hinweise |
+| `docs/gtm/sales_arguments_by_segment.json` | 3–5 Argumente je SKU & Segment |
+| `docs/gtm/lead_to_package_heuristics.json` | Fragen & Routing-Heuristiken |
+| `docs/gtm/sales_enablement_cheat_sheet.md` | Deck-Stichpunkte DE |
+| `docs/gtm/wave19-internal-pricing-and-sales-playbook.md` | dieses Dokument |
+| `app/product/copy_de.py` | UI-Texte mit Tier-/Paket-Positionierung (ohne Preise) |

--- a/tests/test_wave19_pricing_gtm.py
+++ b/tests/test_wave19_pricing_gtm.py
@@ -1,0 +1,69 @@
+"""Wave 19 — internal pricing & sales config sanity checks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from app.product.copy_de import CAPABILITY_UPGRADE_HINTS_DE, VALUE_HINTS_DE
+from app.product.models import Capability
+
+_DOCS_GTM = Path(__file__).resolve().parent.parent / "docs" / "gtm"
+
+
+def test_pricing_internal_yaml_loads() -> None:
+    path = _DOCS_GTM / "pricing_internal.yaml"
+    assert path.is_file()
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert data.get("version")
+    assert data.get("entries")
+    for row in data["entries"]:
+        assert "sku" in row
+        assert "segment" in row
+        assert row["positioning"] in ("entry", "core", "premium_addon")
+        assert "relative_price" in row
+        assert "billing_model_hint" in row
+
+
+def test_sales_arguments_json_structure() -> None:
+    path = _DOCS_GTM / "sales_arguments_by_segment.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    skus = ["SKU_AI_ACT_STARTER", "SKU_GOVERNANCE_PRO", "SKU_ENTERPRISE_CONNECT"]
+    segments = ["kmu_industrie_mittelstand", "kanzlei", "enterprise_sap"]
+    for sku in skus:
+        assert sku in data
+        for seg in segments:
+            block = data[sku][seg]
+            args = block["arguments_de"]
+            assert 3 <= len(args) <= 6
+            joined = " ".join(args).lower()
+            assert "garantiert" not in joined
+            assert "vollständige konformität" not in joined
+
+
+def test_lead_heuristics_json_loads() -> None:
+    path = _DOCS_GTM / "lead_to_package_heuristics.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["qualification_questions"]
+    assert data["routing_heuristics"]
+    assert data["answer_hints_to_packages"]
+
+
+def test_playbook_and_cheat_sheet_exist() -> None:
+    assert (_DOCS_GTM / "wave19-internal-pricing-and-sales-playbook.md").is_file()
+    assert (_DOCS_GTM / "sales_enablement_cheat_sheet.md").is_file()
+
+
+def test_value_hints_include_tier_positioning() -> None:
+    assert "Starter-Tier" in VALUE_HINTS_DE["ai_advisor"]
+    assert "Professional-Tier" in VALUE_HINTS_DE["grc_records"]
+    assert "Zusatzpaket" in VALUE_HINTS_DE["enterprise_integrations"]
+    assert "SAP-/DATEV" in VALUE_HINTS_DE["enterprise_integrations"]
+
+
+def test_upgrade_hints_reference_tiers() -> None:
+    assert "Starter-Tier" in CAPABILITY_UPGRADE_HINTS_DE[Capability.ai_advisor_basic]
+    assert "Professional-Tier" in CAPABILITY_UPGRADE_HINTS_DE[Capability.grc_records]
+    assert "Enterprise-Tier" in CAPABILITY_UPGRADE_HINTS_DE[Capability.enterprise_integrations]


### PR DESCRIPTION
Add docs/gtm/pricing_internal.yaml (relative SKU×segment positioning, no EUR), sales_arguments_by_segment.json, lead_to_package_heuristics.json, sales_enablement_cheat_sheet.md, and wave19 playbook.

Extend copy_de value hints and upgrade hints with tier/package context only (no prices). Add tests validating YAML/JSON and copy constraints.

Made-with: Cursor