### PR TITLE
feat(gtm): Wave 28.1 real HubSpot lead sync

### DIFF
--- a/docs/gtm/wave28-lead-sync-framework.md
+++ b/docs/gtm/wave28-lead-sync-framework.md
@@ -9,7 +9,7 @@ Ziel: Zuverlässiger, nachvollziehbarer Push von Lead-/Inquiry-Daten zu **n8n** 
 - **Ops-Sicht** in der internen Lead-Inbox: Status pro Ziel, Fehler, manueller Retry.
 - **Aktivitäts-Log** (`lead_ops`): `lead_sync_job_created`, `lead_sync_sent`, `lead_sync_failed`, `lead_sync_retried`, `lead_sync_dead_letter`.
 
-Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md).
+Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 28.1 – HubSpot Upsert](wave28.1-hubspot-upsert.md).
 
 ## Job-Modell (`LeadSyncJob`)
 
@@ -18,7 +18,7 @@ Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance
 | `job_id` | UUID |
 | `lead_id` | Verknüpfung zur Inquiry |
 | `lead_contact_key` | Kontext für CRM-Upsert (E-Mail-Schlüssel) |
-| `target` | `n8n_webhook` \| `hubspot_stub` \| `pipedrive_stub` |
+| `target` | `n8n_webhook` \| `hubspot` \| `hubspot_stub` \| `pipedrive_stub` |
 | `payload_version` | z. B. `1.0` (Sync-Payload-Schema) |
 | `status` | `pending` → `retrying` / `sent` / `failed` → ggf. `dead_letter` |
 | `attempt_count` | Anzahl Versuche |
@@ -74,6 +74,7 @@ Stubs (`hubspot_stub`, `pipedrive_stub`) mappen den Payload in ein lokales, stru
 | Target | Aktivierung | Verhalten |
 |--------|-------------|-----------|
 | `n8n_webhook` | `LEAD_SYNC_N8N_URL` gesetzt; optional `LEAD_SYNC_N8N_SECRET` (Bearer) | HTTP POST mit JSON-Payload, Status/Errors am Job |
+| `hubspot` | `HUBSPOT_ACCESS_TOKEN` | Echter HubSpot CRM-Sync (siehe [Wave 28.1](wave28.1-hubspot-upsert.md)) |
 | `hubspot_stub` | `LEAD_SYNC_HUBSPOT_STUB=1` | Lokales Mock-Upsert + Notiz |
 | `pipedrive_stub` | `LEAD_SYNC_PIPEDRIVE_STUB=1` | Lokales Mock-Upsert + Aktivität |
 

--- a/docs/gtm/wave28.1-hubspot-upsert.md
+++ b/docs/gtm/wave28.1-hubspot-upsert.md
@@ -1,0 +1,71 @@
+# Wave 28.1 – HubSpot Upsert (erster echter CRM-Pfad)
+
+Ziel: End-to-end Sync von Website-Leads nach **HubSpot** über das bestehende `LeadSyncJob`-Framework, ohne generische CRM-Abstraktion. Fokus auf **Korrektheit, Nachvollziehbarkeit und konservative Updates**.
+
+Siehe auch: [Wave 28 – Lead-Sync-Framework](wave28-lead-sync-framework.md).
+
+## Aktivierung
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `HUBSPOT_ACCESS_TOKEN` | Private-App- oder OAuth-Token (CRM). **Wenn gesetzt**, wird das Sync-Ziel `hubspot` aktiviert (zusätzlich zu optionalen Stubs/n8n). |
+| `HUBSPOT_DEFAULT_OWNER_ID` | Optional: numerische HubSpot-Owner-ID; wird nur gesetzt, wenn am Kontakt noch kein Owner gesetzt ist. |
+| `HUBSPOT_PIPELINE_HINT` | Optional: freier Text, wird in die **Notiz** geschrieben (kein Deal-Pipeline-Mapping in dieser Welle). |
+| `HUBSPOT_ALLOW_COMPANY_CREATE` | Wenn `1`: bei fehlendem exakten Firmen-Treffer wird eine **neue** Company mit dem Formular-Firmennamen angelegt und verknüpft. Standard: **aus** (nur Match, kein Create). |
+| `HUBSPOT_PROPERTY_CONTACT_KEY` | Optional: **interner** Name eines benutzerdefinierten Kontakt-Felds für `lead_contact_key` (Portal muss Property kennen). |
+| `HUBSPOT_PROPERTY_ACCOUNT_KEY` | Optional: Custom Property für `lead_account_key`. |
+| `HUBSPOT_PROPERTY_SEGMENT` | Optional: Custom Property für Segment. |
+| `HUBSPOT_PROPERTY_SOURCE_PAGE` | Optional: Custom Property für Quell-URL/Pfad. |
+| `HUBSPOT_PROPERTY_LATEST_INQUIRY_AT` | Optional: Custom Property für `contact_latest_seen_at` (ISO-String). |
+
+Ohne gültiges Token gibt es **keinen** `hubspot`-Job. Der Stub `hubspot_stub` bleibt über `LEAD_SYNC_HUBSPOT_STUB=1` unverändert testbar.
+
+## Kontakt-Upsert
+
+- **Match:** Suche per `email` (EQ, normalisiert kleingeschrieben).
+- **Neu:** `POST /crm/v3/objects/contacts` mit `email`, `firstname` / `lastname` (Name aus Formular: erster Token = Vorname, Rest = Nachname; leerer Name → Platzhalter-Vorname), optional `company` (Standard-HubSpot-Kontaktfeld), optional `hubspot_owner_id`.
+- **Bestehend:** `PATCH` nur mit **konservativen** Ergänzungen: `firstname`, `lastname`, `company`, `hubspot_owner_id` und optionale Custom Properties werden **nur gesetzt, wenn das Feld in HubSpot derzeit leer ist**. Bereits gepflegte CRM-Daten werden nicht überschrieben.
+
+Segment, Quellseite, Keys und Zeitstempel liegen standardmäßig in der **Notiz**; optional zusätzlich in Custom Properties, wenn die Env-Variablen gesetzt sind und die Properties im Portal existieren (sonst 400 → nicht retry-fähig).
+
+## Firma (Company)
+
+- Nur wenn der Firmenname **nicht** als schwach eingestuft wird (sehr kurz oder Platzhalter wie „n/a“, „test“, …).
+- **Suche:** exakter `name` EQ auf Companies.
+- **Ein Treffer:** Kontakt mit Company verknüpfen (`contact_to_company`).
+- **Kein Treffer:** Standardmäßig **kein** Anlegen; Ergebnis `company_association: skipped_no_match`. Mit `HUBSPOT_ALLOW_COMPANY_CREATE=1`: Company anlegen und verknüpfen.
+- **Mehrere Treffer / unsicher:** keine Zuordnung; `skipped_ambiguous`.
+
+## Notiz pro Inquiry (Idempotenz)
+
+- Jede Website-Inquiry (`lead_id`) erzeugt höchstens **eine** HubSpot-Notiz pro erfolgreichem Sync-Lauf.
+- Inhalt: Nachricht, `source_page`, `segment`, Route/SLA, Triage, `trace_id`, `lead_id`, Kontakt-Sequenz/Rollup, `duplicate_hint`, optional Pipeline-Hinweis.
+- **Marker:** `COMPLIANCEHUB_LEAD_INQUIRY_ID:{lead_id}` steht im HTML-Body der Notiz.
+- **Retry:** Vor dem Anlegen werden bis zu **40** mit dem Kontakt assoziierte Notizen per Batch-Read geprüft. Enthält eine Notiz den Marker, wird **keine** zweite Notiz erstellt (`note_action: skipped_existing`).
+
+**Grenze:** Kontakte mit sehr vielen Notizen und weniger als 40 zugeordneten (oder Marker außerhalb der zuletzt geladenen Assoziationen) sind theoretisch fehleranfällig; für typische Inbound-Leads ist das akzeptabel.
+
+## Lokales Sync-Ergebnis (`mock_result`)
+
+Nach Erfolg speichert der Job u. a.:
+
+- `system: "hubspot"`
+- `contact_id`, optional `company_id`
+- `note_id`, `note_action` (`created` | `skipped_existing`)
+- `company_association` (siehe oben)
+- `synced_at`, optional `pipeline_hint`
+
+Die interne Lead-Inbox zeigt diese Werte in der Spalte **HubSpot-Referenz**.
+
+## Retry / Dead Letter
+
+- Der Connector setzt `retryable` auf **false** u. a. bei: 401/403, typischen 400-Validierungsfehlern, fehlenden Properties, 404.
+- **429** und **5xx** sowie Netzwerk/Timeout: **retry-fähig** (Backoff im Dispatcher).
+- Bei `retryable === false` landet der Job **sofort** im Dead Letter (ohne alle Versuche zu verbrauchen).
+
+## Bewusste Einschränkungen
+
+- Kein generisches CRM-Interface; nur HubSpot-API-Aufrufe in `hubspotLeadSyncConnector.ts`.
+- Kein Deal-Stage-Mapping; `HUBSPOT_PIPELINE_HINT` ist nur Dokumentation in der Notiz.
+- Keine Domänen-basierte Company-Suche (nur exakter Name, optional Create).
+- Zwei parallele Ziele `hubspot` und `hubspot_stub` erzeugen **zwei** Jobs pro Lead (unterschiedliche `idempotency_key`); in Produktion in der Regel nur eines aktivieren.

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -26,9 +26,41 @@ const DUPLICATE_REVIEW_LABELS: Record<LeadInboxItem["duplicate_review"], string>
 
 const SYNC_TARGET_LABELS: Record<LeadSyncJobApi["target"], string> = {
   n8n_webhook: "n8n (Webhook)",
+  hubspot: "HubSpot",
   hubspot_stub: "HubSpot (Stub)",
   pipedrive_stub: "Pipedrive (Stub)",
 };
+
+const HUBSPOT_COMPANY_ASSOC_DE: Record<string, string> = {
+  linked: "Firma verknüpft",
+  skipped_no_match: "Firma: kein exakter Treffer (Anlegen nicht aktiv)",
+  skipped_ambiguous: "Firma: mehrere Treffer, Zuordnung übersprungen",
+  skipped_weak_name: "Firma: Name zu kurz oder Platzhalter",
+  skipped_create_disabled: "Firma: Anlegen deaktiviert",
+};
+
+/** Client-sichere Auswertung von `mock_result` (kein server-only Import). */
+function hubspotMockDetails(mock: unknown): {
+  contact_id: string;
+  company_id?: string;
+  note_id?: string;
+  note_action: string;
+  company_association: string;
+  synced_at?: string;
+} | null {
+  if (!mock || typeof mock !== "object") return null;
+  const m = mock as Record<string, unknown>;
+  if (m.system !== "hubspot" || typeof m.contact_id !== "string") return null;
+  return {
+    contact_id: m.contact_id,
+    company_id: typeof m.company_id === "string" ? m.company_id : undefined,
+    note_id: typeof m.note_id === "string" ? m.note_id : undefined,
+    note_action: typeof m.note_action === "string" ? m.note_action : "—",
+    company_association:
+      typeof m.company_association === "string" ? m.company_association : "—",
+    synced_at: typeof m.synced_at === "string" ? m.synced_at : undefined,
+  };
+}
 
 function syncStatusLabel(s: LeadSyncJobApi["status"]): string {
   if (s === "pending") return "Ausstehend";
@@ -658,13 +690,13 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
           <div className="mt-6 border-t border-slate-100 pt-4">
             <h3 className="text-sm font-medium text-slate-800">GTM-Sync (Wave 28)</h3>
             <p className="mt-1 text-xs text-slate-500">
-              Status pro Ziel (n8n / CRM-Stubs). Ohne konfigurierte Ziele entstehen keine Jobs.
+              Status pro Ziel (n8n, HubSpot, Stubs). Ohne konfigurierte Ziele entstehen keine Jobs.
             </p>
             {syncJobs.length === 0 ? (
               <p className="mt-2 text-sm text-slate-500">Keine Sync-Jobs für diesen Lead.</p>
             ) : (
               <div className="mt-3 overflow-x-auto rounded-lg border border-slate-200">
-                <table className="w-full min-w-[640px] border-collapse text-left text-xs">
+                <table className="w-full min-w-[880px] border-collapse text-left text-xs">
                   <thead className="border-b border-slate-200 bg-slate-50 text-slate-600">
                     <tr>
                       <th className="px-2 py-2 font-medium">Ziel</th>
@@ -673,43 +705,74 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                       <th className="px-2 py-2 font-medium">Letzter Versuch</th>
                       <th className="px-2 py-2 font-medium">Nächster Retry</th>
                       <th className="px-2 py-2 font-medium">Fehler</th>
+                      <th className="px-2 py-2 font-medium">HubSpot-Referenz</th>
                       <th className="px-2 py-2 font-medium" />
                     </tr>
                   </thead>
                   <tbody>
-                    {syncJobs.map((j) => (
-                      <tr key={j.job_id} className="border-b border-slate-100">
-                        <td className="px-2 py-2 text-slate-800">{SYNC_TARGET_LABELS[j.target]}</td>
-                        <td className="px-2 py-2">{syncStatusLabel(j.status)}</td>
-                        <td className="px-2 py-2 font-mono">{j.attempt_count}</td>
-                        <td className="px-2 py-2 text-slate-600">
-                          {j.last_attempt_at
-                            ? new Date(j.last_attempt_at).toLocaleString("de-DE")
-                            : "—"}
-                        </td>
-                        <td className="px-2 py-2 text-slate-600">
-                          {j.next_retry_at ? new Date(j.next_retry_at).toLocaleString("de-DE") : "—"}
-                        </td>
-                        <td className="max-w-[200px] truncate px-2 py-2 text-red-700" title={j.last_error}>
-                          {j.last_error ?? "—"}
-                        </td>
-                        <td className="px-2 py-2">
-                          {j.status === "failed" ||
-                          j.status === "dead_letter" ||
-                          j.status === "pending" ||
-                          j.status === "retrying" ? (
-                            <button
-                              type="button"
-                              disabled={syncRetryingId === j.job_id}
-                              className="text-cyan-700 underline disabled:opacity-50"
-                              onClick={() => void retryLeadSyncJob(displayLead.lead_id, j.job_id)}
+                    {syncJobs.map((j) => {
+                      const hs = hubspotMockDetails(j.mock_result);
+                      return (
+                          <tr key={j.job_id} className="border-b border-slate-100">
+                            <td className="px-2 py-2 text-slate-800">{SYNC_TARGET_LABELS[j.target]}</td>
+                            <td className="px-2 py-2">{syncStatusLabel(j.status)}</td>
+                            <td className="px-2 py-2 font-mono">{j.attempt_count}</td>
+                            <td className="px-2 py-2 text-slate-600">
+                              {j.last_attempt_at
+                                ? new Date(j.last_attempt_at).toLocaleString("de-DE")
+                                : "—"}
+                            </td>
+                            <td className="px-2 py-2 text-slate-600">
+                              {j.next_retry_at ? new Date(j.next_retry_at).toLocaleString("de-DE") : "—"}
+                            </td>
+                            <td
+                              className="max-w-[200px] truncate px-2 py-2 text-red-700"
+                              title={j.last_error}
                             >
-                              {syncRetryingId === j.job_id ? "…" : "Retry"}
-                            </button>
-                          ) : null}
-                        </td>
-                      </tr>
-                    ))}
+                              {j.last_error ?? "—"}
+                            </td>
+                            <td className="max-w-[220px] px-2 py-2 align-top text-[10px] text-slate-600">
+                              {hs ? (
+                                <ul className="list-inside list-disc space-y-0.5 font-mono">
+                                  <li>Kontakt {hs.contact_id}</li>
+                                  {hs.company_id ? <li>Firma {hs.company_id}</li> : null}
+                                  {hs.note_id ? (
+                                    <li>
+                                      Notiz {hs.note_id} ({hs.note_action})
+                                    </li>
+                                  ) : null}
+                                  <li className="list-none pl-0 font-sans text-slate-500">
+                                    {HUBSPOT_COMPANY_ASSOC_DE[hs.company_association] ??
+                                      hs.company_association}
+                                  </li>
+                                  {hs.synced_at ? (
+                                    <li className="list-none pl-0 font-sans text-slate-400">
+                                      Sync {new Date(hs.synced_at).toLocaleString("de-DE")}
+                                    </li>
+                                  ) : null}
+                                </ul>
+                              ) : (
+                                "—"
+                              )}
+                            </td>
+                            <td className="px-2 py-2">
+                              {j.status === "failed" ||
+                              j.status === "dead_letter" ||
+                              j.status === "pending" ||
+                              j.status === "retrying" ? (
+                                <button
+                                  type="button"
+                                  disabled={syncRetryingId === j.job_id}
+                                  className="text-cyan-700 underline disabled:opacity-50"
+                                  onClick={() => void retryLeadSyncJob(displayLead.lead_id, j.job_id)}
+                                >
+                                  {syncRetryingId === j.job_id ? "…" : "Retry"}
+                                </button>
+                              ) : null}
+                            </td>
+                          </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>

--- a/frontend/src/lib/hubspotLeadSyncConnector.ts
+++ b/frontend/src/lib/hubspotLeadSyncConnector.ts
@@ -1,0 +1,471 @@
+import "server-only";
+
+import type { LeadSyncConnectorResult, LeadSyncPayloadV1 } from "@/lib/leadSyncTypes";
+
+const HUBSPOT_API = "https://api.hubapi.com";
+const REQUEST_TIMEOUT_MS = 28_000;
+/** HubSpot-defined: note → contact (see CRM Notes API). */
+const NOTE_TO_CONTACT_TYPE_ID = 202;
+
+/** Ergebnis in `mock_result` für Admin-UI / Debugging (keine Secrets). */
+export type LeadSyncHubSpotSyncResult = {
+  system: "hubspot";
+  synced_at: string;
+  contact_id: string;
+  company_id?: string;
+  company_association: "linked" | "skipped_no_match" | "skipped_ambiguous" | "skipped_weak_name" | "skipped_create_disabled";
+  note_id?: string;
+  note_action: "created" | "skipped_existing";
+  pipeline_hint?: string;
+};
+
+type HubSpotErrorBody = {
+  status?: string;
+  message?: string;
+  category?: string;
+  errors?: { message?: string }[];
+};
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function splitName(full: string): { firstname: string; lastname: string } {
+  const t = full.trim();
+  if (!t) return { firstname: "Website Lead", lastname: "" };
+  const i = t.indexOf(" ");
+  if (i <= 0) return { firstname: t.slice(0, 120), lastname: "" };
+  return {
+    firstname: t.slice(0, i).slice(0, 120),
+    lastname: t.slice(i + 1).trim().slice(0, 120),
+  };
+}
+
+function isWeakCompanyName(name: string): boolean {
+  const t = name.trim();
+  if (t.length < 2) return true;
+  return /^(n\/a|na|none|unknown|unbekannt|test|xxx|-+)$/i.test(t);
+}
+
+function classifyHubSpotRetryable(status: number, body: HubSpotErrorBody | null): boolean {
+  if (status === 429) return true;
+  if (status >= 500) return true;
+  if (status === 408) return true;
+  if (status === 401 || status === 403) return false;
+  if (status === 404) return false;
+  if (status === 400) {
+    const msg = (body?.message ?? "").toLowerCase();
+    if (msg.includes("invalid") && msg.includes("token")) return false;
+    if (body?.category === "VALIDATION_ERROR") return false;
+    if (msg.includes("property") && msg.includes("does not exist")) return false;
+    return false;
+  }
+  if (status >= 400) return false;
+  return true;
+}
+
+function formatHubSpotError(status: number, rawText: string, parsed: HubSpotErrorBody | null): string {
+  const parts = [`http_${status}`];
+  if (parsed?.message) parts.push(parsed.message);
+  else if (parsed?.errors?.[0]?.message) parts.push(parsed.errors[0].message!);
+  else if (rawText) parts.push(rawText.slice(0, 280));
+  return parts.join(": ");
+}
+
+async function hubspotFetch(
+  token: string,
+  path: string,
+  init: RequestInit,
+): Promise<{ status: number; text: string; json: HubSpotErrorBody | null }> {
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const r = await fetch(`${HUBSPOT_API}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        ...((init.headers as Record<string, string>) ?? {}),
+      },
+    });
+    const text = await r.text();
+    let json: HubSpotErrorBody | null = null;
+    try {
+      json = JSON.parse(text) as HubSpotErrorBody;
+    } catch {
+      /* ignore */
+    }
+    return { status: r.status, text, json };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function strVal(v: string | null | undefined): string {
+  return typeof v === "string" ? v.trim() : "";
+}
+
+function buildOptionalCustomProps(payload: LeadSyncPayloadV1): Record<string, string> {
+  const out: Record<string, string> = {};
+  const ck = process.env.HUBSPOT_PROPERTY_CONTACT_KEY?.trim();
+  const ak = process.env.HUBSPOT_PROPERTY_ACCOUNT_KEY?.trim();
+  const seg = process.env.HUBSPOT_PROPERTY_SEGMENT?.trim();
+  const src = process.env.HUBSPOT_PROPERTY_SOURCE_PAGE?.trim();
+  const seen = process.env.HUBSPOT_PROPERTY_LATEST_INQUIRY_AT?.trim();
+  if (ck) out[ck] = payload.lead_contact_key;
+  if (ak && payload.lead_account_key) out[ak] = payload.lead_account_key;
+  if (seg) out[seg] = payload.segment;
+  if (src) out[src] = payload.source_page;
+  if (seen) out[seen] = payload.contact_latest_seen_at;
+  return out;
+}
+
+async function searchContactByEmail(
+  token: string,
+  email: string,
+): Promise<{ id: string; properties: Record<string, string | null> } | null> {
+  const r = await hubspotFetch(token, "/crm/v3/objects/contacts/search", {
+    method: "POST",
+    body: JSON.stringify({
+      filterGroups: [
+        { filters: [{ propertyName: "email", operator: "EQ", value: email.toLowerCase() }] },
+      ],
+      properties: ["email", "firstname", "lastname", "company", "hubspot_owner_id"],
+      limit: 1,
+    }),
+  });
+  if (r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "contact_search" };
+  }
+  const data = JSON.parse(r.text) as { results?: { id: string; properties?: Record<string, string | null> }[] };
+  const row = data.results?.[0];
+  if (!row) return null;
+  return { id: row.id, properties: row.properties ?? {} };
+}
+
+async function createContact(
+  token: string,
+  props: Record<string, string>,
+): Promise<{ id: string }> {
+  const r = await hubspotFetch(token, "/crm/v3/objects/contacts", {
+    method: "POST",
+    body: JSON.stringify({ properties: props }),
+  });
+  if (r.status !== 201 && r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "contact_create" };
+  }
+  const data = JSON.parse(r.text) as { id: string };
+  return { id: data.id };
+}
+
+async function patchContact(token: string, id: string, props: Record<string, string>): Promise<void> {
+  if (Object.keys(props).length === 0) return;
+  const r = await hubspotFetch(token, `/crm/v3/objects/contacts/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify({ properties: props }),
+  });
+  if (r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "contact_patch" };
+  }
+}
+
+function conservativeContactProps(
+  existing: Record<string, string | null>,
+  incoming: {
+    firstname: string;
+    lastname: string;
+    company: string;
+    ownerId?: string;
+    custom: Record<string, string>;
+  },
+): Record<string, string> {
+  const patch: Record<string, string> = {};
+  if (!strVal(existing.firstname) && incoming.firstname) patch.firstname = incoming.firstname;
+  if (!strVal(existing.lastname) && incoming.lastname) patch.lastname = incoming.lastname;
+  if (!strVal(existing.company) && incoming.company) patch.company = incoming.company;
+  if (!strVal(existing.hubspot_owner_id) && incoming.ownerId) {
+    patch.hubspot_owner_id = incoming.ownerId;
+  }
+  for (const [k, v] of Object.entries(incoming.custom)) {
+    if (!v) continue;
+    const cur = existing[k];
+    if (!strVal(cur)) patch[k] = v;
+  }
+  return patch;
+}
+
+async function searchCompanyByExactName(token: string, name: string): Promise<{ count: number; id?: string }> {
+  const r = await hubspotFetch(token, "/crm/v3/objects/companies/search", {
+    method: "POST",
+    body: JSON.stringify({
+      filterGroups: [{ filters: [{ propertyName: "name", operator: "EQ", value: name }] }],
+      properties: ["name"],
+      limit: 5,
+    }),
+  });
+  if (r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "company_search" };
+  }
+  const data = JSON.parse(r.text) as { total?: number; results?: { id: string }[] };
+  const total =
+    typeof data.total === "number" ? data.total : (data.results?.length ?? 0);
+  if (total === 1 && data.results?.[0]) return { count: 1, id: data.results[0].id };
+  if (total === 0) return { count: 0 };
+  return { count: total };
+}
+
+async function createCompany(token: string, name: string): Promise<{ id: string }> {
+  const r = await hubspotFetch(token, "/crm/v3/objects/companies", {
+    method: "POST",
+    body: JSON.stringify({ properties: { name } }),
+  });
+  if (r.status !== 201 && r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "company_create" };
+  }
+  const data = JSON.parse(r.text) as { id: string };
+  return { id: data.id };
+}
+
+async function associateContactToCompany(token: string, contactId: string, companyId: string): Promise<void> {
+  const r = await hubspotFetch(token, "/crm/v3/associations/contacts/companies/batch/create", {
+    method: "POST",
+    body: JSON.stringify({
+      inputs: [{ from: { id: contactId }, to: { id: companyId }, type: "contact_to_company" }],
+    }),
+  });
+  if (r.status === 200 || r.status === 201) return;
+  const msg = (r.json?.message ?? r.text).toLowerCase();
+  if (r.status === 400 && (msg.includes("already") || msg.includes("existing"))) return;
+  throw { status: r.status, text: r.text, json: r.json, op: "association_contact_company" };
+}
+
+async function listNoteIdsForContact(token: string, contactId: string, limit: number): Promise<string[]> {
+  const r = await hubspotFetch(
+    token,
+    `/crm/v3/objects/contacts/${contactId}/associations/notes?limit=${limit}`,
+    { method: "GET" },
+  );
+  if (r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "list_note_associations" };
+  }
+  const data = JSON.parse(r.text) as { results?: { id?: string; toObjectId?: string }[] };
+  return (data.results ?? [])
+    .map((x) => String(x.id ?? x.toObjectId ?? ""))
+    .filter(Boolean);
+}
+
+async function batchReadNoteBodies(
+  token: string,
+  ids: string[],
+): Promise<{ id: string; body: string }[]> {
+  if (ids.length === 0) return [];
+  const r = await hubspotFetch(token, "/crm/v3/objects/notes/batch/read", {
+    method: "POST",
+    body: JSON.stringify({
+      inputs: ids.map((id) => ({ id })),
+      properties: ["hs_note_body"],
+    }),
+  });
+  if (r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "notes_batch_read" };
+  }
+  const data = JSON.parse(r.text) as {
+    results?: { id: string; properties?: { hs_note_body?: string } }[];
+  };
+  return (data.results ?? []).map((row) => ({
+    id: row.id,
+    body: row.properties?.hs_note_body ?? "",
+  }));
+}
+
+function inquiryMarker(leadId: string): string {
+  return `COMPLIANCEHUB_LEAD_INQUIRY_ID:${leadId}`;
+}
+
+async function findExistingInquiryNote(
+  token: string,
+  contactId: string,
+  leadId: string,
+): Promise<string | null> {
+  const marker = inquiryMarker(leadId);
+  const noteIds = await listNoteIdsForContact(token, contactId, 40);
+  if (noteIds.length === 0) return null;
+  const bodies = await batchReadNoteBodies(token, noteIds);
+  for (const row of bodies) {
+    if (row.body.includes(marker)) return row.id;
+  }
+  return null;
+}
+
+async function createNoteForContact(
+  token: string,
+  contactId: string,
+  payload: LeadSyncPayloadV1,
+  ownerId?: string,
+): Promise<{ id: string }> {
+  const hint = process.env.HUBSPOT_PIPELINE_HINT?.trim();
+  const lines = [
+    `<p><strong>${inquiryMarker(payload.lead_id)}</strong></p>`,
+    `<p>${escapeHtml(payload.message || "(keine Nachricht)")}</p>`,
+    "<hr/>",
+    `<p>Quelle: ${escapeHtml(payload.source_page)} · Segment: ${escapeHtml(payload.segment)}</p>`,
+    `<p>Route: ${escapeHtml(payload.route.route_key)} / ${escapeHtml(payload.route.queue_label)} · Priorität: ${escapeHtml(payload.route.priority)} · SLA: ${escapeHtml(payload.route.sla_bucket)}</p>`,
+    `<p>Triage: ${escapeHtml(payload.triage_status)} · Anfrage #${payload.contact_inquiry_sequence} von ${payload.contact_submission_count} (Kontakt)</p>`,
+    `<p>trace_id: ${escapeHtml(payload.trace_id)} · lead_id: ${escapeHtml(payload.lead_id)}</p>`,
+    `<p>lead_contact_key: ${escapeHtml(payload.lead_contact_key)}${payload.lead_account_key ? ` · lead_account_key: ${escapeHtml(payload.lead_account_key)}` : ""}</p>`,
+    `<p>duplicate_hint: ${escapeHtml(payload.duplicate_hint)}</p>`,
+  ];
+  if (hint) {
+    lines.splice(2, 0, `<p>Pipeline-Hinweis (intern): ${escapeHtml(hint)}</p>`);
+  }
+  const hs_note_body = lines.join("\n");
+  const props: Record<string, string | number> = {
+    hs_timestamp: Date.now(),
+    hs_note_body,
+  };
+  if (ownerId) props.hubspot_owner_id = ownerId;
+
+  const r = await hubspotFetch(token, "/crm/v3/objects/notes", {
+    method: "POST",
+    body: JSON.stringify({
+      properties: props,
+      associations: [
+        {
+          to: { id: contactId },
+          types: [{ associationCategory: "HUBSPOT_DEFINED", associationTypeId: NOTE_TO_CONTACT_TYPE_ID }],
+        },
+      ],
+    }),
+  });
+  if (r.status !== 201 && r.status !== 200) {
+    throw { status: r.status, text: r.text, json: r.json, op: "note_create" };
+  }
+  const data = JSON.parse(r.text) as { id: string };
+  return { id: data.id };
+}
+
+function toConnectorError(err: unknown): LeadSyncConnectorResult {
+  if (err && typeof err === "object" && "status" in err) {
+    const e = err as { status: number; text: string; json: HubSpotErrorBody | null; op?: string };
+    const retryable = classifyHubSpotRetryable(e.status, e.json);
+    return {
+      ok: false,
+      http_status: e.status,
+      error: `${e.op ?? "hubspot"}: ${formatHubSpotError(e.status, e.text, e.json)}`,
+      retryable,
+    };
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return { ok: false, error: `hubspot: ${msg}`, retryable: true };
+}
+
+/** Echter HubSpot-Sync: Kontakt upsert, konservative Firma, idempotente Notiz pro Inquiry. */
+export async function runHubspotLeadSyncConnector(payload: LeadSyncPayloadV1): Promise<LeadSyncConnectorResult> {
+  const token = process.env.HUBSPOT_ACCESS_TOKEN?.trim();
+  if (!token) {
+    return { ok: false, error: "hubspot_token_not_configured", retryable: false };
+  }
+
+  const email = payload.business_email?.trim().toLowerCase();
+  if (!email || !email.includes("@")) {
+    return { ok: false, error: "hubspot: invalid business_email", retryable: false };
+  }
+
+  const ownerId = process.env.HUBSPOT_DEFAULT_OWNER_ID?.trim();
+  const { firstname, lastname } = splitName(payload.name);
+  const companyName = payload.company?.trim() ?? "";
+  const customProps = buildOptionalCustomProps(payload);
+  const synced_at = new Date().toISOString();
+  const pipeline_hint = process.env.HUBSPOT_PIPELINE_HINT?.trim();
+
+  let contactId: string;
+
+  try {
+    const existing = await searchContactByEmail(token, email);
+    if (existing) {
+      contactId = existing.id;
+      const patch = conservativeContactProps(existing.properties, {
+        firstname,
+        lastname,
+        company: companyName,
+        ownerId,
+        custom: customProps,
+      });
+      await patchContact(token, contactId, patch);
+    } else {
+      const createProps: Record<string, string> = {
+        email,
+        firstname,
+        ...(lastname ? { lastname } : {}),
+        ...(companyName ? { company: companyName } : {}),
+        ...(ownerId ? { hubspot_owner_id: ownerId } : {}),
+        ...customProps,
+      };
+      const created = await createContact(token, createProps);
+      contactId = created.id;
+    }
+
+    let company_association: LeadSyncHubSpotSyncResult["company_association"] = "skipped_weak_name";
+    let company_id: string | undefined;
+
+    if (!isWeakCompanyName(companyName)) {
+      const match = await searchCompanyByExactName(token, companyName);
+      if (match.count === 1 && match.id) {
+        company_id = match.id;
+        try {
+          await associateContactToCompany(token, contactId, match.id);
+          company_association = "linked";
+        } catch (e) {
+          return toConnectorError(e);
+        }
+      } else if (match.count === 0) {
+        if (process.env.HUBSPOT_ALLOW_COMPANY_CREATE === "1") {
+          try {
+            const co = await createCompany(token, companyName);
+            company_id = co.id;
+            await associateContactToCompany(token, contactId, co.id);
+            company_association = "linked";
+          } catch (e) {
+            return toConnectorError(e);
+          }
+        } else {
+          company_association = "skipped_no_match";
+        }
+      } else {
+        company_association = "skipped_ambiguous";
+      }
+    }
+
+    const existingNote = await findExistingInquiryNote(token, contactId, payload.lead_id);
+    let note_id: string | undefined;
+    let note_action: LeadSyncHubSpotSyncResult["note_action"] = "skipped_existing";
+
+    if (existingNote) {
+      note_id = existingNote;
+    } else {
+      const note = await createNoteForContact(token, contactId, payload, ownerId);
+      note_id = note.id;
+      note_action = "created";
+    }
+
+    const mock_result: LeadSyncHubSpotSyncResult = {
+      system: "hubspot",
+      synced_at,
+      pipeline_hint,
+      contact_id: contactId,
+      company_id,
+      company_association,
+      note_id,
+      note_action,
+    };
+
+    return { ok: true, http_status: 200, mock_result };
+  } catch (err) {
+    return toConnectorError(err);
+  }
+}

--- a/frontend/src/lib/leadSyncConnectors.ts
+++ b/frontend/src/lib/leadSyncConnectors.ts
@@ -1,13 +1,9 @@
 import "server-only";
 
-import type { LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
+import { runHubspotLeadSyncConnector } from "@/lib/hubspotLeadSyncConnector";
+import type { LeadSyncConnectorResult, LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
 
-export type ConnectorResult = {
-  ok: boolean;
-  http_status?: number;
-  error?: string;
-  mock_result?: unknown;
-};
+export type ConnectorResult = LeadSyncConnectorResult;
 
 const N8N_TIMEOUT_MS = 25_000;
 
@@ -18,6 +14,8 @@ export async function runLeadSyncConnector(
   switch (target) {
     case "n8n_webhook":
       return runN8nWebhookConnector(payload);
+    case "hubspot":
+      return runHubspotLeadSyncConnector(payload);
     case "hubspot_stub":
       return runHubspotStubConnector(payload);
     case "pipedrive_stub":

--- a/frontend/src/lib/leadSyncDispatcher.ts
+++ b/frontend/src/lib/leadSyncDispatcher.ts
@@ -24,6 +24,7 @@ export const LEAD_SYNC_MAX_ATTEMPTS = 6;
 export function getEnabledLeadSyncTargets(): LeadSyncTarget[] {
   const t: LeadSyncTarget[] = [];
   if (process.env.LEAD_SYNC_N8N_URL?.trim()) t.push("n8n_webhook");
+  if (process.env.HUBSPOT_ACCESS_TOKEN?.trim()) t.push("hubspot");
   if (process.env.LEAD_SYNC_HUBSPOT_STUB === "1") t.push("hubspot_stub");
   if (process.env.LEAD_SYNC_PIPEDRIVE_STUB === "1") t.push("pipedrive_stub");
   return t;
@@ -133,7 +134,7 @@ export async function processLeadSyncJobById(jobId: string): Promise<LeadSyncJob
     } catch {
       /* ignore */
     }
-  } else if (attempt >= LEAD_SYNC_MAX_ATTEMPTS) {
+  } else if (result.retryable === false || attempt >= LEAD_SYNC_MAX_ATTEMPTS) {
     await updateLeadSyncJob(jobId, (j) => ({
       ...j,
       status: "dead_letter",
@@ -144,7 +145,7 @@ export async function processLeadSyncJobById(jobId: string): Promise<LeadSyncJob
       await appendLeadOpsActivity(
         job.lead_id,
         "lead_sync_dead_letter",
-        `${job.target}: ${result.error ?? "?"}`,
+        `${job.target}: ${result.error ?? "?"}${result.retryable === false ? " (non-retryable)" : ""}`,
       );
     } catch {
       /* ignore */

--- a/frontend/src/lib/leadSyncTypes.ts
+++ b/frontend/src/lib/leadSyncTypes.ts
@@ -2,7 +2,7 @@
  * Wave 28 – Lead-Sync-Jobs (getrennt von Roh-Anfrage / JSONL lead_inquiry).
  */
 
-export type LeadSyncTarget = "n8n_webhook" | "hubspot_stub" | "pipedrive_stub";
+export type LeadSyncTarget = "n8n_webhook" | "hubspot" | "hubspot_stub" | "pipedrive_stub";
 
 export type LeadSyncJobStatus =
   | "pending"
@@ -65,7 +65,7 @@ export type LeadSyncJob = {
   last_error?: string;
   last_http_status?: number;
   next_retry_at?: string;
-  /** Stub-Ergebnis oder Metadaten (keine Secrets). */
+  /** Downstream-Ergebnis (Stub, n8n-Meta, HubSpot-IDs usw.; keine Secrets). */
   mock_result?: unknown;
   /** Fixierter Payload pro Job (Retries senden dasselbe Snapshot). */
   payload_snapshot?: LeadSyncPayloadV1;
@@ -73,3 +73,13 @@ export type LeadSyncJob = {
 
 /** API-/UI-Ansicht ohne großen Payload-Snapshot. */
 export type LeadSyncJobApi = Omit<LeadSyncJob, "payload_snapshot">;
+
+/** Rückgabe eines Downstream-Connectors (inkl. Retry-Hinweis für den Dispatcher). */
+export type LeadSyncConnectorResult = {
+  ok: boolean;
+  http_status?: number;
+  error?: string;
+  mock_result?: unknown;
+  /** `false` = sofort Dead Letter (z. B. Auth/Validation). */
+  retryable?: boolean;
+};


### PR DESCRIPTION
Add hubspot target with CRM upsert, conservative company match/associate, idempotent inquiry notes, structured sync result for admin UI, connector retry classification with immediate dead-letter for non-retryable errors, and documentation.

Made-with: Cursor