### PR TITLE
feat(gtm): Wave 26 internal lead inbox and triage

### DIFF
--- a/docs/gtm/wave24-contact-and-lead-capture.md
+++ b/docs/gtm/wave24-contact-and-lead-capture.md
@@ -108,4 +108,4 @@ Abgleich: `docs/gtm/compliance-statement-library-de.md`, `docs/gtm/tone_of_voice
 
 *Wave 24 – form-first Kontakt, mailto sekundär.*
 
-**Nachfolger:** [Wave 25 – Lead-Routing & Intake-Governance](./wave25-lead-routing-and-intake-governance.md) (Routing, JSONL-Persistenz, Webhook-Retries, Admin-API, Anti-Abuse).
+**Nachfolger:** [Wave 25 – Lead-Routing & Intake-Governance](./wave25-lead-routing-and-intake-governance.md) (Routing, JSONL-Persistenz, Webhook-Retries, Admin-API, Anti-Abuse) · [Wave 26 – Internes Lead-Inbox](./wave26-internal-lead-inbox.md) (`/admin/leads`, Triage, Ops-State).

--- a/docs/gtm/wave25-lead-routing-and-intake-governance.md
+++ b/docs/gtm/wave25-lead-routing-and-intake-governance.md
@@ -76,6 +76,8 @@ Format: Append-only JSON Lines; Admin-API führt `lead_inquiry` + nachfolgende `
 
 Antwort enthält gekürzte `message_preview` und volle Kontaktdaten – **nur intern**, nicht öffentlich verlinken.
 
+**Weiterführung:** [Wave 26 – Internes Lead-Inbox](./wave26-internal-lead-inbox.md) (`/admin/leads`, Triage-Status, Session-Cookie, `ops-state.json`).
+
 ---
 
 ## 6. Spam / Missbrauch
@@ -126,7 +128,8 @@ Vollständige **Datenschutzerklärung** gehört auf die öffentliche Website; di
 | `LEAD_INBOUND_WEBHOOK_URL` | Ziel-URL für Outbound-Payload |
 | `LEAD_INBOUND_WEBHOOK_SECRET` | Optional: `Authorization: Bearer …` |
 | `LEAD_INQUIRY_STORE_PATH` | Optional: Pfad zur JSONL-Datei |
-| `LEAD_ADMIN_SECRET` | Bearer für Admin-API |
+| `LEAD_ADMIN_SECRET` | Bearer / Session-Login für Admin-API und `/admin/leads` |
+| `LEAD_INQUIRY_OPS_PATH` | Optional: Pfad zu `ops-state.json` (Triage, Wave 26) |
 | `LEAD_REQUIRE_BUSINESS_EMAIL` | `1` = Freemail-Domains ablehnen |
 
 ---

--- a/docs/gtm/wave26-internal-lead-inbox.md
+++ b/docs/gtm/wave26-internal-lead-inbox.md
@@ -1,0 +1,111 @@
+# Wave 26 – Internes Lead-Inbox (Triage ohne CRM)
+
+**Vorgänger:** [Wave 25 – Lead-Routing & Intake-Governance](./wave25-lead-routing-and-intake-governance.md)
+
+---
+
+## 1. Warum diese Inbox existiert
+
+- **Zielgruppe:** Gründer, frühe Sales, Advisor-/Partner-Team.
+- **Problem:** JSONL und Logs sind für tägliche Triage unpraktisch.
+- **Lösung:** Eine **schlanke interne Oberfläche** unter `/admin/leads` mit Liste, Filtern, Detail und einfachen Status-/Notiz-Aktionen.
+- **Kein CRM:** Keine Pipelines, Deals oder Marketing-Automation – nur **Sichtbarkeit und operative Einordnung**, bis ggf. HubSpot/Pipedrive/Salesforce angebunden wird.
+
+---
+
+## 2. Was sich vom CRM unterscheidet
+
+| Aspekt | Lead-Inbox (Wave 26) | Typisches CRM |
+| ------ | -------------------- | ------------- |
+| Zweck | Triage, Owner, kurze Notizen, Webhook-Retry | Pipeline, Forecast, Kampagnen |
+| Daten | Lokal `ops-state.json` + bestehende JSONL | Zentrale CRM-Datenbank |
+| Skalierung | Wenige bis einige Dutzend Leads pro Woche | Großvolumen, Teams |
+| Rechtliches | Interne Verarbeitungshinweise (Wave 25) | Zusätzliche CRM-Verträge/AVV |
+
+---
+
+## 3. Oberfläche und Endpunkte
+
+| Pfad / Methode | Beschreibung |
+| -------------- | ------------ |
+| `GET /admin/leads` | Inbox-UI (Server: `LEAD_ADMIN_SECRET` muss gesetzt sein, sonst Hinweis) |
+| `POST /api/admin/session` | Body `{ "secret": "<LEAD_ADMIN_SECRET>" }` → httpOnly Session-Cookie |
+| `DELETE /api/admin/session` | Cookie löschen (nur mit gültiger Session) |
+| `GET /api/admin/lead-inquiries` | Liste inkl. Triage-Felder; Query-Filter: `triage_status`, `segment`, `source_page`, `forwarding_status`, `limit` |
+| `GET /api/admin/lead-inquiries/[leadId]` | Einzelansicht (volle Nachricht, Aktivität) |
+| `PATCH /api/admin/lead-inquiries/[leadId]` | `triage_status`, `owner`, `internal_note` |
+| `POST /api/admin/lead-inquiries/[leadId]/retry-webhook` | Erneuter Webhook-Versuch (wenn `LEAD_INBOUND_WEBHOOK_URL` gesetzt) |
+
+**Auth (einheitlich mit Wave 25):** Bearer `Authorization: Bearer <LEAD_ADMIN_SECRET>`, optional `?secret=` (nur falls nötig), oder **Session-Cookie** nach `POST /api/admin/session`.
+
+---
+
+## 4. Statusmodell
+
+### 4.1 Pipeline / Speicher (JSONL, unverändert Wave 25)
+
+- `received` → nach Webhook ggf. `forwarded` oder `failed` (Zusammenführung aus `lead_inquiry` + `webhook_result`).
+
+### 4.2 Triage (intern, `ops-state.json`)
+
+| Status | Bedeutung (intern) |
+| ------ | ------------------ |
+| `received` | Neu, noch nicht eingeordnet (Default) |
+| `triaged` | Erste Sichtung erledigt |
+| `contacted` | Kontaktaufnahme erfolgt |
+| `qualified` | Passt strategisch / nächste Schritte klar |
+| `closed_won_interest` | Abschluss- oder Pilot-Interesse |
+| `closed_not_now` | Aktuell kein Bedarf |
+| `spam` | Spam oder ungültig |
+
+Keine CRM-„Stages“ – bei Bedarf später CRM-Sync statt weitere Status in der Hub-App.
+
+---
+
+## 5. Persistenz
+
+- **Leads (Inbound):** weiterhin JSONL (`store.jsonl`), siehe Wave 25.
+- **Ops / Triage:** `frontend/data/lead-inquiries/ops-state.json` (lokal), auf Vercel standardmäßig unter `/tmp/...` (ephemeral).
+- **Override:** `LEAD_INQUIRY_OPS_PATH` für absoluten Pfad zu `ops-state.json`.
+- **Aktivität:** Array pro Lead in `ops-state.json` (Kürzung bei sehr langen Historien technisch begrenzt, z. B. 120 Einträge).
+
+---
+
+## 6. Audit / Aktivität
+
+Append-only Logik auf Dateiebene: bei Änderungen werden Einträge wie `triage_status_changed`, `owner_set`, `internal_note_updated`, `forward_retried` mit Zeitstempel gespeichert. Kein Event-Sourcing, aber **nachvollziehbare Spur** für interne Reviews.
+
+---
+
+## 7. Sortierung und Filter
+
+- **Standard-Sortierung:** Zuerst „Aufmerksamkeit“ (`forwarding_status === failed` **oder** `triage_status === received`), danach **`created_at` absteigend**.
+- **Filter:** Triage-Status, Segment, Quelle (Substring), Weiterleitung (`ok` / `failed` / `not_sent`).
+
+---
+
+## 8. Sicherheit und Roadmap
+
+**Heute (Wave 26):**
+
+- Shared Secret + httpOnly Session; keine öffentliche Verlinkung; `robots: noindex` auf `/admin/*`.
+- UI und APIs geben bei fehlendem `LEAD_ADMIN_SECRET` kein Funktionsleck preis (404 bzw. Hinweis auf der Seite).
+
+**Später (Skizze):**
+
+- **SSO** (Azure AD / SAP IAS) für interne Rollen.
+- **OPA / policy-as-code** oder zentrales IAM: z. B. nur Gruppe `internal-sales` darf Lead-PII lesen; Trennung von „Marketing-Telemetrie“ und „Lead-PII“.
+- **Auditing** in unveränderlichem Store (z. B. Append-Only-Tabelle in Postgres) statt nur JSON-Datei.
+
+---
+
+## 9. Migration zu CRM
+
+1. Webhook (Wave 25) bleibt **Quelle der Wahrheit** für Downstream-Systeme.
+2. n8n mappt Payload auf HubSpot/Pipedrive/Salesforce-Felder.
+3. Inbox kann parallel laufen für **manuelle** Fälle oder schrittweise abgeschaltet werden, wenn CRM die Triage übernimmt.
+4. Optional: Supabase/Postgres als einheitlicher Lead-Store statt JSONL + `ops-state.json`.
+
+---
+
+*Wave 26 – operative Lead-Triage für DACH-B2B, bewusst klein gehalten.*

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 # Lead store (JSONL, lokal / tmp – Ordner via .gitkeep)
 /data/lead-inquiries/*.jsonl
+/data/lead-inquiries/ops-state.json

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "Intern · Compliance Hub",
+  robots: { index: false, follow: false },
+};
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return <>{children}</>;
+}

--- a/frontend/src/app/admin/leads/page.tsx
+++ b/frontend/src/app/admin/leads/page.tsx
@@ -1,0 +1,15 @@
+import { AdminLeadInboxClient } from "@/components/admin/AdminLeadInboxClient";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminLeadsPage() {
+  const adminConfigured = Boolean(process.env.LEAD_ADMIN_SECRET?.trim());
+
+  return (
+    <div className="min-h-screen bg-slate-100 px-4 py-10">
+      <div className="mx-auto max-w-7xl">
+        <AdminLeadInboxClient adminConfigured={adminConfigured} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/retry-webhook/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/retry-webhook/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from "next/server";
+
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+import { mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import { appendLeadOpsActivity, readLeadOpsState } from "@/lib/leadOpsState";
+import {
+  appendLeadWebhookResult,
+  dispatchLeadWebhook,
+  findLeadInquiryRecord,
+  getMergedLeadAdminRow,
+} from "@/lib/leadPersistence";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const webhook = process.env.LEAD_INBOUND_WEBHOOK_URL?.trim();
+  if (!webhook) {
+    return NextResponse.json({ error: "webhook_not_configured" }, { status: 400 });
+  }
+
+  const { leadId } = await ctx.params;
+  const record = await findLeadInquiryRecord(leadId);
+  if (!record) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const wh = await dispatchLeadWebhook(webhook, record.outbound, 3);
+  const at = new Date().toISOString();
+
+  if (wh.ok) {
+    await appendLeadWebhookResult({
+      _kind: "webhook_result",
+      lead_id: leadId,
+      trace_id: record.trace_id,
+      ok: true,
+      at,
+    });
+    await appendLeadOpsActivity(leadId, "forward_retried", "Webhook: Erfolg");
+  } else {
+    await appendLeadWebhookResult({
+      _kind: "webhook_result",
+      lead_id: leadId,
+      trace_id: record.trace_id,
+      ok: false,
+      at,
+      error: wh.error,
+    });
+    await appendLeadOpsActivity(
+      leadId,
+      "forward_retried",
+      `Webhook: Fehler (${wh.error})`,
+    );
+  }
+
+  const row = await getMergedLeadAdminRow(leadId);
+  const ops = await readLeadOpsState();
+  const item = row ? mergeLeadsWithOps([row], ops)[0] : null;
+
+  return NextResponse.json({
+    ok: true,
+    webhook_ok: wh.ok,
+    webhook_error: wh.ok ? undefined : wh.error,
+    item,
+  });
+}

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from "next/server";
+
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+import { mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import { mutateLeadOps, readLeadOpsState } from "@/lib/leadOpsState";
+import { isLeadTriageStatus, type LeadTriageStatus } from "@/lib/leadTriage";
+import { findLeadInquiryRecord, getMergedLeadAdminRow } from "@/lib/leadPersistence";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { leadId } = await ctx.params;
+  const row = await getMergedLeadAdminRow(leadId);
+  if (!row) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const ops = await readLeadOpsState();
+  const [item] = mergeLeadsWithOps([row], ops);
+  return NextResponse.json({ ok: true, item });
+}
+
+type PatchBody = {
+  triage_status?: string;
+  owner?: string;
+  internal_note?: string;
+};
+
+export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { leadId } = await ctx.params;
+  const exists = await findLeadInquiryRecord(leadId);
+  if (!exists) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  let body: PatchBody = {};
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const patch: {
+    triage_status?: LeadTriageStatus;
+    owner?: string;
+    internal_note?: string;
+  } = {};
+
+  if (body.triage_status !== undefined) {
+    if (!isLeadTriageStatus(body.triage_status)) {
+      return NextResponse.json({ error: "validation" }, { status: 400 });
+    }
+    patch.triage_status = body.triage_status;
+  }
+  if (body.owner !== undefined) {
+    patch.owner = String(body.owner);
+  }
+  if (body.internal_note !== undefined) {
+    patch.internal_note = String(body.internal_note);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "empty_patch" }, { status: 400 });
+  }
+
+  const result = await mutateLeadOps(leadId, patch);
+  if (!result.changed) {
+    return NextResponse.json({ ok: true, changed: false, entry: result.entry });
+  }
+
+  const row = await getMergedLeadAdminRow(leadId);
+  const ops = await readLeadOpsState();
+  const item = row ? mergeLeadsWithOps([row], ops)[0] : null;
+
+  return NextResponse.json({
+    ok: true,
+    changed: true,
+    entry: result.entry,
+    item,
+  });
+}

--- a/frontend/src/app/api/admin/lead-inquiries/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/route.ts
@@ -1,12 +1,20 @@
 import { NextResponse } from "next/server";
 
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+import { mergeLeadsWithOps, sortInboxItems } from "@/lib/leadInboxMerge";
+import type { LeadForwardingStatus } from "@/lib/leadInboxTypes";
+import { readLeadOpsState } from "@/lib/leadOpsState";
 import { readRecentLeadRecordsMerged } from "@/lib/leadPersistence";
 
 export const runtime = "nodejs";
 
+function isForwardingFilter(v: string): v is LeadForwardingStatus {
+  return v === "ok" || v === "failed" || v === "not_sent";
+}
+
 /**
- * Interne Übersicht gespeicherter Leads (JSON).
- * Schutz: `Authorization: Bearer <LEAD_ADMIN_SECRET>` oder Query `?secret=` (nur falls nötig).
+ * Interne Lead-Übersicht (JSON) + Inbox-Daten für `/admin/leads`.
+ * Auth: `Authorization: Bearer <LEAD_ADMIN_SECRET>`, `?secret=`, oder Session-Cookie (POST /api/admin/session).
  */
 export async function GET(req: Request) {
   const secret = process.env.LEAD_ADMIN_SECRET?.trim();
@@ -14,41 +22,41 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "not_configured" }, { status: 404 });
   }
 
-  const auth = req.headers.get("authorization");
-  const url = new URL(req.url);
-  const qSecret = url.searchParams.get("secret");
-  const token =
-    auth?.startsWith("Bearer ") ? auth.slice(7).trim() : qSecret?.trim() ?? "";
-  if (token !== secret) {
+  if (!isLeadAdminAuthorized(req)) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
+  const url = new URL(req.url);
   const limit = Math.min(
-    100,
-    Math.max(1, parseInt(url.searchParams.get("limit") ?? "40", 10) || 40),
+    2000,
+    Math.max(1, parseInt(url.searchParams.get("limit") ?? "200", 10) || 200),
   );
 
   const rows = await readRecentLeadRecordsMerged(limit);
+  const ops = await readLeadOpsState();
+  let items = sortInboxItems(mergeLeadsWithOps(rows, ops));
+
+  const triage = url.searchParams.get("triage_status")?.trim();
+  const segment = url.searchParams.get("segment")?.trim();
+  const sourcePage = url.searchParams.get("source_page")?.trim();
+  const forwarding = url.searchParams.get("forwarding_status")?.trim();
+
+  if (triage) {
+    items = items.filter((i) => i.triage_status === triage);
+  }
+  if (segment) {
+    items = items.filter((i) => i.segment === segment);
+  }
+  if (sourcePage) {
+    items = items.filter((i) => i.source_page.includes(sourcePage));
+  }
+  if (forwarding && isForwardingFilter(forwarding)) {
+    items = items.filter((i) => i.forwarding_status === forwarding);
+  }
 
   return NextResponse.json({
     ok: true,
-    count: rows.length,
-    items: rows.map((r) => ({
-      lead_id: r.lead_id,
-      trace_id: r.trace_id,
-      status: r.status,
-      webhook_ok: r.webhook_ok,
-      webhook_at: r.webhook_at,
-      webhook_error: r.webhook_error,
-      created_at: r.created_at,
-      segment: r.outbound.segment,
-      route_key: r.outbound.route.route_key,
-      queue_label: r.outbound.route.queue_label,
-      source_page: r.outbound.source_page,
-      company: r.outbound.company,
-      business_email: r.outbound.business_email,
-      name: r.outbound.name,
-      message_preview: r.outbound.message.slice(0, 280),
-    })),
+    count: items.length,
+    items,
   });
 }

--- a/frontend/src/app/api/admin/session/route.ts
+++ b/frontend/src/app/api/admin/session/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+
+import {
+  createLeadAdminSessionToken,
+  isLeadAdminAuthorized,
+  LEAD_ADMIN_COOKIE_NAME,
+  leadAdminCookieOptions,
+} from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+/** Setzt Session-Cookie nach erfolgreicher Secret-Prüfung (internes Lead-Inbox-UI). */
+export async function POST(req: Request) {
+  const secret = process.env.LEAD_ADMIN_SECRET?.trim();
+  if (!secret) {
+    return NextResponse.json({ ok: false, error: "not_configured" }, { status: 404 });
+  }
+
+  let body: { secret?: string } = {};
+  try {
+    body = (await req.json()) as { secret?: string };
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid_json" }, { status: 400 });
+  }
+
+  const provided = typeof body.secret === "string" ? body.secret.trim() : "";
+  if (!provided || provided !== secret) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const token = createLeadAdminSessionToken();
+  if (!token) {
+    return NextResponse.json({ ok: false, error: "server" }, { status: 500 });
+  }
+
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(LEAD_ADMIN_COOKIE_NAME, token, leadAdminCookieOptions());
+  return res;
+}
+
+export async function DELETE(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ ok: false, error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(LEAD_ADMIN_COOKIE_NAME, "", { ...leadAdminCookieOptions(), maxAge: 0 });
+  return res;
+}

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -1,0 +1,510 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { LEAD_SEGMENTS } from "@/lib/leadCapture";
+import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import { LEAD_TRIAGE_LABELS_DE, LEAD_TRIAGE_STATUSES } from "@/lib/leadTriage";
+
+type Props = {
+  /** Wenn gesetzt, zeigt die UI einen Hinweis (kein Secret im Client-Build). */
+  adminConfigured: boolean;
+};
+
+function forwardingLabel(s: LeadInboxItem["forwarding_status"]): string {
+  if (s === "ok") return "Weitergeleitet";
+  if (s === "failed") return "Weiterleitung fehlgeschlagen";
+  return "Kein Webhook / nicht gesendet";
+}
+
+export function AdminLeadInboxClient({ adminConfigured }: Props) {
+  const [secretInput, setSecretInput] = useState("");
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [items, setItems] = useState<LeadInboxItem[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [filters, setFilters] = useState({
+    triage_status: "",
+    segment: "",
+    source_page: "",
+    forwarding_status: "",
+  });
+  const [draftOwner, setDraftOwner] = useState("");
+  const [draftNote, setDraftNote] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [actionMsg, setActionMsg] = useState<string | null>(null);
+
+  const selected = useMemo(
+    () => items.find((i) => i.lead_id === selectedId) ?? null,
+    [items, selectedId],
+  );
+
+  useEffect(() => {
+    if (!selected) {
+      setDraftOwner("");
+      setDraftNote("");
+      return;
+    }
+    setDraftOwner(selected.owner);
+    setDraftNote(selected.internal_note);
+  }, [selected]);
+
+  const queryString = useMemo(() => {
+    const p = new URLSearchParams();
+    if (filters.triage_status) p.set("triage_status", filters.triage_status);
+    if (filters.segment) p.set("segment", filters.segment);
+    if (filters.source_page) p.set("source_page", filters.source_page);
+    if (filters.forwarding_status) p.set("forwarding_status", filters.forwarding_status);
+    p.set("limit", "500");
+    const q = p.toString();
+    return q ? `?${q}` : "?limit=500";
+  }, [filters]);
+
+  const fetchLeads = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const r = await fetch(`/api/admin/lead-inquiries${queryString}`, {
+        credentials: "include",
+      });
+      if (r.status === 401) {
+        setAuthed(false);
+        setItems([]);
+        return;
+      }
+      if (!r.ok) {
+        setAuthed(true);
+        setLoadError(`Laden fehlgeschlagen (${r.status})`);
+        return;
+      }
+      const data = (await r.json()) as { ok?: boolean; items?: LeadInboxItem[] };
+      setAuthed(true);
+      setItems(data.items ?? []);
+    } catch {
+      setAuthed(true);
+      setLoadError("Netzwerkfehler");
+    } finally {
+      setLoading(false);
+    }
+  }, [queryString]);
+
+  useEffect(() => {
+    if (!adminConfigured) return;
+    void fetchLeads();
+  }, [adminConfigured, fetchLeads]);
+
+  async function login(e: React.FormEvent) {
+    e.preventDefault();
+    setLoginError(null);
+    try {
+      const r = await fetch("/api/admin/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ secret: secretInput }),
+      });
+      if (!r.ok) {
+        setLoginError("Zugang verweigert oder Secret ungültig.");
+        return;
+      }
+      setSecretInput("");
+      setAuthed(true);
+      await fetchLeads();
+    } catch {
+      setLoginError("Anmeldung fehlgeschlagen.");
+    }
+  }
+
+  async function logout() {
+    try {
+      await fetch("/api/admin/session", { method: "DELETE", credentials: "include" });
+    } catch {
+      /* ignore */
+    }
+    setAuthed(false);
+    setItems([]);
+    setSelectedId(null);
+  }
+
+  async function patchLead(
+    leadId: string,
+    body: { triage_status?: string; owner?: string; internal_note?: string },
+  ) {
+    setSaving(true);
+    setActionMsg(null);
+    try {
+      const r = await fetch(`/api/admin/lead-inquiries/${leadId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify(body),
+      });
+      const data = (await r.json()) as { ok?: boolean; item?: LeadInboxItem | null };
+      if (!r.ok) {
+        setActionMsg("Speichern fehlgeschlagen.");
+        return;
+      }
+      if (data.item) {
+        setItems((prev) => prev.map((x) => (x.lead_id === data.item!.lead_id ? data.item! : x)));
+      } else {
+        await fetchLeads();
+      }
+      setActionMsg("Gespeichert.");
+    } catch {
+      setActionMsg("Netzwerkfehler beim Speichern.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function retryWebhook(leadId: string) {
+    setSaving(true);
+    setActionMsg(null);
+    try {
+      const r = await fetch(`/api/admin/lead-inquiries/${leadId}/retry-webhook`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = (await r.json()) as {
+        ok?: boolean;
+        webhook_ok?: boolean;
+        webhook_error?: string;
+        item?: LeadInboxItem | null;
+        error?: string;
+      };
+      if (r.status === 400 && data.error === "webhook_not_configured") {
+        setActionMsg("Webhook-URL ist nicht konfiguriert.");
+        return;
+      }
+      if (!r.ok) {
+        setActionMsg("Retry fehlgeschlagen.");
+        return;
+      }
+      if (data.item) {
+        setItems((prev) => prev.map((x) => (x.lead_id === data.item!.lead_id ? data.item! : x)));
+      }
+      setActionMsg(
+        data.webhook_ok ? "Webhook erneut erfolgreich." : `Webhook-Fehler: ${data.webhook_error ?? "?"}`,
+      );
+    } catch {
+      setActionMsg("Netzwerkfehler beim Retry.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!adminConfigured) {
+    return (
+      <div className="mx-auto max-w-lg rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+        <p className="font-medium">Lead-Inbox nicht verfügbar</p>
+        <p className="mt-2 text-amber-800">
+          <code className="rounded bg-amber-100 px-1 font-mono text-xs">LEAD_ADMIN_SECRET</code> ist auf
+          dieser Umgebung nicht gesetzt. Die interne Ansicht bleibt absichtlich deaktiviert.
+        </p>
+      </div>
+    );
+  }
+
+  if (authed === null || (loading && items.length === 0 && authed !== false)) {
+    return (
+      <div className="py-16 text-center text-sm text-slate-600">Session wird geprüft …</div>
+    );
+  }
+
+  if (authed === false) {
+    return (
+      <div className="mx-auto max-w-md rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">Internes Lead-Postfach</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Anmeldung mit dem konfigurierten Admin-Secret (wie Bearer für die API). Session-Cookie, httpOnly.
+        </p>
+        <form className="mt-6 space-y-4" onSubmit={login}>
+          <label className="block text-sm font-medium text-slate-700">
+            Admin-Secret
+            <input
+              type="password"
+              autoComplete="off"
+              className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-sm"
+              value={secretInput}
+              onChange={(e) => setSecretInput(e.target.value)}
+            />
+          </label>
+          {loginError ? <p className="text-sm text-red-600">{loginError}</p> : null}
+          <button
+            type="submit"
+            className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800"
+          >
+            Anmelden
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Lead-Inbox</h1>
+          <p className="text-sm text-slate-600">
+            Triage und Nachverfolgung – nicht öffentlich, kein CRM. Sortierung: zuerst Aufmerksamkeit
+            (fehlgeschlagene Weiterleitung oder Status &quot;Neu&quot;), dann neueste zuerst.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void logout()}
+          className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+        >
+          Abmelden
+        </button>
+      </div>
+
+      <div className="flex flex-wrap gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm">
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Triage</span>
+          <select
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.triage_status}
+            onChange={(e) => setFilters((f) => ({ ...f, triage_status: e.target.value }))}
+          >
+            <option value="">Alle</option>
+            {LEAD_TRIAGE_STATUSES.map((s) => (
+              <option key={s} value={s}>
+                {LEAD_TRIAGE_LABELS_DE[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Segment</span>
+          <select
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.segment}
+            onChange={(e) => setFilters((f) => ({ ...f, segment: e.target.value }))}
+          >
+            <option value="">Alle</option>
+            {LEAD_SEGMENTS.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Quelle (enthält)</span>
+          <input
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.source_page}
+            onChange={(e) => setFilters((f) => ({ ...f, source_page: e.target.value }))}
+            placeholder="z. B. kontakt"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Weiterleitung</span>
+          <select
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.forwarding_status}
+            onChange={(e) => setFilters((f) => ({ ...f, forwarding_status: e.target.value }))}
+          >
+            <option value="">Alle</option>
+            <option value="ok">OK</option>
+            <option value="failed">Fehlgeschlagen</option>
+            <option value="not_sent">Nicht gesendet</option>
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={() => void fetchLeads()}
+          disabled={loading}
+          className="self-end rounded-lg bg-slate-200 px-3 py-1.5 text-slate-800 hover:bg-slate-300 disabled:opacity-50"
+        >
+          {loading ? "Laden…" : "Aktualisieren"}
+        </button>
+      </div>
+
+      {loadError ? <p className="text-sm text-red-600">{loadError}</p> : null}
+
+      <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-[900px] w-full border-collapse text-left text-sm">
+          <thead className="border-b border-slate-200 bg-slate-50 text-slate-600">
+            <tr>
+              <th className="px-3 py-2 font-medium">Eingang</th>
+              <th className="px-3 py-2 font-medium">Triage</th>
+              <th className="px-3 py-2 font-medium">Weiterleitung</th>
+              <th className="px-3 py-2 font-medium">Segment</th>
+              <th className="px-3 py-2 font-medium">Firma</th>
+              <th className="px-3 py-2 font-medium">Kontakt</th>
+              <th className="px-3 py-2 font-medium">E-Mail</th>
+              <th className="px-3 py-2 font-medium">Quelle</th>
+              <th className="px-3 py-2 font-medium">Route</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((row) => (
+              <tr
+                key={row.lead_id}
+                className={`cursor-pointer border-b border-slate-100 hover:bg-slate-50 ${
+                  selectedId === row.lead_id ? "bg-slate-100" : ""
+                } ${row.needs_attention ? "border-l-4 border-l-amber-400" : ""}`}
+                onClick={() => setSelectedId(row.lead_id)}
+              >
+                <td className="whitespace-nowrap px-3 py-2 text-slate-800">
+                  {new Date(row.created_at).toLocaleString("de-DE")}
+                </td>
+                <td className="px-3 py-2">{LEAD_TRIAGE_LABELS_DE[row.triage_status]}</td>
+                <td className="px-3 py-2 text-slate-700">{forwardingLabel(row.forwarding_status)}</td>
+                <td className="px-3 py-2 text-slate-700">{row.segment}</td>
+                <td className="max-w-[140px] truncate px-3 py-2" title={row.company}>
+                  {row.company}
+                </td>
+                <td className="max-w-[120px] truncate px-3 py-2" title={row.name}>
+                  {row.name}
+                </td>
+                <td className="max-w-[160px] truncate px-3 py-2" title={row.business_email}>
+                  {row.business_email}
+                </td>
+                <td className="max-w-[100px] truncate px-3 py-2" title={row.source_page}>
+                  {row.source_page}
+                </td>
+                <td className="max-w-[160px] truncate px-3 py-2 text-slate-600" title={row.queue_label}>
+                  {row.route_key}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {items.length === 0 && !loading ? (
+          <p className="p-6 text-center text-sm text-slate-500">Keine Leads für die aktuellen Filter.</p>
+        ) : null}
+      </div>
+
+      {selected ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold text-slate-900">Detail</h2>
+              <p className="text-xs text-slate-500">
+                lead_id: {selected.lead_id} · trace_id: {selected.trace_id}
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={saving}
+                className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50"
+                onClick={() => void patchLead(selected.lead_id, { triage_status: "triaged" })}
+              >
+                Triage erledigt
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50"
+                onClick={() => void patchLead(selected.lead_id, { triage_status: "contacted" })}
+              >
+                Kontaktiert
+              </button>
+              <button
+                type="button"
+                disabled={saving}
+                className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-sm text-red-800 hover:bg-red-100 disabled:opacity-50"
+                onClick={() => void patchLead(selected.lead_id, { triage_status: "spam" })}
+              >
+                Spam
+              </button>
+              {selected.forwarding_status === "failed" ? (
+                <button
+                  type="button"
+                  disabled={saving}
+                  className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm text-amber-900 hover:bg-amber-100 disabled:opacity-50"
+                  onClick={() => void retryWebhook(selected.lead_id)}
+                >
+                  Webhook erneut senden
+                </button>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <div>
+              <h3 className="text-sm font-medium text-slate-700">Nachricht</h3>
+              <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-lg bg-slate-50 p-3 text-sm text-slate-800">
+                {selected.message || "(leer)"}
+              </pre>
+            </div>
+            <div className="space-y-3 text-sm">
+              <div>
+                <span className="text-slate-600">Pipeline (Speicher):</span>{" "}
+                <span className="font-mono text-slate-900">{selected.pipeline_status}</span>
+              </div>
+              <div>
+                <span className="text-slate-600">Weiterleitung:</span> {forwardingLabel(selected.forwarding_status)}
+                {selected.webhook_at ? (
+                  <span className="ml-2 text-slate-500">({selected.webhook_at})</span>
+                ) : null}
+              </div>
+              {selected.webhook_error ? (
+                <div className="rounded-lg bg-red-50 p-2 text-red-800">
+                  Fehler: {selected.webhook_error}
+                </div>
+              ) : null}
+              <div>
+                <span className="text-slate-600">Priorität / SLA-Bucket:</span> {selected.priority} /{" "}
+                {selected.sla_bucket}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-6 grid gap-4 border-t border-slate-100 pt-4 md:grid-cols-2">
+            <label className="block text-sm">
+              <span className="font-medium text-slate-700">Owner (intern)</span>
+              <input
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                value={draftOwner}
+                onChange={(e) => setDraftOwner(e.target.value)}
+              />
+            </label>
+            <div className="md:col-span-2">
+              <label className="block text-sm">
+                <span className="font-medium text-slate-700">Interne Notiz</span>
+                <textarea
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                  rows={4}
+                  value={draftNote}
+                  onChange={(e) => setDraftNote(e.target.value)}
+                />
+              </label>
+            </div>
+            <button
+              type="button"
+              disabled={saving}
+              className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
+              onClick={() =>
+                void patchLead(selected.lead_id, { owner: draftOwner, internal_note: draftNote })
+              }
+            >
+              Notiz &amp; Owner speichern
+            </button>
+            {actionMsg ? <p className="text-sm text-slate-600">{actionMsg}</p> : null}
+          </div>
+
+          <div className="mt-6 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-medium text-slate-700">Aktivität (intern)</h3>
+            <ul className="mt-2 max-h-48 space-y-2 overflow-auto text-xs text-slate-600">
+              {[...selected.activities].reverse().map((a, i) => (
+                <li key={`${a.at}-${i}`} className="border-b border-slate-100 pb-2">
+                  <span className="font-mono text-slate-500">{a.at}</span> · {a.action}
+                  {a.detail ? <span className="text-slate-700"> — {a.detail}</span> : null}
+                </li>
+              ))}
+              {selected.activities.length === 0 ? <li>Keine Einträge.</li> : null}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/lib/leadAdminAuth.ts
+++ b/frontend/src/lib/leadAdminAuth.ts
@@ -1,0 +1,76 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+import "server-only";
+
+const COOKIE_NAME = "ch_lead_admin";
+const SESSION_MS = 7 * 24 * 60 * 60 * 1000;
+
+function adminSecret(): string | null {
+  return process.env.LEAD_ADMIN_SECRET?.trim() ?? null;
+}
+
+export function createLeadAdminSessionToken(): string | null {
+  const secret = adminSecret();
+  if (!secret) return null;
+  const exp = Date.now() + SESSION_MS;
+  const sig = createHmac("sha256", secret).update(`v1|${exp}`).digest("hex");
+  const payload = JSON.stringify({ exp, sig });
+  return Buffer.from(payload, "utf8").toString("base64url");
+}
+
+export function verifyLeadAdminSession(token: string | null | undefined): boolean {
+  const secret = adminSecret();
+  if (!secret || !token?.trim()) return false;
+  try {
+    const raw = Buffer.from(token.trim(), "base64url").toString("utf8");
+    const { exp, sig } = JSON.parse(raw) as { exp?: number; sig?: string };
+    if (typeof exp !== "number" || typeof sig !== "string") return false;
+    if (Date.now() > exp) return false;
+    const expected = createHmac("sha256", secret).update(`v1|${exp}`).digest("hex");
+    const a = Buffer.from(sig, "hex");
+    const b = Buffer.from(expected, "hex");
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+export const LEAD_ADMIN_COOKIE_NAME = COOKIE_NAME;
+
+export function leadAdminCookieOptions(): {
+  httpOnly: boolean;
+  secure: boolean;
+  sameSite: "lax";
+  path: string;
+  maxAge: number;
+} {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: Math.floor(SESSION_MS / 1000),
+  };
+}
+
+/**
+ * Bearer / Query-Secret (wie Wave 25) oder gültige Admin-Session-Cookie.
+ */
+export function isLeadAdminAuthorized(req: Request): boolean {
+  const secret = adminSecret();
+  if (!secret) return false;
+
+  const auth = req.headers.get("authorization");
+  const url = new URL(req.url);
+  const qSecret = url.searchParams.get("secret");
+  const bearer =
+    auth?.startsWith("Bearer ") ? auth.slice(7).trim() : qSecret?.trim() ?? "";
+  if (bearer === secret) return true;
+
+  const cookieHeader = req.headers.get("cookie") ?? "";
+  const match = cookieHeader.split(";").map((s) => s.trim()).find((s) => s.startsWith(`${COOKIE_NAME}=`));
+  if (!match) return false;
+  const value = decodeURIComponent(match.slice(`${COOKIE_NAME}=`.length));
+  return verifyLeadAdminSession(value);
+}

--- a/frontend/src/lib/leadInboxMerge.test.ts
+++ b/frontend/src/lib/leadInboxMerge.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import { mergeLeadsWithOps, sortInboxItems } from "@/lib/leadInboxMerge";
+import type { LeadAdminRow } from "@/lib/leadPersistence";
+import type { LeadOpsFile } from "@/lib/leadOpsTypes";
+import { LEAD_OUTBOUND_SCHEMA_VERSION } from "@/lib/leadOutbound";
+
+function baseRow(over: Partial<LeadAdminRow> & { lead_id: string }): LeadAdminRow {
+  const created = "2026-04-01T12:00:00.000Z";
+  return {
+    _kind: "lead_inquiry",
+    lead_id: over.lead_id,
+    trace_id: "t1",
+    status: "received",
+    created_at: created,
+    outbound: {
+      schema_version: LEAD_OUTBOUND_SCHEMA_VERSION,
+      lead_id: over.lead_id,
+      trace_id: "t1",
+      timestamp: created,
+      source_page: "/kontakt",
+      segment: "sonstiges",
+      name: "N",
+      business_email: "n@example.com",
+      company: "C",
+      message: "Hi",
+      route: {
+        route_key: "queue_other",
+        queue_label: "Other",
+        priority: "low",
+        sla_bucket: "standard",
+      },
+    },
+    ...over,
+  };
+}
+
+describe("mergeLeadsWithOps", () => {
+  it("marks needs_attention for failed webhook", () => {
+    const ops: LeadOpsFile = { version: 1, entries: {} };
+    const rows: LeadAdminRow[] = [
+      baseRow({
+        lead_id: "a",
+        webhook_ok: false,
+        status: "failed",
+      }),
+    ];
+    const items = mergeLeadsWithOps(rows, ops);
+    expect(items[0]?.needs_attention).toBe(true);
+    expect(items[0]?.forwarding_status).toBe("failed");
+  });
+
+  it("sorts needs_attention before ok leads", () => {
+    const ops: LeadOpsFile = { version: 1, entries: {} };
+    const rows: LeadAdminRow[] = [
+      baseRow({
+        lead_id: "old-ok",
+        created_at: "2026-04-01T10:00:00.000Z",
+        webhook_ok: true,
+        status: "forwarded",
+      }),
+      baseRow({
+        lead_id: "new-fail",
+        created_at: "2026-04-02T10:00:00.000Z",
+        webhook_ok: false,
+        status: "failed",
+      }),
+    ];
+    const sorted = sortInboxItems(mergeLeadsWithOps(rows, ops));
+    expect(sorted[0]?.lead_id).toBe("new-fail");
+    expect(sorted[1]?.lead_id).toBe("old-ok");
+  });
+});

--- a/frontend/src/lib/leadInboxMerge.ts
+++ b/frontend/src/lib/leadInboxMerge.ts
@@ -1,0 +1,54 @@
+import type { LeadInboxItem, LeadForwardingStatus } from "@/lib/leadInboxTypes";
+import type { LeadAdminRow } from "@/lib/leadPersistence";
+import type { LeadOpsFile } from "@/lib/leadOpsTypes";
+import { getOpsEntryForLead } from "@/lib/leadOpsSelectors";
+
+function forwardingStatus(r: LeadAdminRow): LeadForwardingStatus {
+  if (r.webhook_ok === true) return "ok";
+  if (r.webhook_ok === false) return "failed";
+  return "not_sent";
+}
+
+export function mergeLeadsWithOps(rows: LeadAdminRow[], ops: LeadOpsFile): LeadInboxItem[] {
+  return rows.map((r) => {
+    const o = getOpsEntryForLead(ops, r.lead_id);
+    const fw = forwardingStatus(r);
+    const needs_attention = fw === "failed" || o.triage_status === "received";
+    const ob = r.outbound;
+    return {
+      lead_id: r.lead_id,
+      trace_id: r.trace_id,
+      pipeline_status: r.status,
+      forwarding_status: fw,
+      triage_status: o.triage_status,
+      owner: o.owner,
+      internal_note: o.internal_note,
+      created_at: r.created_at,
+      segment: ob.segment,
+      route_key: ob.route.route_key,
+      queue_label: ob.route.queue_label,
+      priority: ob.route.priority,
+      sla_bucket: ob.route.sla_bucket,
+      source_page: ob.source_page,
+      company: ob.company,
+      business_email: ob.business_email,
+      name: ob.name,
+      message_preview: ob.message.slice(0, 280),
+      message: ob.message,
+      webhook_ok: r.webhook_ok,
+      webhook_at: r.webhook_at,
+      webhook_error: r.webhook_error,
+      needs_attention,
+      activities: o.activities,
+    };
+  });
+}
+
+export function sortInboxItems(items: LeadInboxItem[]): LeadInboxItem[] {
+  return [...items].sort((a, b) => {
+    const na = a.needs_attention ? 0 : 1;
+    const nb = b.needs_attention ? 0 : 1;
+    if (na !== nb) return na - nb;
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+}

--- a/frontend/src/lib/leadInboxTypes.ts
+++ b/frontend/src/lib/leadInboxTypes.ts
@@ -1,0 +1,33 @@
+import type { LeadSegment } from "@/lib/leadCapture";
+import type { LeadOpsActivity } from "@/lib/leadOpsTypes";
+import type { LeadTriageStatus } from "@/lib/leadTriage";
+
+export type LeadForwardingStatus = "ok" | "failed" | "not_sent";
+
+/** Liste + Detail (intern, `/admin/leads`). */
+export type LeadInboxItem = {
+  lead_id: string;
+  trace_id: string;
+  pipeline_status: string;
+  forwarding_status: LeadForwardingStatus;
+  triage_status: LeadTriageStatus;
+  owner: string;
+  internal_note: string;
+  created_at: string;
+  segment: LeadSegment;
+  route_key: string;
+  queue_label: string;
+  priority: string;
+  sla_bucket: string;
+  source_page: string;
+  company: string;
+  business_email: string;
+  name: string;
+  message_preview: string;
+  message: string;
+  webhook_ok?: boolean;
+  webhook_at?: string;
+  webhook_error?: string;
+  needs_attention: boolean;
+  activities: LeadOpsActivity[];
+};

--- a/frontend/src/lib/leadOpsSelectors.ts
+++ b/frontend/src/lib/leadOpsSelectors.ts
@@ -1,0 +1,16 @@
+import type { LeadOpsEntry, LeadOpsFile } from "@/lib/leadOpsTypes";
+
+export function defaultLeadOpsEntry(): LeadOpsEntry {
+  const now = new Date().toISOString();
+  return {
+    triage_status: "received",
+    owner: "",
+    internal_note: "",
+    updated_at: now,
+    activities: [],
+  };
+}
+
+export function getOpsEntryForLead(state: LeadOpsFile, leadId: string): LeadOpsEntry {
+  return state.entries[leadId] ?? defaultLeadOpsEntry();
+}

--- a/frontend/src/lib/leadOpsState.ts
+++ b/frontend/src/lib/leadOpsState.ts
@@ -1,0 +1,127 @@
+import { mkdir, readFile, rename, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import "server-only";
+
+import type {
+  LeadOpsActivityAction,
+  LeadOpsEntry,
+  LeadOpsFile,
+} from "@/lib/leadOpsTypes";
+import { defaultLeadOpsEntry } from "@/lib/leadOpsSelectors";
+import type { LeadTriageStatus } from "@/lib/leadTriage";
+
+const MAX_ACTIVITIES_PER_LEAD = 120;
+const OPS_VERSION = 1;
+
+export type { LeadOpsActivity, LeadOpsActivityAction, LeadOpsEntry, LeadOpsFile } from "@/lib/leadOpsTypes";
+
+export { getOpsEntryForLead } from "@/lib/leadOpsSelectors";
+
+function resolveOpsPath(): string {
+  const fromEnv = process.env.LEAD_INQUIRY_OPS_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-lead-ops-state.json");
+  }
+  return join(process.cwd(), "data", "lead-inquiries", "ops-state.json");
+}
+
+export async function readLeadOpsState(): Promise<LeadOpsFile> {
+  const path = resolveOpsPath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const parsed = JSON.parse(raw) as LeadOpsFile;
+    if (parsed?.version !== OPS_VERSION || typeof parsed.entries !== "object" || !parsed.entries) {
+      return { version: OPS_VERSION, entries: {} };
+    }
+    return parsed;
+  } catch {
+    return { version: OPS_VERSION, entries: {} };
+  }
+}
+
+function pushActivity(entry: LeadOpsEntry, action: LeadOpsActivityAction, detail?: string): void {
+  const at = new Date().toISOString();
+  entry.activities.push({ at, action, detail });
+  if (entry.activities.length > MAX_ACTIVITIES_PER_LEAD) {
+    entry.activities = entry.activities.slice(-MAX_ACTIVITIES_PER_LEAD);
+  }
+  entry.updated_at = at;
+}
+
+export async function mutateLeadOps(
+  leadId: string,
+  patch: {
+    triage_status?: LeadTriageStatus;
+    owner?: string;
+    internal_note?: string;
+  },
+): Promise<{ entry: LeadOpsEntry; path: string; changed: boolean }> {
+  const path = resolveOpsPath();
+  await mkdir(dirname(path), { recursive: true });
+
+  const state = await readLeadOpsState();
+  const prev = state.entries[leadId] ?? defaultLeadOpsEntry();
+  const nextOwner =
+    patch.owner !== undefined ? patch.owner.trim().slice(0, 120) : prev.owner;
+  const nextNote =
+    patch.internal_note !== undefined
+      ? patch.internal_note.trim().slice(0, 4000)
+      : prev.internal_note;
+  const nextTriage = patch.triage_status ?? prev.triage_status;
+
+  const entry: LeadOpsEntry = {
+    ...prev,
+    triage_status: nextTriage,
+    owner: nextOwner,
+    internal_note: nextNote,
+    updated_at: prev.updated_at,
+    activities: [...prev.activities],
+  };
+
+  let changed = false;
+  if (patch.triage_status !== undefined && patch.triage_status !== prev.triage_status) {
+    pushActivity(
+      entry,
+      "triage_status_changed",
+      `${prev.triage_status} → ${patch.triage_status}`,
+    );
+    changed = true;
+  }
+  if (patch.owner !== undefined && nextOwner !== prev.owner) {
+    pushActivity(entry, "owner_set", nextOwner || "(leer)");
+    changed = true;
+  }
+  if (patch.internal_note !== undefined && nextNote !== prev.internal_note) {
+    pushActivity(entry, "internal_note_updated", "Notiz aktualisiert");
+    changed = true;
+  }
+
+  if (!changed) {
+    return { entry: prev, path, changed: false };
+  }
+
+  state.entries[leadId] = entry;
+
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(state, null, 0)}\n`, "utf8");
+  await rename(tmp, path);
+  return { entry, path, changed: true };
+}
+
+export async function appendLeadOpsActivity(
+  leadId: string,
+  action: LeadOpsActivityAction,
+  detail?: string,
+): Promise<void> {
+  const path = resolveOpsPath();
+  await mkdir(dirname(path), { recursive: true });
+  const state = await readLeadOpsState();
+  const prev = state.entries[leadId] ?? defaultLeadOpsEntry();
+  pushActivity(prev, action, detail);
+  state.entries[leadId] = prev;
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(state, null, 0)}\n`, "utf8");
+  await rename(tmp, path);
+}

--- a/frontend/src/lib/leadOpsTypes.ts
+++ b/frontend/src/lib/leadOpsTypes.ts
@@ -1,0 +1,27 @@
+import type { LeadTriageStatus } from "@/lib/leadTriage";
+
+export type LeadOpsActivityAction =
+  | "triage_status_changed"
+  | "owner_set"
+  | "internal_note_updated"
+  | "forward_retried"
+  | "ops_touch";
+
+export type LeadOpsActivity = {
+  at: string;
+  action: LeadOpsActivityAction;
+  detail?: string;
+};
+
+export type LeadOpsEntry = {
+  triage_status: LeadTriageStatus;
+  owner: string;
+  internal_note: string;
+  updated_at: string;
+  activities: LeadOpsActivity[];
+};
+
+export type LeadOpsFile = {
+  version: number;
+  entries: Record<string, LeadOpsEntry>;
+};

--- a/frontend/src/lib/leadPersistence.ts
+++ b/frontend/src/lib/leadPersistence.ts
@@ -91,6 +91,59 @@ export async function readRecentLeadRecordsMerged(maxRecords: number): Promise<L
   }
 }
 
+/** Liest die gesamte JSONL und liefert die erste passende `lead_inquiry`-Zeile (Outbound inkl.). */
+export async function findLeadInquiryRecord(leadId: string): Promise<LeadStoreRecord | null> {
+  const path = resolveStorePath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    let found: LeadStoreRecord | null = null;
+    for (const line of lines) {
+      try {
+        const row = JSON.parse(line) as { _kind?: string; lead_id?: string };
+        if (row._kind === "lead_inquiry" && row.lead_id === leadId) {
+          found = row as LeadStoreRecord;
+        }
+      } catch {
+        /* skip */
+      }
+    }
+    return found;
+  } catch {
+    return null;
+  }
+}
+
+/** Einzelnen Lead inkl. Webhook-Zeilen zusammenführen (unabhängig vom List-Limit). */
+export async function getMergedLeadAdminRow(leadId: string): Promise<LeadAdminRow | null> {
+  const base = await findLeadInquiryRecord(leadId);
+  if (!base) return null;
+  const row: LeadAdminRow = { ...base };
+  const path = resolveStorePath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const lines = raw.trim().split("\n").filter(Boolean);
+    for (const line of lines) {
+      try {
+        const o = JSON.parse(line) as { _kind?: string; lead_id?: string };
+        if (o._kind === "webhook_result" && o.lead_id === leadId) {
+          const wr = o as LeadWebhookResultLine;
+          row.webhook_ok = wr.ok;
+          row.webhook_at = wr.at;
+          row.webhook_error = wr.error;
+          row.status = wr.ok ? "forwarded" : "failed";
+          row.forwarded_at = wr.ok ? wr.at : row.forwarded_at;
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  } catch {
+    /* keep base row */
+  }
+  return row;
+}
+
 export async function dispatchLeadWebhook(
   url: string,
   body: LeadOutboundPayloadV1,

--- a/frontend/src/lib/leadTriage.ts
+++ b/frontend/src/lib/leadTriage.ts
@@ -1,0 +1,32 @@
+/**
+ * Interne Lead-Triage (Wave 26) – kein CRM, nur operative Einordnung.
+ */
+
+export const LEAD_TRIAGE_STATUSES = [
+  "received",
+  "triaged",
+  "contacted",
+  "qualified",
+  "closed_won_interest",
+  "closed_not_now",
+  "spam",
+] as const;
+
+export type LeadTriageStatus = (typeof LEAD_TRIAGE_STATUSES)[number];
+
+const TRIAGE_SET = new Set<string>(LEAD_TRIAGE_STATUSES);
+
+export function isLeadTriageStatus(v: string): v is LeadTriageStatus {
+  return TRIAGE_SET.has(v);
+}
+
+/** Kurzlabels für UI (DACH-B2B, intern) */
+export const LEAD_TRIAGE_LABELS_DE: Record<LeadTriageStatus, string> = {
+  received: "Neu / unbearbeitet",
+  triaged: "Triage erledigt",
+  contacted: "Kontaktiert",
+  qualified: "Qualifiziert",
+  closed_won_interest: "Abschluss-Interesse",
+  closed_not_now: "Zurückgestellt",
+  spam: "Spam / ungültig",
+};


### PR DESCRIPTION
- Add /admin/leads UI with filters, detail panel, quick actions, session login
- Triage model in ops-state.json; merge with JSONL via getMergedLeadAdminRow
- APIs: admin session POST/DELETE, lead PATCH/GET by id, webhook retry
- Shared isLeadAdminAuthorized (Bearer, query secret, httpOnly cookie)
- Docs wave26; wave24/25 cross-links; gitignore ops-state.json
- Unit tests for lead inbox merge/sort

Made-with: Cursor