### PR TITLE
feat(gtm): Wave 28.2 Pipedrive qualified deal sync

### DIFF
--- a/docs/gtm/wave28-lead-sync-framework.md
+++ b/docs/gtm/wave28-lead-sync-framework.md
@@ -9,7 +9,7 @@ Ziel: Zuverlässiger, nachvollziehbarer Push von Lead-/Inquiry-Daten zu **n8n** 
 - **Ops-Sicht** in der internen Lead-Inbox: Status pro Ziel, Fehler, manueller Retry.
 - **Aktivitäts-Log** (`lead_ops`): `lead_sync_job_created`, `lead_sync_sent`, `lead_sync_failed`, `lead_sync_retried`, `lead_sync_dead_letter`.
 
-Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 28.1 – HubSpot Upsert](wave28.1-hubspot-upsert.md).
+Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 28.1 – HubSpot Upsert](wave28.1-hubspot-upsert.md), [Wave 28.2 – Pipedrive qualifizierte Deals](wave28.2-pipedrive-qualified-deals.md).
 
 ## Job-Modell (`LeadSyncJob`)
 
@@ -18,7 +18,7 @@ Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance
 | `job_id` | UUID |
 | `lead_id` | Verknüpfung zur Inquiry |
 | `lead_contact_key` | Kontext für CRM-Upsert (E-Mail-Schlüssel) |
-| `target` | `n8n_webhook` \| `hubspot` \| `hubspot_stub` \| `pipedrive_stub` |
+| `target` | `n8n_webhook` \| `hubspot` \| `hubspot_stub` \| `pipedrive` \| `pipedrive_stub` |
 | `payload_version` | z. B. `1.0` (Sync-Payload-Schema) |
 | `status` | `pending` → `retrying` / `sent` / `failed` → ggf. `dead_letter` |
 | `attempt_count` | Anzahl Versuche |
@@ -76,6 +76,7 @@ Stubs (`hubspot_stub`, `pipedrive_stub`) mappen den Payload in ein lokales, stru
 | `n8n_webhook` | `LEAD_SYNC_N8N_URL` gesetzt; optional `LEAD_SYNC_N8N_SECRET` (Bearer) | HTTP POST mit JSON-Payload, Status/Errors am Job |
 | `hubspot` | `HUBSPOT_ACCESS_TOKEN` | Echter HubSpot CRM-Sync (siehe [Wave 28.1](wave28.1-hubspot-upsert.md)) |
 | `hubspot_stub` | `LEAD_SYNC_HUBSPOT_STUB=1` | Lokales Mock-Upsert + Notiz |
+| `pipedrive` | `PIPEDRIVE_API_TOKEN` + Pipeline/Stage-IDs | Qualifizierte Deals nur (siehe [Wave 28.2](wave28.2-pipedrive-qualified-deals.md)) |
 | `pipedrive_stub` | `LEAD_SYNC_PIPEDRIVE_STUB=1` | Lokales Mock-Upsert + Aktivität |
 
 ## APIs (intern)

--- a/docs/gtm/wave28.1-hubspot-upsert.md
+++ b/docs/gtm/wave28.1-hubspot-upsert.md
@@ -2,7 +2,7 @@
 
 Ziel: End-to-end Sync von Website-Leads nach **HubSpot** über das bestehende `LeadSyncJob`-Framework, ohne generische CRM-Abstraktion. Fokus auf **Korrektheit, Nachvollziehbarkeit und konservative Updates**.
 
-Siehe auch: [Wave 28 – Lead-Sync-Framework](wave28-lead-sync-framework.md).
+Siehe auch: [Wave 28 – Lead-Sync-Framework](wave28-lead-sync-framework.md), [Wave 28.2 – Pipedrive qualifizierte Deals](wave28.2-pipedrive-qualified-deals.md) (Pipedrive ergänzt HubSpot, ersetzt es nicht).
 
 ## Aktivierung
 

--- a/docs/gtm/wave28.2-pipedrive-qualified-deals.md
+++ b/docs/gtm/wave28.2-pipedrive-qualified-deals.md
@@ -1,0 +1,74 @@
+# Wave 28.2 – Pipedrive: qualifizierte Deals (schmaler Vertriebspfad)
+
+## Rolle im Stack
+
+- **HubSpot** bleibt das **breitere** System für Kontakt, Historie und Website-Inquiries (Wave 28.1).
+- **Pipedrive** ist ein **optionaler Ausführungs-Layer** für **qualifizierte Verkaufschancen** (Pipeline/Deal), kein zweites „System of Truth“ für jeden Lead.
+
+Wenn beide Ziele aktiv sind, laufen **HubSpot-Jobs für alle** eingehenden Leads (so konfiguriert), **Pipedrive-Jobs nur**, wenn die untenstehenden **Qualifikationsregeln** erfüllt sind.
+
+## Aktivierung
+
+| Variable | Bedeutung |
+|----------|-----------|
+| `PIPEDRIVE_API_TOKEN` | API-Token; wenn gesetzt, Ziel `pipedrive` in `getEnabledLeadSyncTargets()`. |
+| `PIPEDRIVE_DEFAULT_PIPELINE_ID` | **Pflicht** (numerisch): Pipeline für neue Deals. |
+| `PIPEDRIVE_DEFAULT_STAGE_ID` | **Pflicht** (numerisch): Start-Stage in dieser Pipeline. |
+| `PIPEDRIVE_DEFAULT_OWNER_ID` | Optional: numerischer User/Owner für Person (Create) und Deal. |
+| `PIPEDRIVE_ALLOW_ORG_CREATE` | `1`: bei fehlendem exakten Organisations-Treffer Organisation anlegen; sonst nur Match. |
+
+Der **Stub** `pipedrive_stub` bleibt über `LEAD_SYNC_PIPEDRIVE_STUB=1` für Tests; echtes Pipedrive nutzt Ziel `pipedrive`.
+
+## Qualifikations-Gate (explizit)
+
+Ein Lead ist **nur dann** für einen Pipedrive-Deal-Sync vorgesehen, wenn **alle** zutreffen:
+
+1. **Geschäfts-E-Mail** vorhanden und plausibel (enthält `@`).
+2. **Kein Spam:** `triage_status !== "spam"`.
+3. **Qualifiziert:** `triage_status === "qualified"`.
+4. **Zusätzlich mindestens eines:**
+   - **Firma** mit ausreichend belastbarem Namen (nicht leer/Platzhalter wie „n/a“, „test“, …), oder
+   - **Segment** `enterprise_sap` oder `kanzlei_wp`, oder
+   - **Owner** in der Inbox gesetzt (nicht leer).
+
+Implementierung: `frontend/src/lib/pipedriveDealEligibility.ts` (`isLeadPipedriveDealEligible`).
+
+**Warum nicht jeder Lead ein Deal wird:** Pipedrive soll **Pipeline-Rauschen** vermeiden; Roh-Anfragen und frühe Triage-Stufen bleiben bei HubSpot/Inbox.
+
+## Wann wird ein Job erzeugt?
+
+- Beim **öffentlichen Ingest** (`POST /api/lead-inquiry`): Pipedrive wird in der Sync-Schleife **übersprungen**, solange das Gate nicht erfüllt (typisch: Triage noch `received`).
+- Nach **Admin-PATCH** (Triage, Owner, …): `enqueuePipedriveDealSyncIfEligible` legt bei erfülltem Gate einen Job an und verarbeitet ihn direkt danach (best effort).
+
+## Idempotency & Deal-Dedup
+
+- **Job-Idempotency:** `computeLeadSyncIdempotencyKey("pipedrive", lead_id, …, pipedrive_deal:{lead_id})` — **ein Job pro Lead-Inquiry** (`lead_id`).
+- **Fresh Payload:** Der Connector lädt vor der Ausführung **aktuelle** Triage/Owner/Segment aus der Inbox (wie bei Bedarf auch HubSpot später denkbar); das verhindert veraltete Deal-Daten nach Ops-Änderungen.
+- **Deal-Dedup:** Deal-Titel enthält den Marker `CH-LID:{lead_id}`. Gesucht wird unter `GET /deals?person_id=…` nach einem Deal, dessen Titel den Marker enthält; **Update** statt zweitem Deal.
+
+**Grenze:** Wenn der Marker im Titel in Pipedrive manuell entfernt wird, kann ein zweiter Deal entstehen.
+
+## Person & Organisation
+
+- **Person:** Suche per `itemSearch` (Person), dann exakter Abgleich der E-Mail; sonst **Create** mit Name, E-Mail, optional `org_id` und `owner_id` (nur beim Anlegen).
+- **Update bestehender Person:** nur **leeren Namen** füllen — keine Organisation/Owner überschreiben.
+- **Organisation:** Suche per `itemSearch` (Organization), **exakter** Name-Match nach Nachladen des Datensatzes; bei Mehrdeutigkeit **keine** Verknüpfung; optional **Create** mit `PIPEDRIVE_ALLOW_ORG_CREATE=1`.
+- **Schwache Firmennamen:** wie bei HubSpot konservativ — kein Org-Match/Create für Platzhalter.
+
+## Deal-Inhalt
+
+- Titel: `CH-LID:{lead_id} | {Firma oder Name oder E-Mail} · {segment}` (gekürzt).
+- Deal verknüpft mit Person und optional Org; Pipeline/Stage aus Env.
+- **Notiz** am Deal mit Nachricht-Auszug, Quelle, Route, Owner (Inbox), Triage, `trace_id`, `lead_id`, Kontakt-Sequenz / `duplicate_hint`.
+
+## Retries & Dead Letter
+
+- Gleiches Muster wie HubSpot: `retryable` im Connector-Ergebnis; **nicht retry-fähig** (z. B. fehlende Pipeline/Stage, Token, harte 400er) → **schneller Dead Letter** über den Dispatcher.
+
+## Admin-UI
+
+- Hinweiszeile **„Pipedrive-Deal möglich“** mit deutscher Begründung.
+- Tabelle **CRM / Deal-Referenz** mit Pipedrive **Person / Org / Deal**-IDs bei erfolgreichem Sync.
+- Schnellaktion **„Qualifiziert (Pipedrive)“** setzt Triage auf `qualified` (weitere Bedingungen des Gates ggf. über Firma/Segment/Owner).
+
+Siehe auch: [Wave 28 – Lead-Sync-Framework](wave28-lead-sync-framework.md), [Wave 28.1 – HubSpot](wave28.1-hubspot-upsert.md).

--- a/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/[leadId]/route.ts
@@ -14,7 +14,11 @@ import {
   getMergedLeadAdminRow,
   readAllLeadRecordsMerged,
 } from "@/lib/leadPersistence";
-import { redactLeadSyncJobForApi } from "@/lib/leadSyncDispatcher";
+import {
+  enqueuePipedriveDealSyncIfEligible,
+  processLeadSyncJobById,
+  redactLeadSyncJobForApi,
+} from "@/lib/leadSyncDispatcher";
 import { listLeadSyncJobsForLead } from "@/lib/leadSyncStore";
 
 export const runtime = "nodejs";
@@ -143,11 +147,24 @@ export async function PATCH(req: Request, ctx: { params: Promise<{ leadId: strin
   const item = row ? (attachContactRollups(merged, allRows, ops)[0] ?? null) : null;
   const contact_history = row ? buildContactHistoryItems(leadId, allRows, ops) : [];
 
+  try {
+    const pdJobIds = await enqueuePipedriveDealSyncIfEligible(leadId);
+    for (const jid of pdJobIds) {
+      await processLeadSyncJobById(jid);
+    }
+  } catch (e) {
+    console.warn("[lead-admin] pipedrive_enqueue_process", e);
+  }
+
+  const sync_jobs_raw = await listLeadSyncJobsForLead(leadId);
+  const sync_jobs = sync_jobs_raw.map(redactLeadSyncJobForApi);
+
   return NextResponse.json({
     ok: true,
     changed: true,
     entry: result.entry,
     item,
     contact_history,
+    sync_jobs,
   });
 }

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
 import type { LeadContactHistoryEntry, LeadInboxItem } from "@/lib/leadInboxTypes";
+import { describePipedriveDealEligibility } from "@/lib/pipedriveDealEligibility";
 import type { LeadSyncJobApi } from "@/lib/leadSyncTypes";
 import { LEAD_TRIAGE_LABELS_DE, LEAD_TRIAGE_STATUSES } from "@/lib/leadTriage";
 
@@ -28,6 +29,7 @@ const SYNC_TARGET_LABELS: Record<LeadSyncJobApi["target"], string> = {
   n8n_webhook: "n8n (Webhook)",
   hubspot: "HubSpot",
   hubspot_stub: "HubSpot (Stub)",
+  pipedrive: "Pipedrive (Deal)",
   pipedrive_stub: "Pipedrive (Stub)",
 };
 
@@ -40,6 +42,37 @@ const HUBSPOT_COMPANY_ASSOC_DE: Record<string, string> = {
 };
 
 /** Client-sichere Auswertung von `mock_result` (kein server-only Import). */
+const PIPEDRIVE_ORG_ASSOC_DE: Record<string, string> = {
+  linked: "Organisation verknüpft",
+  skipped_weak_name: "Organisation: Name zu schwach",
+  skipped_no_match: "Organisation: kein exakter Treffer",
+  skipped_ambiguous: "Organisation: mehrdeutig",
+  skipped_create_disabled: "Organisation: Anlegen deaktiviert",
+};
+
+function pipedriveMockDetails(mock: unknown): {
+  person_id: string;
+  org_id?: string;
+  deal_id: string;
+  deal_action: string;
+  org_association: string;
+  synced_at?: string;
+} | null {
+  if (!mock || typeof mock !== "object") return null;
+  const m = mock as Record<string, unknown>;
+  if (m.system !== "pipedrive" || typeof m.person_id !== "string" || typeof m.deal_id !== "string") {
+    return null;
+  }
+  return {
+    person_id: m.person_id,
+    org_id: typeof m.org_id === "string" ? m.org_id : undefined,
+    deal_id: m.deal_id,
+    deal_action: typeof m.deal_action === "string" ? m.deal_action : "—",
+    org_association: typeof m.org_association === "string" ? m.org_association : "—",
+    synced_at: typeof m.synced_at === "string" ? m.synced_at : undefined,
+  };
+}
+
 function hubspotMockDetails(mock: unknown): {
   contact_id: string;
   company_id?: string;
@@ -113,6 +146,11 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
   );
 
   const displayLead = detailItem ?? selected;
+
+  const pipedriveEligibility = useMemo(
+    () => (displayLead ? describePipedriveDealEligibility(displayLead) : null),
+    [displayLead],
+  );
 
   useEffect(() => {
     if (!displayLead) {
@@ -263,6 +301,7 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
         ok?: boolean;
         item?: LeadInboxItem | null;
         contact_history?: LeadContactHistoryEntry[];
+        sync_jobs?: LeadSyncJobApi[];
       };
       if (!r.ok) {
         setActionMsg("Speichern fehlgeschlagen.");
@@ -276,6 +315,9 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
       }
       if (data.contact_history && selectedId === leadId) {
         setContactHistory(data.contact_history);
+      }
+      if (Array.isArray(data.sync_jobs) && selectedId === leadId) {
+        setSyncJobs(data.sync_jobs);
       }
       setActionMsg("Gespeichert.");
     } catch {
@@ -627,6 +669,14 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
               <button
                 type="button"
                 disabled={saving}
+                className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-1.5 text-sm text-emerald-900 hover:bg-emerald-100 disabled:opacity-50"
+                onClick={() => void patchLead(displayLead.lead_id, { triage_status: "qualified" })}
+              >
+                Qualifiziert (Pipedrive)
+              </button>
+              <button
+                type="button"
+                disabled={saving}
                 className="rounded-lg border border-red-200 bg-red-50 px-3 py-1.5 text-sm text-red-800 hover:bg-red-100 disabled:opacity-50"
                 onClick={() => void patchLead(displayLead.lead_id, { triage_status: "spam" })}
               >
@@ -690,13 +740,23 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
           <div className="mt-6 border-t border-slate-100 pt-4">
             <h3 className="text-sm font-medium text-slate-800">GTM-Sync (Wave 28)</h3>
             <p className="mt-1 text-xs text-slate-500">
-              Status pro Ziel (n8n, HubSpot, Stubs). Ohne konfigurierte Ziele entstehen keine Jobs.
+              HubSpot = Kontakt/Historie; Pipedrive = optional Deals nur bei qualifizierten Leads. Ohne
+              konfigurierte Ziele entstehen keine Jobs.
             </p>
+            {pipedriveEligibility ? (
+              <p className="mt-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-700">
+                <span className="font-medium text-slate-800">Pipedrive-Deal möglich:</span>{" "}
+                <span className={pipedriveEligibility.eligible ? "text-emerald-800" : ""}>
+                  {pipedriveEligibility.eligible ? "Ja — " : "Nein — "}
+                </span>
+                {pipedriveEligibility.summary}
+              </p>
+            ) : null}
             {syncJobs.length === 0 ? (
               <p className="mt-2 text-sm text-slate-500">Keine Sync-Jobs für diesen Lead.</p>
             ) : (
               <div className="mt-3 overflow-x-auto rounded-lg border border-slate-200">
-                <table className="w-full min-w-[880px] border-collapse text-left text-xs">
+                <table className="w-full min-w-[960px] border-collapse text-left text-xs">
                   <thead className="border-b border-slate-200 bg-slate-50 text-slate-600">
                     <tr>
                       <th className="px-2 py-2 font-medium">Ziel</th>
@@ -705,13 +765,14 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                       <th className="px-2 py-2 font-medium">Letzter Versuch</th>
                       <th className="px-2 py-2 font-medium">Nächster Retry</th>
                       <th className="px-2 py-2 font-medium">Fehler</th>
-                      <th className="px-2 py-2 font-medium">HubSpot-Referenz</th>
+                      <th className="px-2 py-2 font-medium">CRM / Deal-Referenz</th>
                       <th className="px-2 py-2 font-medium" />
                     </tr>
                   </thead>
                   <tbody>
                     {syncJobs.map((j) => {
                       const hs = hubspotMockDetails(j.mock_result);
+                      const pd = pipedriveMockDetails(j.mock_result);
                       return (
                           <tr key={j.job_id} className="border-b border-slate-100">
                             <td className="px-2 py-2 text-slate-800">{SYNC_TARGET_LABELS[j.target]}</td>
@@ -731,9 +792,12 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                             >
                               {j.last_error ?? "—"}
                             </td>
-                            <td className="max-w-[220px] px-2 py-2 align-top text-[10px] text-slate-600">
+                            <td className="max-w-[240px] px-2 py-2 align-top text-[10px] text-slate-600">
                               {hs ? (
                                 <ul className="list-inside list-disc space-y-0.5 font-mono">
+                                  <li className="list-none pl-0 font-sans font-medium text-slate-700">
+                                    HubSpot
+                                  </li>
                                   <li>Kontakt {hs.contact_id}</li>
                                   {hs.company_id ? <li>Firma {hs.company_id}</li> : null}
                                   {hs.note_id ? (
@@ -751,9 +815,28 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                                     </li>
                                   ) : null}
                                 </ul>
-                              ) : (
-                                "—"
-                              )}
+                              ) : null}
+                              {pd ? (
+                                <ul className="mt-1 list-inside list-disc space-y-0.5 border-t border-slate-100 pt-1 font-mono">
+                                  <li className="list-none pl-0 font-sans font-medium text-slate-700">
+                                    Pipedrive
+                                  </li>
+                                  <li>Person {pd.person_id}</li>
+                                  {pd.org_id ? <li>Org {pd.org_id}</li> : null}
+                                  <li>
+                                    Deal {pd.deal_id} ({pd.deal_action})
+                                  </li>
+                                  <li className="list-none pl-0 font-sans text-slate-500">
+                                    {PIPEDRIVE_ORG_ASSOC_DE[pd.org_association] ?? pd.org_association}
+                                  </li>
+                                  {pd.synced_at ? (
+                                    <li className="list-none pl-0 font-sans text-slate-400">
+                                      Sync {new Date(pd.synced_at).toLocaleString("de-DE")}
+                                    </li>
+                                  ) : null}
+                                </ul>
+                              ) : null}
+                              {!hs && !pd ? "—" : null}
                             </td>
                             <td className="px-2 py-2">
                               {j.status === "failed" ||

--- a/frontend/src/lib/leadSyncConnectors.ts
+++ b/frontend/src/lib/leadSyncConnectors.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { runHubspotLeadSyncConnector } from "@/lib/hubspotLeadSyncConnector";
+import { runPipedriveLeadSyncConnector } from "@/lib/pipedriveLeadSyncConnector";
 import type { LeadSyncConnectorResult, LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
 
 export type ConnectorResult = LeadSyncConnectorResult;
@@ -18,6 +19,8 @@ export async function runLeadSyncConnector(
       return runHubspotLeadSyncConnector(payload);
     case "hubspot_stub":
       return runHubspotStubConnector(payload);
+    case "pipedrive":
+      return runPipedriveLeadSyncConnector(payload);
     case "pipedrive_stub":
       return runPipedriveStubConnector(payload);
     default:

--- a/frontend/src/lib/leadSyncDispatcher.ts
+++ b/frontend/src/lib/leadSyncDispatcher.ts
@@ -2,11 +2,13 @@ import "server-only";
 
 import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
 import { appendLeadOpsActivity, readLeadOpsState } from "@/lib/leadOpsState";
+import { isLeadPipedriveDealEligible } from "@/lib/pipedriveDealEligibility";
 import {
   buildLeadSyncPayloadV1,
   computeLeadSyncIdempotencyKey,
   defaultMaterialRevisionForIngest,
   LEAD_SYNC_PAYLOAD_VERSION,
+  pipedriveDealMaterialRevision,
   type LegacyInboundDelivery,
 } from "@/lib/leadSyncPayload";
 import { runLeadSyncConnector } from "@/lib/leadSyncConnectors";
@@ -26,6 +28,7 @@ export function getEnabledLeadSyncTargets(): LeadSyncTarget[] {
   if (process.env.LEAD_SYNC_N8N_URL?.trim()) t.push("n8n_webhook");
   if (process.env.HUBSPOT_ACCESS_TOKEN?.trim()) t.push("hubspot");
   if (process.env.LEAD_SYNC_HUBSPOT_STUB === "1") t.push("hubspot_stub");
+  if (process.env.PIPEDRIVE_API_TOKEN?.trim()) t.push("pipedrive");
   if (process.env.LEAD_SYNC_PIPEDRIVE_STUB === "1") t.push("pipedrive_stub");
   return t;
 }
@@ -52,11 +55,18 @@ export async function enqueueLeadSyncAfterIngest(input: {
   const contactKey = row.lead_contact_key ?? inboxItem.lead_contact_key;
 
   for (const target of targets) {
+    if (target === "pipedrive" && !isLeadPipedriveDealEligible(inboxItem)) {
+      continue;
+    }
+
+    const materialRev =
+      target === "pipedrive" ? pipedriveDealMaterialRevision(row.lead_id) : material;
+
     const idempotency_key = computeLeadSyncIdempotencyKey(
       target,
       row.lead_id,
       LEAD_SYNC_PAYLOAD_VERSION,
-      material,
+      materialRev,
     );
     const payload = buildLeadSyncPayloadV1({
       row,
@@ -86,6 +96,61 @@ export async function enqueueLeadSyncAfterIngest(input: {
     }
   }
   return jobIds;
+}
+
+/**
+ * Nach Qualifizierung (z. B. Admin-PATCH): Pipedrive-Deal-Job anlegen, falls Token + Gate erfüllt.
+ * Idempotency stabil pro lead_id über `pipedriveDealMaterialRevision`.
+ */
+export async function enqueuePipedriveDealSyncIfEligible(leadId: string): Promise<string[]> {
+  if (!process.env.PIPEDRIVE_API_TOKEN?.trim()) return [];
+
+  const row = await getMergedLeadAdminRow(leadId);
+  if (!row) return [];
+
+  const allRows = await readAllLeadRecordsMerged();
+  const ops = await readLeadOpsState();
+  const merged = mergeLeadsWithOps([row], ops);
+  const inboxItem = attachContactRollups(merged, allRows, ops)[0];
+  if (!inboxItem || !isLeadPipedriveDealEligible(inboxItem)) return [];
+
+  const materialRev = pipedriveDealMaterialRevision(row.lead_id);
+  const idempotency_key = computeLeadSyncIdempotencyKey(
+    "pipedrive",
+    row.lead_id,
+    LEAD_SYNC_PAYLOAD_VERSION,
+    materialRev,
+  );
+  const payload = buildLeadSyncPayloadV1({
+    row,
+    inboxItem,
+    legacyInboundDelivery: "not_configured",
+    idempotency_key,
+  });
+  const contactKey = row.lead_contact_key ?? inboxItem.lead_contact_key;
+
+  const { job, created } = await ensureLeadSyncJob({
+    lead_id: row.lead_id,
+    lead_contact_key: contactKey,
+    target: "pipedrive",
+    payload_version: LEAD_SYNC_PAYLOAD_VERSION,
+    idempotency_key,
+    payload_snapshot: payload,
+  });
+
+  if (created) {
+    try {
+      await appendLeadOpsActivity(
+        leadId,
+        "lead_sync_job_created",
+        `pipedrive job=${job.job_id.slice(0, 8)}`,
+      );
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return [job.job_id];
 }
 
 function backoffMs(attemptNumber: number): number {

--- a/frontend/src/lib/leadSyncPayload.ts
+++ b/frontend/src/lib/leadSyncPayload.ts
@@ -36,6 +36,11 @@ export function defaultMaterialRevisionForIngest(createdAtIso: string): string {
   return `ingest:${createdAtIso}`;
 }
 
+/** Eine stabile Revision pro Lead für den Pipedrive-Deal-Job (nicht ingest-Zeit). */
+export function pipedriveDealMaterialRevision(leadId: string): string {
+  return `pipedrive_deal:${leadId}`;
+}
+
 export function buildLeadSyncPayloadV1(input: {
   row: LeadAdminRow;
   inboxItem: LeadInboxItem;

--- a/frontend/src/lib/leadSyncTypes.ts
+++ b/frontend/src/lib/leadSyncTypes.ts
@@ -2,7 +2,12 @@
  * Wave 28 – Lead-Sync-Jobs (getrennt von Roh-Anfrage / JSONL lead_inquiry).
  */
 
-export type LeadSyncTarget = "n8n_webhook" | "hubspot" | "hubspot_stub" | "pipedrive_stub";
+export type LeadSyncTarget =
+  | "n8n_webhook"
+  | "hubspot"
+  | "hubspot_stub"
+  | "pipedrive"
+  | "pipedrive_stub";
 
 export type LeadSyncJobStatus =
   | "pending"

--- a/frontend/src/lib/pipedriveDealEligibility.test.ts
+++ b/frontend/src/lib/pipedriveDealEligibility.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  describePipedriveDealEligibility,
+  isLeadPipedriveDealEligible,
+} from "@/lib/pipedriveDealEligibility";
+
+const base = {
+  business_email: "a@firma.de",
+  company: "Acme GmbH",
+  segment: "sonstiges" as const,
+  owner: "",
+  triage_status: "qualified" as const,
+};
+
+describe("isLeadPipedriveDealEligible", () => {
+  it("requires qualified triage and not spam", () => {
+    expect(isLeadPipedriveDealEligible({ ...base, triage_status: "received" })).toBe(false);
+    expect(isLeadPipedriveDealEligible({ ...base, triage_status: "spam" })).toBe(false);
+    expect(isLeadPipedriveDealEligible({ ...base, triage_status: "qualified" })).toBe(true);
+  });
+
+  it("allows enterprise_sap without strong company", () => {
+    expect(
+      isLeadPipedriveDealEligible({
+        ...base,
+        company: "x",
+        segment: "enterprise_sap",
+        triage_status: "qualified",
+      }),
+    ).toBe(true);
+  });
+
+  it("allows owner without company when qualified", () => {
+    expect(
+      isLeadPipedriveDealEligible({
+        ...base,
+        company: "n/a",
+        owner: "sales",
+        segment: "sonstiges",
+        triage_status: "qualified",
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects weak company without segment or owner", () => {
+    expect(
+      isLeadPipedriveDealEligible({
+        ...base,
+        company: "test",
+        segment: "sonstiges",
+        owner: "",
+        triage_status: "qualified",
+      }),
+    ).toBe(false);
+  });
+
+  it("describe includes eligible true for company path", () => {
+    const d = describePipedriveDealEligibility(base);
+    expect(d.eligible).toBe(true);
+    expect(d.summary).toContain("Firma");
+  });
+});

--- a/frontend/src/lib/pipedriveDealEligibility.ts
+++ b/frontend/src/lib/pipedriveDealEligibility.ts
@@ -1,0 +1,76 @@
+/**
+ * Wave 28.2 – Pipedrive-Deal nur für qualifizierte, vertriebstaugliche Leads.
+ * Geteilt zwischen Admin-UI und Server (kein server-only).
+ */
+
+/** Segmente, die auch ohne ausgefüllte Firma als deal-würdig gelten (B2B-Schwerpunkt). */
+export const PIPEDRIVE_PRIORITY_SEGMENTS = ["enterprise_sap", "kanzlei_wp"] as const;
+
+function isWeakCompanyName(name: string): boolean {
+  const t = name.trim();
+  if (t.length < 2) return true;
+  return /^(n\/a|na|none|unknown|unbekannt|test|xxx|-+)$/i.test(t);
+}
+
+/** Bewusst `string` für Triage/Segment, damit `LeadSyncPayloadV1` und Inbox-Item passen. */
+export type PipedriveEligibilityInput = {
+  triage_status: string;
+  owner: string;
+  segment: string;
+  company: string;
+  business_email: string;
+};
+
+export function isLeadPipedriveDealEligible(item: PipedriveEligibilityInput): boolean {
+  const email = item.business_email?.trim().toLowerCase() ?? "";
+  if (!email || !email.includes("@")) return false;
+  if (item.triage_status === "spam") return false;
+  if (item.triage_status !== "qualified") return false;
+
+  const companyOk = item.company.trim().length >= 2 && !isWeakCompanyName(item.company);
+  const segmentOk = (PIPEDRIVE_PRIORITY_SEGMENTS as readonly string[]).includes(item.segment);
+  const ownerOk = item.owner.trim().length > 0;
+
+  return companyOk || segmentOk || ownerOk;
+}
+
+/** Kompakte deutsche Zeile für die Admin-UI. */
+export function describePipedriveDealEligibility(item: PipedriveEligibilityInput): {
+  eligible: boolean;
+  summary: string;
+} {
+  const email = item.business_email?.trim().toLowerCase() ?? "";
+  if (!email || !email.includes("@")) {
+    return { eligible: false, summary: "Keine gültige Geschäfts-E-Mail." };
+  }
+  if (item.triage_status === "spam") {
+    return { eligible: false, summary: "Als Spam markiert — kein Pipedrive-Deal." };
+  }
+  if (item.triage_status !== "qualified") {
+    return {
+      eligible: false,
+      summary: `Triage ist „${item.triage_status}“ — erforderlich: „qualifiziert“.`,
+    };
+  }
+
+  const companyOk = item.company.trim().length >= 2 && !isWeakCompanyName(item.company);
+  const segmentOk = (PIPEDRIVE_PRIORITY_SEGMENTS as readonly string[]).includes(item.segment);
+  const ownerOk = item.owner.trim().length > 0;
+
+  if (companyOk || segmentOk || ownerOk) {
+    const parts: string[] = [];
+    if (companyOk) parts.push("Firma");
+    if (segmentOk) parts.push(`Segment ${item.segment}`);
+    if (ownerOk) parts.push("Owner gesetzt");
+    return {
+      eligible: true,
+      summary: `Deal-würdig (${parts.join(", ")}). HubSpot bleibt Kontakt-/Historie-System.`,
+    };
+  }
+
+  return {
+    eligible: false,
+    summary:
+      "Qualifiziert, aber ohne belastbare Firma, ohne Prioritäts-Segment (enterprise_sap / kanzlei_wp) und ohne Owner.",
+  };
+}

--- a/frontend/src/lib/pipedriveLeadSyncConnector.ts
+++ b/frontend/src/lib/pipedriveLeadSyncConnector.ts
@@ -1,0 +1,478 @@
+/**
+ * Wave 28.2 – Pipedrive-Deals nur für qualifizierte Leads (siehe `pipedriveDealEligibility`).
+ * HubSpot bleibt breiteres Kontakt-/Aktivitäts-System; Pipedrive = schmaler Pipeline-Pfad.
+ */
+import "server-only";
+
+import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import { readLeadOpsState } from "@/lib/leadOpsState";
+import {
+  buildLeadSyncPayloadV1,
+  type LegacyInboundDelivery,
+} from "@/lib/leadSyncPayload";
+import { getMergedLeadAdminRow, readAllLeadRecordsMerged } from "@/lib/leadPersistence";
+import { isLeadPipedriveDealEligible } from "@/lib/pipedriveDealEligibility";
+import type { LeadSyncConnectorResult, LeadSyncPayloadV1 } from "@/lib/leadSyncTypes";
+
+const PD_BASE = "https://api.pipedrive.com/v1";
+const REQUEST_TIMEOUT_MS = 28_000;
+
+const DEAL_TITLE_PREFIX = "CH-LID:";
+
+export type LeadSyncPipedriveSyncResult = {
+  system: "pipedrive";
+  synced_at: string;
+  person_id: string;
+  org_id?: string;
+  org_association:
+    | "linked"
+    | "skipped_weak_name"
+    | "skipped_no_match"
+    | "skipped_ambiguous"
+    | "skipped_create_disabled";
+  deal_id: string;
+  deal_action: "created" | "updated";
+  pipeline_id: number;
+  stage_id: number;
+};
+
+type PdEnvelope<T> = {
+  success?: boolean;
+  data?: T;
+  error?: string;
+  error_info?: string;
+};
+
+function isWeakOrgName(name: string): boolean {
+  const t = name.trim();
+  if (t.length < 2) return true;
+  return /^(n\/a|na|none|unknown|unbekannt|test|xxx|-+)$/i.test(t);
+}
+
+function classifyPipedriveRetryable(status: number, errMsg: string): boolean {
+  const m = errMsg.toLowerCase();
+  if (status === 429) return true;
+  if (status >= 500) return true;
+  if (status === 401) return false;
+  if (status === 403) return false;
+  if (status === 404 && m.includes("not found")) return false;
+  if (status === 400) return false;
+  if (status >= 400) return false;
+  return true;
+}
+
+function formatPdError(status: number, parsed: PdEnvelope<unknown> | null, raw: string): string {
+  const parts = [`http_${status}`];
+  if (parsed?.error) parts.push(parsed.error);
+  if (parsed?.error_info) parts.push(String(parsed.error_info).slice(0, 200));
+  else if (raw) parts.push(raw.slice(0, 280));
+  return parts.join(": ");
+}
+
+async function pdFetch(
+  token: string,
+  method: "GET" | "POST" | "PUT",
+  path: string,
+  opts?: { query?: Record<string, string>; body?: unknown },
+): Promise<{ status: number; parsed: PdEnvelope<unknown> | null; raw: string }> {
+  const url = new URL(`${PD_BASE}${path.startsWith("/") ? path : `/${path}`}`);
+  url.searchParams.set("api_token", token);
+  if (opts?.query) {
+    for (const [k, v] of Object.entries(opts.query)) {
+      if (v !== "") url.searchParams.set(k, v);
+    }
+  }
+  const controller = new AbortController();
+  const t = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const init: RequestInit = {
+      method,
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+    };
+    if (opts?.body !== undefined && method !== "GET") {
+      init.body = JSON.stringify(opts.body);
+    }
+    const r = await fetch(url.toString(), init);
+    const raw = await r.text();
+    let parsed: PdEnvelope<unknown> | null = null;
+    try {
+      parsed = JSON.parse(raw) as PdEnvelope<unknown>;
+    } catch {
+      /* ignore */
+    }
+    return { status: r.status, parsed, raw };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+function requirePdSuccess(
+  r: { status: number; parsed: PdEnvelope<unknown> | null; raw: string },
+  op: string,
+): void {
+  if (r.parsed?.success === true) return;
+  const st = r.status >= 400 ? r.status : 400;
+  throw { status: st, parsed: r.parsed, raw: r.raw, op };
+}
+
+async function resolveFreshPayload(snapshot: LeadSyncPayloadV1): Promise<LeadSyncPayloadV1 | null> {
+  const row = await getMergedLeadAdminRow(snapshot.lead_id);
+  if (!row) return null;
+  const allRows = await readAllLeadRecordsMerged();
+  const ops = await readLeadOpsState();
+  const merged = mergeLeadsWithOps([row], ops);
+  const inboxItem = attachContactRollups(merged, allRows, ops)[0];
+  if (!inboxItem) return null;
+  const legacy = snapshot.legacy_inbound_webhook_delivery as LegacyInboundDelivery;
+  return buildLeadSyncPayloadV1({
+    row,
+    inboxItem,
+    legacyInboundDelivery: legacy,
+    idempotency_key: snapshot.idempotency_key,
+  });
+}
+
+function extractItemSearchIds(parsed: PdEnvelope<unknown> | null, wantType: string): number[] {
+  if (!parsed?.data) return [];
+  const d = parsed.data as Record<string, unknown> | unknown[];
+  const list: unknown[] = Array.isArray(d)
+    ? d
+    : Array.isArray((d as { items?: unknown }).items)
+      ? ((d as { items: unknown[] }).items ?? [])
+      : [];
+  const ids: number[] = [];
+  for (const row of list) {
+    if (!row || typeof row !== "object") continue;
+    const o = row as Record<string, unknown>;
+    const item = (o.item ?? o) as Record<string, unknown> | undefined;
+    const id = typeof item?.id === "number" ? item.id : typeof o.id === "number" ? o.id : null;
+    const type = String(item?.type ?? o.type ?? "").toLowerCase();
+    if (id != null && type === wantType) ids.push(id);
+  }
+  return ids;
+}
+
+async function findPersonIdByEmail(token: string, email: string): Promise<number | null> {
+  const r = await pdFetch(token, "GET", "/itemSearch", {
+    query: { term: email, item_types: "person", limit: "25" },
+  });
+  requirePdSuccess(r, "itemSearch_person");
+  const ids = extractItemSearchIds(r.parsed, "person");
+  const lower = email.toLowerCase();
+  for (const id of ids.slice(0, 12)) {
+    const pr = await pdFetch(token, "GET", `/persons/${id}`);
+    if (pr.parsed?.success !== true) continue;
+    const data = pr.parsed?.data as { email?: { value?: string }[] } | undefined;
+    const emails = (data?.email ?? []).map((e) => String(e.value ?? "").toLowerCase());
+    if (emails.includes(lower)) return id;
+  }
+  return null;
+}
+
+async function getPerson(token: string, id: number): Promise<{ name: string } | null> {
+  const r = await pdFetch(token, "GET", `/persons/${id}`);
+  if (r.parsed?.success !== true) return null;
+  const data = r.parsed?.data as { name?: string } | undefined;
+  return { name: String(data?.name ?? "") };
+}
+
+async function createPerson(
+  token: string,
+  input: { name: string; email: string; org_id?: number; owner_id?: number },
+): Promise<number> {
+  const body: Record<string, unknown> = {
+    name: input.name.slice(0, 200),
+    email: [{ value: input.email, primary: true, label: "work" }],
+  };
+  if (input.org_id != null) body.org_id = input.org_id;
+  if (input.owner_id != null) body.owner_id = input.owner_id;
+  const r = await pdFetch(token, "POST", "/persons", { body });
+  requirePdSuccess(r, "person_create");
+  const data = r.parsed?.data as { id?: number } | undefined;
+  if (typeof data?.id !== "number") {
+    throw { status: r.status, parsed: r.parsed, raw: r.raw, op: "person_create_no_id" };
+  }
+  return data.id;
+}
+
+/** Nur leeren Namen füllen — keine Organisation/Owner überschreiben (konservativ). */
+async function updatePersonConservative(token: string, id: number, input: { name: string }): Promise<void> {
+  const cur = await getPerson(token, id);
+  const body: Record<string, unknown> = {};
+  if (cur && !cur.name.trim() && input.name.trim()) body.name = input.name.slice(0, 200);
+  if (Object.keys(body).length === 0) return;
+  const r = await pdFetch(token, "PUT", `/persons/${id}`, { body });
+  requirePdSuccess(r, "person_update");
+}
+
+async function findOrgIdByExactName(token: string, name: string): Promise<{ id: number | null; ambiguous: boolean }> {
+  const r = await pdFetch(token, "GET", "/itemSearch", {
+    query: { term: name.trim(), item_types: "organization", limit: "25" },
+  });
+  requirePdSuccess(r, "itemSearch_org");
+  const ids = extractItemSearchIds(r.parsed, "organization");
+  const matches: number[] = [];
+  const target = name.trim().toLowerCase();
+  for (const id of ids.slice(0, 15)) {
+    const or = await pdFetch(token, "GET", `/organizations/${id}`);
+    if (or.parsed?.success !== true) continue;
+    const data = or.parsed?.data as { name?: string } | undefined;
+    if (String(data?.name ?? "").trim().toLowerCase() === target) matches.push(id);
+  }
+  if (matches.length === 1) return { id: matches[0]!, ambiguous: false };
+  if (matches.length === 0) return { id: null, ambiguous: false };
+  return { id: null, ambiguous: true };
+}
+
+async function createOrg(token: string, name: string): Promise<number> {
+  const r = await pdFetch(token, "POST", "/organizations", {
+    body: { name: name.trim().slice(0, 200) },
+  });
+  requirePdSuccess(r, "org_create");
+  const data = r.parsed?.data as { id?: number } | undefined;
+  if (typeof data?.id !== "number") {
+    throw { status: r.status, parsed: r.parsed, raw: r.raw, op: "org_create_no_id" };
+  }
+  return data.id;
+}
+
+async function listDealsForPerson(token: string, personId: number): Promise<{ id: number; title: string }[]> {
+  const r = await pdFetch(token, "GET", "/deals", {
+    query: { person_id: String(personId), limit: "100" },
+  });
+  requirePdSuccess(r, "deals_by_person");
+  const data = r.parsed?.data as unknown;
+  const list = Array.isArray(data) ? data : [];
+  return list
+    .map((row) => {
+      const o = row as { id?: number; title?: string };
+      return { id: Number(o.id), title: String(o.title ?? "") };
+    })
+    .filter((x) => Number.isFinite(x.id));
+}
+
+function dealTitleForLead(payload: LeadSyncPayloadV1): string {
+  const label = payload.company.trim() || payload.name.trim() || payload.business_email;
+  const core = `${DEAL_TITLE_PREFIX}${payload.lead_id} | ${label} · ${payload.segment}`;
+  return core.slice(0, 400);
+}
+
+function dealNoteContent(payload: LeadSyncPayloadV1): string {
+  const body = [
+    `ComplianceHub Pipedrive-Sync (${payload.contact_latest_seen_at})`,
+    "",
+    `Nachricht (Auszug): ${(payload.message || "").slice(0, 2000)}`,
+    "",
+    `Quelle: ${payload.source_page} · Segment: ${payload.segment}`,
+    `Route: ${payload.route.route_key} / ${payload.route.queue_label} · Owner (Inbox): ${payload.owner || "—"}`,
+    `Triage: ${payload.triage_status} · trace_id: ${payload.trace_id} · lead_id: ${payload.lead_id}`,
+    `Kontakt-Anfrage #${payload.contact_inquiry_sequence} von ${payload.contact_submission_count} · duplicate_hint: ${payload.duplicate_hint}`,
+  ].join("\n");
+  return body.slice(0, 8000);
+}
+
+async function createDeal(
+  token: string,
+  input: {
+    title: string;
+    person_id: number;
+    org_id?: number;
+    pipeline_id: number;
+    stage_id: number;
+    user_id?: number;
+  },
+): Promise<number> {
+  const body: Record<string, unknown> = {
+    title: input.title,
+    person_id: input.person_id,
+    pipeline_id: input.pipeline_id,
+    stage_id: input.stage_id,
+  };
+  if (input.org_id != null) body.org_id = input.org_id;
+  if (input.user_id != null) body.user_id = input.user_id;
+  const r = await pdFetch(token, "POST", "/deals", { body });
+  requirePdSuccess(r, "deal_create");
+  const data = r.parsed?.data as { id?: number } | undefined;
+  if (typeof data?.id !== "number") {
+    throw { status: r.status, parsed: r.parsed, raw: r.raw, op: "deal_create_no_id" };
+  }
+  return data.id;
+}
+
+async function updateDeal(
+  token: string,
+  dealId: number,
+  input: {
+    title: string;
+    org_id?: number;
+    user_id?: number;
+  },
+): Promise<void> {
+  const body: Record<string, unknown> = { title: input.title };
+  if (input.org_id != null) body.org_id = input.org_id;
+  if (input.user_id != null) body.user_id = input.user_id;
+  const r = await pdFetch(token, "PUT", `/deals/${dealId}`, { body });
+  requirePdSuccess(r, "deal_update");
+}
+
+async function addDealNote(
+  token: string,
+  dealId: number,
+  personId: number,
+  content: string,
+): Promise<void> {
+  const r = await pdFetch(token, "POST", "/notes", {
+    body: { content, deal_id: dealId, person_id: personId },
+  });
+  requirePdSuccess(r, "note_create");
+}
+
+function toConnectorError(err: unknown): LeadSyncConnectorResult {
+  if (err && typeof err === "object" && "status" in err) {
+    const e = err as {
+      status: number;
+      parsed: PdEnvelope<unknown> | null;
+      raw: string;
+      op?: string;
+    };
+    const msg = formatPdError(e.status, e.parsed, e.raw);
+    return {
+      ok: false,
+      http_status: e.status,
+      error: `${e.op ?? "pipedrive"}: ${msg}`,
+      retryable: classifyPipedriveRetryable(e.status, msg),
+    };
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  return { ok: false, error: `pipedrive: ${msg}`, retryable: true };
+}
+
+export async function runPipedriveLeadSyncConnector(snapshot: LeadSyncPayloadV1): Promise<LeadSyncConnectorResult> {
+  const token = process.env.PIPEDRIVE_API_TOKEN?.trim();
+  if (!token) {
+    return { ok: false, error: "pipedrive_token_not_configured", retryable: false };
+  }
+
+  const pipelineIdRaw = process.env.PIPEDRIVE_DEFAULT_PIPELINE_ID?.trim();
+  const stageIdRaw = process.env.PIPEDRIVE_DEFAULT_STAGE_ID?.trim();
+  const pipeline_id = pipelineIdRaw ? Number(pipelineIdRaw) : NaN;
+  const stage_id = stageIdRaw ? Number(stageIdRaw) : NaN;
+  if (!Number.isFinite(pipeline_id) || !Number.isFinite(stage_id)) {
+    return {
+      ok: false,
+      error:
+        "pipedrive: PIPEDRIVE_DEFAULT_PIPELINE_ID and PIPEDRIVE_DEFAULT_STAGE_ID must be set to numeric IDs",
+      retryable: false,
+    };
+  }
+
+  const ownerIdRaw = process.env.PIPEDRIVE_DEFAULT_OWNER_ID?.trim();
+  const user_id = ownerIdRaw ? Number(ownerIdRaw) : undefined;
+  if (ownerIdRaw && !Number.isFinite(user_id)) {
+    return { ok: false, error: "pipedrive: PIPEDRIVE_DEFAULT_OWNER_ID invalid", retryable: false };
+  }
+
+  let payload: LeadSyncPayloadV1;
+  try {
+    const fresh = await resolveFreshPayload(snapshot);
+    if (!fresh) {
+      return { ok: false, error: "pipedrive: lead_not_found", retryable: false };
+    }
+    payload = fresh;
+  } catch (e) {
+    return toConnectorError(e);
+  }
+
+  if (!isLeadPipedriveDealEligible(payload)) {
+    return {
+      ok: false,
+      error: "pipedrive: not_deal_eligible (triage/segment/owner/company)",
+      retryable: false,
+    };
+  }
+
+  const email = payload.business_email.trim().toLowerCase();
+  const synced_at = new Date().toISOString();
+
+  try {
+    let personId = await findPersonIdByEmail(token, email);
+    let org_association: LeadSyncPipedriveSyncResult["org_association"] = "skipped_weak_name";
+    let orgId: number | undefined;
+
+    const companyName = payload.company.trim();
+    if (!isWeakOrgName(companyName)) {
+      const orgMatch = await findOrgIdByExactName(token, companyName);
+      if (orgMatch.ambiguous) {
+        org_association = "skipped_ambiguous";
+      } else if (orgMatch.id != null) {
+        orgId = orgMatch.id;
+        org_association = "linked";
+      } else if (process.env.PIPEDRIVE_ALLOW_ORG_CREATE === "1") {
+        orgId = await createOrg(token, companyName);
+        org_association = "linked";
+      } else {
+        org_association = "skipped_no_match";
+      }
+    }
+
+    if (personId == null) {
+      personId = await createPerson(token, {
+        name: payload.name.trim() || email,
+        email,
+        org_id: orgId,
+        owner_id: user_id,
+      });
+    } else {
+      await updatePersonConservative(token, personId, {
+        name: payload.name.trim() || email,
+      });
+    }
+
+    const deals = await listDealsForPerson(token, personId);
+    const marker = `${DEAL_TITLE_PREFIX}${payload.lead_id}`;
+    const existing = deals.find((d) => d.title.includes(marker) || d.title.startsWith(marker));
+
+    const title = dealTitleForLead(payload);
+    let dealId: number;
+    let deal_action: LeadSyncPipedriveSyncResult["deal_action"];
+
+    if (existing) {
+      dealId = existing.id;
+      deal_action = "updated";
+      await updateDeal(token, dealId, {
+        title,
+        org_id: orgId,
+        user_id,
+      });
+    } else {
+      deal_action = "created";
+      dealId = await createDeal(token, {
+        title,
+        person_id: personId,
+        org_id: orgId,
+        pipeline_id,
+        stage_id,
+        user_id,
+      });
+    }
+
+    await addDealNote(token, dealId, personId, dealNoteContent(payload));
+
+    const mock_result: LeadSyncPipedriveSyncResult = {
+      system: "pipedrive",
+      synced_at,
+      person_id: String(personId),
+      org_id: orgId != null ? String(orgId) : undefined,
+      org_association,
+      deal_id: String(dealId),
+      deal_action,
+      pipeline_id,
+      stage_id,
+    };
+
+    return { ok: true, http_status: 200, mock_result };
+  } catch (e) {
+    return toConnectorError(e);
+  }
+}


### PR DESCRIPTION
Add pipedrive target gated by eligibility, person/org/deal flow with fresh payload and CH-LID deal dedup, enqueue on admin PATCH, CRM column and qualification UI, shared eligibility rules and docs.

Made-with: Cursor