### PR TITLE
feat(frontend): Wave 24 contact form and lead capture

### DIFF
--- a/docs/gtm/wave20-website-messaging-de.md
+++ b/docs/gtm/wave20-website-messaging-de.md
@@ -143,3 +143,4 @@ Die konkrete rechtliche Bewertung verbleibt bei Ihnen und Ihren Beauftragten; Co
 - **Claims / Disclaimers (Wave 21):** `docs/gtm/compliance-statement-library-de.md`, `docs/gtm/statements/statements.v1.json`
 - **Wave 22 (statisches Artefakt):** `website/compliancehub-landing.html` · [`wave22-landingpage-notes.md`](./wave22-landingpage-notes.md) · **Kanonische Homepage:** [complywithai.de](https://complywithai.de/)
 - **Wave 23 (Homepage-Copy & CTA-Plan):** [`wave23-homepage-content-and-assets.md`](./wave23-homepage-content-and-assets.md)
+- **Wave 24 (Kontaktformular & Lead-Capture):** [`wave24-contact-and-lead-capture.md`](./wave24-contact-and-lead-capture.md)

--- a/docs/gtm/wave23-homepage-content-and-assets.md
+++ b/docs/gtm/wave23-homepage-content-and-assets.md
@@ -7,7 +7,7 @@
 - Startseite: `frontend/src/app/page.tsx`
 - Produktvorschau (Hero rechts): `frontend/src/components/home/HomeProductPreview.tsx`
 - Globale Meta-Beschreibung: `frontend/src/app/layout.tsx`
-- Öffentlicher Kontakt (eine Quelle): `frontend/src/lib/publicContact.ts` → `PUBLIC_CONTACT_MAILTO`
+- Öffentlicher Kontakt: **`/kontakt`** (Wave 24) + Fallback `PUBLIC_CONTACT_MAILTO` in `frontend/src/lib/publicContact.ts`
 - Footer-Link „Kontakt“: `frontend/src/components/sbs/SbsFooter.tsx`
 - Optionaler Sales-One-Pager (statisch, gleiche Tokens wie Wave 22): `website/sales-one-pager.html` (CSS: `website/css/compliancehub-landing.css`)
 
@@ -44,14 +44,16 @@ Bestehende Slots beibehalten; folgende **Dateien/Konzepte** für spätere Produk
 
 ## 3. CTAs – stabil vs. temporär
 
+*Aktualisiert in Wave 24 – siehe [`wave24-contact-and-lead-capture.md`](./wave24-contact-and-lead-capture.md).*
+
 | CTA / Link | Ziel | Status |
 | ---------- | ---- | ------ |
-| **Demo anfragen** (Hero, Mid-CTA, One-Pager, statische Wave-22-Seite) | `mailto:kontakt@complywithai.de` via `PUBLIC_CONTACT_MAILTO` | **Temporär stabil**, bis Postfach/Formular/CRM final ist |
+| **Demo anfragen** / **Kontakt** (Next.js) | **`/kontakt?quelle=…`** (Formular) | **Stabil** (Primärpfad) |
+| **Demo anfragen** (statische HTML unter `website/`) | `https://complywithai.de/kontakt?quelle=…` | **Stabil** |
+| **Fallback** | `mailto:kontakt@complywithai.de` | Sekundär (Formular + Fehlerfall) |
 | **Board öffnen** | `/board/kpis` | **Stabil** (Produkteintritt) |
 | **Board-Ansicht** (Mid-CTA) | `/board/kpis` | **Stabil** |
 | **Mandant öffnen** | `/tenant/compliance-overview` | **Stabil** (Workspace-Einstieg) |
-| **Kontakt** (Footer) | gleiches `mailto:` | **Temporär stabil** |
-| **Kontakt aufnehmen** (Integrationen) | gleiches `mailto:` | **Temporär stabil** |
 | **5-Minuten Produkt-Tour** | *entfernt aus Hero zugunsten zweier klarer CTAs*; Tour weiter über **Board/Navigation** erreichbar | Bewusst **vereinfacht**; optional später wieder als dritter Link oder Header-Link |
 
 **SKU-Bezug:** Mid-CTA-Text nennt explizit **AI Act Readiness**, **Governance & Evidence**, **Enterprise Connectors** (Abgleich Wave 19/20).

--- a/docs/gtm/wave24-contact-and-lead-capture.md
+++ b/docs/gtm/wave24-contact-and-lead-capture.md
@@ -1,0 +1,109 @@
+# Wave 24 – Kontakt, Lead-Capture & CTA-Architektur
+
+**Ziel:** Von **mailto-first** zu **form-first** mit minimaler UI-Änderung; zuverlässigere Erfassung, Segmentierung für Sales-Triage, statement-sichere Begleittexte.
+
+**Kanonische Homepage:** [complywithai.de](https://complywithai.de/)
+
+---
+
+## 1. Architektur (Überblick)
+
+| Element | Pfad / Mechanismus |
+| ------- | ------------------ |
+| **Kontaktseite** | `GET /kontakt?quelle=<string>` – Next.js `frontend/src/app/kontakt/page.tsx` |
+| **Formular** | Client: `frontend/src/components/contact/ContactLeadForm.tsx` |
+| **Lead-POST** | `POST /api/lead-inquiry` – `frontend/src/app/api/lead-inquiry/route.ts` |
+| **Telemetrie (leicht)** | `POST /api/marketing-event` – `frontend/src/app/api/marketing-event/route.ts` |
+| **CTA mit Klick-Tracking** | `TrackedContactLink` – `frontend/src/components/contact/TrackedContactLink.tsx` |
+| **URL-Helfer** | `contactPageHref(quelle)` – `frontend/src/lib/publicContact.ts` |
+| **Segment-Enum & Limits** | `frontend/src/lib/leadCapture.ts` |
+| **Fallback mailto** | `PUBLIC_CONTACT_MAILTO` / `PUBLIC_CONTACT_EMAIL` – weiterhin gültig |
+
+---
+
+## 2. Lead-Datenmodell (POST-Body)
+
+| Feld | Pflicht | Beschreibung |
+| ---- | ------- | ------------ |
+| `name` | ja | Ansprechpartner |
+| `work_email` | ja | Geschäftliche E-Mail |
+| `company` | ja | Unternehmen / Kanzlei |
+| `segment` | ja | `industrie_mittelstand` · `kanzlei_wp` · `enterprise_sap` · `sonstiges` |
+| `message` | nein | Freitext (optional) |
+| `source_page` | ja | Serverseitig aus Formular: Wert von Query `quelle` (Triage: Herkunft der Anfrage) |
+| `company_website` | nein | **Honeypot** – muss leer bleiben |
+
+**Routing heute:** Strukturierter **Server-Log** (`console.info` mit Präfix `[lead-inquiry]`) inkl. vollständiger geschäftlicher E-Mail für manuelle Bearbeitung / Monitoring.
+
+**Optional:** `LEAD_INBOUND_WEBHOOK_URL` (Env) – POST derselben JSON-Nutzlast + `received_at` an CRM, Slack, Zapier o. Ä.
+
+---
+
+## 3. Was sich gegenüber Wave 23 ändert
+
+| Vorher | Nachher |
+| ------ | ------- |
+| „Demo anfragen“ → direkt `mailto:` | Primär **`/kontakt?quelle=…`** mit Formular |
+| Kein Segment | **Dropdown** Industrie / Kanzlei / Enterprise / Sonstiges |
+| Keine serverseitige Erfassung | **API-Route** + optional Webhook |
+| Kein Klick-Tracking | **`cta_click`** per `sendBeacon` / `fetch` (keine PII) |
+| Footer „Kontakt“ → mailto | Footer **Link** zur Kontaktseite (`quelle=footer`) |
+
+**Sekundärer Fallback:** Auf der Kontaktseite Button **„Stattdessen E-Mail öffnen“** (`mailto:`); bei Submit-Fehler Hinweis mit derselben Adresse.
+
+---
+
+## 4. `quelle`-Werte (Triage)
+
+| `quelle` | Bedeutung |
+| -------- | --------- |
+| `home-hero` | Hero „Demo anfragen“ |
+| `home-integrations` | Abschnitt Integrationen „Kontakt aufnehmen“ |
+| `home-mid-cta` | Mid-Page-CTA „Demo anfragen“ |
+| `footer` | Footer-Link „Kontakt“ |
+| `kontakt-direct` | `/kontakt` ohne Query |
+| `static-wave22-header` / `…-hero` / … | Statische HTML-Artefakte unter `website/` (absolute URL auf complywithai.de) |
+| `one-pager-*` | `website/sales-one-pager.html` |
+
+---
+
+## 5. Telemetrie-Events (ohne PII)
+
+| Event | Auslöser |
+| ----- | -------- |
+| `cta_click` | Klick auf `TrackedContactLink` |
+| `lead_form_started` | Erste Interaktion mit Formularfeld |
+| `lead_form_submit_attempt` | Submit |
+| `lead_form_submitted` | HTTP 200 von `/api/lead-inquiry` |
+| `lead_form_submit_error` | Validierungs- oder Netzwerkfehler |
+
+Logs: `[marketing-event]` mit `event`, optional `cta_id`, `quelle`, `t`.
+
+---
+
+## 6. Compliance-Copy (Kurz)
+
+- Formular: **unverbindlich**, **keine automatischen Verträge**, Erstkontakt **keine Rechtsberatung**.
+- Erfolg: Rückmeldung in wenigen Werktagen, keine rechtsverbindliche Zusage.
+
+Abgleich: `docs/gtm/compliance-statement-library-de.md`, `docs/gtm/tone_of_voice_de.md`.
+
+---
+
+## 7. Statische HTML-Dateien
+
+`website/compliancehub-landing.html` und `website/sales-one-pager.html` verlinken CTAs per **absoluter URL** `https://complywithai.de/kontakt?quelle=…`, damit sie auch außerhalb des Next-Hostings funktionieren.
+
+---
+
+## 8. Erweiterungen (später)
+
+- **CRM** (HubSpot, Pipedrive): Webhook oder serverseitiger Adapter statt nur Log.
+- **Calendly / Terminlink** nach erfolgreichem Submit oder als zweite CTA.
+- **Rate-Limiting** / CAPTCHA bei Missbrauch.
+- **Double-Opt-In** nur wenn rechtlich/marketingseitig nötig (derzeit reine Geschäftsanfrage).
+- **i18n** für `quelle`-Mapping in Reports.
+
+---
+
+*Wave 24 – form-first Kontakt, mailto sekundär.*

--- a/frontend/src/app/api/lead-inquiry/route.ts
+++ b/frontend/src/app/api/lead-inquiry/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+
+import {
+  isLeadSegment,
+  LEAD_FIELD_LIMITS,
+  type LeadInquiryPayload,
+} from "@/lib/leadCapture";
+
+type Incoming = {
+  name?: string;
+  work_email?: string;
+  company?: string;
+  segment?: string;
+  message?: string;
+  source_page?: string;
+  /** Honeypot – Bots füllen oft versteckte Felder */
+  company_website?: string;
+};
+
+function trimStr(v: unknown, max: number): string {
+  if (typeof v !== "string") return "";
+  return v.trim().slice(0, max);
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Öffentlicher Lead-Endpunkt (ohne Auth).
+ * Produktion: optional `LEAD_INBOUND_WEBHOOK_URL` für CRM/Slack; sonst strukturierte Logs.
+ */
+export async function POST(req: Request) {
+  let body: Incoming;
+  try {
+    body = (await req.json()) as Incoming;
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  if (body.company_website && String(body.company_website).trim() !== "") {
+    return NextResponse.json({ ok: true });
+  }
+
+  const name = trimStr(body.name, LEAD_FIELD_LIMITS.name);
+  const work_email = trimStr(body.work_email, LEAD_FIELD_LIMITS.email).toLowerCase();
+  const company = trimStr(body.company, LEAD_FIELD_LIMITS.company);
+  const message = trimStr(body.message ?? "", LEAD_FIELD_LIMITS.message);
+  const source_page = trimStr(body.source_page, LEAD_FIELD_LIMITS.source_page);
+
+  if (!name || !work_email || !company || !source_page) {
+    return NextResponse.json({ ok: false, error: "validation" }, { status: 400 });
+  }
+
+  if (!EMAIL_RE.test(work_email)) {
+    return NextResponse.json({ ok: false, error: "validation" }, { status: 400 });
+  }
+
+  const segRaw = typeof body.segment === "string" ? body.segment.trim() : "";
+  if (!isLeadSegment(segRaw)) {
+    return NextResponse.json({ ok: false, error: "validation" }, { status: 400 });
+  }
+
+  const payload: LeadInquiryPayload = {
+    name,
+    work_email,
+    company,
+    segment: segRaw,
+    message,
+    source_page,
+  };
+
+  const webhook = process.env.LEAD_INBOUND_WEBHOOK_URL?.trim();
+  if (webhook) {
+    try {
+      const r = await fetch(webhook, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...payload,
+          received_at: new Date().toISOString(),
+        }),
+      });
+      if (!r.ok) {
+        console.warn("[lead-inquiry] webhook_non_ok", r.status);
+      }
+    } catch (e) {
+      console.warn("[lead-inquiry] webhook_error", e);
+    }
+  }
+
+  console.info(
+    "[lead-inquiry]",
+    JSON.stringify({
+      ...payload,
+      received_at: new Date().toISOString(),
+    }),
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/api/marketing-event/route.ts
+++ b/frontend/src/app/api/marketing-event/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+type Body = {
+  event?: string;
+  cta_id?: string;
+  quelle?: string;
+  t?: number;
+};
+
+/**
+ * Minimal internal observability (structured log line).
+ * Keine PII; nur Event-Namen und optionale Quell-Marker.
+ */
+export async function POST(req: Request) {
+  let parsed: Body;
+  try {
+    parsed = (await req.json()) as Body;
+  } catch {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const event = typeof parsed.event === "string" ? parsed.event.trim() : "";
+  if (!event || event.length > 64) {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+
+  const ctaId =
+    typeof parsed.cta_id === "string" ? parsed.cta_id.slice(0, 120) : undefined;
+  const quelle =
+    typeof parsed.quelle === "string" ? parsed.quelle.slice(0, 120) : undefined;
+
+  console.info(
+    "[marketing-event]",
+    JSON.stringify({
+      event,
+      cta_id: ctaId,
+      quelle,
+      t: typeof parsed.t === "number" ? parsed.t : Date.now(),
+    }),
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/frontend/src/app/kontakt/page.tsx
+++ b/frontend/src/app/kontakt/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+
+import { ContactLeadForm } from "@/components/contact/ContactLeadForm";
+import { CH_PAGE_SUB, CH_PAGE_TITLE, CH_SHELL } from "@/lib/boardLayout";
+
+export const metadata: Metadata = {
+  title: "Kontakt & Demo · Compliance Hub",
+  description:
+    "Unverbindliche Demo- oder Beratungsanfrage zu AI Act Readiness, Governance & Evidence und Enterprise Connectors. Keine Rechtsberatung.",
+};
+
+function FormFallback() {
+  return (
+    <p className="rounded-xl border border-slate-200 bg-white p-6 text-sm text-slate-600 shadow-sm">
+      Formular wird geladen …
+    </p>
+  );
+}
+
+export default function KontaktPage() {
+  return (
+    <div className={CH_SHELL}>
+      <div className="max-w-2xl">
+        <h1 className={CH_PAGE_TITLE}>Kontakt &amp; Demo anfragen</h1>
+        <p className={CH_PAGE_SUB}>
+          Beschreiben Sie kurz Ihr Anliegen. Wir melden uns für ein unverbindliches Gespräch zu
+          Paketen (AI Act Readiness, Governance &amp; Evidence, Enterprise Connectors) und
+          nächsten Schritten.
+        </p>
+      </div>
+      <Suspense fallback={<FormFallback />}>
+        <ContactLeadForm />
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,10 @@
 import Link from "next/link";
 import React from "react";
 
+import { TrackedContactLink } from "@/components/contact/TrackedContactLink";
 import { HomeProductPreview } from "@/components/home/HomeProductPreview";
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY } from "@/lib/boardLayout";
-import { PUBLIC_CONTACT_MAILTO } from "@/lib/publicContact";
+import { contactPageHref } from "@/lib/publicContact";
 
 function SectionTitle({
   title,
@@ -62,12 +63,14 @@ export default function HomePage() {
               Bewertungen verbleiben bei Ihnen und Ihren Beauftragten.
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
-              <a
-                href={PUBLIC_CONTACT_MAILTO}
+              <TrackedContactLink
+                href={contactPageHref("home-hero")}
+                ctaId="home-hero-demo"
+                quelle="home-hero"
                 className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-2.5 text-sm font-semibold text-white shadow-md shadow-emerald-900/15 transition hover:from-emerald-700 hover:to-emerald-600"
               >
                 Demo anfragen
-              </a>
+              </TrackedContactLink>
               <Link
                 href="/board/kpis"
                 className="inline-flex items-center justify-center rounded-full border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
@@ -247,12 +250,14 @@ export default function HomePage() {
           </div>
           <p className="mt-6 text-center text-xs text-slate-500">
             Ihre Plattform fehlt?{" "}
-            <a
-              href={PUBLIC_CONTACT_MAILTO}
+            <TrackedContactLink
+              href={contactPageHref("home-integrations")}
+              ctaId="home-integrations-kontakt"
+              quelle="home-integrations"
               className="font-medium text-cyan-700 underline-offset-2 hover:underline"
             >
               Kontakt aufnehmen
-            </a>{" "}
+            </TrackedContactLink>{" "}
             oder über Ihr Compliance-Team.
           </p>
         </div>
@@ -272,12 +277,14 @@ export default function HomePage() {
             wir gern im Gespräch.
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
-            <a
-              href={PUBLIC_CONTACT_MAILTO}
+            <TrackedContactLink
+              href={contactPageHref("home-mid-cta")}
+              ctaId="home-mid-cta-demo"
+              quelle="home-mid-cta"
               className="inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:from-emerald-700 hover:to-emerald-600"
             >
               Demo anfragen
-            </a>
+            </TrackedContactLink>
             <Link href="/tenant/compliance-overview" className={`${CH_BTN_SECONDARY} px-6 py-3`}>
               Mandant öffnen
             </Link>

--- a/frontend/src/components/contact/ContactLeadForm.tsx
+++ b/frontend/src/components/contact/ContactLeadForm.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useSearchParams } from "next/navigation";
+
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY } from "@/lib/boardLayout";
+import { LEAD_SEGMENTS } from "@/lib/leadCapture";
+import { sendMarketingEvent } from "@/lib/marketingTelemetryClient";
+import { PUBLIC_CONTACT_EMAIL, PUBLIC_CONTACT_MAILTO } from "@/lib/publicContact";
+
+type Status = "idle" | "submitting" | "success" | "error";
+
+export function ContactLeadForm() {
+  const sp = useSearchParams();
+  const quelleRaw = sp.get("quelle");
+  const quelle =
+    quelleRaw && quelleRaw.trim() ? quelleRaw.trim().slice(0, 120) : "kontakt-direct";
+
+  const startedRef = useRef(false);
+  const [status, setStatus] = useState<Status>("idle");
+  const [errorDetail, setErrorDetail] = useState<string | null>(null);
+
+  const markStarted = () => {
+    if (startedRef.current) return;
+    startedRef.current = true;
+    sendMarketingEvent({
+      event: "lead_form_started",
+      quelle,
+    });
+  };
+
+  const clearError = () => {
+    if (status === "error") {
+      setStatus("idle");
+      setErrorDetail(null);
+    }
+  };
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErrorDetail(null);
+    sendMarketingEvent({ event: "lead_form_submit_attempt", quelle });
+    setStatus("submitting");
+
+    const fd = new FormData(e.currentTarget);
+    const company_website = (fd.get("company_website") as string) || "";
+    const payload = {
+      name: (fd.get("name") as string) || "",
+      work_email: (fd.get("work_email") as string) || "",
+      company: (fd.get("company") as string) || "",
+      segment: (fd.get("segment") as string) || "",
+      message: (fd.get("message") as string) || "",
+      source_page: quelle,
+      company_website,
+    };
+
+    try {
+      const res = await fetch("/api/lead-inquiry", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        setStatus("error");
+        setErrorDetail("validation");
+        sendMarketingEvent({ event: "lead_form_submit_error", quelle });
+        return;
+      }
+      setStatus("success");
+      sendMarketingEvent({ event: "lead_form_submitted", quelle });
+      e.currentTarget.reset();
+    } catch {
+      setStatus("error");
+      setErrorDetail("network");
+      sendMarketingEvent({ event: "lead_form_submit_error", quelle });
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <div
+        className="rounded-2xl border border-emerald-200/90 bg-emerald-50/50 p-6 shadow-sm"
+        role="status"
+        aria-live="polite"
+      >
+        <p className="text-sm font-semibold text-emerald-900">Vielen Dank für Ihre Anfrage.</p>
+        <p className="mt-2 text-sm leading-relaxed text-emerald-900/90">
+          Wir prüfen Ihre Angaben und melden uns in der Regel innerhalb weniger Werktage bei Ihnen.
+          Die Anfrage ist unverbindlich und begründet keine rechtsverbindliche Zusage.
+        </p>
+        <p className="mt-3 text-xs text-emerald-900/80">
+          Hinweis: Erstkontakt ersetzt keine Rechts- oder Steuerberatung.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-2xl border border-slate-200/90 bg-white p-6 shadow-md shadow-slate-200/40 sm:p-8">
+      <p className="text-sm leading-relaxed text-slate-600">
+        Füllen Sie die Pflichtfelder aus. Wir nutzen Ihre geschäftliche E-Mail ausschließlich zur
+        Bearbeitung dieser Anfrage. Die Anfrage ist <strong>unverbindlich</strong>. Es entstehen
+        keine automatischen Verträge. Erstkontakt ersetzt <strong>keine Rechtsberatung</strong>.
+      </p>
+
+      <form className="relative mt-6 space-y-4" onSubmit={onSubmit} noValidate>
+        {/* Honeypot */}
+        <div className="absolute -left-[9999px] h-0 w-0 overflow-hidden" aria-hidden="true">
+          <label htmlFor="company_website">Website</label>
+          <input
+            type="text"
+            id="company_website"
+            name="company_website"
+            tabIndex={-1}
+            autoComplete="off"
+          />
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="lead-name" className="block text-xs font-semibold text-slate-700">
+              Name <span className="text-red-600">*</span>
+            </label>
+            <input
+              id="lead-name"
+              name="name"
+              type="text"
+              required
+              autoComplete="name"
+              maxLength={120}
+              onFocus={markStarted}
+              onChange={clearError}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            />
+          </div>
+          <div>
+            <label htmlFor="lead-email" className="block text-xs font-semibold text-slate-700">
+              Geschäftliche E-Mail <span className="text-red-600">*</span>
+            </label>
+            <input
+              id="lead-email"
+              name="work_email"
+              type="email"
+              required
+              autoComplete="email"
+              maxLength={254}
+              onFocus={markStarted}
+              className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+            />
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="lead-company" className="block text-xs font-semibold text-slate-700">
+            Unternehmen / Kanzlei <span className="text-red-600">*</span>
+          </label>
+          <input
+            id="lead-company"
+            name="company"
+            type="text"
+            required
+            autoComplete="organization"
+            maxLength={200}
+            onFocus={markStarted}
+            onChange={clearError}
+            className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="lead-segment" className="block text-xs font-semibold text-slate-700">
+            Sie sind … <span className="text-red-600">*</span>
+          </label>
+          <select
+            id="lead-segment"
+            name="segment"
+            required
+            defaultValue=""
+            onFocus={markStarted}
+            onChange={clearError}
+            className="mt-1 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+          >
+            <option value="" disabled>
+              Bitte wählen
+            </option>
+            {LEAD_SEGMENTS.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="lead-message" className="block text-xs font-semibold text-slate-700">
+            Nachricht (optional)
+          </label>
+          <textarea
+            id="lead-message"
+            name="message"
+            rows={4}
+            maxLength={4000}
+            onFocus={markStarted}
+            onChange={clearError}
+            placeholder="z. B. gewünschtes Paket, Zeitfenster, Fragen zu SAP oder Kanzlei-Dossiers"
+            className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-cyan-500 focus:outline-none focus:ring-1 focus:ring-cyan-500"
+          />
+        </div>
+
+        {status === "error" && (
+          <div
+            className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950"
+            role="alert"
+            aria-live="assertive"
+          >
+            <p className="font-medium">Senden fehlgeschlagen.</p>
+            <p className="mt-1 text-amber-900/90">
+              {errorDetail === "network"
+                ? "Bitte prüfen Sie Ihre Verbindung und versuchen Sie es erneut."
+                : "Bitte prüfen Sie die Pflichtfelder und Ihre E-Mail-Adresse."}
+            </p>
+            <p className="mt-2 text-xs">
+              Alternativ erreichen Sie uns direkt per E-Mail:{" "}
+              <a className="font-semibold text-cyan-800 underline" href={PUBLIC_CONTACT_MAILTO}>
+                {PUBLIC_CONTACT_EMAIL}
+              </a>
+            </p>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-3 pt-2">
+          <button type="submit" disabled={status === "submitting"} className={CH_BTN_PRIMARY}>
+            {status === "submitting" ? "Wird gesendet …" : "Anfrage senden"}
+          </button>
+          <a href={PUBLIC_CONTACT_MAILTO} className={CH_BTN_SECONDARY}>
+            Stattdessen E-Mail öffnen
+          </a>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/contact/TrackedContactLink.tsx
+++ b/frontend/src/components/contact/TrackedContactLink.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import Link from "next/link";
+
+import { sendMarketingEvent } from "@/lib/marketingTelemetryClient";
+
+type Props = {
+  href: string;
+  ctaId: string;
+  quelle: string;
+  className: string;
+  children: React.ReactNode;
+};
+
+export function TrackedContactLink({ href, ctaId, quelle, className, children }: Props) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      prefetch={false}
+      onClick={() =>
+        sendMarketingEvent({ event: "cta_click", cta_id: ctaId, quelle })
+      }
+    >
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/sbs/SbsFooter.tsx
+++ b/frontend/src/components/sbs/SbsFooter.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import React from "react";
 
-import { PUBLIC_CONTACT_MAILTO } from "@/lib/publicContact";
+import { contactPageHref } from "@/lib/publicContact";
 
 export function SbsFooter() {
   const y = new Date().getFullYear();
@@ -27,12 +27,12 @@ export function SbsFooter() {
           <Link href="/board/suppliers" className="font-medium text-slate-600 hover:text-slate-900">
             Supplier
           </Link>
-          <a
-            href={PUBLIC_CONTACT_MAILTO}
+          <Link
+            href={contactPageHref("footer")}
             className="font-medium text-slate-600 hover:text-slate-900"
           >
             Kontakt
-          </a>
+          </Link>
         </div>
       </div>
     </footer>

--- a/frontend/src/lib/leadCapture.ts
+++ b/frontend/src/lib/leadCapture.ts
@@ -1,0 +1,38 @@
+/**
+ * Öffentliche Lead-Erfassung (Marketing / Sales).
+ * Server-Handling: `app/api/lead-inquiry/route.ts`.
+ */
+
+export const LEAD_SEGMENTS = [
+  { value: "industrie_mittelstand", label: "Industrie / Mittelstand" },
+  { value: "kanzlei_wp", label: "Kanzlei / WP" },
+  { value: "enterprise_sap", label: "Enterprise / SAP" },
+  { value: "sonstiges", label: "Sonstiges" },
+] as const;
+
+export type LeadSegment = (typeof LEAD_SEGMENTS)[number]["value"];
+
+const SEGMENT_SET = new Set<string>(LEAD_SEGMENTS.map((s) => s.value));
+
+export function isLeadSegment(v: string): v is LeadSegment {
+  return SEGMENT_SET.has(v);
+}
+
+export type LeadInquiryPayload = {
+  name: string;
+  work_email: string;
+  company: string;
+  segment: LeadSegment;
+  message: string;
+  source_page: string;
+  /** Honeypot: muss leer sein */
+  company_website?: string;
+};
+
+export const LEAD_FIELD_LIMITS = {
+  name: 120,
+  company: 200,
+  message: 4000,
+  email: 254,
+  source_page: 120,
+} as const;

--- a/frontend/src/lib/marketingTelemetryClient.ts
+++ b/frontend/src/lib/marketingTelemetryClient.ts
@@ -1,0 +1,36 @@
+"use client";
+
+/**
+ * Leichtgewichtige Client-Events (Vercel/Server-Logs via `/api/marketing-event`).
+ * Keine Drittanbieter-Analytics; keine sensiblen Formularinhalte.
+ */
+
+export type MarketingClientEvent =
+  | "cta_click"
+  | "lead_form_started"
+  | "lead_form_submit_attempt"
+  | "lead_form_submitted"
+  | "lead_form_submit_error";
+
+export function sendMarketingEvent(payload: {
+  event: MarketingClientEvent;
+  cta_id?: string;
+  quelle?: string;
+}): void {
+  if (typeof navigator === "undefined") return;
+  try {
+    const body = JSON.stringify({ ...payload, t: Date.now() });
+    const blob = new Blob([body], { type: "application/json" });
+    const ok = navigator.sendBeacon("/api/marketing-event", blob);
+    if (!ok) {
+      void fetch("/api/marketing-event", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body,
+        keepalive: true,
+      });
+    }
+  } catch {
+    /* ignore */
+  }
+}

--- a/frontend/src/lib/publicContact.ts
+++ b/frontend/src/lib/publicContact.ts
@@ -1,2 +1,14 @@
-/** Öffentlicher Kontakt-Link (kanonische Homepage: complywithai.de). Bei Änderung wave23-Doku mitziehen. */
-export const PUBLIC_CONTACT_MAILTO = "mailto:kontakt@complywithai.de";
+/**
+ * Öffentlicher Kontakt (kanonische Homepage: complywithai.de).
+ * Primär: Formular unter `PUBLIC_CONTACT_PATH` (Wave 24).
+ * Fallback: direktes `mailto:` bei technischen Störungen.
+ */
+export const PUBLIC_CONTACT_EMAIL = "kontakt@complywithai.de";
+export const PUBLIC_CONTACT_MAILTO = `mailto:${PUBLIC_CONTACT_EMAIL}`;
+export const PUBLIC_CONTACT_PATH = "/kontakt" as const;
+
+/** `quelle` = Query-Parameter für Sales-Triage (z. B. home-hero, footer). */
+export function contactPageHref(quelle: string): string {
+  const q = quelle.trim() || "unbekannt";
+  return `${PUBLIC_CONTACT_PATH}?quelle=${encodeURIComponent(q)}`;
+}

--- a/website/compliancehub-landing.html
+++ b/website/compliancehub-landing.html
@@ -41,7 +41,11 @@
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
             </svg>
           </button>
-          <a class="btn btn-primary" href="#kontakt">Demo anfragen</a>
+          <a
+            class="btn btn-primary"
+            href="https://complywithai.de/kontakt?quelle=static-wave22-header"
+            >Demo anfragen</a
+          >
         </div>
       </div>
     </header>
@@ -62,7 +66,11 @@
               Steuerberater</strong> – ohne Garantieanspruch auf „vollständige Konformität“.
             </p>
             <div class="hero-ctas">
-              <a class="btn btn-primary" href="#kontakt">Demo anfragen</a>
+              <a
+                class="btn btn-primary"
+                href="https://complywithai.de/kontakt?quelle=static-wave22-hero"
+                >Demo anfragen</a
+              >
               <a class="btn btn-secondary" href="#pakete">Produktüberblick</a>
             </div>
             <p class="hero-trust">
@@ -323,7 +331,12 @@
             Wir empfehlen ein kurzes Erstgespräch mit klarem Scope (z. B. Division, Anzahl Systeme, Zeitrahmen).
             Kontaktdaten folgen – Platzhalter für Ihre produktive Domain.
           </p>
-          <a class="btn btn-primary" href="mailto:kontakt@example.com">Demo anfragen (E-Mail-Platzhalter)</a>
+          <a
+            class="btn btn-primary"
+            href="https://complywithai.de/kontakt?quelle=static-wave22-section"
+            >Zum Kontaktformular</a
+          >
+          <a class="btn btn-secondary" href="mailto:kontakt@complywithai.de">Oder E-Mail öffnen</a>
         </div>
       </section>
     </main>
@@ -340,7 +353,7 @@
         <nav class="footer-links" aria-label="Fußnavigation">
           <a href="#pakete">Produkt</a>
           <a href="#zielgruppen">Einsatzbereiche</a>
-          <a href="#kontakt">Kontakt</a>
+          <a href="https://complywithai.de/kontakt?quelle=static-wave22-footer">Kontakt</a>
           <a href="#" aria-current="false">Datenschutz (Platzhalter)</a>
         </nav>
       </div>

--- a/website/sales-one-pager.html
+++ b/website/sales-one-pager.html
@@ -30,7 +30,11 @@
               <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
             </svg>
           </button>
-          <a class="btn btn-primary" href="mailto:kontakt@complywithai.de">Demo anfragen</a>
+          <a
+            class="btn btn-primary"
+            href="https://complywithai.de/kontakt?quelle=one-pager-header"
+            >Demo anfragen</a
+          >
         </div>
       </div>
     </header>
@@ -46,7 +50,11 @@
             <a href="https://complywithai.de/">kanonischen Homepage</a>.
           </p>
           <div class="hero-ctas">
-            <a class="btn btn-primary" href="mailto:kontakt@complywithai.de">Demo anfragen</a>
+            <a
+              class="btn btn-primary"
+              href="https://complywithai.de/kontakt?quelle=one-pager-hero"
+              >Demo anfragen</a
+            >
             <a class="btn btn-secondary" href="https://complywithai.de/">Zur Homepage</a>
           </div>
         </div>
@@ -115,7 +123,7 @@
         </div>
         <nav class="footer-links" aria-label="Fußnavigation">
           <a href="https://complywithai.de/">Homepage</a>
-          <a href="mailto:kontakt@complywithai.de">Kontakt</a>
+          <a href="https://complywithai.de/kontakt?quelle=one-pager-footer">Kontakt</a>
         </nav>
       </div>
     </footer>


### PR DESCRIPTION
Add /kontakt with segment dropdown, POST /api/lead-inquiry and optional LEAD_INBOUND_WEBHOOK_URL, marketing-event telemetry, TrackedContactLink. Replace mailto-first CTAs on homepage/footer; update static HTML to complywithai.de/kontakt. Document in wave24 GTM doc.

Made-with: Cursor