### PR TITLE
feat(gtm): Wave 28 lead sync framework

### DIFF
--- a/docs/gtm/wave28-lead-sync-framework.md
+++ b/docs/gtm/wave28-lead-sync-framework.md
@@ -1,0 +1,96 @@
+# Wave 28 – Lead-Sync-Framework (GTM Downstream)
+
+Ziel: Zuverlässiger, nachvollziehbarer Push von Lead-/Inquiry-Daten zu **n8n** und vorbereiteten **CRM-Abstraktionen** (HubSpot / Pipedrive als Stubs), getrennt vom Rohdatensatz `lead_inquiry` und vom Legacy-Inbound-Webhook (Wave 25).
+
+## Überblick
+
+- **Persistierte Sync-Jobs** pro Ziel (`LeadSyncJob`) mit Status, Versuchen, Idempotency-Key und optionalem Payload-Snapshot für stabile Retries.
+- **Dispatcher** erzeugt Jobs bei Ingest (`POST /api/lead-inquiry`), verarbeitet Pending-Jobs mit Backoff und Dead-Letter nach N Versuchen.
+- **Ops-Sicht** in der internen Lead-Inbox: Status pro Ziel, Fehler, manueller Retry.
+- **Aktivitäts-Log** (`lead_ops`): `lead_sync_job_created`, `lead_sync_sent`, `lead_sync_failed`, `lead_sync_retried`, `lead_sync_dead_letter`.
+
+Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md).
+
+## Job-Modell (`LeadSyncJob`)
+
+| Feld | Bedeutung |
+|------|-----------|
+| `job_id` | UUID |
+| `lead_id` | Verknüpfung zur Inquiry |
+| `lead_contact_key` | Kontext für CRM-Upsert (E-Mail-Schlüssel) |
+| `target` | `n8n_webhook` \| `hubspot_stub` \| `pipedrive_stub` |
+| `payload_version` | z. B. `1.0` (Sync-Payload-Schema) |
+| `status` | `pending` → `retrying` / `sent` / `failed` → ggf. `dead_letter` |
+| `attempt_count` | Anzahl Versuche |
+| `idempotency_key` | deterministisch (siehe unten) |
+| `created_at` / `updated_at` | ISO |
+| `last_attempt_at`, `last_error`, `last_http_status` | Observability |
+| `next_retry_at` | Backoff |
+| `mock_result` | strukturiertes Stub-Ergebnis (keine Secrets) |
+| `payload_snapshot` | fixierter JSON-Payload pro Job (nur Server-Store, API redacted) |
+
+Speicher: JSON-Datei (Standard `data/lead-inquiries/sync-jobs.json`), überschreibbar mit `LEAD_SYNC_JOBS_STORE_PATH` (z. B. für Vercel `/tmp/...`).
+
+## Payload-Vertrag (`LeadSyncPayloadV1`, Schema `1.0`)
+
+Snake_case, stabil für n8n/CRM:
+
+- **Inquiry:** `lead_id`, `trace_id`, `created_at`, `source_page`, `segment`, `name`, `business_email`, `company`, `message`, `route` (Key, Queue, Priorität, SLA).
+- **Kontakt-Rollup:** `lead_contact_key`, `lead_account_key`, `contact_inquiry_sequence`, `contact_first_seen_at`, `contact_latest_seen_at`, `contact_submission_count`, `duplicate_hint`.
+- **Ops:** `triage_status`, `owner`, `pipeline_status`, `forwarding_status`.
+- **Legacy-Hinweis:** `legacy_inbound_webhook_delivery` (`forwarded` \| `stored` \| `stored_forward_failed` \| `not_configured`).
+
+Implementierung: `frontend/src/lib/leadSyncPayload.ts`, Typen: `frontend/src/lib/leadSyncTypes.ts`.
+
+## Idempotency
+
+```
+computeLeadSyncIdempotencyKey(target, lead_id, payload_version, material_revision)
+→ SHA-256-Prefix, Präfix `idem_`
+```
+
+Bei Ingest ist `material_revision` aktuell `ingest:<created_at_iso>` der Inquiry (immutable). **Gleicher Lead + gleiche Revision + gleicher Target** → gleicher Key → ein logischer Job pro Ziel (Dedup im Store über `idempotency_index`).
+
+**Re-Sync bei inhaltlicher Änderung** (später): neue `material_revision` (z. B. `triage:<updated_at>`) erzeugt neuen Key und einen neuen Job – explizit, nicht „magisch“.
+
+## Upsert-Semantik (konzeptionell)
+
+Downstream wird modelliert als:
+
+1. **Kontakt upserten** anhand Geschäfts-E-Mail / `lead_contact_key`.
+2. **Inquiry / Notiz / Aktivität** anlegen oder anhängen.
+3. **Letzte Sichtung / Sequenz** aktualisieren (`contact_latest_seen_at`, `contact_submission_count`, … im Payload).
+
+Stubs (`hubspot_stub`, `pipedrive_stub`) mappen den Payload in ein lokales, strukturiertes `mock_result` (kein echter API-Call).
+
+## Retry & Dead Letter
+
+- Konstante `LEAD_SYNC_MAX_ATTEMPTS` (6): nach Überschreiten → `dead_letter`.
+- Backoff zwischen Versuchen (Dispatcher).
+- **Manueller Retry** (Admin): setzt Job auf `pending`, setzt Zähler zurück, verarbeitet sofort; Ops-Eintrag `lead_sync_retried`.
+
+## Ziele (Connectors)
+
+| Target | Aktivierung | Verhalten |
+|--------|-------------|-----------|
+| `n8n_webhook` | `LEAD_SYNC_N8N_URL` gesetzt; optional `LEAD_SYNC_N8N_SECRET` (Bearer) | HTTP POST mit JSON-Payload, Status/Errors am Job |
+| `hubspot_stub` | `LEAD_SYNC_HUBSPOT_STUB=1` | Lokales Mock-Upsert + Notiz |
+| `pipedrive_stub` | `LEAD_SYNC_PIPEDRIVE_STUB=1` | Lokales Mock-Upsert + Aktivität |
+
+## APIs (intern)
+
+- `GET /api/admin/lead-inquiries/[leadId]` – enthält `sync_jobs` (ohne `payload_snapshot`).
+- `POST /api/admin/lead-inquiries/[leadId]/sync-retry` – Body `{ "job_id": "<uuid>" }`.
+- `POST /api/admin/lead-sync/process` – Body optional `{ "limit": 25 }` – Worker/Cron zum Abarbeiten der Warteschlange (gleiche Auth wie Lead-Admin).
+
+## Migration: Webhook-only → CRM-Sync
+
+1. **Weiter** `LEAD_INBOUND_WEBHOOK_URL` für bestehende Automationen; das Sync-Payload-Feld `legacy_inbound_webhook_delivery` dokumentiert den Zustand.
+2. **Parallel** `LEAD_SYNC_N8N_URL` setzen: n8n empfängt den strukturierten **Wave-28-Payload** und kann in CRMs schreiben (oder nur enrich/loggen).
+3. Stubs aktivieren zum Testen der Pipeline ohne API-Keys.
+4. Später: `hubspot_stub` / `pipedrive_stub` durch echte Connectors ersetzen (gleiche Job-/Payload-Schicht, andere `runLeadSyncConnector`-Zweige).
+
+## Nicht-Ziele
+
+- Keine vollständige CRM-Integrationsplattform.
+- Keine Änderung des öffentlichen Kontaktformulars außerhalb der bestehenden Ingest-Pipeline.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -43,3 +43,4 @@ next-env.d.ts
 # Lead store (JSONL, lokal / tmp – Ordner via .gitkeep)
 /data/lead-inquiries/*.jsonl
 /data/lead-inquiries/ops-state.json
+/data/lead-inquiries/sync-jobs.json

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
@@ -14,6 +14,8 @@ import {
   getMergedLeadAdminRow,
   readAllLeadRecordsMerged,
 } from "@/lib/leadPersistence";
+import { redactLeadSyncJobForApi } from "@/lib/leadSyncDispatcher";
+import { listLeadSyncJobsForLead } from "@/lib/leadSyncStore";
 
 export const runtime = "nodejs";
 
@@ -43,8 +45,10 @@ export async function GET(req: Request, ctx: { params: Promise<{ leadId: string 
   const merged = mergeLeadsWithOps([row], ops);
   const item = attachContactRollups(merged, allRows, ops)[0] ?? merged[0]!;
   const contact_history = buildContactHistoryItems(leadId, allRows, ops);
+  const sync_jobs_raw = await listLeadSyncJobsForLead(leadId);
+  const sync_jobs = sync_jobs_raw.map(redactLeadSyncJobForApi);
 
-  return NextResponse.json({ ok: true, item, contact_history });
+  return NextResponse.json({ ok: true, item, contact_history, sync_jobs });
 }
 
 type PatchBody = {

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/sync-retry/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/sync-retry/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+import { manualRetryLeadSyncJob, redactLeadSyncJobForApi } from "@/lib/leadSyncDispatcher";
+import { getLeadSyncJobById } from "@/lib/leadSyncStore";
+
+export const runtime = "nodejs";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function POST(req: Request, ctx: { params: Promise<{ leadId: string }> }) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const { leadId } = await ctx.params;
+  let body: { job_id?: string } = {};
+  try {
+    body = (await req.json()) as { job_id?: string };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const jobId = typeof body.job_id === "string" ? body.job_id.trim() : "";
+  if (!jobId || !UUID_RE.test(jobId)) {
+    return NextResponse.json({ error: "validation" }, { status: 400 });
+  }
+
+  const job = await getLeadSyncJobById(jobId);
+  if (!job || job.lead_id !== leadId) {
+    return NextResponse.json({ error: "not_found" }, { status: 404 });
+  }
+
+  const updated = await manualRetryLeadSyncJob(jobId);
+  return NextResponse.json({
+    ok: true,
+    job: updated ? redactLeadSyncJobForApi(updated) : null,
+  });
+}

--- a/frontend/src/app/api/admin/lead-sync/process/route.ts
+++ b/frontend/src/app/api/admin/lead-sync/process/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+import { processPendingLeadSyncJobs } from "@/lib/leadSyncDispatcher";
+
+export const runtime = "nodejs";
+
+/** Warteschlange abarbeiten (Cron oder manuell). */
+export async function POST(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let limit = 25;
+  try {
+    const body = (await req.json()) as { limit?: number };
+    if (typeof body.limit === "number" && Number.isFinite(body.limit)) {
+      limit = Math.min(200, Math.max(1, Math.floor(body.limit)));
+    }
+  } catch {
+    /* empty body ok */
+  }
+
+  const processed = await processPendingLeadSyncJobs(limit);
+  return NextResponse.json({ ok: true, processed });
+}

--- a/frontend/src/app/api/lead-inquiry/route.ts
+++ b/frontend/src/app/api/lead-inquiry/route.ts
@@ -23,6 +23,11 @@ import {
   type LeadStoreRecord,
 } from "@/lib/leadPersistence";
 import { appendLeadOpsActivity } from "@/lib/leadOpsState";
+import type { LegacyInboundDelivery } from "@/lib/leadSyncPayload";
+import {
+  enqueueLeadSyncAfterIngest,
+  processLeadSyncJobById,
+} from "@/lib/leadSyncDispatcher";
 import { getClientIp, checkLeadIpRateLimit } from "@/lib/leadRateLimit";
 import { determineLeadRoute } from "@/lib/leadRouting";
 
@@ -220,6 +225,7 @@ export async function POST(req: Request) {
   const webhook = process.env.LEAD_INBOUND_WEBHOOK_URL?.trim();
   let delivery: "forwarded" | "stored" | "stored_forward_failed" = "stored";
   let delivery_note_de: string | undefined;
+  let legacyInboundDelivery: LegacyInboundDelivery = "not_configured";
 
   if (webhook) {
     const wh = await dispatchLeadWebhook(webhook, outbound, 3);
@@ -248,6 +254,24 @@ export async function POST(req: Request) {
       });
       console.warn("[lead-webhook]", JSON.stringify({ trace_id, lead_id, ok: false, err: wh.error }));
     }
+    legacyInboundDelivery =
+      delivery === "forwarded"
+        ? "forwarded"
+        : delivery === "stored_forward_failed"
+          ? "stored_forward_failed"
+          : "stored";
+  }
+
+  try {
+    const jobIds = await enqueueLeadSyncAfterIngest({
+      lead_id,
+      legacyInboundDelivery,
+    });
+    for (const jid of jobIds) {
+      await processLeadSyncJobById(jid);
+    }
+  } catch (e) {
+    console.warn("[lead-sync] enqueue_process_failed", e);
   }
 
   return NextResponse.json({

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
 import type { LeadContactHistoryEntry, LeadInboxItem } from "@/lib/leadInboxTypes";
+import type { LeadSyncJobApi } from "@/lib/leadSyncTypes";
 import { LEAD_TRIAGE_LABELS_DE, LEAD_TRIAGE_STATUSES } from "@/lib/leadTriage";
 
 type Props = {
@@ -23,6 +24,20 @@ const DUPLICATE_REVIEW_LABELS: Record<LeadInboxItem["duplicate_review"], string>
   confirmed: "Zusammenhang bestätigt (manuell)",
 };
 
+const SYNC_TARGET_LABELS: Record<LeadSyncJobApi["target"], string> = {
+  n8n_webhook: "n8n (Webhook)",
+  hubspot_stub: "HubSpot (Stub)",
+  pipedrive_stub: "Pipedrive (Stub)",
+};
+
+function syncStatusLabel(s: LeadSyncJobApi["status"]): string {
+  if (s === "pending") return "Ausstehend";
+  if (s === "retrying") return "Wiederholung";
+  if (s === "sent") return "Gesendet";
+  if (s === "failed") return "Fehlgeschlagen";
+  return "Dead Letter";
+}
+
 type PatchBody = {
   triage_status?: string;
   owner?: string;
@@ -41,7 +56,9 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [detailItem, setDetailItem] = useState<LeadInboxItem | null>(null);
   const [contactHistory, setContactHistory] = useState<LeadContactHistoryEntry[]>([]);
+  const [syncJobs, setSyncJobs] = useState<LeadSyncJobApi[]>([]);
   const [detailLoading, setDetailLoading] = useState(false);
+  const [syncRetryingId, setSyncRetryingId] = useState<string | null>(null);
   const [filters, setFilters] = useState({
     triage_status: "",
     segment: "",
@@ -128,6 +145,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     if (!selectedId || authed !== true) {
       setDetailItem(null);
       setContactHistory([]);
+      setSyncJobs([]);
       return;
     }
     let cancelled = false;
@@ -138,12 +156,14 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
         return (await r.json()) as {
           item?: LeadInboxItem;
           contact_history?: LeadContactHistoryEntry[];
+          sync_jobs?: LeadSyncJobApi[];
         };
       })
       .then((data) => {
         if (cancelled || !data) return;
         if (data.item) setDetailItem(data.item);
         if (data.contact_history) setContactHistory(data.contact_history);
+        setSyncJobs(Array.isArray(data.sync_jobs) ? data.sync_jobs : []);
       })
       .finally(() => {
         if (!cancelled) setDetailLoading(false);
@@ -186,6 +206,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     setSelectedId(null);
     setDetailItem(null);
     setContactHistory([]);
+    setSyncJobs([]);
   }
 
   function parseRelatedIds(raw: string): string[] {
@@ -229,6 +250,41 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
       setActionMsg("Netzwerkfehler beim Speichern.");
     } finally {
       setSaving(false);
+    }
+  }
+
+  async function retryLeadSyncJob(leadId: string, jobId: string) {
+    setSyncRetryingId(jobId);
+    setActionMsg(null);
+    try {
+      const r = await fetch(`/api/admin/lead-inquiries/${leadId}/sync-retry`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ job_id: jobId }),
+      });
+      const data = (await r.json()) as { ok?: boolean; job?: LeadSyncJobApi | null };
+      if (!r.ok) {
+        setActionMsg("Sync-Retry fehlgeschlagen.");
+        return;
+      }
+      if (data.job) {
+        setSyncJobs((prev) => {
+          const rest = prev.filter((j) => j.job_id !== data.job!.job_id);
+          return [...rest, data.job!].sort((a, b) => a.target.localeCompare(b.target));
+        });
+      }
+      const detailR = await fetch(`/api/admin/lead-inquiries/${leadId}`, { credentials: "include" });
+      if (detailR.ok) {
+        const d = (await detailR.json()) as { item?: LeadInboxItem; sync_jobs?: LeadSyncJobApi[] };
+        if (d.item && selectedId === leadId) setDetailItem(d.item);
+        if (Array.isArray(d.sync_jobs) && selectedId === leadId) setSyncJobs(d.sync_jobs);
+      }
+      setActionMsg("Sync-Job erneut ausgeführt.");
+    } catch {
+      setActionMsg("Netzwerkfehler beim Sync-Retry.");
+    } finally {
+      setSyncRetryingId(null);
     }
   }
 
@@ -597,6 +653,67 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 </li>
               ))}
             </ul>
+          </div>
+
+          <div className="mt-6 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-medium text-slate-800">GTM-Sync (Wave 28)</h3>
+            <p className="mt-1 text-xs text-slate-500">
+              Status pro Ziel (n8n / CRM-Stubs). Ohne konfigurierte Ziele entstehen keine Jobs.
+            </p>
+            {syncJobs.length === 0 ? (
+              <p className="mt-2 text-sm text-slate-500">Keine Sync-Jobs für diesen Lead.</p>
+            ) : (
+              <div className="mt-3 overflow-x-auto rounded-lg border border-slate-200">
+                <table className="w-full min-w-[640px] border-collapse text-left text-xs">
+                  <thead className="border-b border-slate-200 bg-slate-50 text-slate-600">
+                    <tr>
+                      <th className="px-2 py-2 font-medium">Ziel</th>
+                      <th className="px-2 py-2 font-medium">Status</th>
+                      <th className="px-2 py-2 font-medium">Versuche</th>
+                      <th className="px-2 py-2 font-medium">Letzter Versuch</th>
+                      <th className="px-2 py-2 font-medium">Nächster Retry</th>
+                      <th className="px-2 py-2 font-medium">Fehler</th>
+                      <th className="px-2 py-2 font-medium" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {syncJobs.map((j) => (
+                      <tr key={j.job_id} className="border-b border-slate-100">
+                        <td className="px-2 py-2 text-slate-800">{SYNC_TARGET_LABELS[j.target]}</td>
+                        <td className="px-2 py-2">{syncStatusLabel(j.status)}</td>
+                        <td className="px-2 py-2 font-mono">{j.attempt_count}</td>
+                        <td className="px-2 py-2 text-slate-600">
+                          {j.last_attempt_at
+                            ? new Date(j.last_attempt_at).toLocaleString("de-DE")
+                            : "—"}
+                        </td>
+                        <td className="px-2 py-2 text-slate-600">
+                          {j.next_retry_at ? new Date(j.next_retry_at).toLocaleString("de-DE") : "—"}
+                        </td>
+                        <td className="max-w-[200px] truncate px-2 py-2 text-red-700" title={j.last_error}>
+                          {j.last_error ?? "—"}
+                        </td>
+                        <td className="px-2 py-2">
+                          {j.status === "failed" ||
+                          j.status === "dead_letter" ||
+                          j.status === "pending" ||
+                          j.status === "retrying" ? (
+                            <button
+                              type="button"
+                              disabled={syncRetryingId === j.job_id}
+                              className="text-cyan-700 underline disabled:opacity-50"
+                              onClick={() => void retryLeadSyncJob(displayLead.lead_id, j.job_id)}
+                            >
+                              {syncRetryingId === j.job_id ? "…" : "Retry"}
+                            </button>
+                          ) : null}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
           </div>
 
           <div className="mt-4 grid gap-4 md:grid-cols-2">

--- a/frontend/src/lib/leadOpsTypes.ts
+++ b/frontend/src/lib/leadOpsTypes.ts
@@ -12,7 +12,12 @@ export type LeadOpsActivityAction =
   | "contact_repeat_detected"
   | "manual_related_leads_updated"
   | "duplicate_review_updated"
-  | "possible_duplicate_noted";
+  | "possible_duplicate_noted"
+  | "lead_sync_job_created"
+  | "lead_sync_sent"
+  | "lead_sync_failed"
+  | "lead_sync_retried"
+  | "lead_sync_dead_letter";
 
 export type LeadOpsActivity = {
   at: string;

--- a/frontend/src/lib/leadSyncConnectors.ts
+++ b/frontend/src/lib/leadSyncConnectors.ts
@@ -1,0 +1,122 @@
+import "server-only";
+
+import type { LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
+
+export type ConnectorResult = {
+  ok: boolean;
+  http_status?: number;
+  error?: string;
+  mock_result?: unknown;
+};
+
+const N8N_TIMEOUT_MS = 25_000;
+
+export async function runLeadSyncConnector(
+  target: LeadSyncTarget,
+  payload: LeadSyncPayloadV1,
+): Promise<ConnectorResult> {
+  switch (target) {
+    case "n8n_webhook":
+      return runN8nWebhookConnector(payload);
+    case "hubspot_stub":
+      return runHubspotStubConnector(payload);
+    case "pipedrive_stub":
+      return runPipedriveStubConnector(payload);
+    default:
+      return { ok: false, error: "unknown_target" };
+  }
+}
+
+async function runN8nWebhookConnector(payload: LeadSyncPayloadV1): Promise<ConnectorResult> {
+  const url = process.env.LEAD_SYNC_N8N_URL?.trim();
+  if (!url) {
+    return { ok: false, error: "n8n_url_not_configured" };
+  }
+  try {
+    const controller = new AbortController();
+    const t = setTimeout(() => controller.abort(), N8N_TIMEOUT_MS);
+    const secret = process.env.LEAD_SYNC_N8N_SECRET?.trim();
+    const r = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(secret ? { Authorization: `Bearer ${secret}` } : {}),
+      },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    clearTimeout(t);
+    if (r.ok) {
+      return { ok: true, http_status: r.status, mock_result: { target: "n8n_webhook", status: r.status } };
+    }
+    const errText = await r.text().catch(() => "");
+    return {
+      ok: false,
+      http_status: r.status,
+      error: `http_${r.status}${errText ? ` ${errText.slice(0, 200)}` : ""}`,
+    };
+  } catch (e) {
+    return {
+      ok: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+/**
+ * Konzept: Upsert Kontakt per E-Mail / contact_key, Notiz pro Inquiry anhängen.
+ */
+function runHubspotStubConnector(payload: LeadSyncPayloadV1): ConnectorResult {
+  const conceptual = {
+    system: "hubspot_stub",
+    upsert_contact: {
+      match_by: "email_and_external_id",
+      email: payload.business_email,
+      external_contact_key: payload.lead_contact_key,
+      properties: {
+        company: payload.company,
+        last_seen: payload.contact_latest_seen_at,
+        inquiry_count: payload.contact_submission_count,
+      },
+    },
+    append_timeline: {
+      type: "note",
+      body_preview: payload.message.slice(0, 500),
+      lead_id: payload.lead_id,
+      trace_id: payload.trace_id,
+    },
+    idempotency_key: payload.idempotency_key,
+  };
+  return {
+    ok: true,
+    http_status: 200,
+    mock_result: conceptual,
+  };
+}
+
+/**
+ * Konzept: Person + Deal-Notiz / Aktivität.
+ */
+function runPipedriveStubConnector(payload: LeadSyncPayloadV1): ConnectorResult {
+  const conceptual = {
+    system: "pipedrive_stub",
+    upsert_person: {
+      email: payload.business_email,
+      name: payload.name,
+      org_name: payload.company,
+      custom_field_contact_key: payload.lead_contact_key,
+    },
+    add_activity: {
+      type: "note",
+      subject: `Lead inquiry ${payload.lead_id.slice(0, 8)}`,
+      lead_id: payload.lead_id,
+      sequence: payload.contact_inquiry_sequence,
+    },
+    idempotency_key: payload.idempotency_key,
+  };
+  return {
+    ok: true,
+    http_status: 200,
+    mock_result: conceptual,
+  };
+}

--- a/frontend/src/lib/leadSyncDispatcher.ts
+++ b/frontend/src/lib/leadSyncDispatcher.ts
@@ -1,0 +1,221 @@
+import "server-only";
+
+import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import { appendLeadOpsActivity, readLeadOpsState } from "@/lib/leadOpsState";
+import {
+  buildLeadSyncPayloadV1,
+  computeLeadSyncIdempotencyKey,
+  defaultMaterialRevisionForIngest,
+  LEAD_SYNC_PAYLOAD_VERSION,
+  type LegacyInboundDelivery,
+} from "@/lib/leadSyncPayload";
+import { runLeadSyncConnector } from "@/lib/leadSyncConnectors";
+import {
+  ensureLeadSyncJob,
+  getLeadSyncJobById,
+  listProcessableLeadSyncJobs,
+  updateLeadSyncJob,
+} from "@/lib/leadSyncStore";
+import type { LeadSyncJob, LeadSyncJobApi, LeadSyncTarget } from "@/lib/leadSyncTypes";
+import { getMergedLeadAdminRow, readAllLeadRecordsMerged } from "@/lib/leadPersistence";
+
+export const LEAD_SYNC_MAX_ATTEMPTS = 6;
+
+export function getEnabledLeadSyncTargets(): LeadSyncTarget[] {
+  const t: LeadSyncTarget[] = [];
+  if (process.env.LEAD_SYNC_N8N_URL?.trim()) t.push("n8n_webhook");
+  if (process.env.LEAD_SYNC_HUBSPOT_STUB === "1") t.push("hubspot_stub");
+  if (process.env.LEAD_SYNC_PIPEDRIVE_STUB === "1") t.push("pipedrive_stub");
+  return t;
+}
+
+export async function enqueueLeadSyncAfterIngest(input: {
+  lead_id: string;
+  legacyInboundDelivery: LegacyInboundDelivery;
+}): Promise<string[]> {
+  const targets = getEnabledLeadSyncTargets();
+  if (targets.length === 0) return [];
+
+  const row = await getMergedLeadAdminRow(input.lead_id);
+  if (!row) return [];
+
+  const allRows = await readAllLeadRecordsMerged();
+  const ops = await readLeadOpsState();
+  const merged = mergeLeadsWithOps([row], ops);
+  const items = attachContactRollups(merged, allRows, ops);
+  const inboxItem = items[0];
+  if (!inboxItem) return [];
+
+  const material = defaultMaterialRevisionForIngest(row.created_at);
+  const jobIds: string[] = [];
+  const contactKey = row.lead_contact_key ?? inboxItem.lead_contact_key;
+
+  for (const target of targets) {
+    const idempotency_key = computeLeadSyncIdempotencyKey(
+      target,
+      row.lead_id,
+      LEAD_SYNC_PAYLOAD_VERSION,
+      material,
+    );
+    const payload = buildLeadSyncPayloadV1({
+      row,
+      inboxItem,
+      legacyInboundDelivery: input.legacyInboundDelivery,
+      idempotency_key,
+    });
+    const { job, created } = await ensureLeadSyncJob({
+      lead_id: row.lead_id,
+      lead_contact_key: contactKey,
+      target,
+      payload_version: LEAD_SYNC_PAYLOAD_VERSION,
+      idempotency_key,
+      payload_snapshot: payload,
+    });
+    jobIds.push(job.job_id);
+    if (created) {
+      try {
+        await appendLeadOpsActivity(
+          input.lead_id,
+          "lead_sync_job_created",
+          `${target} job=${job.job_id.slice(0, 8)}`,
+        );
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  return jobIds;
+}
+
+function backoffMs(attemptNumber: number): number {
+  return Math.min(120_000, 2000 * Math.pow(2, Math.max(0, attemptNumber - 1)));
+}
+
+export async function processLeadSyncJobById(jobId: string): Promise<LeadSyncJob | null> {
+  let job = await getLeadSyncJobById(jobId);
+  if (!job?.payload_snapshot) return job;
+
+  if (job.status === "sent" || job.status === "dead_letter") return job;
+
+  const nowMs = Date.now();
+  if (job.status === "failed" && job.next_retry_at && new Date(job.next_retry_at).getTime() > nowMs) {
+    return job;
+  }
+
+  const attempt = job.attempt_count + 1;
+  await updateLeadSyncJob(jobId, (j) => ({
+    ...j,
+    status: "retrying",
+    attempt_count: attempt,
+    last_attempt_at: new Date().toISOString(),
+    next_retry_at: undefined,
+  }));
+
+  job = await getLeadSyncJobById(jobId);
+  if (!job?.payload_snapshot) return job;
+
+  const result = await runLeadSyncConnector(job.target, job.payload_snapshot);
+
+  if (result.ok) {
+    await updateLeadSyncJob(jobId, (j) => ({
+      ...j,
+      status: "sent",
+      last_error: undefined,
+      last_http_status: result.http_status,
+      mock_result: result.mock_result,
+    }));
+    try {
+      await appendLeadOpsActivity(
+        job.lead_id,
+        "lead_sync_sent",
+        `${job.target} Versuch ${attempt}`,
+      );
+    } catch {
+      /* ignore */
+    }
+  } else if (attempt >= LEAD_SYNC_MAX_ATTEMPTS) {
+    await updateLeadSyncJob(jobId, (j) => ({
+      ...j,
+      status: "dead_letter",
+      last_error: result.error,
+      last_http_status: result.http_status,
+    }));
+    try {
+      await appendLeadOpsActivity(
+        job.lead_id,
+        "lead_sync_dead_letter",
+        `${job.target}: ${result.error ?? "?"}`,
+      );
+    } catch {
+      /* ignore */
+    }
+  } else {
+    const next = new Date(nowMs + backoffMs(attempt)).toISOString();
+    await updateLeadSyncJob(jobId, (j) => ({
+      ...j,
+      status: "failed",
+      last_error: result.error,
+      last_http_status: result.http_status,
+      next_retry_at: next,
+    }));
+    try {
+      await appendLeadOpsActivity(
+        job.lead_id,
+        "lead_sync_failed",
+        `${job.target} (${attempt}/${LEAD_SYNC_MAX_ATTEMPTS}): ${result.error ?? "?"}`,
+      );
+    } catch {
+      /* ignore */
+    }
+    if (attempt > 1) {
+      try {
+        await appendLeadOpsActivity(job.lead_id, "lead_sync_retried", job.target);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return getLeadSyncJobById(jobId);
+}
+
+export async function processPendingLeadSyncJobs(limit: number): Promise<number> {
+  const pending = await listProcessableLeadSyncJobs(limit);
+  for (const j of pending) {
+    await processLeadSyncJobById(j.job_id);
+  }
+  return pending.length;
+}
+
+export async function manualRetryLeadSyncJob(jobId: string): Promise<LeadSyncJob | null> {
+  const before = await getLeadSyncJobById(jobId);
+  if (!before) return null;
+
+  await updateLeadSyncJob(jobId, (j) => ({
+    ...j,
+    status: "pending",
+    next_retry_at: undefined,
+    last_error: undefined,
+    attempt_count: 0,
+  }));
+
+  try {
+    await appendLeadOpsActivity(
+      before.lead_id,
+      "lead_sync_retried",
+      `manual retry ${before.target} job=${jobId.slice(0, 8)}`,
+    );
+  } catch {
+    /* ignore */
+  }
+
+  await processLeadSyncJobById(jobId);
+  return getLeadSyncJobById(jobId);
+}
+
+/** API-Antwort ohne großen Payload-Body. */
+export function redactLeadSyncJobForApi(j: LeadSyncJob): LeadSyncJobApi {
+  const { payload_snapshot: _snap, ...rest } = j;
+  void _snap;
+  return rest;
+}

--- a/frontend/src/lib/leadSyncPayload.test.ts
+++ b/frontend/src/lib/leadSyncPayload.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { computeLeadSyncIdempotencyKey, LEAD_SYNC_PAYLOAD_VERSION } from "@/lib/leadSyncPayload";
+
+describe("computeLeadSyncIdempotencyKey", () => {
+  it("is deterministic for same inputs", () => {
+    const a = computeLeadSyncIdempotencyKey(
+      "n8n_webhook",
+      "550e8400-e29b-41d4-a716-446655440000",
+      LEAD_SYNC_PAYLOAD_VERSION,
+      "ingest:2026-04-01T12:00:00.000Z",
+    );
+    const b = computeLeadSyncIdempotencyKey(
+      "n8n_webhook",
+      "550e8400-e29b-41d4-a716-446655440000",
+      LEAD_SYNC_PAYLOAD_VERSION,
+      "ingest:2026-04-01T12:00:00.000Z",
+    );
+    expect(a).toBe(b);
+    expect(a.startsWith("idem_")).toBe(true);
+    expect(a.length).toBeGreaterThan(10);
+  });
+
+  it("differs when target or material revision changes", () => {
+    const base = computeLeadSyncIdempotencyKey(
+      "n8n_webhook",
+      "550e8400-e29b-41d4-a716-446655440000",
+      LEAD_SYNC_PAYLOAD_VERSION,
+      "ingest:2026-04-01T12:00:00.000Z",
+    );
+    const otherTarget = computeLeadSyncIdempotencyKey(
+      "hubspot_stub",
+      "550e8400-e29b-41d4-a716-446655440000",
+      LEAD_SYNC_PAYLOAD_VERSION,
+      "ingest:2026-04-01T12:00:00.000Z",
+    );
+    const otherRev = computeLeadSyncIdempotencyKey(
+      "n8n_webhook",
+      "550e8400-e29b-41d4-a716-446655440000",
+      LEAD_SYNC_PAYLOAD_VERSION,
+      "ingest:2026-04-01T13:00:00.000Z",
+    );
+    expect(otherTarget).not.toBe(base);
+    expect(otherRev).not.toBe(base);
+  });
+});

--- a/frontend/src/lib/leadSyncPayload.ts
+++ b/frontend/src/lib/leadSyncPayload.ts
@@ -1,0 +1,80 @@
+import { createHash } from "crypto";
+
+import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import type { LeadAdminRow } from "@/lib/leadPersistence";
+import type { LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
+
+export const LEAD_SYNC_PAYLOAD_VERSION = "1.0" as const;
+
+export type LegacyInboundDelivery =
+  | "forwarded"
+  | "stored"
+  | "stored_forward_failed"
+  | "not_configured";
+
+function forwardingToStatus(row: LeadAdminRow): "ok" | "failed" | "not_sent" {
+  if (row.webhook_ok === true) return "ok";
+  if (row.webhook_ok === false) return "failed";
+  return "not_sent";
+}
+
+/**
+ * Deterministisch: gleicher Target + Lead + Payload-Version + Material-Revision → gleicher Key.
+ * Revision = created_at der Inquiry (immutable); später z. B. `triage:${updated_at}` für Re-Sync.
+ */
+export function computeLeadSyncIdempotencyKey(
+  target: LeadSyncTarget,
+  leadId: string,
+  payloadVersion: string,
+  materialRevision: string,
+): string {
+  const raw = `sync_idemp_v1|${target}|${leadId}|${payloadVersion}|${materialRevision}`;
+  return `idem_${createHash("sha256").update(raw, "utf8").digest("hex").slice(0, 40)}`;
+}
+
+export function defaultMaterialRevisionForIngest(createdAtIso: string): string {
+  return `ingest:${createdAtIso}`;
+}
+
+export function buildLeadSyncPayloadV1(input: {
+  row: LeadAdminRow;
+  inboxItem: LeadInboxItem;
+  legacyInboundDelivery: LegacyInboundDelivery;
+  idempotency_key: string;
+}): LeadSyncPayloadV1 {
+  const { row, inboxItem, legacyInboundDelivery, idempotency_key } = input;
+  const ob = row.outbound;
+  const fw = forwardingToStatus(row);
+  const forwarding_status = fw === "ok" ? "ok" : fw === "failed" ? "failed" : "not_sent";
+  return {
+    schema_version: "1.0",
+    idempotency_key,
+    lead_id: row.lead_id,
+    trace_id: row.trace_id,
+    created_at: row.created_at,
+    source_page: ob.source_page,
+    segment: ob.segment,
+    name: ob.name,
+    business_email: ob.business_email,
+    company: ob.company,
+    message: ob.message,
+    route: {
+      route_key: ob.route.route_key,
+      queue_label: ob.route.queue_label,
+      priority: ob.route.priority,
+      sla_bucket: ob.route.sla_bucket,
+    },
+    lead_contact_key: inboxItem.lead_contact_key,
+    lead_account_key: inboxItem.lead_account_key,
+    contact_inquiry_sequence: inboxItem.contact_inquiry_sequence,
+    contact_first_seen_at: inboxItem.contact_first_seen_at,
+    contact_latest_seen_at: inboxItem.contact_latest_seen_at,
+    contact_submission_count: inboxItem.contact_submission_count,
+    duplicate_hint: inboxItem.duplicate_hint,
+    triage_status: inboxItem.triage_status,
+    owner: inboxItem.owner,
+    pipeline_status: row.status,
+    forwarding_status,
+    legacy_inbound_webhook_delivery: legacyInboundDelivery,
+  };
+}

--- a/frontend/src/lib/leadSyncStore.ts
+++ b/frontend/src/lib/leadSyncStore.ts
@@ -1,0 +1,135 @@
+import { randomUUID } from "crypto";
+import { mkdir, readFile, rename, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import "server-only";
+
+import type { LeadSyncJob, LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
+
+const STORE_VERSION = 1;
+
+type JobsStoreFile = {
+  version: number;
+  jobs: Record<string, LeadSyncJob>;
+  /** idempotency_key → job_id */
+  idempotency_index: Record<string, string>;
+};
+
+function resolveSyncStorePath(): string {
+  const fromEnv = process.env.LEAD_SYNC_JOBS_STORE_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-lead-sync-jobs.json");
+  }
+  return join(process.cwd(), "data", "lead-inquiries", "sync-jobs.json");
+}
+
+function emptyStore(): JobsStoreFile {
+  return { version: STORE_VERSION, jobs: {}, idempotency_index: {} };
+}
+
+export async function readLeadSyncStore(): Promise<JobsStoreFile> {
+  const path = resolveSyncStorePath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const p = JSON.parse(raw) as JobsStoreFile;
+    if (p?.version !== STORE_VERSION || typeof p.jobs !== "object" || !p.jobs) {
+      return emptyStore();
+    }
+    if (typeof p.idempotency_index !== "object" || !p.idempotency_index) {
+      p.idempotency_index = {};
+    }
+    return p;
+  } catch {
+    return emptyStore();
+  }
+}
+
+export async function writeLeadSyncStore(store: JobsStoreFile): Promise<void> {
+  const path = resolveSyncStorePath();
+  await mkdir(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  await writeFile(tmp, `${JSON.stringify(store)}\n`, "utf8");
+  await rename(tmp, path);
+}
+
+export async function getLeadSyncJobById(jobId: string): Promise<LeadSyncJob | null> {
+  const s = await readLeadSyncStore();
+  return s.jobs[jobId] ?? null;
+}
+
+export async function listLeadSyncJobsForLead(leadId: string): Promise<LeadSyncJob[]> {
+  const s = await readLeadSyncStore();
+  return Object.values(s.jobs)
+    .filter((j) => j.lead_id === leadId)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+}
+
+/**
+ * Legt einen Job an, wenn für dieselbe idempotency_key noch keiner existiert.
+ */
+export async function ensureLeadSyncJob(input: {
+  lead_id: string;
+  lead_contact_key: string;
+  target: LeadSyncTarget;
+  payload_version: string;
+  idempotency_key: string;
+  payload_snapshot: LeadSyncPayloadV1;
+}): Promise<{ job: LeadSyncJob; created: boolean }> {
+  const store = await readLeadSyncStore();
+  const existingId = store.idempotency_index[input.idempotency_key];
+  if (existingId && store.jobs[existingId]) {
+    return { job: store.jobs[existingId]!, created: false };
+  }
+
+  const now = new Date().toISOString();
+  const job: LeadSyncJob = {
+    job_id: randomUUID(),
+    lead_id: input.lead_id,
+    lead_contact_key: input.lead_contact_key,
+    target: input.target,
+    payload_version: input.payload_version,
+    status: "pending",
+    attempt_count: 0,
+    idempotency_key: input.idempotency_key,
+    created_at: now,
+    updated_at: now,
+    payload_snapshot: input.payload_snapshot,
+  };
+  store.jobs[job.job_id] = job;
+  store.idempotency_index[input.idempotency_key] = job.job_id;
+  await writeLeadSyncStore(store);
+  return { job, created: true };
+}
+
+export async function updateLeadSyncJob(
+  jobId: string,
+  mutator: (job: LeadSyncJob) => LeadSyncJob,
+): Promise<LeadSyncJob | null> {
+  const store = await readLeadSyncStore();
+  const prev = store.jobs[jobId];
+  if (!prev) return null;
+  const next = mutator({ ...prev });
+  next.updated_at = new Date().toISOString();
+  store.jobs[jobId] = next;
+  await writeLeadSyncStore(store);
+  return next;
+}
+
+export async function listProcessableLeadSyncJobs(limit: number): Promise<LeadSyncJob[]> {
+  const s = await readLeadSyncStore();
+  const now = Date.now();
+  const list = Object.values(s.jobs).filter((j) => {
+    if (j.status === "sent") return false;
+    if (j.status === "dead_letter") return false;
+    if (j.status === "pending") return true;
+    if (j.status === "retrying") return true;
+    if (j.status === "failed") {
+      if (!j.next_retry_at) return true;
+      return new Date(j.next_retry_at).getTime() <= now;
+    }
+    return false;
+  });
+  list.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+  return list.slice(0, limit);
+}

--- a/frontend/src/lib/leadSyncTypes.ts
+++ b/frontend/src/lib/leadSyncTypes.ts
@@ -1,0 +1,75 @@
+/**
+ * Wave 28 – Lead-Sync-Jobs (getrennt von Roh-Anfrage / JSONL lead_inquiry).
+ */
+
+export type LeadSyncTarget = "n8n_webhook" | "hubspot_stub" | "pipedrive_stub";
+
+export type LeadSyncJobStatus =
+  | "pending"
+  | "retrying"
+  | "sent"
+  | "failed"
+  | "dead_letter";
+
+/** Stabiler Vertrag für Downstream (n8n / CRM), snake_case. */
+export type LeadSyncPayloadV1 = {
+  schema_version: "1.0";
+  idempotency_key: string;
+  lead_id: string;
+  trace_id: string;
+  created_at: string;
+  /** Inquiry */
+  source_page: string;
+  segment: string;
+  name: string;
+  business_email: string;
+  company: string;
+  message: string;
+  route: {
+    route_key: string;
+    queue_label: string;
+    priority: string;
+    sla_bucket: string;
+  };
+  /** Kontakt-Rollup (Wave 27) */
+  lead_contact_key: string;
+  lead_account_key: string | null;
+  contact_inquiry_sequence: number;
+  contact_first_seen_at: string;
+  contact_latest_seen_at: string;
+  contact_submission_count: number;
+  duplicate_hint: string;
+  /** Interne Triage zum Sync-Zeitpunkt */
+  triage_status: string;
+  owner: string;
+  /** Pipeline / Weiterleitung */
+  pipeline_status: string;
+  forwarding_status: string;
+  /** Hinweis: separates Legacy-Webhook (Wave 25) vs. Sync-Framework */
+  legacy_inbound_webhook_delivery: "forwarded" | "stored" | "stored_forward_failed" | "not_configured";
+};
+
+export type LeadSyncJob = {
+  job_id: string;
+  lead_id: string;
+  lead_contact_key: string;
+  target: LeadSyncTarget;
+  /** Sync-Payload-Schema, z. B. 1.0 */
+  payload_version: string;
+  status: LeadSyncJobStatus;
+  attempt_count: number;
+  idempotency_key: string;
+  created_at: string;
+  updated_at: string;
+  last_attempt_at?: string;
+  last_error?: string;
+  last_http_status?: number;
+  next_retry_at?: string;
+  /** Stub-Ergebnis oder Metadaten (keine Secrets). */
+  mock_result?: unknown;
+  /** Fixierter Payload pro Job (Retries senden dasselbe Snapshot). */
+  payload_snapshot?: LeadSyncPayloadV1;
+};
+
+/** API-/UI-Ansicht ohne großen Payload-Snapshot. */
+export type LeadSyncJobApi = Omit<LeadSyncJob, "payload_snapshot">;


### PR DESCRIPTION
Add LeadSyncJob store, idempotent payload v1, dispatcher with retries and dead-letter, n8n webhook plus HubSpot/Pipedrive stubs, admin inbox sync status and manual retry, ops audit actions, and documentation.

Made-with: Cursor