### PR TITLE
docs(gtm): add Wave 19 SKU stub and link Wave 20 messaging

### DIFF
--- a/docs/gtm/tone_of_voice_de.md
+++ b/docs/gtm/tone_of_voice_de.md
@@ -1,0 +1,94 @@
+# ComplianceHub – Tone of Voice (Deutsch)
+
+**Gültigkeit:** Website, Sales-Material, Kampagnen, In-App-Hilfetexte (soweit nicht bereits durch UI-Glossar festgelegt).  
+**Abgleich:** Mit Legal/Compliance bei allen Aussagen zu Regulierung, Zertifizierung und Produktfähigkeiten.  
+**SKU-Quelle:** [`wave19-pricing-sales-playbook-stub.md`](./wave19-pricing-sales-playbook-stub.md) (Wave 19 → Wave 20).
+
+---
+
+## 1. Tonalität
+
+- **Sachlich und ruhig:** Wir wirken wie ein **DACH-Enterprise-Produkt**, nicht wie ein Consumer-App-Hype.
+- **Vertrauenswürdig:** Präzise Begriffe (Governance, Register, Nachweis, Audit-Trail); keine übertriebenen Superlative.
+- **Partnerschaftlich:** Der Kunde trägt Verantwortung für rechtliche Bewertungen; wir **unterstützen** bei Vorbereitung, Dokumentation und Transparenz.
+- **Klar:** Kurze Sätze, aktive Verben, wenig Substantiv-Ketten („Durchführung einer Implementierung“ → „Sie setzen um“).
+
+---
+
+## 2. Do / Don’t
+
+### DO (bevorzugte Begriffe und Muster)
+
+| Thema        | Beispiele |
+| ------------ | --------- |
+| Zielbild     | Readiness, Governance, Nachweise, Dokumentation, Transparenz |
+| Prozess      | Inventarisieren, bewerten, evidenzieren, reviewen, reporten |
+| Vertrauen    | Audit-Trail, mandantenfähig, nachvollziehbar, revisionssicher (nur wenn fachlich korrekt) |
+| Regulatorik  | „Unterstützung bei der Vorbereitung auf …“, „Abbildung von Anforderungen …“, „im Kontext von …“ |
+| DACH         | Mittelstand, Kanzlei, Konzern, Vorstand, interne Revision, Wirtschaftsprüfung (sachlich) |
+
+### DON’T (vermeiden oder stark einschränken)
+
+| Vermeiden | Warum |
+| --------- | ----- |
+| „Garantierte Konformität“, „100 % compliant“, „vollautomatische Konformität“ | Rechtlich riskant; setzt externe Bewertung voraus |
+| „Magische KI“, „ein Klick und fertig“, „revolutionär“ | Widerspricht Enterprise-Erwartung und AI-Act-Seriosität |
+| „Der AI Act verlangt genau …“ ohne Einschränkung | Zu absolut; immer Kontext (Risikoklasse, Anwendungsfall) |
+| „Wir zertifizieren Sie nach ISO 42001“ | ComplianceHub ist **kein** Zertifizierer |
+| Übermäßig englische Mischsprache in der Hauptcopy | Fachbegriffe (Governance, Board Report) ok; Fließtext bevorzugt deutsch |
+
+---
+
+## 3. Beispiele: gut vs. schlecht
+
+### Regulatorik / AI Act
+
+| Schlecht | Besser |
+| -------- | ------ |
+| „Mit ComplianceHub sind Sie AI Act compliant.“ | „ComplianceHub unterstützt Sie bei der **Dokumentation und Readiness** für EU-AI-Act-Anforderungen – abhängig von Risikoklasse und Einsatzszenario.“ |
+| „Unsere KI erledigt die Compliance für Sie.“ | „Strukturierte Vorschläge und Checklisten **unterstützen Ihre Experten** – Entscheidungen und Freigaben bleiben bei Ihnen.“ |
+
+### NIS2 / KRITIS
+
+| Schlecht | Besser |
+| -------- | ------ |
+| „NIS2 erledigt.“ | „**NIS2-relevante Themen** (z. B. Incidents, Lieferanten) können in Übersichten und Reports **sichtbar gemacht** werden – im Abgleich mit Ihrer Notifizierung und Ihrem ISMS.“ |
+
+### ISO 42001 / 27001
+
+| Schlecht | Besser |
+| -------- | ------ |
+| „ISO 42001 in 2 Wochen.“ | „**Nachweise und Prozessschritte** für Ihr KI-Managementsystem können Sie in Evidence und Reports **bündeln** – die Zertifizierung führt Ihr Auditor durch.“ |
+
+### GoBD / Steuern
+
+| Schlecht | Besser |
+| -------- | ------ |
+| „GoBD-konform out of the box.“ | „**GoBD-relevante Dokumentationsfragen** können Sie im Austausch mit Steuerberater und Fachbereich **strukturiert vorbereiten**; Aufbewahrung und Details klären Sie mandantenspezifisch.“ |
+
+### Enterprise / SAP
+
+| Schlecht | Besser |
+| -------- | ------ |
+| „Vollständig in SAP integriert, alles live.“ | „**Anbindung an SAP BTP und Unternehmensprozesse** je nach Paket und Projekt – Umfang und Datenflüsse definieren wir im Integrationsworkshop.“ |
+
+---
+
+## 4. Englische Taglines (nur bewusst einsetzen)
+
+- **„Map once, comply many“** – ok als **kurze Leitidee** neben deutscher Erklärung, nicht als alleinige rechtliche Aussage.
+- Produkt- und Modulnamen auf Englisch (Advisor, Evidence, Board Report) beibehalten, wenn sie der UI entsprechen.
+
+---
+
+## 5. Review-Checkliste (vor Veröffentlichung)
+
+- [ ] Keine Garantie- oder Zertifizierungsansprüche ohne Freigabe  
+- [ ] AI Act / NIS2 / ISO / GoBD mit Kontext und „Unterstützung bei …“ formuliert  
+- [ ] SKUs identisch zu [Wave-19-Stub](wave19-pricing-sales-playbook-stub.md): *AI Act Readiness*, *Governance & Evidence*, *Enterprise Connectors*  
+- [ ] Keine erfundenen Kunden, Zahlen oder Awards  
+- [ ] Abgleich mit `docs/gtm/wave20-website-messaging-de.md` und `wave20-sales-deck-outline.md`
+
+---
+
+*Version: Wave 20 – ergänzt Sales- und Website-Messaging; bei Produktänderungen Tone-of-Voice-Beispiele mitziehen.*

--- a/docs/gtm/wave19-pricing-sales-playbook-stub.md
+++ b/docs/gtm/wave19-pricing-sales-playbook-stub.md
@@ -1,0 +1,40 @@
+# Wave 19 – Pricing & Sales-Playbook (Stub, Repo-Verankerung)
+
+**Zweck:** Im Repository die **kanonischen SKU-/Paketbezeichnungen** und die **Verkettung zu Wave 20** festhalten. Detaillierte Preise, Bundles, Lead-zu-Paket-Heuristiken und interne Sales-Argumente liegen im **vollständigen Wave-19-Artefakt** (nicht öffentlich im Repo) – dieses Dokument ist der **Stub** für Navigation und Abgleich.
+
+**Vertraulichkeit:** Keine Beträge oder rabattierten Konditionen hier dokumentieren.
+
+---
+
+## Kanonische SKUs (Pakete)
+
+| SKU (Anzeige- & Vertragsname) | Kurzbeschreibung (Fit) | Typische Module / Schwerpunkte (Orientierung) |
+| ----------------------------- | ---------------------- | --------------------------------------------- |
+| **AI Act Readiness** | Einstieg: KI-Register, Readiness, Board-KPIs, geführte nächste Schritte | AiSystem, Lifecycle/Readiness, Advisor, Board Reports |
+| **Governance & Evidence** | Vertiefung: Evidenzketten, GRC-Kontext, wiederholbare Reviews, Audit-Pfade | Evidence, GRC, Register, erweiterte Reports |
+| **Enterprise Connectors** | Skalierung: SAP BTP / Enterprise-Landschaft, Mandanten-Portfolio, Integrationsworkshops | Integrationen, Advisor-Portfolio, konzernweite Reports |
+
+*Tiers und Bundle-Kombinationen: nur im vollständigen Wave-19-Playbook; hier nicht duplizieren.*
+
+---
+
+## Bezug zu Wave 20 (öffentliche / halböffentliche Messaging-Rohbauten)
+
+| Wave | Dokument | Inhalt |
+| ---- | -------- | ------ |
+| **20** | [`wave20-sales-deck-outline.md`](./wave20-sales-deck-outline.md) | Sales-Deck-Struktur, Persona-Module, Visual-Platzhalter |
+| **20** | [`wave20-website-messaging-de.md`](./wave20-website-messaging-de.md) | Landingpage-Copy (DE), ohne Preise |
+| **20** | [`tone_of_voice_de.md`](./tone_of_voice_de.md) | Tonalität, Do/Don’t, Review-Checkliste |
+
+**Regel:** In Deck, Website und Kampagnen dieselben **drei SKU-Namen** wie oben verwenden; Abweichungen nur nach Produkt-/GTM-Abstimmung und Legal-Review.
+
+---
+
+## Pflege
+
+- Bei Umbenennung einer SKU: zuerst **Wave-19-Master**, dann **diesen Stub** und **alle Wave-20-Dateien** anpassen.
+- Versionierung: im Commit oder im internen Playbook festhalten; dieser Stub braucht keine eigene Versionsnummer, solange das Datum im Changelog/PR genügt.
+
+---
+
+*Stub angelegt für sichtbare Kette Wave 19 → Wave 20 im Repo.*

--- a/docs/gtm/wave20-sales-deck-outline.md
+++ b/docs/gtm/wave20-sales-deck-outline.md
@@ -1,0 +1,259 @@
+# Wave 20 – Sales-Deck-Outline (Messaging-Rohbau)
+
+**Zweck:** Wiederverwendbare Struktur und Kurztexte für Website, Sales-Decks und Kampagnen.  
+**Sprache der Beispieltexte:** Deutsch.  
+**Preise:** bewusst nicht enthalten (nur Paket-Fit).  
+**Regulatorik:** vorsichtige Formulierungen („Unterstützung bei Readiness“, „Nachweise dokumentieren“) – finale Zusagen nur nach Legal/Compliance-Review.
+
+**Bezug Wave 19:** Baut auf dem **Pricing & Sales-Playbook (Wave 19)** auf – SKU-Definition und Repo-Anker: [`wave19-pricing-sales-playbook-stub.md`](./wave19-pricing-sales-playbook-stub.md). Dieselbe **SKU-/Paketbezeichnung** und Tier-Logik wie dort (ohne hier Beträge zu nennen):
+
+| SKU (Paket)            | Kurzbezeichnung im Deck |
+| ---------------------- | ----------------------- |
+| AI Act Readiness       | **Paket: AI Act Readiness** |
+| Governance & Evidence  | **Paket: Governance & Evidence** |
+| Enterprise Connectors  | **Paket: Enterprise Connectors** |
+
+**Module (konsistent zur Produktlandschaft):** Advisor · Evidence · GRC · AiSystem · Integrationen · Lifecycle/Readiness · Board Reports · Kanzlei-Dossiers (wo relevant erwähnen, nicht alle auf einer Folie überfrachten).
+
+**Leitidee (ein Satz):** *ComplianceHub: einmal mappen, viele Anforderungen abdecken – KI-Register, Nachweise und Reports aus einer mandantenfähigen Quelle.*
+
+---
+
+## 1. Generische Deck-Struktur (12–15 Folien)
+
+Jede Folie: **Titel** + **Kernaussagen** (Bullets) + **Platzhalter** `[ … ]` für Kundenname, Branche, Datum.
+
+### Folie 1 – Titel & Credibility
+
+- **Titel:** ComplianceHub – AI-Governance & Compliance für den DACH-Raum
+- **Untertitel:** Mandantenfähige Plattform für Register, Nachweise und Board-taugliche Übersichten
+- **Bullets:**
+  - Fokus: Unternehmen, Kanzleien und Konzerne mit SAP-/Enterprise-Landschaft
+  - Technische Basis: strukturierte Evidenz, Audit-Trails, Integrationen (ohne Cloud-Anbieter-Name zu erzwingen)
+- **Platzhalter:** `[Kunde] · [Datum] · [Vertraulichkeit: nur zur internen Verwendung]`
+
+### Folie 2 – Agenda
+
+- Kurzüberblick: Herausforderung → Risiko heutiger Ad-hoc-Lösungen → ComplianceHub → Pakete → Beispiele → Rollen → Nächste Schritte
+- **Platzhalter:** `[Dauer der Session · z. B. 45 Min.]`
+
+### Folie 3 – Problem-Landschaft (Regulatorik, sachlich)
+
+- **Titel:** Was sich für Organisationen in der EU/DACH verschärft
+- **Bullets:**
+  - **EU AI Act:** zunehmende Pflichten je nach Risikoklasse und Einsatzszenario; Dokumentation und Nachvollziehbarkeit gewinnen an Gewicht
+  - **NIS2 / nationales KRITIS-Rahmenwerk:** Erwartung an Incident-Prozesse, Lieferketten und Nachweise – auch für mittelständische kritische Anbieter relevant
+  - **ISO/IEC 42001 & ISO 27001/27701:** KI-Managementsystem und ISMS greifen ineinander; Audits erwarten konsistente Spuren
+  - **GoBD / steuerliche Dokumentation:** wo KI Systeme buchungs- oder belegrelevante Prozesse berührt, steigen Anforderungen an Nachvollziehbarkeit und Aufbewahrung
+- **Hinweis für Sprecher:** „Wir unterstützen bei der Vorbereitung und Dokumentation – keine Garantie für Konformität.“
+
+### Folie 4 – Branchen-Brille (optional kurz)
+
+- **Titel:** Gleiche Regeln, unterschiedliche Schwerpunkte
+- **Bullets:**
+  - **Industrie / Mittelstand:** Lieferanten, Produktion, SAP-lastige Prozesse, AI Act Readiness unter Zeitdruck
+  - **Kanzlei:** Mandantenfähige Beratung, GoBD/DATEV-Ökosystem, wiederholbare Dossiers
+  - **Enterprise:** Konzernweite Transparenz, viele KI-Nutzer, Anbindung an SAP BTP / Event-getriebene Landschaften
+- **Platzhalter:** `[Welche Persona heute im Fokus?]`
+
+### Folie 5 – Risiken von Excel, E-Mail und Einzeltools
+
+- **Titel:** Ad-hoc heißt: Lücken beim Audit
+- **Bullets:**
+  - Verstreute Listen: kein durchgängiger **Audit-Trail** über Änderungen und Freigaben
+  - Manuelle Abstimmung zwischen Legal, IT und Fachbereich: Fehler, Verzögerung, Versionskonflikte
+  - Isolierte „KI-Checklisten“ ohne Anbindung an Register, Incidents und Board-Reporting
+  - Folge: teure Firefighting-Phasen vor Audits oder Vorstandsterminen
+
+### Folie 6 – ComplianceHub in einem Satz
+
+- **Titel:** Eine Plattform für Register, Governance und Nachweise
+- **Zentraler Satz:** **Map once, comply many** – Anforderungen aus AI Act, ISO- und Security-Governance sowie Nachweispflichten an einer Stelle abbilden und für Reports und Mandanten-Akten nutzbar machen.
+- **Bullets:**
+  - Mandantenfähig (Multi-Tenant) – geeignet für Beratungshäuser und Konzerne mit Tochtergesellschaften
+  - Deutschsprachige Oberfläche und Outcomes für DACH-Entscheider
+
+### Folie 7 – Modul-Übersicht
+
+- **Titel:** Was ComplianceHub modular abdeckt
+- **Bullets:**
+  - **Advisor:** Portfolio- und Mandantensicht, Priorisierung, Snapshots für Beratung und interne Steuerung
+  - **Evidence:** strukturierte Nachweise, Verknüpfung zu Controls und Systemen
+  - **GRC:** Risiko- und Compliance-Objekte im Kontext von KI und IT
+  - **AiSystem:** KI-Register, Klassifizierung, Lifecycle – inkl. High-Risk-Themen nachvollziehbar dokumentieren
+  - **Integrationen:** u. a. SAP-Umfeld, DMS-/Exportpfade für Kanzleien und Board-Reports
+  - **Lifecycle / Readiness:** geführte Readiness, Scores, Meilensteine – ohne „fertige Compliance“ zu versprechen
+
+### Folie 8 – Drei Pakete (SKUs) – Fit, nicht Preis
+
+- **Titel:** Pakete – vom Einstieg bis zur Enterprise-Anbindung
+- **Paket: AI Act Readiness**
+  - Für Teams, die **schnell Klarheit** zu KI-Systemen, Risikoklassen und Dokumentationslücken brauchen
+  - Fokus: Register, Readiness-Pfade, Board-taugliche KPIs
+- **Paket: Governance & Evidence**
+  - Für Organisationen mit **Audit- und ISO-Bezug**: Evidenzketten, wiederholbare Reviews, erweiterte GRC-Nutzung
+- **Paket: Enterprise Connectors**
+  - Für **SAP-/Konzernsetups**: tiefere Integration, Event-/Betriebssignale einbeziehen, skalierbare Governance über viele Einheiten
+- **Platzhalter:** `[Empfohlenes Paket für diesen Account: … + Begründung in einem Satz]`
+
+### Folie 9 – Beispiel-Workflow A
+
+- **Titel:** Beispiel: AI Act Readiness in 30 Tagen (Pilotlogik)
+- **Bullets:**
+  - Woche 1–2: Inventar KI-Use-Cases und Systeme im Register; erste Risikoeinstufung; Lückenliste
+  - Woche 3: Verknüpfung mit Evidence und Verantwortlichkeiten (RACI light)
+  - Woche 4: Readiness-Übersicht und Kurzreport für Management – **als Entscheidungsgrundlage**, nicht als Zertifikat
+- **Platzhalter:** `[Anzahl Systeme · Zielgruppe im Projekt]`
+
+### Folie 10 – Beispiel-Workflow B
+
+- **Titel:** Beispiel: Kanzlei – Mandanten-Dossier „Mandant X“
+- **Bullets:**
+  - Mandanten-Stammdaten und Scope festlegen
+  - Board-Report / Governance-Export als **Prüfungs- oder Beratungsdokument** strukturieren
+  - DATEV-/DMS-taugliche Weiterverarbeitung vorbereiten (technischer Export-Pfad – Details im Integrationsgespräch)
+- **Platzhalter:** `[Mandantenname · Beratungsprodukt der Kanzlei]`
+
+### Folie 11 – Rollen & Nutzen
+
+- **Titel:** Wer arbeitet womit?
+- **Bullets:**
+  - **CISO / Informationssicherheit:** übergreifende Risiko- und Incident-Themen, NIS2-Bezug in der Darstellung
+  - **AI Owner / Produkt:** Systempflege im Register, Nachweise zu Modellen und Änderungen
+  - **Kanzlei-Partner / Berater:** Mandanten-Portfolio, Dossiers, Wiederholbarkeit
+  - **Mandanten / Fachbereiche:** klare Aufgaben und Nachweispunkte – weniger Rückfragen in der Endphase
+
+### Folie 12 – Datenhaltung & Vertrauen (kurz, ohne Marketing)
+
+- **Titel:** Was Sie dokumentieren – und was Sie selbst entscheiden
+- **Bullets:**
+  - Mandantenfähige Datenhaltung; **keine** automatische Rechtsberatung
+  - Audit-Logs **immutable** (Produktprinzip) – geeignet für Prüfpfade
+  - DSGVO- und Aufbewahrungsthemen mit Ihrem DSB / WP abzustimmen
+
+### Folie 13 – Nächste Schritte
+
+- **Titel:** Von hier zum Pilot
+- **Bullets:**
+  - **Pilot:** klarer Scope (z. B. eine Division, 5–15 Systeme, 4–6 Wochen)
+  - **Onboarding:** Rollen, Mandantenstruktur, Schulung der Kernuser
+  - **Integration:** SAP BTP / DMS / DATEV-Pfad je nach Paket – technischer Workshop
+- **Platzhalter:** `[Nächstes Meeting · verantwortliche Personen]`
+
+### Folie 14 – Q&A / Anhang-Hinweis (optional)
+
+- **Titel:** Fragen & Tiefgang
+- **Bullets:**
+  - Vertiefung: Norm-Mapping, konkrete Integrations-Screenshots, Demo-Mandant
+  - **Anhang-Folien** (optional): Architektur-Skizze, Beispiel-Board-Report-Auszug
+
+### Folie 15 – Kontakt / Call to Action (optional)
+
+- **Titel:** Kontakt
+- **Platzhalter:** `[Name · Rolle · E-Mail · Kalenderlink]`
+
+---
+
+## 2. Persona-spezifische Varianten (modulare Zusatz-Folien)
+
+*Nicht ein zweites Deck – diese Folien **einfügen oder Folie 4/8/9–10 ersetzen** je nach Audience.*
+
+### Variante A – Industrie-Mittelstand
+
+**A1 – Titelfolie (optional, Untertitel anpassen)**  
+- **Untertitel-Zusatz:** AI Act Readiness, NIS2-Relevanz und SAP-nahe Prozesse – ohne Konzern-Overhead
+
+**A2 – Schwerpunktfolie „Mittelstand unter Druck“**  
+- Lieferketten und kritische Dienstleistungen: NIS2 verschärft Erwartungen an Nachweise und Lieferanten
+- ISO 27001 besteht oft schon – **ISO 42001** und KI-Register als sinnvolle Erweiterung
+- SAP als „System der Wahrheit“: Governance-Daten mit Unternehmensprozessen verzahnen (Richtung Enterprise Connectors)
+
+**A3 – Mini-Case (Platzhalter)**  
+- **Bullets:** `[Branche]` · `[Anzahl Standorte]` · `[SAP S/4 oder andere ERP-Linie]` · Ergebnis: „Readiness-Score und Prioritätenliste für den Vorstand in Woche 4“
+
+### Variante B – Kanzlei
+
+**B1 – Untertitel-Zusatz (Titelfolie)**  
+- Mandanten-Compliance, GoBD-Kontext und skalierbare Beratungsprodukte
+
+**B2 – Schwerpunktfolie „Wiederholbare Mandanten-Akte“**  
+- GoBD: Nachvollziehbarkeit und Aufbewahrung bei KI-gestützten Buchungs- oder Belegprozessen **thematisieren** – Umsetzung mit Mandant abstimmen
+- DATEV-Ökosystem: strukturierte Exporte / Metadaten für die Kanzlei-DMS-Praxis
+- Neues Angebot: „AI Governance Review“ als Standardpaket mit ComplianceHub-Dossier
+
+**B3 – Mini-Case (Platzhalter)**  
+- **Bullets:** Mandant `[Name]` · Branche `[…]` · Deliverable: „Governance-Dossier + Board-Report-Auszug für Jahresgespräch“
+
+### Variante C – Enterprise SAP
+
+**C1 – Untertitel-Zusatz (Titelfolie)**  
+- SAP BTP, Event-getriebene Architekturen und konzernweite AI Governance
+
+**C2 – Schwerpunktfolie „Skalierung & Signale“**  
+- Viele KI-Deployments (SAP AI Core, Partner-Tools): **ein** Governance-Register und einheitliche Reports
+- Event Mesh / Betriebsereignisse: Anknüpfungspunkte für Monitoring-Narrative (OAMI) – Fachlichkeit im Integrationsworkshop
+- Konzern: Mandanten / Subsidiaries im Advisor-Portfolio vergleichen
+
+**C3 – Mini-Case (Platzhalter)**  
+- **Bullets:** `[Konzernbereich]` · `[SAP-Landschaft Kurzbeschreibung]` · Ergebnis: „einheitlicher Board-Report über mehrere Einheiten“
+
+---
+
+## 3. Maschinenlesbare Kurzform (JSON)
+
+```json
+{
+  "wave": 20,
+  "references_wave_19_doc": "docs/gtm/wave19-pricing-sales-playbook-stub.md",
+  "skus": [
+    "AI Act Readiness",
+    "Governance & Evidence",
+    "Enterprise Connectors"
+  ],
+  "generic_slides": [
+    {"id": 1, "key": "title_credibility"},
+    {"id": 2, "key": "agenda"},
+    {"id": 3, "key": "problem_regulatory_landscape"},
+    {"id": 4, "key": "persona_lens_optional"},
+    {"id": 5, "key": "risks_ad_hoc"},
+    {"id": 6, "key": "one_liner_map_once"},
+    {"id": 7, "key": "module_overview"},
+    {"id": 8, "key": "three_skus_fit"},
+    {"id": 9, "key": "workflow_ai_act_30d"},
+    {"id": 10, "key": "workflow_law_firm_dossier"},
+    {"id": 11, "key": "roles_benefits"},
+    {"id": 12, "key": "trust_data_governance"},
+    {"id": 13, "key": "next_steps_pilot"},
+    {"id": 14, "key": "qa_appendix_optional"},
+    {"id": 15, "key": "contact_cta_optional"}
+  ],
+  "persona_insert_slides": {
+    "industry_mittelstand": ["A1_title_sub", "A2_pressure_nis2_sap", "A3_mini_case"],
+    "kanzlei": ["B1_title_sub", "B2_mandantenakte_gobd_datev", "B3_mini_case"],
+    "enterprise_sap": ["C1_title_sub", "C2_scale_events", "C3_mini_case"]
+  }
+}
+```
+
+---
+
+## 4. Platzhalter für Visuals / Diagramme (Sales-Deck)
+
+| Folie(n)        | Empfohlene Visualisierung (später) |
+| --------------- | ---------------------------------- |
+| 1               | Logo + eine Zeile „DACH / Enterprise“-Key-Visual (kein Stock-Foto-Zwang) |
+| 3               | **Regulatorik-Timeline** oder vier Kacheln (AI Act · NIS2 · ISO · GoBD) mit kurzen Untertiteln |
+| 4               | Drei Spalten: Industrie · Kanzlei · Enterprise (Icons sachlich) |
+| 5               | **Vorher/Nachher:** verstreute Icons (Excel, Mail, PDF) vs. eine zentrale Plattform-Silhouette |
+| 6               | Ein Satz groß, darunter kleines **„Map once → comply many“**-Schema (Pfeil) |
+| 7               | **Systemlandkarte** Module als Boxen mit kurzen Labels |
+| 8               | Drei Spalten/SKUs mit je 3 Icon-Bullets (Outcome-fokussiert) |
+| 9–10            | **Workflow-Schritte** (1–2–3–4) als horizontale oder vertikale Swimlane |
+| 11              | **RACI-light-Matrix** oder Rollen-Avatare mit einem Nutzen-Satz je Rolle |
+| 12              | Einfache **Trust-Stack**-Grafik (Tenant · Audit · Ihre Policies) |
+| 13              | **Roadmap-Balken** Pilot → Onboarding → Integration |
+| 14–15           | Nur Text oder Kontakt-Card |
+
+---
+
+*Review-Hinweis: Alle regulatorischen Aussagen mit Legal/Compliance gegen Finaltexte des Produkts und der Website abgleichen.*

--- a/docs/gtm/wave20-website-messaging-de.md
+++ b/docs/gtm/wave20-website-messaging-de.md
@@ -1,0 +1,139 @@
+# Wave 20 – Website-Landingpage (Messaging, DE)
+
+**Zweck:** Copy-Rohbau für Hero, Paket-Sektionen und Ablauf – **ohne Layout/Design**.  
+**Bezug Wave 19:** Gleiche **SKU-Bezeichnungen** wie im [Wave-19-Stub](./wave19-pricing-sales-playbook-stub.md): *AI Act Readiness*, *Governance & Evidence*, *Enterprise Connectors*.  
+**Rechtliches:** Formulierungen sind bewusst vorsichtig; vor Go-Live **Legal/Compliance-Review**.
+
+---
+
+## Hero-Section
+
+### Headline (Claim)
+
+**AI Act Readiness und KI-Governance für den DACH-Mittelstand – strukturiert dokumentiert und für Audits vorbereitet**
+
+### Subline
+
+ComplianceHub bündelt KI-Register, Nachweise und Reports in einer mandantenfähigen Plattform. Sie erhalten Unterstützung bei der **Vorbereitung** auf EU AI Act, NIS2, ISO 42001/27001 und – wo relevant – GoBD-konforme Dokumentationspraxis **im Abgleich mit Ihrem Steuerberater** – ohne Garantieanspruch auf „vollständige Konformität“.
+
+### Primärer Button (CTA)
+
+**Gespräch vereinbaren** / **Demo anfragen**
+
+*(Platzhalter sekundärer Link: „Pakete vergleichen“ → Anker zu `#pakete`)*
+
+### Kurz-Bullets unter Hero (optional, 3 Stück)
+
+- Mandantenfähig – für Unternehmen, Konzerne und Kanzleien
+- Audit-Trails und strukturierte Evidence – weniger Excel-Chaos
+- Integrationen u. a. für SAP-Umfeld und Kanzlei-Workflows
+
+---
+
+## Sektion: Drei Pakete (je SKU)
+
+Anker-ID-Vorschlag: `id="pakete"`
+
+### Paket: AI Act Readiness
+
+**Zwischenüberschrift:** Schnell Klarheit im KI-Portfolio
+
+**Einleitung (1 Satz):**  
+Ideal, wenn Sie **Überblick und Prioritäten** brauchen, bevor Budget und Ressourcen für tiefe GRC- und Integrationsprojekte freigegeben werden.
+
+**Nutzen (Outcomes, 4 Bullets):**
+
+- KI-Systeme und Use-Cases **gebündelt erfassen** – Grundlage für Risikoklassen und nächste Schritte
+- **Readiness- und Setup-Logik** nutzbar machen: Lücken sichtbar, Fortschritt messbar
+- **Vorstand- und Board-taugliche KPIs** – Entscheidungsunterlagen statt Folienbau in der Nacht vor dem Termin
+- **Schneller Pilot** möglich – fokussierter Scope, klarer Zeitrahmen (z. B. 30 Tage)
+
+---
+
+### Paket: Governance & Evidence
+
+**Zwischenüberschrift:** Nachweise, die Prüfer und Auditoren nachvollziehen können
+
+**Einleitung (1 Satz):**  
+Für Organisationen und Berater, die **Evidenzketten** zwischen Controls, Systemen und Reports brauchen – etwa im ISO- oder internen Prüfungskontext.
+
+**Nutzen (Outcomes, 4 Bullets):**
+
+- Evidence **strukturiert** an Systeme und Maßnahmen koppeln – weniger Medienbruch
+- GRC- und Register-Logik **zusammen denken** – Risiko- und Compliance-Kontext für KI
+- **Wiederholbare Reviews** – gleiche Datenbasis für Quartals- und Jahresgespräche
+- **Governance-Aktivität** sichtbar machen (Nutzung der Werkzeuge) – Unterscheidung von „Papier-Compliance“
+
+---
+
+### Paket: Enterprise Connectors
+
+**Zwischenüberschrift:** Konzernweite Steuerung – angebunden an Ihre Systemlandschaft
+
+**Einleitung (1 Satz):**  
+Wenn **SAP BTP**, Event-getriebene Architekturen oder viele Tochtergesellschaften im Spiel sind: Governance-Daten **skalierbar** erfassen und in Reports zusammenführen.
+
+**Nutzen (Outcomes, 4 Bullets):**
+
+- **Integration in Enterprise-Landschaften** – weniger manuelle CSV-Exports zwischen Teams
+- Signale aus dem **Betrieb** stärker in Governance-Narrative einbeziehen (Ausrichtung im Projekt zu definieren)
+- **Portfolio über Mandanten/Einheiten** – Advisor-Sicht für Priorisierung und Vergleich
+- **Board Reports und Exportpfade** für interne und externe Stakeholder vorbereiten
+
+---
+
+## Sektion: Wie ComplianceHub hilft
+
+**Überschrift:** In drei Schritten zur belastbaren Dokumentation
+
+**Unterzeile:** Kein „KI-Magie-Knopf“ – sondern ein durchgängiger Prozess von Inventar bis Report.
+
+| Schritt | Titel | Kurztext (Website) |
+| ------- | ----- | ------------------ |
+| **1** | **Inventarisieren** | KI-Systeme, Verantwortliche und Anknüpfungspunkte zu Fachprozessen erfassen – als Grundlage für AI Act und interne Policies. |
+| **2** | **Bewerten** | Risiken, Controls und offene Nachweise zuordnen; NIS2- und ISO-Bezüge dort einbeziehen, wo sie für Ihre Organisation tragen. |
+| **3** | **Evidence & Reports** | Nachweise bündeln, Audit-Trail nutzen, Board-Reports und Mandanten-Dossiers erzeugen – **unterstützend** zur Prüfung durch interne Revision oder externe Partner. |
+
+**Abschluss-Satz (optional):**  
+Die konkrete rechtliche Bewertung verbleibt bei Ihnen und Ihren Beauftragten; ComplianceHub liefert **Struktur, Transparenz und Dokumentation**.
+
+---
+
+## Social Proof (Platzhalter – ohne echte Logos)
+
+**Überschrift:** Vertrauenswürdig für anspruchsvolle Regulierungs- und IT-Umgebungen
+
+**Platzhalter-Zeilen (ersetzen, sobald freigegeben):**
+
+- „Mitteleuropäische **Industrie- und Dienstleistungsunternehmen** mit SAP- und Cloud-Mix“
+- **Steuerberatungs- und Wirtschaftsprüfungskanzleien**, die Mandanten-Dossiers standardisieren wollen
+- **Konzerne** mit mehreren Rechtseinheiten und Bedarf an konsolidierter KI-Governance-Sicht
+
+**Hinweis für Redaktion:** Keine erfundenen Kundennamen oder Zitate ohne Freigabe.
+
+---
+
+## SEO / Meta (optional, kurz)
+
+- **Title-Tag (Vorschlag):** ComplianceHub – AI Act Readiness & KI-Governance für DACH
+- **Meta-Description (Vorschlag):** Mandantenfähige Plattform für KI-Register, Nachweise und Reports. Unterstützung bei AI Act, NIS2, ISO 42001/27001 und GoBD-relevanten Dokumentationsfragen.
+
+---
+
+## Platzhalter für Visuals / Diagramme (Website)
+
+| Sektion              | Empfohlene Visualisierung (später) |
+| -------------------- | ------------------------------------ |
+| Hero                 | Produkt-Screenshot (Register oder Dashboard) **oder** abstrakte **DACH-Karte + Modul-Icons** (sachlich) |
+| Pakete (3 Spalten)   | Je Paket eine **Outcome-Karte** mit Icon (Lesbarkeit > Dekoration) |
+| „Wie wir helfen“     | **Drei Schritte** als horizontale Steps oder vertikale Timeline |
+| Social Proof         | **Logo-Leiste** (grau, gleiche Höhe) – erst nach Freigaben |
+| Fußbereich / Trust   | Kleine Icons: „Audit-Logs“, „Mandantenfähig“, „DSGVO-Themen mit DSB klären“ |
+
+---
+
+## Cross-Links zu internen Docs (für Redaktion)
+
+- Norm-Mapping und vorsichtige Formulierungen: `docs/compliance/ai-governance-norm-evidence-mapping.md`
+- Tone of Voice: `docs/gtm/tone_of_voice_de.md`
+- Sales-Deck-Struktur: `docs/gtm/wave20-sales-deck-outline.md`


### PR DESCRIPTION
Introduce wave19-pricing-sales-playbook-stub.md with canonical SKU names and pointers to Wave 20 sales deck, website copy, and tone-of-voice docs. Cross-link Wave 20 files and JSON reference to the stub.

Made-with: Cursor