### PR TITLE
feat(gtm): Wave 27 lead identity, contact history, webhook 1.1

### DIFF
--- a/docs/gtm/wave25-lead-routing-and-intake-governance.md
+++ b/docs/gtm/wave25-lead-routing-and-intake-governance.md
@@ -36,13 +36,13 @@
 
 ---
 
-## 3. Webhook-Payload (Contract v1.0)
+## 3. Webhook-Payload (Contract v1.0 / v1.1)
 
 Feldname im JSON (snake_case, stabil):
 
 | Feld | Typ | Beschreibung |
 | ---- | --- | ------------ |
-| `schema_version` | `"1.0"` | Version des Vertrags |
+| `schema_version` | `"1.0"` oder `"1.1"` | Version des Vertrags (neue Anfragen: **1.1**) |
 | `lead_id` | UUID | Primärschlüssel der Anfrage |
 | `trace_id` | UUID | Korrelation Logs / Webhook / Support |
 | `timestamp` | ISO-8601 | Erzeugung des Payloads |
@@ -53,6 +53,17 @@ Feldname im JSON (snake_case, stabil):
 | `company` | string | Unternehmen / Kanzlei |
 | `message` | string | Freitext (kann leer sein) |
 | `route` | object | `route_key`, `queue_label`, `priority`, `sla_bucket` |
+
+**Zusatz ab v1.1** (CRM-/Dedup-Vorbereitung, siehe [Wave 27](./wave27-lead-dedup-and-history.md)):
+
+| Feld | Typ | Beschreibung |
+| ---- | --- | ------------ |
+| `lead_contact_key` | string | Stabiler Kontakt-Schlüssel (Hash der normalisierten E-Mail) |
+| `lead_account_key` | string \| null | Optionale Firmen-/Domain-Gruppe |
+| `contact_inquiry_sequence` | number | n-te Anfrage dieses Kontakts |
+| `contact_first_seen_at` | ISO-8601 | Erste bekannte Anfrage |
+| `contact_latest_seen_at` | ISO-8601 | Diese Anfrage |
+| `duplicate_hint` | `none` \| `same_email_repeat` | Nur Hinweis, kein Merge |
 
 Implementierung: `buildLeadOutboundPayload` in `frontend/src/lib/leadOutbound.ts`.
 

--- a/docs/gtm/wave26-internal-lead-inbox.md
+++ b/docs/gtm/wave26-internal-lead-inbox.md
@@ -108,4 +108,8 @@ Append-only Logik auf Dateiebene: bei Änderungen werden Einträge wie `triage_s
 
 ---
 
+**Nachfolger:** [Wave 27 – Lead-Dedup & Kontakt-Historie](./wave27-lead-dedup-and-history.md) (`lead_contact_key`, Historie in der Inbox, Webhook 1.1).
+
+---
+
 *Wave 26 – operative Lead-Triage für DACH-B2B, bewusst klein gehalten.*

--- a/docs/gtm/wave27-lead-dedup-and-history.md
+++ b/docs/gtm/wave27-lead-dedup-and-history.md
@@ -1,0 +1,103 @@
+# Wave 27 – Lead-Identität, Dedup-Hinweise & Kontakt-Historie
+
+**Vorgänger:** [Wave 26 – Internes Lead-Inbox](./wave26-internal-lead-inbox.md)
+
+---
+
+## 1. Ziel
+
+- Wiederholte Anfragen **derselben Person** (gleiche geschäftliche E-Mail) sollen **sichtbar gruppiert** werden, ohne Anfragen zu **löschen oder still zusammenzuführen**.
+- **CRM/n8n** können später an stabilen Schlüsseln und Sequenzen andocken, ohne dass Compliance Hub ein CRM wird.
+
+---
+
+## 2. Dedup-Regeln (konservativ)
+
+| Schlüssel | Herkunft | Verwendung |
+| --------- | -------- | ----------- |
+| `lead_contact_key` | `ct_v1_` + SHA-256 über normalisierte E-Mail (`email\|…`) | **Primär:** gleiche Person = gleicher Key |
+| `lead_account_key` | `ac_v1_co_` + Hash des normalisierten Firmennamens, oder `ac_v1_dom_` + Domain (wenn Firma leer und keine Consumer-Domain) | **Sekundär:** Kontext „gleiche Organisation“, **kein** automatischer Kontakt-Merge |
+
+- **Normalisierung E-Mail:** trim, lowercase.
+- **Normalisierung Firma:** trim, lowercase, Whitespace zusammenziehen, trailing Satzzeichen entfernt.
+- **Consumer-Domains** (gmail, web.de, …): für `lead_account_key` keine reine Domain-Gruppe, wenn keine sinnvolle Firma – vermeidet falsche Firmen-Dubletten bei Privatmail.
+
+**Prinzip:** Lieber „Hinweis“ und manuelle Verknüpfung als aggressiver Merge.
+
+---
+
+## 3. Jede Einreichung bleibt eigener Datensatz
+
+- JSONL: weiterhin **eine Zeile** `lead_inquiry` pro Formular-Submit (**immutable** Inhalt).
+- Webhook: jede Einreichung erzeugt einen eigenen Payload mit eigener `lead_id` / `trace_id`.
+- Zusätzlich werden **Snapshot-Felder** gesetzt (auch in `outbound`):
+
+| Feld | Bedeutung |
+| ---- | --------- |
+| `schema_version` | `1.1` für neue Anfragen (ältere Zeilen können `1.0` bleiben) |
+| `lead_contact_key` | Stabiler Kontakt-Schlüssel |
+| `lead_account_key` | Optional, Account-/Firmen-Gruppierung |
+| `contact_inquiry_sequence` | Laufnummer dieser Person (1, 2, 3, …) |
+| `contact_first_seen_at` | Erste bekannte Anfrage dieses Kontakts |
+| `contact_latest_seen_at` | Zeitpunkt **dieser** Anfrage |
+| `duplicate_hint` | `none` \| `same_email_repeat` (nur bei wiederholter E-Mail) |
+
+Lesende APIs leiten fehlende Wave-27-Felder bei **alten** Zeilen aus `business_email` / Firma **nach** (Retrofit beim Merge).
+
+---
+
+## 4. Gruppierte Kontakt-Historie (Inbox)
+
+- Liste: Rollup über **gesamten** Store (`readAllLeadRecordsMerged`) pro `lead_contact_key`:
+  - `contact_submission_count`
+  - `contact_has_unresolved_repeat` (mehr als eine Anfrage **und** mindestens eine mit Aufmerksamkeit: Triage `received` oder Weiterleitung `failed`)
+  - `other_contacts_on_same_account` (Anzahl **weiterer** Kontakt-Keys unter gleichem `lead_account_key`)
+- Detail: `GET /api/admin/lead-inquiries/[leadId]` liefert `contact_history` (chronologische Timeline derselben E-Mail).
+
+**Filter (Query):**
+
+- `repeated_contacts=1` – nur Kontakte mit mehr als einer Submission.
+- `unresolved_repeated=1` – wiederholt **und** mindestens eine offene Aufmerksamkeit in der Gruppe.
+
+---
+
+## 5. Ops / Audit (Wave 26+27)
+
+Neue oder erweiterte Aktivitäten:
+
+| Aktion | Wann |
+| ------ | ---- |
+| `contact_repeat_detected` | Zweite und jede weitere Anfrage gleicher E-Mail (nach Persist) |
+| `possible_duplicate_noted` | Gleiche Account-Gruppe, aber **anderer** Kontakt-Key (Hinweis, kein Merge) |
+| `manual_related_leads_updated` | Manuelle Verknüpfung zu anderen `lead_id` |
+| `duplicate_review_updated` | Status `none` / `suggested` / `confirmed` |
+
+**PATCH** (intern): `manual_related_lead_ids` (max. 20 UUIDs, müssen existieren), `duplicate_review`.
+
+---
+
+## 6. CRM / n8n Sync (Vorbereitung, kein vollständiger Sync)
+
+Webhook-Body (`schema_version` **1.1**) enthält u. a.:
+
+- `lead_id` – diese Einreichung
+- `lead_contact_key` – stabiler Kontakt in Downstream-Systemen
+- `lead_account_key` – optionale Firmen-/Domain-Gruppe
+- `contact_inquiry_sequence` – wie viele Anfragen diese E-Mail bisher hatte (inkl. dieser)
+- `contact_first_seen_at` / `contact_latest_seen_at` – Zeitfenster für Deduplizierungs-Logik im CRM
+
+Empfohlene spätere Muster:
+
+- **HubSpot / Pipedrive:** Kontakt anhand `lead_contact_key` oder abgeleiteter E-Mail; **Deal/Aktivität** pro `lead_id` oder pro Sequenz.
+- **n8n:** Branch nach `duplicate_hint` und `contact_inquiry_sequence`, z. B. andere Slack-Queue ab der zweiten Anfrage.
+
+---
+
+## 7. Grenzen & Skalierung
+
+- Rollups lesen die **gesamte** JSONL pro Admin-Request – für Gründer-/Sales-Volumen gedacht, nicht für sehr große Stores.
+- Persistenz ephemer auf Vercel unverändert: **CRM/Webhook** bleibt Quelle der Wahrheit für längerfristige Historie.
+
+---
+
+*Wave 27 – additive Identität und Historie ohne CRM-Komplexität.*

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/retry-webhook/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/retry-webhook/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from "next/server";
 
 import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
-import { mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
 import { appendLeadOpsActivity, readLeadOpsState } from "@/lib/leadOpsState";
 import {
   appendLeadWebhookResult,
   dispatchLeadWebhook,
   findLeadInquiryRecord,
   getMergedLeadAdminRow,
+  readAllLeadRecordsMerged,
 } from "@/lib/leadPersistence";
 
 export const runtime = "nodejs";
@@ -60,8 +61,10 @@ export async function POST(req: Request, ctx: { params: Promise<{ leadId: string
   }
 
   const row = await getMergedLeadAdminRow(leadId);
+  const allRows = await readAllLeadRecordsMerged();
   const ops = await readLeadOpsState();
-  const item = row ? mergeLeadsWithOps([row], ops)[0] : null;
+  const merged = row ? mergeLeadsWithOps([row], ops) : [];
+  const item = row ? (attachContactRollups(merged, allRows, ops)[0] ?? null) : null;
 
   return NextResponse.json({
     ok: true,

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
@@ -1,12 +1,28 @@
 import { NextResponse } from "next/server";
 
 import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
-import { mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import {
+  attachContactRollups,
+  buildContactHistoryItems,
+  mergeLeadsWithOps,
+} from "@/lib/leadInboxMerge";
 import { mutateLeadOps, readLeadOpsState } from "@/lib/leadOpsState";
+import type { LeadDuplicateReviewStatus } from "@/lib/leadOpsTypes";
 import { isLeadTriageStatus, type LeadTriageStatus } from "@/lib/leadTriage";
-import { findLeadInquiryRecord, getMergedLeadAdminRow } from "@/lib/leadPersistence";
+import {
+  findLeadInquiryRecord,
+  getMergedLeadAdminRow,
+  readAllLeadRecordsMerged,
+} from "@/lib/leadPersistence";
 
 export const runtime = "nodejs";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isDuplicateReview(v: string): v is LeadDuplicateReviewStatus {
+  return v === "none" || v === "suggested" || v === "confirmed";
+}
 
 export async function GET(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
   if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
@@ -22,15 +38,21 @@ export async function GET(req: Request, ctx: { params: Promise<{ leadId: string 
     return NextResponse.json({ error: "not_found" }, { status: 404 });
   }
 
+  const allRows = await readAllLeadRecordsMerged();
   const ops = await readLeadOpsState();
-  const [item] = mergeLeadsWithOps([row], ops);
-  return NextResponse.json({ ok: true, item });
+  const merged = mergeLeadsWithOps([row], ops);
+  const item = attachContactRollups(merged, allRows, ops)[0] ?? merged[0]!;
+  const contact_history = buildContactHistoryItems(leadId, allRows, ops);
+
+  return NextResponse.json({ ok: true, item, contact_history });
 }
 
 type PatchBody = {
   triage_status?: string;
   owner?: string;
   internal_note?: string;
+  manual_related_lead_ids?: string[];
+  duplicate_review?: string;
 };
 
 export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
@@ -58,6 +80,8 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: strin
     triage_status?: LeadTriageStatus;
     owner?: string;
     internal_note?: string;
+    manual_related_lead_ids?: string[];
+    duplicate_review?: LeadDuplicateReviewStatus;
   } = {};
 
   if (body.triage_status !== undefined) {
@@ -72,6 +96,32 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: strin
   if (body.internal_note !== undefined) {
     patch.internal_note = String(body.internal_note);
   }
+  if (body.duplicate_review !== undefined) {
+    if (!isDuplicateReview(body.duplicate_review)) {
+      return NextResponse.json({ error: "validation" }, { status: 400 });
+    }
+    patch.duplicate_review = body.duplicate_review;
+  }
+  if (body.manual_related_lead_ids !== undefined) {
+    if (!Array.isArray(body.manual_related_lead_ids)) {
+      return NextResponse.json({ error: "validation" }, { status: 400 });
+    }
+    const ids = body.manual_related_lead_ids.slice(0, 20);
+    for (const id of ids) {
+      if (typeof id !== "string" || !UUID_RE.test(id.trim())) {
+        return NextResponse.json({ error: "validation" }, { status: 400 });
+      }
+      const tid = id.trim();
+      if (tid === leadId) {
+        return NextResponse.json({ error: "validation" }, { status: 400 });
+      }
+      const rec = await findLeadInquiryRecord(tid);
+      if (!rec) {
+        return NextResponse.json({ error: "related_not_found" }, { status: 400 });
+      }
+    }
+    patch.manual_related_lead_ids = ids.map((x) => String(x).trim());
+  }
 
   if (Object.keys(patch).length === 0) {
     return NextResponse.json({ error: "empty_patch" }, { status: 400 });
@@ -83,13 +133,17 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: strin
   }
 
   const row = await getMergedLeadAdminRow(leadId);
+  const allRows = await readAllLeadRecordsMerged();
   const ops = await readLeadOpsState();
-  const item = row ? mergeLeadsWithOps([row], ops)[0] : null;
+  const merged = row ? mergeLeadsWithOps([row], ops) : [];
+  const item = row ? (attachContactRollups(merged, allRows, ops)[0] ?? null) : null;
+  const contact_history = row ? buildContactHistoryItems(leadId, allRows, ops) : [];
 
   return NextResponse.json({
     ok: true,
     changed: true,
     entry: result.entry,
     item,
+    contact_history,
   });
 }

--- a/frontend/src/app/api/admin/lead-inquiries/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/route.ts
@@ -1,10 +1,14 @@
 import { NextResponse } from "next/server";
 
 import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
-import { mergeLeadsWithOps, sortInboxItems } from "@/lib/leadInboxMerge";
+import {
+  attachContactRollups,
+  mergeLeadsWithOps,
+  sortInboxItems,
+} from "@/lib/leadInboxMerge";
 import type { LeadForwardingStatus } from "@/lib/leadInboxTypes";
 import { readLeadOpsState } from "@/lib/leadOpsState";
-import { readRecentLeadRecordsMerged } from "@/lib/leadPersistence";
+import { readAllLeadRecordsMerged } from "@/lib/leadPersistence";
 
 export const runtime = "nodejs";
 
@@ -32,14 +36,19 @@ export async function GET(req: Request) {
     Math.max(1, parseInt(url.searchParams.get("limit") ?? "200", 10) || 200),
   );
 
-  const rows = await readRecentLeadRecordsMerged(limit);
+  const allRows = await readAllLeadRecordsMerged();
+  const pageRows = allRows.slice(0, limit);
   const ops = await readLeadOpsState();
-  let items = sortInboxItems(mergeLeadsWithOps(rows, ops));
+  let items = sortInboxItems(
+    attachContactRollups(mergeLeadsWithOps(pageRows, ops), allRows, ops),
+  );
 
   const triage = url.searchParams.get("triage_status")?.trim();
   const segment = url.searchParams.get("segment")?.trim();
   const sourcePage = url.searchParams.get("source_page")?.trim();
   const forwarding = url.searchParams.get("forwarding_status")?.trim();
+  const repeated = url.searchParams.get("repeated_contacts")?.trim();
+  const unresolvedRep = url.searchParams.get("unresolved_repeated")?.trim();
 
   if (triage) {
     items = items.filter((i) => i.triage_status === triage);
@@ -52,6 +61,12 @@ export async function GET(req: Request) {
   }
   if (forwarding && isForwardingFilter(forwarding)) {
     items = items.filter((i) => i.forwarding_status === forwarding);
+  }
+  if (repeated === "1" || repeated === "true") {
+    items = items.filter((i) => i.contact_submission_count > 1);
+  }
+  if (unresolvedRep === "1" || unresolvedRep === "true") {
+    items = items.filter((i) => i.contact_has_unresolved_repeat);
   }
 
   return NextResponse.json({

--- a/frontend/src/app/api/lead-inquiry/route.ts
+++ b/frontend/src/app/api/lead-inquiry/route.ts
@@ -7,13 +7,22 @@ import {
   rollbackLeadEmailCooldown,
 } from "@/lib/leadDuplicateGuard";
 import { isLeadSegment, LEAD_FIELD_LIMITS } from "@/lib/leadCapture";
+import {
+  buildLeadAccountKey,
+  buildLeadContactKey,
+  normalizeLeadEmail,
+} from "@/lib/leadIdentity";
 import { buildLeadOutboundPayload } from "@/lib/leadOutbound";
 import {
   appendLeadWebhookResult,
+  computeContactKeyStatsFromRows,
+  countOtherContactKeysOnAccount,
   dispatchLeadWebhook,
   persistLeadReceived,
+  readAllLeadRecordsMerged,
   type LeadStoreRecord,
 } from "@/lib/leadPersistence";
+import { appendLeadOpsActivity } from "@/lib/leadOpsState";
 import { getClientIp, checkLeadIpRateLimit } from "@/lib/leadRateLimit";
 import { determineLeadRoute } from "@/lib/leadRouting";
 
@@ -112,6 +121,25 @@ export async function POST(req: Request) {
   const lead_id = randomUUID();
   const trace_id = randomUUID();
   const route = determineLeadRoute(segRaw, company, message, source_page);
+
+  const normEmail = normalizeLeadEmail(work_email);
+  const lead_contact_key = buildLeadContactKey(normEmail);
+  const lead_account_key = buildLeadAccountKey(company, work_email);
+
+  const allRows = await readAllLeadRecordsMerged();
+  const contactStats = computeContactKeyStatsFromRows(allRows, lead_contact_key);
+  const sequence = contactStats.prior_count + 1;
+  const created_at = new Date().toISOString();
+  const contact_first_seen_at = contactStats.first_seen_at ?? created_at;
+  const contact_latest_seen_at = created_at;
+  const duplicate_hint = sequence > 1 ? ("same_email_repeat" as const) : ("none" as const);
+
+  const otherContactsOnAccount = countOtherContactKeysOnAccount(
+    allRows,
+    lead_account_key,
+    lead_contact_key,
+  );
+
   const outbound = buildLeadOutboundPayload({
     lead_id,
     trace_id,
@@ -122,9 +150,17 @@ export async function POST(req: Request) {
     company,
     message,
     route,
+    timestamp: created_at,
+    identity: {
+      lead_contact_key,
+      lead_account_key,
+      contact_inquiry_sequence: sequence,
+      contact_first_seen_at,
+      contact_latest_seen_at,
+      duplicate_hint,
+    },
   });
 
-  const created_at = new Date().toISOString();
   const storeRecord: LeadStoreRecord = {
     _kind: "lead_inquiry",
     lead_id,
@@ -132,6 +168,12 @@ export async function POST(req: Request) {
     status: "received",
     created_at,
     outbound,
+    lead_contact_key,
+    lead_account_key,
+    contact_inquiry_sequence: sequence,
+    contact_first_seen_at,
+    contact_latest_seen_at,
+    duplicate_hint,
   };
 
   try {
@@ -142,6 +184,25 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: "server" }, { status: 500 });
   }
 
+  try {
+    if (sequence > 1) {
+      await appendLeadOpsActivity(
+        lead_id,
+        "contact_repeat_detected",
+        `Wiederholte Anfrage (#${sequence}) für denselben Kontakt-Schlüssel`,
+      );
+    }
+    if (otherContactsOnAccount > 0) {
+      await appendLeadOpsActivity(
+        lead_id,
+        "possible_duplicate_noted",
+        `Account-Gruppe: ${otherContactsOnAccount} weiterer Kontext (anderer E-Mail-Kontakt)`,
+      );
+    }
+  } catch (e) {
+    console.warn("[lead-inquiry] ops_activity_append_failed", e);
+  }
+
   console.info(
     "[lead-inquiry]",
     JSON.stringify({
@@ -150,6 +211,8 @@ export async function POST(req: Request) {
       segment: segRaw,
       route_key: route.route_key,
       source_page,
+      lead_contact_key,
+      contact_inquiry_sequence: sequence,
       client_ip_prefix: clientIp.slice(0, 12),
     }),
   );

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
-import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import type { LeadContactHistoryEntry, LeadInboxItem } from "@/lib/leadInboxTypes";
 import { LEAD_TRIAGE_LABELS_DE, LEAD_TRIAGE_STATUSES } from "@/lib/leadTriage";
 
 type Props = {
@@ -17,6 +17,20 @@ function forwardingLabel(s: LeadInboxItem["forwarding_status"]): string {
   return "Kein Webhook / nicht gesendet";
 }
 
+const DUPLICATE_REVIEW_LABELS: Record<LeadInboxItem["duplicate_review"], string> = {
+  none: "Keine Markierung",
+  suggested: "Zur Prüfung (mögliche Dublette)",
+  confirmed: "Zusammenhang bestätigt (manuell)",
+};
+
+type PatchBody = {
+  triage_status?: string;
+  owner?: string;
+  internal_note?: string;
+  manual_related_lead_ids?: string[];
+  duplicate_review?: LeadInboxItem["duplicate_review"];
+};
+
 export function AdminLeadInboxClient({ adminConfigured }: Props) {
   const [secretInput, setSecretInput] = useState("");
   const [loginError, setLoginError] = useState<string | null>(null);
@@ -25,14 +39,22 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [detailItem, setDetailItem] = useState<LeadInboxItem | null>(null);
+  const [contactHistory, setContactHistory] = useState<LeadContactHistoryEntry[]>([]);
+  const [detailLoading, setDetailLoading] = useState(false);
   const [filters, setFilters] = useState({
     triage_status: "",
     segment: "",
     source_page: "",
     forwarding_status: "",
+    repeated_contacts: false,
+    unresolved_repeated: false,
   });
   const [draftOwner, setDraftOwner] = useState("");
   const [draftNote, setDraftNote] = useState("");
+  const [draftDuplicateReview, setDraftDuplicateReview] =
+    useState<LeadInboxItem["duplicate_review"]>("none");
+  const [draftRelatedRaw, setDraftRelatedRaw] = useState("");
   const [saving, setSaving] = useState(false);
   const [actionMsg, setActionMsg] = useState<string | null>(null);
 
@@ -41,15 +63,21 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     [items, selectedId],
   );
 
+  const displayLead = detailItem ?? selected;
+
   useEffect(() => {
-    if (!selected) {
+    if (!displayLead) {
       setDraftOwner("");
       setDraftNote("");
+      setDraftDuplicateReview("none");
+      setDraftRelatedRaw("");
       return;
     }
-    setDraftOwner(selected.owner);
-    setDraftNote(selected.internal_note);
-  }, [selected]);
+    setDraftOwner(displayLead.owner);
+    setDraftNote(displayLead.internal_note);
+    setDraftDuplicateReview(displayLead.duplicate_review);
+    setDraftRelatedRaw(displayLead.manual_related_lead_ids.join(", "));
+  }, [displayLead]);
 
   const queryString = useMemo(() => {
     const p = new URLSearchParams();
@@ -57,9 +85,10 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     if (filters.segment) p.set("segment", filters.segment);
     if (filters.source_page) p.set("source_page", filters.source_page);
     if (filters.forwarding_status) p.set("forwarding_status", filters.forwarding_status);
+    if (filters.repeated_contacts) p.set("repeated_contacts", "1");
+    if (filters.unresolved_repeated) p.set("unresolved_repeated", "1");
     p.set("limit", "500");
-    const q = p.toString();
-    return q ? `?${q}` : "?limit=500";
+    return `?${p.toString()}`;
   }, [filters]);
 
   const fetchLeads = useCallback(async () => {
@@ -95,6 +124,35 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     void fetchLeads();
   }, [adminConfigured, fetchLeads]);
 
+  useEffect(() => {
+    if (!selectedId || authed !== true) {
+      setDetailItem(null);
+      setContactHistory([]);
+      return;
+    }
+    let cancelled = false;
+    setDetailLoading(true);
+    void fetch(`/api/admin/lead-inquiries/${selectedId}`, { credentials: "include" })
+      .then(async (r) => {
+        if (!r.ok) return null;
+        return (await r.json()) as {
+          item?: LeadInboxItem;
+          contact_history?: LeadContactHistoryEntry[];
+        };
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        if (data.item) setDetailItem(data.item);
+        if (data.contact_history) setContactHistory(data.contact_history);
+      })
+      .finally(() => {
+        if (!cancelled) setDetailLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId, authed]);
+
   async function login(e: React.FormEvent) {
     e.preventDefault();
     setLoginError(null);
@@ -126,12 +184,19 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     setAuthed(false);
     setItems([]);
     setSelectedId(null);
+    setDetailItem(null);
+    setContactHistory([]);
   }
 
-  async function patchLead(
-    leadId: string,
-    body: { triage_status?: string; owner?: string; internal_note?: string },
-  ) {
+  function parseRelatedIds(raw: string): string[] {
+    return raw
+      .split(/[\s,;]+/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .slice(0, 20);
+  }
+
+  async function patchLead(leadId: string, body: PatchBody) {
     setSaving(true);
     setActionMsg(null);
     try {
@@ -141,15 +206,23 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
         credentials: "include",
         body: JSON.stringify(body),
       });
-      const data = (await r.json()) as { ok?: boolean; item?: LeadInboxItem | null };
+      const data = (await r.json()) as {
+        ok?: boolean;
+        item?: LeadInboxItem | null;
+        contact_history?: LeadContactHistoryEntry[];
+      };
       if (!r.ok) {
         setActionMsg("Speichern fehlgeschlagen.");
         return;
       }
       if (data.item) {
         setItems((prev) => prev.map((x) => (x.lead_id === data.item!.lead_id ? data.item! : x)));
+        if (selectedId === leadId) setDetailItem(data.item);
       } else {
         await fetchLeads();
+      }
+      if (data.contact_history && selectedId === leadId) {
+        setContactHistory(data.contact_history);
       }
       setActionMsg("Gespeichert.");
     } catch {
@@ -184,6 +257,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
       }
       if (data.item) {
         setItems((prev) => prev.map((x) => (x.lead_id === data.item!.lead_id ? data.item! : x)));
+        if (selectedId === leadId) setDetailItem(data.item);
       }
       setActionMsg(
         data.webhook_ok ? "Webhook erneut erfolgreich." : `Webhook-Fehler: ${data.webhook_error ?? "?"}`,
@@ -249,8 +323,9 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
         <div>
           <h1 className="text-xl font-semibold text-slate-900">Lead-Inbox</h1>
           <p className="text-sm text-slate-600">
-            Triage und Nachverfolgung – nicht öffentlich, kein CRM. Sortierung: zuerst Aufmerksamkeit
-            (fehlgeschlagene Weiterleitung oder Status &quot;Neu&quot;), dann neueste zuerst.
+            Triage und Nachverfolgung – nicht öffentlich, kein CRM. Kontakt-Historie gruppiert nach
+            E-Mail-Schlüssel; jede Einreichung bleibt eigener Datensatz. Sortierung: zuerst
+            Aufmerksamkeit, dann neueste zuerst.
           </p>
         </div>
         <button
@@ -315,6 +390,22 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
             <option value="not_sent">Nicht gesendet</option>
           </select>
         </label>
+        <label className="flex items-center gap-2 self-end pb-1">
+          <input
+            type="checkbox"
+            checked={filters.repeated_contacts}
+            onChange={(e) => setFilters((f) => ({ ...f, repeated_contacts: e.target.checked }))}
+          />
+          <span className="text-slate-700">Wiederholte Kontakte</span>
+        </label>
+        <label className="flex items-center gap-2 self-end pb-1">
+          <input
+            type="checkbox"
+            checked={filters.unresolved_repeated}
+            onChange={(e) => setFilters((f) => ({ ...f, unresolved_repeated: e.target.checked }))}
+          />
+          <span className="text-slate-700">Offen &amp; mehrfach</span>
+        </label>
         <button
           type="button"
           onClick={() => void fetchLeads()}
@@ -328,10 +419,11 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
       {loadError ? <p className="text-sm text-red-600">{loadError}</p> : null}
 
       <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
-        <table className="min-w-[900px] w-full border-collapse text-left text-sm">
+        <table className="min-w-[980px] w-full border-collapse text-left text-sm">
           <thead className="border-b border-slate-200 bg-slate-50 text-slate-600">
             <tr>
               <th className="px-3 py-2 font-medium">Eingang</th>
+              <th className="px-3 py-2 font-medium">Kontext</th>
               <th className="px-3 py-2 font-medium">Triage</th>
               <th className="px-3 py-2 font-medium">Weiterleitung</th>
               <th className="px-3 py-2 font-medium">Segment</th>
@@ -354,22 +446,52 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 <td className="whitespace-nowrap px-3 py-2 text-slate-800">
                   {new Date(row.created_at).toLocaleString("de-DE")}
                 </td>
+                <td className="px-3 py-2">
+                  <div className="flex flex-wrap gap-1">
+                    {row.contact_submission_count > 1 ? (
+                      <span
+                        className="rounded bg-violet-100 px-1.5 py-0.5 text-xs text-violet-900"
+                        title="Mehrfach eingereicht (gleiche E-Mail)"
+                      >
+                        ×{row.contact_submission_count}
+                      </span>
+                    ) : null}
+                    {row.duplicate_hint === "same_email_repeat" ? (
+                      <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs text-amber-900">
+                        Wdh.
+                      </span>
+                    ) : null}
+                    {row.other_contacts_on_same_account > 0 ? (
+                      <span
+                        className="rounded bg-sky-100 px-1.5 py-0.5 text-xs text-sky-900"
+                        title="Weitere Kontakte unter gleicher Firmen-/Domain-Gruppe"
+                      >
+                        Firma+
+                      </span>
+                    ) : null}
+                    {row.duplicate_review !== "none" ? (
+                      <span className="rounded border border-slate-300 px-1.5 py-0.5 text-xs text-slate-700">
+                        {row.duplicate_review === "confirmed" ? "OK manuell" : "Prüfen"}
+                      </span>
+                    ) : null}
+                  </div>
+                </td>
                 <td className="px-3 py-2">{LEAD_TRIAGE_LABELS_DE[row.triage_status]}</td>
                 <td className="px-3 py-2 text-slate-700">{forwardingLabel(row.forwarding_status)}</td>
                 <td className="px-3 py-2 text-slate-700">{row.segment}</td>
-                <td className="max-w-[140px] truncate px-3 py-2" title={row.company}>
+                <td className="max-w-[120px] truncate px-3 py-2" title={row.company}>
                   {row.company}
                 </td>
-                <td className="max-w-[120px] truncate px-3 py-2" title={row.name}>
+                <td className="max-w-[100px] truncate px-3 py-2" title={row.name}>
                   {row.name}
                 </td>
-                <td className="max-w-[160px] truncate px-3 py-2" title={row.business_email}>
+                <td className="max-w-[140px] truncate px-3 py-2" title={row.business_email}>
                   {row.business_email}
                 </td>
-                <td className="max-w-[100px] truncate px-3 py-2" title={row.source_page}>
+                <td className="max-w-[90px] truncate px-3 py-2" title={row.source_page}>
                   {row.source_page}
                 </td>
-                <td className="max-w-[160px] truncate px-3 py-2 text-slate-600" title={row.queue_label}>
+                <td className="max-w-[140px] truncate px-3 py-2 text-slate-600" title={row.queue_label}>
                   {row.route_key}
                 </td>
               </tr>
@@ -381,13 +503,20 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
         ) : null}
       </div>
 
-      {selected ? (
+      {displayLead ? (
         <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+          {detailLoading ? (
+            <p className="mb-4 text-sm text-slate-500">Detail &amp; Historie werden geladen …</p>
+          ) : null}
           <div className="flex flex-wrap items-start justify-between gap-4">
             <div>
               <h2 className="text-lg font-semibold text-slate-900">Detail</h2>
               <p className="text-xs text-slate-500">
-                lead_id: {selected.lead_id} · trace_id: {selected.trace_id}
+                lead_id: {displayLead.lead_id} · trace_id: {displayLead.trace_id}
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                Kontakt #{displayLead.contact_inquiry_sequence} von {displayLead.contact_submission_count}{" "}
+                (Schlüssel: <span className="font-mono">{displayLead.lead_contact_key.slice(0, 18)}…</span>)
               </p>
             </div>
             <div className="flex flex-wrap gap-2">
@@ -395,7 +524,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 type="button"
                 disabled={saving}
                 className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50"
-                onClick={() => void patchLead(selected.lead_id, { triage_status: "triaged" })}
+                onClick={() => void patchLead(displayLead.lead_id, { triage_status: "triaged" })}
               >
                 Triage erledigt
               </button>
@@ -403,7 +532,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 type="button"
                 disabled={saving}
                 className="rounded-lg border border-slate-300 px-3 py-1.5 text-sm hover:bg-slate-50 disabled:opacity-50"
-                onClick={() => void patchLead(selected.lead_id, { triage_status: "contacted" })}
+                onClick={() => void patchLead(displayLead.lead_id, { triage_status: "contacted" })}
               >
                 Kontaktiert
               </button>
@@ -411,16 +540,16 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 type="button"
                 disabled={saving}
                 className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-sm text-red-800 hover:bg-red-100 disabled:opacity-50"
-                onClick={() => void patchLead(selected.lead_id, { triage_status: "spam" })}
+                onClick={() => void patchLead(displayLead.lead_id, { triage_status: "spam" })}
               >
                 Spam
               </button>
-              {selected.forwarding_status === "failed" ? (
+              {displayLead.forwarding_status === "failed" ? (
                 <button
                   type="button"
                   disabled={saving}
                   className="rounded-lg border border-amber-300 bg-amber-50 px-3 py-1.5 text-sm text-amber-900 hover:bg-amber-100 disabled:opacity-50"
-                  onClick={() => void retryWebhook(selected.lead_id)}
+                  onClick={() => void retryWebhook(displayLead.lead_id)}
                 >
                   Webhook erneut senden
                 </button>
@@ -428,32 +557,75 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
             </div>
           </div>
 
+          <div className="mt-6 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-medium text-slate-800">Kontakt-Historie (gleiche E-Mail)</h3>
+            <p className="mt-1 text-xs text-slate-500">
+              Chronologisch; jede Zeile ist eine eigene Formular-Einreichung (unverändert gespeichert).
+            </p>
+            <ul className="mt-3 max-h-56 space-y-2 overflow-auto text-sm">
+              {contactHistory.map((h) => (
+                <li
+                  key={h.lead_id}
+                  className={`rounded-lg border px-3 py-2 ${
+                    h.lead_id === displayLead.lead_id ? "border-violet-300 bg-violet-50" : "border-slate-200"
+                  }`}
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-mono text-xs text-slate-600">
+                      #{h.contact_inquiry_sequence} · {new Date(h.created_at).toLocaleString("de-DE")}
+                    </span>
+                    {h.lead_id !== displayLead.lead_id ? (
+                      <button
+                        type="button"
+                        className="text-xs text-cyan-700 underline"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSelectedId(h.lead_id);
+                        }}
+                      >
+                        öffnen
+                      </button>
+                    ) : (
+                      <span className="text-xs text-violet-700">aktuell</span>
+                    )}
+                  </div>
+                  <p className="mt-1 text-xs text-slate-600">
+                    {forwardingLabel(h.forwarding_status)} · {LEAD_TRIAGE_LABELS_DE[h.triage_status]}
+                    {h.owner ? ` · Owner: ${h.owner}` : ""}
+                  </p>
+                  <p className="mt-1 line-clamp-2 text-xs text-slate-700">{h.message_preview}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+
           <div className="mt-4 grid gap-4 md:grid-cols-2">
             <div>
               <h3 className="text-sm font-medium text-slate-700">Nachricht</h3>
               <pre className="mt-2 max-h-64 overflow-auto whitespace-pre-wrap rounded-lg bg-slate-50 p-3 text-sm text-slate-800">
-                {selected.message || "(leer)"}
+                {displayLead.message || "(leer)"}
               </pre>
             </div>
             <div className="space-y-3 text-sm">
               <div>
                 <span className="text-slate-600">Pipeline (Speicher):</span>{" "}
-                <span className="font-mono text-slate-900">{selected.pipeline_status}</span>
+                <span className="font-mono text-slate-900">{displayLead.pipeline_status}</span>
               </div>
               <div>
-                <span className="text-slate-600">Weiterleitung:</span> {forwardingLabel(selected.forwarding_status)}
-                {selected.webhook_at ? (
-                  <span className="ml-2 text-slate-500">({selected.webhook_at})</span>
+                <span className="text-slate-600">Weiterleitung:</span>{" "}
+                {forwardingLabel(displayLead.forwarding_status)}
+                {displayLead.webhook_at ? (
+                  <span className="ml-2 text-slate-500">({displayLead.webhook_at})</span>
                 ) : null}
               </div>
-              {selected.webhook_error ? (
+              {displayLead.webhook_error ? (
                 <div className="rounded-lg bg-red-50 p-2 text-red-800">
-                  Fehler: {selected.webhook_error}
+                  Fehler: {displayLead.webhook_error}
                 </div>
               ) : null}
               <div>
-                <span className="text-slate-600">Priorität / SLA-Bucket:</span> {selected.priority} /{" "}
-                {selected.sla_bucket}
+                <span className="text-slate-600">Priorität / SLA-Bucket:</span> {displayLead.priority} /{" "}
+                {displayLead.sla_bucket}
               </div>
             </div>
           </div>
@@ -467,6 +639,36 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 onChange={(e) => setDraftOwner(e.target.value)}
               />
             </label>
+            <label className="block text-sm">
+              <span className="font-medium text-slate-700">Dubletten-Review</span>
+              <select
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2"
+                value={draftDuplicateReview}
+                onChange={(e) =>
+                  setDraftDuplicateReview(e.target.value as LeadInboxItem["duplicate_review"])
+                }
+              >
+                {(Object.keys(DUPLICATE_REVIEW_LABELS) as LeadInboxItem["duplicate_review"][]).map((k) => (
+                  <option key={k} value={k}>
+                    {DUPLICATE_REVIEW_LABELS[k]}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="md:col-span-2">
+              <label className="block text-sm">
+                <span className="font-medium text-slate-700">
+                  Verknüpfte Anfrage-IDs (UUID, kommagetrennt, max. 20)
+                </span>
+                <textarea
+                  className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 font-mono text-xs"
+                  rows={2}
+                  placeholder="z. B. manuell zusammenhängende Leads"
+                  value={draftRelatedRaw}
+                  onChange={(e) => setDraftRelatedRaw(e.target.value)}
+                />
+              </label>
+            </div>
             <div className="md:col-span-2">
               <label className="block text-sm">
                 <span className="font-medium text-slate-700">Interne Notiz</span>
@@ -483,10 +685,15 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
               disabled={saving}
               className="rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white hover:bg-slate-800 disabled:opacity-50"
               onClick={() =>
-                void patchLead(selected.lead_id, { owner: draftOwner, internal_note: draftNote })
+                void patchLead(displayLead.lead_id, {
+                  owner: draftOwner,
+                  internal_note: draftNote,
+                  duplicate_review: draftDuplicateReview,
+                  manual_related_lead_ids: parseRelatedIds(draftRelatedRaw),
+                })
               }
             >
-              Notiz &amp; Owner speichern
+              Ops-Felder speichern
             </button>
             {actionMsg ? <p className="text-sm text-slate-600">{actionMsg}</p> : null}
           </div>
@@ -494,13 +701,13 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
           <div className="mt-6 border-t border-slate-100 pt-4">
             <h3 className="text-sm font-medium text-slate-700">Aktivität (intern)</h3>
             <ul className="mt-2 max-h-48 space-y-2 overflow-auto text-xs text-slate-600">
-              {[...selected.activities].reverse().map((a, i) => (
+              {[...displayLead.activities].reverse().map((a, i) => (
                 <li key={`${a.at}-${i}`} className="border-b border-slate-100 pb-2">
                   <span className="font-mono text-slate-500">{a.at}</span> · {a.action}
                   {a.detail ? <span className="text-slate-700"> — {a.detail}</span> : null}
                 </li>
               ))}
-              {selected.activities.length === 0 ? <li>Keine Einträge.</li> : null}
+              {displayLead.activities.length === 0 ? <li>Keine Einträge.</li> : null}
             </ul>
           </div>
         </div>

--- a/frontend/src/lib/leadAntiAbuse.ts
+++ b/frontend/src/lib/leadAntiAbuse.ts
@@ -13,6 +13,10 @@ const CONSUMER_DOMAINS = new Set([
   "t-online.de",
 ]);
 
+export function isConsumerEmailDomain(domain: string): boolean {
+  return CONSUMER_DOMAINS.has(domain.toLowerCase().trim());
+}
+
 /**
  * Optional: Nur geschäftliche Domains (Env `LEAD_REQUIRE_BUSINESS_EMAIL=1`).
  */

--- a/frontend/src/lib/leadIdentity.test.ts
+++ b/frontend/src/lib/leadIdentity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLeadAccountKey,
+  buildLeadContactKey,
+  normalizeLeadCompany,
+  normalizeLeadEmail,
+} from "@/lib/leadIdentity";
+
+describe("leadIdentity", () => {
+  it("normalizes email consistently for contact keys", () => {
+    const a = buildLeadContactKey(normalizeLeadEmail("  User@Example.COM "));
+    const b = buildLeadContactKey(normalizeLeadEmail("user@example.com"));
+    expect(a).toBe(b);
+    expect(a.startsWith("ct_v1_")).toBe(true);
+  });
+
+  it("uses company hash when company present", () => {
+    const k1 = buildLeadAccountKey("  Acme GmbH  ", "x@acme.de");
+    const k2 = buildLeadAccountKey("acme gmbh", "y@acme.de");
+    expect(k1).toBe(k2);
+    expect(k1?.startsWith("ac_v1_co_")).toBe(true);
+  });
+
+  it("normalizes company whitespace", () => {
+    expect(normalizeLeadCompany("Foo   Bar")).toBe("foo bar");
+  });
+});

--- a/frontend/src/lib/leadIdentity.ts
+++ b/frontend/src/lib/leadIdentity.ts
@@ -1,0 +1,71 @@
+import { createHash } from "crypto";
+
+import { isConsumerEmailDomain } from "@/lib/leadAntiAbuse";
+
+/** Konservativ: wiederholte Anfrage derselben E-Mail (kein stiller Merge). */
+export type LeadDuplicateHint = "none" | "same_email_repeat";
+
+/**
+ * Primärer Kontakt-Schlüssel: normalisierte geschäftliche E-Mail (Hash, kein Klartext im Key).
+ * Stabil über alle Submissions einer Person.
+ */
+export function normalizeLeadEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+/** Sekundär: Firmenname nur für Account-Gruppierung, nicht zum automatischen Zusammenführen von Kontakten. */
+export function normalizeLeadCompany(company: string): string {
+  return company
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .replace(/[.,;]+$/g, "")
+    .trim();
+}
+
+export function extractEmailDomain(email: string): string | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return null;
+  return email.slice(at + 1).toLowerCase().trim() || null;
+}
+
+function sha256Hex(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+export function buildLeadContactKey(normalizedEmail: string): string {
+  return `ct_v1_${sha256Hex(`email|${normalizedEmail}`)}`;
+}
+
+/**
+ * Account-/Firmen-Gruppierung (schwächer als Kontakt-Key).
+ * – Bei sinnvollem Firmennamen: Hash des normalisierten Namens.
+ * – Sonst: registrierte Domain, wenn nicht Consumer-Domain.
+ */
+export function buildLeadAccountKey(company: string, businessEmail: string): string | null {
+  const co = normalizeLeadCompany(company);
+  if (co.length >= 2) {
+    return `ac_v1_co_${sha256Hex(`co|${co}`)}`;
+  }
+  const dom = extractEmailDomain(businessEmail);
+  if (!dom || isConsumerEmailDomain(dom)) return null;
+  return `ac_v1_dom_${dom}`;
+}
+
+export function deriveLeadContactKeyFromStoredRecord(record: {
+  lead_contact_key?: string;
+  outbound: { business_email: string; schema_version?: string };
+}): string {
+  if (record.lead_contact_key?.trim()) return record.lead_contact_key.trim();
+  return buildLeadContactKey(normalizeLeadEmail(record.outbound.business_email));
+}
+
+export function deriveLeadAccountKeyFromStoredRecord(record: {
+  lead_account_key?: string | null;
+  outbound: { company: string; business_email: string };
+}): string | null {
+  if (record.lead_account_key !== undefined) {
+    return record.lead_account_key;
+  }
+  return buildLeadAccountKey(record.outbound.company, record.outbound.business_email);
+}

--- a/frontend/src/lib/leadInboxMerge.test.ts
+++ b/frontend/src/lib/leadInboxMerge.test.ts
@@ -1,12 +1,24 @@
 import { describe, expect, it } from "vitest";
 
-import { mergeLeadsWithOps, sortInboxItems } from "@/lib/leadInboxMerge";
+import {
+  attachContactRollups,
+  mergeLeadsWithOps,
+  sortInboxItems,
+} from "@/lib/leadInboxMerge";
+import {
+  buildLeadAccountKey,
+  buildLeadContactKey,
+  normalizeLeadEmail,
+} from "@/lib/leadIdentity";
 import type { LeadAdminRow } from "@/lib/leadPersistence";
 import type { LeadOpsFile } from "@/lib/leadOpsTypes";
 import { LEAD_OUTBOUND_SCHEMA_VERSION } from "@/lib/leadOutbound";
 
 function baseRow(over: Partial<LeadAdminRow> & { lead_id: string }): LeadAdminRow {
   const created = "2026-04-01T12:00:00.000Z";
+  const email = "n@example.com";
+  const ck = buildLeadContactKey(normalizeLeadEmail(email));
+  const ak = buildLeadAccountKey("C", email);
   return {
     _kind: "lead_inquiry",
     lead_id: over.lead_id,
@@ -21,7 +33,7 @@ function baseRow(over: Partial<LeadAdminRow> & { lead_id: string }): LeadAdminRo
       source_page: "/kontakt",
       segment: "sonstiges",
       name: "N",
-      business_email: "n@example.com",
+      business_email: email,
       company: "C",
       message: "Hi",
       route: {
@@ -30,7 +42,19 @@ function baseRow(over: Partial<LeadAdminRow> & { lead_id: string }): LeadAdminRo
         priority: "low",
         sla_bucket: "standard",
       },
+      lead_contact_key: ck,
+      lead_account_key: ak,
+      contact_inquiry_sequence: 1,
+      contact_first_seen_at: created,
+      contact_latest_seen_at: created,
+      duplicate_hint: "none",
     },
+    lead_contact_key: ck,
+    lead_account_key: ak,
+    contact_inquiry_sequence: 1,
+    contact_first_seen_at: created,
+    contact_latest_seen_at: created,
+    duplicate_hint: "none",
     ...over,
   };
 }
@@ -69,5 +93,50 @@ describe("mergeLeadsWithOps", () => {
     const sorted = sortInboxItems(mergeLeadsWithOps(rows, ops));
     expect(sorted[0]?.lead_id).toBe("new-fail");
     expect(sorted[1]?.lead_id).toBe("old-ok");
+  });
+});
+
+describe("attachContactRollups", () => {
+  it("aggregates submission count for same email contact key", () => {
+    const ops: LeadOpsFile = { version: 1, entries: {} };
+    const email = "repeat@firma.de";
+    const ck = buildLeadContactKey(normalizeLeadEmail(email));
+    const ak = buildLeadAccountKey("Firma AG", email);
+    const r1 = baseRow({
+      lead_id: "l1",
+      created_at: "2026-04-01T10:00:00.000Z",
+      outbound: {
+        ...baseRow({ lead_id: "l1" }).outbound,
+        business_email: email,
+        company: "Firma AG",
+        lead_contact_key: ck,
+        lead_account_key: ak,
+      },
+      lead_contact_key: ck,
+      lead_account_key: ak,
+    });
+    const r2 = baseRow({
+      lead_id: "l2",
+      created_at: "2026-04-02T10:00:00.000Z",
+      outbound: {
+        ...baseRow({ lead_id: "l2" }).outbound,
+        business_email: email,
+        company: "Firma AG",
+        lead_contact_key: ck,
+        lead_account_key: ak,
+        duplicate_hint: "same_email_repeat",
+        contact_inquiry_sequence: 2,
+      },
+      lead_contact_key: ck,
+      lead_account_key: ak,
+      duplicate_hint: "same_email_repeat",
+      contact_inquiry_sequence: 2,
+    });
+    const allRows = [r1, r2];
+    const merged = mergeLeadsWithOps(allRows, ops);
+    const rolled = attachContactRollups(merged, allRows, ops);
+    const i2 = rolled.find((x) => x.lead_id === "l2");
+    expect(i2?.contact_submission_count).toBe(2);
+    expect(i2?.contact_inquiry_sequence).toBe(2);
   });
 });

--- a/frontend/src/lib/leadInboxMerge.ts
+++ b/frontend/src/lib/leadInboxMerge.ts
@@ -1,4 +1,8 @@
-import type { LeadInboxItem, LeadForwardingStatus } from "@/lib/leadInboxTypes";
+import {
+  deriveLeadAccountKeyFromStoredRecord,
+  deriveLeadContactKeyFromStoredRecord,
+} from "@/lib/leadIdentity";
+import type { LeadContactHistoryEntry, LeadInboxItem, LeadForwardingStatus } from "@/lib/leadInboxTypes";
 import type { LeadAdminRow } from "@/lib/leadPersistence";
 import type { LeadOpsFile } from "@/lib/leadOpsTypes";
 import { getOpsEntryForLead } from "@/lib/leadOpsSelectors";
@@ -9,12 +13,27 @@ function forwardingStatus(r: LeadAdminRow): LeadForwardingStatus {
   return "not_sent";
 }
 
+function rowNeedsAttention(r: LeadAdminRow, ops: LeadOpsFile): boolean {
+  const o = getOpsEntryForLead(ops, r.lead_id);
+  const fw = forwardingStatus(r);
+  return fw === "failed" || o.triage_status === "received";
+}
+
 export function mergeLeadsWithOps(rows: LeadAdminRow[], ops: LeadOpsFile): LeadInboxItem[] {
   return rows.map((r) => {
     const o = getOpsEntryForLead(ops, r.lead_id);
     const fw = forwardingStatus(r);
-    const needs_attention = fw === "failed" || o.triage_status === "received";
+    const needs_attention = rowNeedsAttention(r, ops);
     const ob = r.outbound;
+    const lead_contact_key = deriveLeadContactKeyFromStoredRecord(r);
+    const lead_account_key = deriveLeadAccountKeyFromStoredRecord(r);
+    const contact_inquiry_sequence =
+      r.contact_inquiry_sequence ?? ob.contact_inquiry_sequence ?? 0;
+    const contact_first_seen_at =
+      r.contact_first_seen_at ?? ob.contact_first_seen_at ?? r.created_at;
+    const contact_latest_seen_at =
+      r.contact_latest_seen_at ?? ob.contact_latest_seen_at ?? r.created_at;
+    const duplicate_hint = r.duplicate_hint ?? ob.duplicate_hint ?? "none";
     return {
       lead_id: r.lead_id,
       trace_id: r.trace_id,
@@ -40,6 +59,84 @@ export function mergeLeadsWithOps(rows: LeadAdminRow[], ops: LeadOpsFile): LeadI
       webhook_error: r.webhook_error,
       needs_attention,
       activities: o.activities,
+      lead_contact_key,
+      lead_account_key,
+      contact_inquiry_sequence,
+      contact_first_seen_at,
+      contact_latest_seen_at,
+      duplicate_hint,
+      contact_submission_count: 0,
+      contact_has_unresolved_repeat: false,
+      other_contacts_on_same_account: 0,
+      manual_related_lead_ids: o.manual_related_lead_ids,
+      duplicate_review: o.duplicate_review,
+    };
+  });
+}
+
+/**
+ * Rollups über den gesamten Store: Anzahl Submissions pro Kontakt, offene Dubletten, Account-Überlappung.
+ */
+export function attachContactRollups(
+  items: LeadInboxItem[],
+  allRows: LeadAdminRow[],
+  ops: LeadOpsFile,
+): LeadInboxItem[] {
+  const byContact = new Map<string, LeadAdminRow[]>();
+  const accountToContacts = new Map<string, Set<string>>();
+
+  for (const r of allRows) {
+    const ct = deriveLeadContactKeyFromStoredRecord(r);
+    const list = byContact.get(ct) ?? [];
+    list.push(r);
+    byContact.set(ct, list);
+    const ac = deriveLeadAccountKeyFromStoredRecord(r);
+    if (ac) {
+      const set = accountToContacts.get(ac) ?? new Set<string>();
+      set.add(ct);
+      accountToContacts.set(ac, set);
+    }
+  }
+
+  for (const [, group] of byContact) {
+    group.sort(
+      (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime(),
+    );
+  }
+
+  const sequenceByLeadId = new Map<string, number>();
+  for (const [, group] of byContact) {
+    group.forEach((row, idx) => {
+      sequenceByLeadId.set(row.lead_id, idx + 1);
+    });
+  }
+
+  const rollupUnresolved = new Map<string, boolean>();
+  for (const [ct, group] of byContact) {
+    const any = group.some((row) => rowNeedsAttention(row, ops));
+    rollupUnresolved.set(ct, any);
+  }
+
+  return items.map((item) => {
+    const group = byContact.get(item.lead_contact_key) ?? [];
+    const count = group.length;
+    const seqStored = item.contact_inquiry_sequence > 0;
+    const seq = seqStored ? item.contact_inquiry_sequence : (sequenceByLeadId.get(item.lead_id) ?? 1);
+    const unresolvedRepeat =
+      count > 1 && (rollupUnresolved.get(item.lead_contact_key) ?? false);
+    let otherOnAccount = 0;
+    if (item.lead_account_key) {
+      const set = accountToContacts.get(item.lead_account_key);
+      if (set) {
+        otherOnAccount = Math.max(0, set.size - 1);
+      }
+    }
+    return {
+      ...item,
+      contact_inquiry_sequence: seq,
+      contact_submission_count: count,
+      contact_has_unresolved_repeat: unresolvedRepeat,
+      other_contacts_on_same_account: otherOnAccount,
     };
   });
 }
@@ -50,5 +147,45 @@ export function sortInboxItems(items: LeadInboxItem[]): LeadInboxItem[] {
     const nb = b.needs_attention ? 0 : 1;
     if (na !== nb) return na - nb;
     return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+}
+
+export function buildContactHistoryItems(
+  focusLeadId: string,
+  allRows: LeadAdminRow[],
+  ops: LeadOpsFile,
+): LeadContactHistoryEntry[] {
+  const focus = allRows.find((r) => r.lead_id === focusLeadId);
+  if (!focus) return [];
+  const ct = deriveLeadContactKeyFromStoredRecord(focus);
+  const group = allRows
+    .filter((r) => deriveLeadContactKeyFromStoredRecord(r) === ct)
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+
+  const sequenceByLeadId = new Map<string, number>();
+  group.forEach((row, idx) => sequenceByLeadId.set(row.lead_id, idx + 1));
+
+  return group.map((r) => {
+    const o = getOpsEntryForLead(ops, r.lead_id);
+    const fw = forwardingStatus(r);
+    const ob = r.outbound;
+    return {
+      lead_id: r.lead_id,
+      trace_id: r.trace_id,
+      created_at: r.created_at,
+      pipeline_status: r.status,
+      forwarding_status: fw,
+      triage_status: o.triage_status,
+      owner: o.owner,
+      internal_note: o.internal_note,
+      source_page: ob.source_page,
+      segment: ob.segment,
+      message_preview: ob.message.slice(0, 200),
+      contact_inquiry_sequence:
+        r.contact_inquiry_sequence ?? ob.contact_inquiry_sequence ?? sequenceByLeadId.get(r.lead_id) ?? 1,
+      duplicate_hint: r.duplicate_hint ?? ob.duplicate_hint ?? "none",
+      duplicate_review: o.duplicate_review,
+      needs_attention: rowNeedsAttention(r, ops),
+    };
   });
 }

--- a/frontend/src/lib/leadInboxTypes.ts
+++ b/frontend/src/lib/leadInboxTypes.ts
@@ -1,5 +1,6 @@
 import type { LeadSegment } from "@/lib/leadCapture";
-import type { LeadOpsActivity } from "@/lib/leadOpsTypes";
+import type { LeadDuplicateHint } from "@/lib/leadIdentity";
+import type { LeadDuplicateReviewStatus, LeadOpsActivity } from "@/lib/leadOpsTypes";
 import type { LeadTriageStatus } from "@/lib/leadTriage";
 
 export type LeadForwardingStatus = "ok" | "failed" | "not_sent";
@@ -30,4 +31,37 @@ export type LeadInboxItem = {
   webhook_error?: string;
   needs_attention: boolean;
   activities: LeadOpsActivity[];
+  /** Wave 27 – Kontakt-/Account-Identität (Dedup-Vorbereitung). */
+  lead_contact_key: string;
+  lead_account_key: string | null;
+  /** Gespeichert oder nach Chronologie berechnet (attachContactRollups). */
+  contact_inquiry_sequence: number;
+  contact_first_seen_at: string;
+  contact_latest_seen_at: string;
+  duplicate_hint: LeadDuplicateHint;
+  contact_submission_count: number;
+  contact_has_unresolved_repeat: boolean;
+  /** Weitere distinct Kontakt-Keys derselben Account-Gruppe (Firma/Domain). */
+  other_contacts_on_same_account: number;
+  manual_related_lead_ids: string[];
+  duplicate_review: LeadDuplicateReviewStatus;
+};
+
+/** Timeline-Eintrag für Kontakt-Historie (Detail). */
+export type LeadContactHistoryEntry = {
+  lead_id: string;
+  trace_id: string;
+  created_at: string;
+  pipeline_status: string;
+  forwarding_status: LeadForwardingStatus;
+  triage_status: LeadTriageStatus;
+  owner: string;
+  internal_note: string;
+  source_page: string;
+  segment: LeadSegment;
+  message_preview: string;
+  contact_inquiry_sequence: number;
+  duplicate_hint: LeadDuplicateHint;
+  duplicate_review: LeadDuplicateReviewStatus;
+  needs_attention: boolean;
 };

--- a/frontend/src/lib/leadOpsSelectors.ts
+++ b/frontend/src/lib/leadOpsSelectors.ts
@@ -8,9 +8,24 @@ export function defaultLeadOpsEntry(): LeadOpsEntry {
     internal_note: "",
     updated_at: now,
     activities: [],
+    manual_related_lead_ids: [],
+    duplicate_review: "none",
+  };
+}
+
+/** Liest rohe Ops-Zeile aus Datei (ohne Defaults bei fehlenden Wave-27-Feldern). */
+export function coerceOpsEntry(raw: LeadOpsEntry | undefined): LeadOpsEntry {
+  if (!raw) return defaultLeadOpsEntry();
+  const d = defaultLeadOpsEntry();
+  return {
+    ...d,
+    ...raw,
+    manual_related_lead_ids: raw.manual_related_lead_ids ?? d.manual_related_lead_ids,
+    duplicate_review: raw.duplicate_review ?? d.duplicate_review,
+    activities: raw.activities ?? d.activities,
   };
 }
 
 export function getOpsEntryForLead(state: LeadOpsFile, leadId: string): LeadOpsEntry {
-  return state.entries[leadId] ?? defaultLeadOpsEntry();
+  return coerceOpsEntry(state.entries[leadId]);
 }

--- a/frontend/src/lib/leadOpsState.ts
+++ b/frontend/src/lib/leadOpsState.ts
@@ -4,11 +4,12 @@ import { dirname, join } from "path";
 import "server-only";
 
 import type {
+  LeadDuplicateReviewStatus,
   LeadOpsActivityAction,
   LeadOpsEntry,
   LeadOpsFile,
 } from "@/lib/leadOpsTypes";
-import { defaultLeadOpsEntry } from "@/lib/leadOpsSelectors";
+import { coerceOpsEntry } from "@/lib/leadOpsSelectors";
 import type { LeadTriageStatus } from "@/lib/leadTriage";
 
 const MAX_ACTIVITIES_PER_LEAD = 120;
@@ -50,19 +51,25 @@ function pushActivity(entry: LeadOpsEntry, action: LeadOpsActivityAction, detail
   entry.updated_at = at;
 }
 
+function sortedIds(ids: string[]): string {
+  return JSON.stringify([...ids].sort());
+}
+
 export async function mutateLeadOps(
   leadId: string,
   patch: {
     triage_status?: LeadTriageStatus;
     owner?: string;
     internal_note?: string;
+    manual_related_lead_ids?: string[];
+    duplicate_review?: LeadDuplicateReviewStatus;
   },
 ): Promise<{ entry: LeadOpsEntry; path: string; changed: boolean }> {
   const path = resolveOpsPath();
   await mkdir(dirname(path), { recursive: true });
 
   const state = await readLeadOpsState();
-  const prev = state.entries[leadId] ?? defaultLeadOpsEntry();
+  const prev = coerceOpsEntry(state.entries[leadId]);
   const nextOwner =
     patch.owner !== undefined ? patch.owner.trim().slice(0, 120) : prev.owner;
   const nextNote =
@@ -70,12 +77,19 @@ export async function mutateLeadOps(
       ? patch.internal_note.trim().slice(0, 4000)
       : prev.internal_note;
   const nextTriage = patch.triage_status ?? prev.triage_status;
+  const nextRelated =
+    patch.manual_related_lead_ids !== undefined
+      ? [...new Set(patch.manual_related_lead_ids.map((x) => x.trim()).filter(Boolean))].slice(0, 20)
+      : prev.manual_related_lead_ids;
+  const nextDupReview = patch.duplicate_review ?? prev.duplicate_review;
 
   const entry: LeadOpsEntry = {
     ...prev,
     triage_status: nextTriage,
     owner: nextOwner,
     internal_note: nextNote,
+    manual_related_lead_ids: nextRelated,
+    duplicate_review: nextDupReview,
     updated_at: prev.updated_at,
     activities: [...prev.activities],
   };
@@ -95,6 +109,25 @@ export async function mutateLeadOps(
   }
   if (patch.internal_note !== undefined && nextNote !== prev.internal_note) {
     pushActivity(entry, "internal_note_updated", "Notiz aktualisiert");
+    changed = true;
+  }
+  if (
+    patch.manual_related_lead_ids !== undefined &&
+    sortedIds(nextRelated) !== sortedIds(prev.manual_related_lead_ids)
+  ) {
+    pushActivity(
+      entry,
+      "manual_related_leads_updated",
+      nextRelated.length ? nextRelated.join(", ") : "(leer)",
+    );
+    changed = true;
+  }
+  if (patch.duplicate_review !== undefined && patch.duplicate_review !== prev.duplicate_review) {
+    pushActivity(
+      entry,
+      "duplicate_review_updated",
+      `${prev.duplicate_review} → ${patch.duplicate_review}`,
+    );
     changed = true;
   }
 
@@ -118,7 +151,7 @@ export async function appendLeadOpsActivity(
   const path = resolveOpsPath();
   await mkdir(dirname(path), { recursive: true });
   const state = await readLeadOpsState();
-  const prev = state.entries[leadId] ?? defaultLeadOpsEntry();
+  const prev = coerceOpsEntry(state.entries[leadId]);
   pushActivity(prev, action, detail);
   state.entries[leadId] = prev;
   const tmp = `${path}.tmp`;

--- a/frontend/src/lib/leadOpsTypes.ts
+++ b/frontend/src/lib/leadOpsTypes.ts
@@ -1,11 +1,18 @@
 import type { LeadTriageStatus } from "@/lib/leadTriage";
 
+/** Manuelle Dubletten-Einordnung (kein automatischer Merge). */
+export type LeadDuplicateReviewStatus = "none" | "suggested" | "confirmed";
+
 export type LeadOpsActivityAction =
   | "triage_status_changed"
   | "owner_set"
   | "internal_note_updated"
   | "forward_retried"
-  | "ops_touch";
+  | "ops_touch"
+  | "contact_repeat_detected"
+  | "manual_related_leads_updated"
+  | "duplicate_review_updated"
+  | "possible_duplicate_noted";
 
 export type LeadOpsActivity = {
   at: string;
@@ -19,6 +26,9 @@ export type LeadOpsEntry = {
   internal_note: string;
   updated_at: string;
   activities: LeadOpsActivity[];
+  /** Verknüpfung zu anderen Anfrage-IDs (manuell). */
+  manual_related_lead_ids: string[];
+  duplicate_review: LeadDuplicateReviewStatus;
 };
 
 export type LeadOpsFile = {

--- a/frontend/src/lib/leadOutbound.ts
+++ b/frontend/src/lib/leadOutbound.ts
@@ -1,15 +1,18 @@
 import type { LeadSegment } from "@/lib/leadCapture";
+import type { LeadDuplicateHint } from "@/lib/leadIdentity";
 import type { LeadRoute } from "@/lib/leadRouting";
 
 /** Stabile Webhook-/CRM-Version – bei Breaking Changes hochzählen. */
-export const LEAD_OUTBOUND_SCHEMA_VERSION = "1.0" as const;
+export const LEAD_OUTBOUND_SCHEMA_VERSION = "1.1" as const;
+
+export type LeadOutboundSchemaVersion = "1.0" | "1.1";
 
 /**
- * n8n-/CRM-freundlicher Outbound-Vertrag (Wave 25).
- * Felder stabil halten; neue optionale Keys sind OK, Umbenennungen nur mit Version bump.
+ * n8n-/CRM-freundlicher Outbound-Vertrag (Wave 25, erweitert Wave 27).
+ * Neue Anfragen nutzen `1.1` inkl. Identity-Feldern; ältere JSONL-Zeilen können `1.0` sein.
  */
 export type LeadOutboundPayloadV1 = {
-  schema_version: typeof LEAD_OUTBOUND_SCHEMA_VERSION;
+  schema_version: LeadOutboundSchemaVersion;
   lead_id: string;
   trace_id: string;
   timestamp: string;
@@ -25,6 +28,22 @@ export type LeadOutboundPayloadV1 = {
     priority: LeadRoute["priority"];
     sla_bucket: LeadRoute["sla_bucket"];
   };
+  /** Wave 27 – nur bei schema_version 1.1 gesetzt (CRM/n8n Dedup-Vorbereitung). */
+  lead_contact_key?: string;
+  lead_account_key?: string | null;
+  contact_inquiry_sequence?: number;
+  contact_first_seen_at?: string;
+  contact_latest_seen_at?: string;
+  duplicate_hint?: LeadDuplicateHint;
+};
+
+export type LeadOutboundIdentitySnapshot = {
+  lead_contact_key: string;
+  lead_account_key: string | null;
+  contact_inquiry_sequence: number;
+  contact_first_seen_at: string;
+  contact_latest_seen_at: string;
+  duplicate_hint: LeadDuplicateHint;
 };
 
 export function buildLeadOutboundPayload(input: {
@@ -37,12 +56,16 @@ export function buildLeadOutboundPayload(input: {
   company: string;
   message: string;
   route: LeadRoute;
+  identity: LeadOutboundIdentitySnapshot;
+  /** Optional: gleicher Zeitstempel wie JSONL-Zeile (Persistenz/Webhook konsistent). */
+  timestamp?: string;
 }): LeadOutboundPayloadV1 {
+  const { identity } = input;
   return {
     schema_version: LEAD_OUTBOUND_SCHEMA_VERSION,
     lead_id: input.lead_id,
     trace_id: input.trace_id,
-    timestamp: new Date().toISOString(),
+    timestamp: input.timestamp ?? new Date().toISOString(),
     source_page: input.source_page,
     segment: input.segment,
     name: input.name,
@@ -55,5 +78,11 @@ export function buildLeadOutboundPayload(input: {
       priority: input.route.priority,
       sla_bucket: input.route.sla_bucket,
     },
+    lead_contact_key: identity.lead_contact_key,
+    lead_account_key: identity.lead_account_key,
+    contact_inquiry_sequence: identity.contact_inquiry_sequence,
+    contact_first_seen_at: identity.contact_first_seen_at,
+    contact_latest_seen_at: identity.contact_latest_seen_at,
+    duplicate_hint: identity.duplicate_hint,
   };
 }

--- a/frontend/src/lib/leadPersistence.ts
+++ b/frontend/src/lib/leadPersistence.ts
@@ -1,6 +1,11 @@
 import { appendFile, mkdir, readFile } from "fs/promises";
 import { dirname, join } from "path";
 
+import {
+  deriveLeadAccountKeyFromStoredRecord,
+  deriveLeadContactKeyFromStoredRecord,
+} from "@/lib/leadIdentity";
+import type { LeadDuplicateHint } from "@/lib/leadIdentity";
 import type { LeadOutboundPayloadV1 } from "@/lib/leadOutbound";
 
 export type LeadStoreStatus = "received" | "forwarded" | "failed" | "reviewed";
@@ -14,6 +19,13 @@ export type LeadStoreRecord = {
   forwarded_at?: string;
   webhook_error?: string;
   outbound: LeadOutboundPayloadV1;
+  /** Wave 27 – gespiegelt für schnelle JSONL-Scans (auch in outbound 1.1). */
+  lead_contact_key?: string;
+  lead_account_key?: string | null;
+  contact_inquiry_sequence?: number;
+  contact_first_seen_at?: string;
+  contact_latest_seen_at?: string;
+  duplicate_hint?: LeadDuplicateHint;
 };
 
 export type LeadWebhookResultLine = {
@@ -52,9 +64,7 @@ export type LeadAdminRow = LeadStoreRecord & {
   webhook_error?: string;
 };
 
-/** Liest JSONL und führt Basis-Events pro lead_id zusammen (Admin-Ansicht). */
-export async function readRecentLeadRecordsMerged(maxRecords: number): Promise<LeadAdminRow[]> {
-  const path = resolveStorePath();
+async function mergeAllLeadAdminRowsFromPath(path: string): Promise<LeadAdminRow[]> {
   try {
     const raw = await readFile(path, "utf8");
     const lines = raw.trim().split("\n").filter(Boolean);
@@ -82,13 +92,47 @@ export async function readRecentLeadRecordsMerged(maxRecords: number): Promise<L
         }
       }
     }
-    const list = Array.from(byId.values()).sort(
+    return Array.from(byId.values()).sort(
       (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
     );
-    return list.slice(0, maxRecords);
   } catch {
     return [];
   }
+}
+
+/** Alle Anfragen (für Kontakt-Rollups / Historie). */
+export async function readAllLeadRecordsMerged(): Promise<LeadAdminRow[]> {
+  return mergeAllLeadAdminRowsFromPath(resolveStorePath());
+}
+
+export function computeContactKeyStatsFromRows(
+  all: LeadAdminRow[],
+  contactKey: string,
+): { prior_count: number; first_seen_at: string | null; prior_lead_ids: string[] } {
+  const matching = all
+    .filter((r) => deriveLeadContactKeyFromStoredRecord(r) === contactKey)
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+  return {
+    prior_count: matching.length,
+    first_seen_at: matching[0]?.created_at ?? null,
+    prior_lead_ids: matching.map((m) => m.lead_id),
+  };
+}
+
+/** Andere Kontakt-Keys unter derselben Account-Gruppe (Firma/Domain) – nur Hinweis, kein Merge. */
+export function countOtherContactKeysOnAccount(
+  all: LeadAdminRow[],
+  accountKey: string | null,
+  excludeContactKey: string,
+): number {
+  if (!accountKey) return 0;
+  const set = new Set<string>();
+  for (const r of all) {
+    if (deriveLeadAccountKeyFromStoredRecord(r) !== accountKey) continue;
+    set.add(deriveLeadContactKeyFromStoredRecord(r));
+  }
+  set.delete(excludeContactKey);
+  return set.size;
 }
 
 /** Liest die gesamte JSONL und liefert die erste passende `lead_inquiry`-Zeile (Outbound inkl.). */


### PR DESCRIPTION
- lead_contact_key / lead_account_key, sequence, first/last seen, duplicate_hint
- Outbound schema 1.1; ingest audits (repeat + possible account peers)
- Admin rollups, filters repeated_contacts / unresolved_repeated, contact_history
- PATCH manual_related_lead_ids, duplicate_review; coerceOpsEntry for legacy ops
- Docs wave27; wave25 payload table 1.1; wave26 link

Made-with: Cursor