### PR TITLE
feat(gtm): Wave 29 founder dashboard at /admin/gtm

### DIFF
--- a/docs/gtm/wave28-lead-sync-framework.md
+++ b/docs/gtm/wave28-lead-sync-framework.md
@@ -9,7 +9,7 @@ Ziel: Zuverlässiger, nachvollziehbarer Push von Lead-/Inquiry-Daten zu **n8n** 
 - **Ops-Sicht** in der internen Lead-Inbox: Status pro Ziel, Fehler, manueller Retry.
 - **Aktivitäts-Log** (`lead_ops`): `lead_sync_job_created`, `lead_sync_sent`, `lead_sync_failed`, `lead_sync_retried`, `lead_sync_dead_letter`.
 
-Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 28.1 – HubSpot Upsert](wave28.1-hubspot-upsert.md), [Wave 28.2 – Pipedrive qualifizierte Deals](wave28.2-pipedrive-qualified-deals.md).
+Siehe auch: [Wave 25 – Lead-Routing](wave25-lead-routing-and-intake-governance.md), [Wave 27 – Dedup & Historie](wave27-lead-dedup-and-history.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 28.1 – HubSpot Upsert](wave28.1-hubspot-upsert.md), [Wave 28.2 – Pipedrive qualifizierte Deals](wave28.2-pipedrive-qualified-deals.md), [Wave 29 – GTM Command Center](wave29-founder-dashboard.md).
 
 ## Job-Modell (`LeadSyncJob`)
 

--- a/docs/gtm/wave29-founder-dashboard.md
+++ b/docs/gtm/wave29-founder-dashboard.md
@@ -1,0 +1,65 @@
+# Wave 29 – Founder Dashboard / GTM Command Center
+
+Ziel: **eine** interne, pragmatische Übersicht für operative GTM-Steuerung (Founder, frühe Sales, Ops) — **ohne** BI-Stack. Daten kommen aus dem bestehenden Lead-Store, Triage (`ops-state.json`) und Sync-Job-Store.
+
+## Zugriff
+
+- Route: **`/admin/gtm`**
+- Autorisierung wie Lead-Inbox: `LEAD_ADMIN_SECRET`, Session-Cookie nach Login unter **`/admin/leads`**, oder Bearer/Query beim API-Zugriff.
+- API: `GET /api/admin/gtm/summary` → JSON `snapshot` (nur mit gültiger Admin-Auth).
+
+## Architektur
+
+- **Aggregation:** `frontend/src/lib/gtmDashboardAggregate.ts` (server-only) lädt `readAllLeadRecordsMerged`, `readLeadOpsState`, `listAllLeadSyncJobs`, merged/rollups wie die Inbox (`mergeLeadsWithOps`, `attachContactRollups`).
+- **Zeit-Hilfen (testbar):** `frontend/src/lib/gtmDashboardTime.ts`
+- **Typen (Client + Server):** `frontend/src/lib/gtmDashboardTypes.ts`
+- **UI:** `frontend/src/components/admin/GtmCommandCenterClient.tsx`
+
+## KPI-Karten (7 / 30 Tage)
+
+Zeitfenster beziehen sich auf **`created_at` der Anfrage** (Inbound), außer bei Sync-Zählern (siehe unten).
+
+| KPI | Bedeutung |
+|-----|-----------|
+| **Inbound-Anfragen** | Anzahl `lead_inquiry` im Fenster. |
+| **Wiederholte Kontakte** | Anfragen mit `contact_submission_count > 1` (gleiche E-Mail-Gruppe). |
+| **Qualifiziert** | Triage `qualified` oder `closed_won_interest`. |
+| **Kontaktiert** | Triage exakt `contacted`. |
+| **Webhook fehlgeschlagen** | `forwarding_status === failed` (Legacy-Inbound-Webhook). |
+| **Sync Dead Letters** | Jobs `dead_letter`; Zeitfilter auf `updated_at` / letzter Versuch. |
+| **HubSpot erfolgreich** | Jobs `target === hubspot`, `status === sent` (echter Connector, kein Stub). |
+| **Pipedrive Deals neu** | Jobs `pipedrive`, `sent`, `mock_result.deal_action === "created"`; Zeitfilter nach `synced_at` im Ergebnis. |
+
+## Segmenttabelle (30 Tage)
+
+Zeilen: `industrie_mittelstand`, `kanzlei_wp`, `enterprise_sap`, **Sonstiges** (inkl. `sonstiges`).
+
+- **Anfragen / Qualifiziert:** wie KPI, nur auf Segment aufgeteilt.
+- **CRM-Sync-Probleme:** Anzahl Jobs mit `failed` oder `dead_letter` für `hubspot` oder `pipedrive`, deren letztes Update im 30-Tage-Fenster liegt, pro Segment des zugehörigen Leads.
+
+## Trichter
+
+Absolute **Stückzahlen**, keine automatischen Conversion-Raten (vermeidet falsche Schlüsse bei verzögertem Triage).
+
+- **CTA-Klicks:** aktuell **nicht** in einem abfragbaren Store — nur serverseitiges Log (`/api/marketing-event`). Im Dashboard **0** mit Hinweistext.
+- Weitere Stufen: Anfragen nach Einreichungsdatum mit aktuellem Triage-Status bzw. Pipedrive-Deal-Count wie oben.
+
+Hinweis: Ein Lead kann **nach** dem 30-Tage-Fenster qualifiziert werden; daher können spätere Stufen in einem Fenster nicht strikt „unter“ der vorherigen Stufe liegen.
+
+## Aufmerksamkeit
+
+Kurze Listen (jeweils bis ca. 8 Einträge): fehlgeschlagene Webhooks, Dead-Letter-Syncs, wiederholte Kontakte ohne Triage-Wechsel, CRM-Sync-Fehler. Links zur Inbox nutzen `?focus=<lead_id>` (UUID).
+
+## Trends
+
+- **Täglich:** Anfragen pro Kalendertag **UTC**, letzte 14 Tage.
+- **Wöchentlich:** Qualifizierte nach **Kalenderwoche der Einreichung (UTC)**; Pipedrive „Deal neu“ nach **Sync-Zeitpunkt** in der jeweiligen Woche.
+
+## Bekannte Grenzen
+
+- Keine persistente CTA-Zeitreihe → Trichter beginnt faktisch bei Formular-Anfragen.
+- Qualifizierung in der Wochenansicht bezieht sich auf **Einreichungsdatum**, nicht auf das Datum der Triage-Änderung (dafür fehlt eine dedizierte Event-Tabelle).
+- Sehr große JSONL/Job-Stores: Aggregation ist O(n); bei Bedarf später cachen oder Zeitraum begrenzen.
+- Fokus-Link setzt nur die `lead_id` in der Inbox, wenn die Liste geladen ist und die ID existiert.
+
+Siehe auch: [Wave 28 – Lead-Sync](wave28-lead-sync-framework.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md).

--- a/frontend/src/app/admin/gtm/page.tsx
+++ b/frontend/src/app/admin/gtm/page.tsx
@@ -1,0 +1,15 @@
+import { GtmCommandCenterClient } from "@/components/admin/GtmCommandCenterClient";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminGtmPage() {
+  const adminConfigured = Boolean(process.env.LEAD_ADMIN_SECRET?.trim());
+
+  return (
+    <div className="min-h-screen bg-slate-100 px-4 py-10">
+      <div className="mx-auto max-w-7xl">
+        <GtmCommandCenterClient adminConfigured={adminConfigured} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/leads/page.tsx
+++ b/frontend/src/app/admin/leads/page.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from "react";
+
 import { AdminLeadInboxClient } from "@/components/admin/AdminLeadInboxClient";
 
 export const dynamic = "force-dynamic";
@@ -8,7 +10,9 @@ export default function AdminLeadsPage() {
   return (
     <div className="min-h-screen bg-slate-100 px-4 py-10">
       <div className="mx-auto max-w-7xl">
-        <AdminLeadInboxClient adminConfigured={adminConfigured} />
+        <Suspense fallback={<div className="py-16 text-center text-sm text-slate-500">Laden…</div>}>
+          <AdminLeadInboxClient adminConfigured={adminConfigured} />
+        </Suspense>
       </div>
     </div>
   );

--- a/frontend/src/app/api/admin/gtm/summary/route.ts
+++ b/frontend/src/app/api/admin/gtm/summary/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { computeGtmDashboardSnapshot } from "@/lib/gtmDashboardAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const snapshot = await computeGtmDashboardSnapshot();
+  return NextResponse.json({ ok: true, snapshot });
+}

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
@@ -24,6 +25,9 @@ const DUPLICATE_REVIEW_LABELS: Record<LeadInboxItem["duplicate_review"], string>
   suggested: "Zur Prüfung (mögliche Dublette)",
   confirmed: "Zusammenhang bestätigt (manuell)",
 };
+
+const FOCUS_UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 const SYNC_TARGET_LABELS: Record<LeadSyncJobApi["target"], string> = {
   n8n_webhook: "n8n (Webhook)",
@@ -112,6 +116,7 @@ type PatchBody = {
 };
 
 export function AdminLeadInboxClient({ adminConfigured }: Props) {
+  const searchParams = useSearchParams();
   const [secretInput, setSecretInput] = useState("");
   const [loginError, setLoginError] = useState<string | null>(null);
   const [authed, setAuthed] = useState<boolean | null>(null);
@@ -210,6 +215,13 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     if (!adminConfigured) return;
     void fetchLeads();
   }, [adminConfigured, fetchLeads]);
+
+  useEffect(() => {
+    const raw = searchParams.get("focus")?.trim() ?? "";
+    if (raw && FOCUS_UUID_RE.test(raw)) {
+      setSelectedId(raw);
+    }
+  }, [searchParams]);
 
   useEffect(() => {
     if (!selectedId || authed !== true) {
@@ -451,7 +463,15 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     <div className="space-y-6">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <h1 className="text-xl font-semibold text-slate-900">Lead-Inbox</h1>
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-xl font-semibold text-slate-900">Lead-Inbox</h1>
+            <a
+              href="/admin/gtm"
+              className="text-xs font-medium text-cyan-800 underline hover:text-cyan-950"
+            >
+              GTM Command Center
+            </a>
+          </div>
           <p className="text-sm text-slate-600">
             Triage und Nachverfolgung – nicht öffentlich, kein CRM. Kontakt-Historie gruppiert nach
             E-Mail-Schlüssel; jede Einreichung bleibt eigener Datensatz. Sortierung: zuerst

--- a/frontend/src/components/admin/GtmCommandCenterClient.tsx
+++ b/frontend/src/components/admin/GtmCommandCenterClient.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import type { GtmDashboardSnapshot, GtmWindowKey } from "@/lib/gtmDashboardTypes";
+
+type Props = { adminConfigured: boolean };
+
+function KpiCard({
+  title,
+  v7,
+  v30,
+  sub,
+}: {
+  title: string;
+  v7: number;
+  v30: number;
+  sub?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-medium uppercase tracking-wide text-slate-500">{title}</p>
+      <div className="mt-2 flex flex-wrap items-baseline gap-3">
+        <div>
+          <span className="text-2xl font-semibold text-slate-900">{v7}</span>
+          <span className="ml-1 text-xs text-slate-500">7 Tage</span>
+        </div>
+        <div className="text-slate-300">|</div>
+        <div>
+          <span className="text-xl font-semibold text-slate-700">{v30}</span>
+          <span className="ml-1 text-xs text-slate-500">30 Tage</span>
+        </div>
+      </div>
+      {sub ? <p className="mt-1 text-xs text-slate-500">{sub}</p> : null}
+    </div>
+  );
+}
+
+function attentionLabel(kind: string): string {
+  if (kind === "failed_webhook") return "Webhook fehlgeschlagen";
+  if (kind === "dead_letter_sync") return "Sync Dead Letter";
+  if (kind === "unresolved_repeat_contact") return "Wiederholung ohne Triage";
+  if (kind === "crm_sync_failed") return "CRM-Sync fehlgeschlagen";
+  return kind;
+}
+
+export function GtmCommandCenterClient({ adminConfigured }: Props) {
+  const [snapshot, setSnapshot] = useState<GtmDashboardSnapshot | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const r = await fetch("/api/admin/gtm/summary", { credentials: "include" });
+      if (r.status === 401) {
+        setSnapshot(null);
+        setLoadError("unauthorized");
+        return;
+      }
+      if (!r.ok) {
+        setLoadError(`HTTP ${r.status}`);
+        return;
+      }
+      const data = (await r.json()) as { ok?: boolean; snapshot?: GtmDashboardSnapshot };
+      setSnapshot(data.snapshot ?? null);
+    } catch {
+      setLoadError("Netzwerkfehler");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!adminConfigured) return;
+    void load();
+  }, [adminConfigured, load]);
+
+  const k = (w: GtmWindowKey) => snapshot?.kpis[w];
+
+  const maxDaily =
+    snapshot?.trends.inquiries_per_day_utc.reduce((m, d) => Math.max(m, d.inquiries), 0) ?? 1;
+
+  if (!adminConfigured) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+        GTM Command Center ist nicht konfiguriert (<code className="font-mono">LEAD_ADMIN_SECRET</code>
+        ).
+      </div>
+    );
+  }
+
+  if (loadError === "unauthorized") {
+    return (
+      <div className="mx-auto max-w-lg rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">GTM Command Center</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Bitte zuerst unter{" "}
+          <a className="text-cyan-700 underline" href="/admin/leads">
+            Lead-Inbox
+          </a>{" "}
+          mit dem Admin-Secret anmelden (Session-Cookie), dann diese Seite neu laden.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-900">GTM Command Center</h1>
+          <p className="mt-1 text-sm text-slate-600">
+            Operative Kennzahlen aus Lead-Store, Triage und Sync-Jobs — kein BI-Tool.
+          </p>
+          {snapshot ? (
+            <p className="mt-1 font-mono text-xs text-slate-400">
+              Stand: {new Date(snapshot.generated_at).toLocaleString("de-DE")}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href="/admin/leads"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Lead-Inbox
+          </a>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {loading ? "Laden…" : "Aktualisieren"}
+          </button>
+        </div>
+      </div>
+
+      {loadError && loadError !== "unauthorized" ? (
+        <p className="text-sm text-red-600">{loadError}</p>
+      ) : null}
+
+      {loading && !snapshot ? (
+        <p className="text-sm text-slate-500">Daten werden geladen …</p>
+      ) : null}
+
+      {snapshot ? (
+        <>
+          <section>
+            <h2 className="mb-3 text-sm font-semibold text-slate-800">Kern-KPIs</h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              <KpiCard
+                title="Inbound-Anfragen"
+                v7={k("7d")!.inbound_inquiries}
+                v30={k("30d")!.inbound_inquiries}
+              />
+              <KpiCard
+                title="Wiederholte Kontakte (Anfragen)"
+                v7={k("7d")!.repeated_contact_inquiries}
+                v30={k("30d")!.repeated_contact_inquiries}
+                sub="Mehrfach-Einreichungen gleiche E-Mail"
+              />
+              <KpiCard
+                title="Qualifiziert"
+                v7={k("7d")!.qualified_leads}
+                v30={k("30d")!.qualified_leads}
+                sub="Triage qualifiziert / Abschluss-Interesse"
+              />
+              <KpiCard
+                title="Kontaktiert (Triage)"
+                v7={k("7d")!.contacted_leads}
+                v30={k("30d")!.contacted_leads}
+                sub="Exakt Status „kontaktiert“"
+              />
+              <KpiCard
+                title="Webhook-Weiterleitung fehlgeschlagen"
+                v7={k("7d")!.failed_webhook_forwards}
+                v30={k("30d")!.failed_webhook_forwards}
+              />
+              <KpiCard
+                title="Sync Dead Letters"
+                v7={k("7d")!.dead_letter_sync_jobs}
+                v30={k("30d")!.dead_letter_sync_jobs}
+                sub="Alle Ziele, Zeit nach letztem Job-Update"
+              />
+              <KpiCard
+                title="HubSpot erfolgreich (Jobs)"
+                v7={k("7d")!.hubspot_synced_jobs}
+                v30={k("30d")!.hubspot_synced_jobs}
+                sub="Ziel hubspot, Status gesendet"
+              />
+              <KpiCard
+                title="Pipedrive Deals neu"
+                v7={k("7d")!.pipedrive_deals_created}
+                v30={k("30d")!.pipedrive_deals_created}
+                sub="Sync: deal_action created"
+              />
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-800">Segmente (30 Tage)</h2>
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full min-w-[520px] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-xs text-slate-500">
+                    <th className="py-2 pr-2">Segment</th>
+                    <th className="py-2 pr-2">Anfragen</th>
+                    <th className="py-2 pr-2">Qualifiziert</th>
+                    <th className="py-2">CRM-Sync-Probleme</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshot.segment_table.map((row) => (
+                    <tr key={row.segment} className="border-b border-slate-100">
+                      <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
+                      <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
+                      <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
+                      <td className="py-2 font-mono text-amber-800">{row.sync_issues_30d}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <p className="mt-2 text-xs text-slate-500">
+              Sync-Probleme: fehlgeschlagen oder Dead Letter bei HubSpot/Pipedrive (letztes Update im
+              30-Tage-Fenster).
+            </p>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-800">Trichter (absolute Zahlen)</h2>
+            <p className="mt-1 text-xs text-slate-500">{snapshot.data_notes.funnel_note_de}</p>
+            <p className="mt-2 text-xs text-amber-800">{snapshot.data_notes.cta_note_de}</p>
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full min-w-[480px] border-collapse text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-xs text-slate-500">
+                    <th className="py-2 pr-2 text-left">Stufe</th>
+                    <th className="py-2 pr-2">7 Tage</th>
+                    <th className="py-2">30 Tage</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshot.funnel.map((row) => (
+                    <tr key={row.id} className="border-b border-slate-100">
+                      <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
+                      <td className="py-2 pr-2 font-mono text-slate-700">{row.counts["7d"]}</td>
+                      <td className="py-2 font-mono text-slate-700">{row.counts["30d"]}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-amber-50/80 p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-amber-950">Aufmerksamkeit</h2>
+            <ul className="mt-3 max-h-64 space-y-2 overflow-auto text-xs">
+              {snapshot.attention.length === 0 ? (
+                <li className="text-slate-600">Keine priorisierten Einträge.</li>
+              ) : (
+                snapshot.attention.map((a, i) => (
+                  <li
+                    key={`${a.kind}-${a.lead_id ?? a.job_id}-${i}`}
+                    className="rounded border border-amber-200/80 bg-white px-2 py-1.5 text-slate-800"
+                  >
+                    <span className="font-medium text-amber-900">{attentionLabel(a.kind)}</span>
+                    {a.lead_id ? (
+                      <>
+                        {" "}
+                        ·{" "}
+                        <a
+                          className="font-mono text-cyan-800 underline"
+                          href={`/admin/leads?focus=${encodeURIComponent(a.lead_id)}`}
+                        >
+                          {a.lead_id.slice(0, 8)}…
+                        </a>
+                      </>
+                    ) : null}
+                    {a.target ? <span className="text-slate-500"> · {a.target}</span> : null}
+                    {a.detail ? <span className="block text-slate-600">{a.detail}</span> : null}
+                    <span className="text-slate-400">
+                      {a.at ? new Date(a.at).toLocaleString("de-DE") : ""}
+                    </span>
+                  </li>
+                ))
+              )}
+            </ul>
+            <p className="mt-2 text-xs text-slate-600">
+              Links mit <code className="font-mono">focus</code> dienen als Orientierung — in der
+              Inbox die passende UUID auswählen.
+            </p>
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-2">
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-800">Anfragen pro Tag (UTC)</h2>
+              <p className="text-xs text-slate-500">Letzte 14 Tage, Einreichungsdatum</p>
+              <div className="mt-4 flex h-32 items-end gap-0.5">
+                {snapshot.trends.inquiries_per_day_utc.map((d) => {
+                  const h = maxDaily > 0 ? Math.max(4, (d.inquiries / maxDaily) * 100) : 4;
+                  return (
+                    <div
+                      key={d.day}
+                      className="min-w-0 flex-1 rounded-t bg-slate-700"
+                      style={{ height: `${h}%` }}
+                      title={`${d.day}: ${d.inquiries}`}
+                    />
+                  );
+                })}
+              </div>
+              <div className="mt-1 flex justify-between font-mono text-[10px] text-slate-400">
+                <span>{snapshot.trends.inquiries_per_day_utc[0]?.day}</span>
+                <span>{snapshot.trends.inquiries_per_day_utc.at(-1)?.day}</span>
+              </div>
+            </div>
+
+            <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-800">Wochen-Trend (UTC)</h2>
+              <p className="text-xs text-slate-500">
+                Qualifiziert nach Einreichungswoche; Pipedrive-Deals nach Sync-Zeitpunkt
+              </p>
+              <div className="mt-3 max-h-40 overflow-auto text-xs">
+                <table className="w-full border-collapse">
+                  <thead>
+                    <tr className="border-b border-slate-200 text-slate-500">
+                      <th className="py-1 text-left">Woche ab</th>
+                      <th className="py-1 text-right">Qual.</th>
+                      <th className="py-1 text-right">PD neu</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {snapshot.trends.qualified_and_deals_per_week_utc.map((w) => (
+                      <tr key={w.week_start} className="border-b border-slate-100">
+                        <td className="py-1 font-mono text-slate-700">{w.week_start}</td>
+                        <td className="py-1 text-right font-mono">{w.qualified}</td>
+                        <td className="py-1 text-right font-mono">{w.pipedrive_deals_created}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/lib/gtmDashboardAggregate.ts
+++ b/frontend/src/lib/gtmDashboardAggregate.ts
@@ -1,0 +1,393 @@
+import "server-only";
+
+import {
+  isoInWindow,
+  MS_PER_DAY,
+  utcDayKeyFromMs,
+  utcWeekStartMondayFromMs,
+  windowBoundsMs,
+} from "@/lib/gtmDashboardTime";
+import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import { readLeadOpsState } from "@/lib/leadOpsState";
+import { readAllLeadRecordsMerged } from "@/lib/leadPersistence";
+import { listAllLeadSyncJobs } from "@/lib/leadSyncStore";
+import type {
+  GtmAttentionItem,
+  GtmDailyPoint,
+  GtmDashboardSnapshot,
+  GtmFunnelStage,
+  GtmSegmentBucket,
+  GtmWeeklyPoint,
+  GtmWindowMetrics,
+} from "@/lib/gtmDashboardTypes";
+import type { LeadSyncJob, LeadSyncTarget } from "@/lib/leadSyncTypes";
+
+export type { GtmWindowKey } from "@/lib/gtmDashboardTime";
+export type {
+  GtmAttentionItem,
+  GtmDailyPoint,
+  GtmDashboardSnapshot,
+  GtmFunnelStage,
+  GtmSegmentBucket,
+  GtmWeeklyPoint,
+  GtmWindowMetrics,
+} from "@/lib/gtmDashboardTypes";
+
+function segmentBucket(seg: string): GtmSegmentBucket {
+  if (seg === "industrie_mittelstand") return "industrie_mittelstand";
+  if (seg === "kanzlei_wp") return "kanzlei_wp";
+  if (seg === "enterprise_sap") return "enterprise_sap";
+  return "other";
+}
+
+const SEGMENT_LABELS_DE: Record<GtmSegmentBucket, string> = {
+  industrie_mittelstand: "Industrie / Mittelstand",
+  kanzlei_wp: "Kanzlei / WP",
+  enterprise_sap: "Enterprise / SAP",
+  other: "Sonstiges",
+};
+
+function isQualifiedTriage(t: LeadInboxItem["triage_status"]): boolean {
+  return t === "qualified" || t === "closed_won_interest";
+}
+
+function isContactedOrBeyond(t: LeadInboxItem["triage_status"]): boolean {
+  return (
+    t === "contacted" ||
+    t === "qualified" ||
+    t === "closed_won_interest" ||
+    t === "closed_not_now"
+  );
+}
+
+function emptySegmentCounts(): Record<GtmSegmentBucket, { inquiries: number; qualified: number }> {
+  return {
+    industrie_mittelstand: { inquiries: 0, qualified: 0 },
+    kanzlei_wp: { inquiries: 0, qualified: 0 },
+    enterprise_sap: { inquiries: 0, qualified: 0 },
+    other: { inquiries: 0, qualified: 0 },
+  };
+}
+
+function jobTimestampForStatus(j: LeadSyncJob): string {
+  return j.updated_at ?? j.last_attempt_at ?? j.created_at;
+}
+
+function isHubspotSyncedJob(j: LeadSyncJob, startMs: number, endMs: number): boolean {
+  if (j.target !== "hubspot" || j.status !== "sent") return false;
+  return isoInWindow(jobTimestampForStatus(j), startMs, endMs);
+}
+
+function isDeadLetterInWindow(j: LeadSyncJob, startMs: number, endMs: number): boolean {
+  if (j.status !== "dead_letter") return false;
+  return isoInWindow(jobTimestampForStatus(j), startMs, endMs);
+}
+
+function isPipedriveDealCreatedJob(j: LeadSyncJob): boolean {
+  if (j.target !== "pipedrive" || j.status !== "sent") return false;
+  const m = j.mock_result;
+  if (!m || typeof m !== "object") return false;
+  const o = m as Record<string, unknown>;
+  return o.system === "pipedrive" && o.deal_action === "created";
+}
+
+function pipedriveDealCreatedAt(j: LeadSyncJob): string {
+  const m = j.mock_result as Record<string, unknown> | undefined;
+  return typeof m?.synced_at === "string" ? m.synced_at : jobTimestampForStatus(j);
+}
+
+function pipedriveDealCreatedInWindow(j: LeadSyncJob, startMs: number, endMs: number): boolean {
+  if (!isPipedriveDealCreatedJob(j)) return false;
+  return isoInWindow(pipedriveDealCreatedAt(j), startMs, endMs);
+}
+
+function syncJobBad(j: LeadSyncJob): boolean {
+  return j.status === "failed" || j.status === "dead_letter";
+}
+
+function isCrmTarget(t: LeadSyncTarget): boolean {
+  return t === "hubspot" || t === "pipedrive";
+}
+
+export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promise<GtmDashboardSnapshot> {
+  const nowMs = now.getTime();
+  const w7 = windowBoundsMs(7, nowMs);
+  const w30 = windowBoundsMs(30, nowMs);
+
+  const allRows = await readAllLeadRecordsMerged();
+  const ops = await readLeadOpsState();
+  const merged = mergeLeadsWithOps(allRows, ops);
+  const items = attachContactRollups(merged, allRows, ops);
+  const jobs = await listAllLeadSyncJobs();
+
+  const leadIdToSegment = new Map<string, GtmSegmentBucket>();
+  for (const it of items) {
+    leadIdToSegment.set(it.lead_id, segmentBucket(it.segment));
+  }
+
+  const syncIssuesBySegment: Record<GtmSegmentBucket, number> = {
+    industrie_mittelstand: 0,
+    kanzlei_wp: 0,
+    enterprise_sap: 0,
+    other: 0,
+  };
+
+  for (const j of jobs) {
+    if (!syncJobBad(j) || !isCrmTarget(j.target)) continue;
+    const ts = jobTimestampForStatus(j);
+    if (!isoInWindow(ts, w30.start, w30.end)) continue;
+    const seg = leadIdToSegment.get(j.lead_id) ?? "other";
+    syncIssuesBySegment[seg] += 1;
+  }
+
+  function metricsForWindow(startMs: number, endMs: number): GtmWindowMetrics {
+    const inW = (iso: string) => isoInWindow(iso, startMs, endMs);
+    const windowItems = items.filter((it) => inW(it.created_at));
+
+    const bySeg = emptySegmentCounts();
+    let repeated = 0;
+    let qualified = 0;
+    let contacted = 0;
+    let failedWh = 0;
+
+    for (const it of windowItems) {
+      const b = segmentBucket(it.segment);
+      bySeg[b].inquiries += 1;
+      if (isQualifiedTriage(it.triage_status)) {
+        qualified += 1;
+        bySeg[b].qualified += 1;
+      }
+      if (it.contact_submission_count > 1) repeated += 1;
+      if (it.triage_status === "contacted") contacted += 1;
+      if (it.forwarding_status === "failed") failedWh += 1;
+    }
+
+    let deadLetter = 0;
+    let hubspotSent = 0;
+    let pdCreated = 0;
+    for (const j of jobs) {
+      if (isDeadLetterInWindow(j, startMs, endMs)) deadLetter += 1;
+      if (isHubspotSyncedJob(j, startMs, endMs)) hubspotSent += 1;
+      if (pipedriveDealCreatedInWindow(j, startMs, endMs)) pdCreated += 1;
+    }
+
+    return {
+      inbound_inquiries: windowItems.length,
+      repeated_contact_inquiries: repeated,
+      qualified_leads: qualified,
+      contacted_leads: contacted,
+      failed_webhook_forwards: failedWh,
+      dead_letter_sync_jobs: deadLetter,
+      hubspot_synced_jobs: hubspotSent,
+      pipedrive_deals_created: pdCreated,
+      by_segment: bySeg,
+    };
+  }
+
+  const kpis: GtmDashboardSnapshot["kpis"] = {
+    "7d": metricsForWindow(w7.start, w7.end),
+    "30d": metricsForWindow(w30.start, w30.end),
+  };
+
+  function funnelCount(
+    startMs: number,
+    endMs: number,
+    pred: (it: LeadInboxItem) => boolean,
+  ): number {
+    return items.filter((it) => isoInWindow(it.created_at, startMs, endMs) && pred(it)).length;
+  }
+
+  const funnel: GtmFunnelStage[] = [
+    {
+      id: "cta",
+      label_de: "CTA-Klicks (Homepage)",
+      counts: { "7d": 0, "30d": 0 },
+    },
+    {
+      id: "submissions",
+      label_de: "Kontaktanfragen (Formular)",
+      counts: {
+        "7d": funnelCount(w7.start, w7.end, () => true),
+        "30d": funnelCount(w30.start, w30.end, () => true),
+      },
+    },
+    {
+      id: "triaged",
+      label_de: "Triage gestartet (nicht mehr „Neu“)",
+      counts: {
+        "7d": funnelCount(w7.start, w7.end, (it) => it.triage_status !== "received"),
+        "30d": funnelCount(w30.start, w30.end, (it) => it.triage_status !== "received"),
+      },
+    },
+    {
+      id: "contacted_funnel",
+      label_de: "Kontaktiert oder weiter (Pipeline)",
+      counts: {
+        "7d": funnelCount(w7.start, w7.end, (it) => isContactedOrBeyond(it.triage_status)),
+        "30d": funnelCount(w30.start, w30.end, (it) => isContactedOrBeyond(it.triage_status)),
+      },
+    },
+    {
+      id: "qualified_funnel",
+      label_de: "Qualifiziert / Abschluss-Interesse",
+      counts: {
+        "7d": funnelCount(w7.start, w7.end, (it) => isQualifiedTriage(it.triage_status)),
+        "30d": funnelCount(w30.start, w30.end, (it) => isQualifiedTriage(it.triage_status)),
+      },
+    },
+    {
+      id: "pipedrive_deals",
+      label_de: "Pipedrive-Deals neu angelegt (Sync)",
+      counts: {
+        "7d": kpis["7d"].pipedrive_deals_created,
+        "30d": kpis["30d"].pipedrive_deals_created,
+      },
+    },
+  ];
+
+  const segment_table: GtmDashboardSnapshot["segment_table"] = (
+    [
+      "industrie_mittelstand",
+      "kanzlei_wp",
+      "enterprise_sap",
+      "other",
+    ] as const
+  ).map((segment) => ({
+    segment,
+    label_de: SEGMENT_LABELS_DE[segment],
+    inquiries_30d: kpis["30d"].by_segment[segment].inquiries,
+    qualified_30d: kpis["30d"].by_segment[segment].qualified,
+    sync_issues_30d: syncIssuesBySegment[segment],
+  }));
+
+  const webhookFails = items
+    .filter((it) => it.forwarding_status === "failed")
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+    .slice(0, 8)
+    .map(
+      (it): GtmAttentionItem => ({
+        kind: "failed_webhook",
+        lead_id: it.lead_id,
+        detail: it.webhook_error?.slice(0, 120),
+        at: it.created_at,
+      }),
+    );
+
+  const deadLetterItems = jobs
+    .filter((j) => j.status === "dead_letter")
+    .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))
+    .slice(0, 8)
+    .map(
+      (j): GtmAttentionItem => ({
+        kind: "dead_letter_sync",
+        lead_id: j.lead_id,
+        job_id: j.job_id,
+        target: j.target,
+        detail: j.last_error?.slice(0, 160),
+        at: j.updated_at,
+      }),
+    );
+
+  const repeatItems = items
+    .filter(
+      (it) =>
+        it.contact_submission_count > 1 &&
+        it.triage_status === "received" &&
+        it.duplicate_hint === "same_email_repeat",
+    )
+    .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+    .slice(0, 8)
+    .map(
+      (it): GtmAttentionItem => ({
+        kind: "unresolved_repeat_contact",
+        lead_id: it.lead_id,
+        detail: `×${it.contact_submission_count} · ${it.segment}`,
+        at: it.created_at,
+      }),
+    );
+
+  const crmSyncFails = [...jobs]
+    .filter((j) => syncJobBad(j) && isCrmTarget(j.target))
+    .sort((a, b) => Date.parse(b.updated_at) - Date.parse(a.updated_at))
+    .slice(0, 8)
+    .map(
+      (j): GtmAttentionItem => ({
+        kind: "crm_sync_failed",
+        lead_id: j.lead_id,
+        job_id: j.job_id,
+        target: j.target,
+        detail: j.last_error?.slice(0, 120),
+        at: j.updated_at,
+      }),
+    );
+
+  const attentionMerged: GtmAttentionItem[] = [
+    ...webhookFails,
+    ...deadLetterItems,
+    ...repeatItems,
+    ...crmSyncFails,
+  ].slice(0, 28);
+
+  /* Tagesreihe: letzte 14 Tage UTC, alle Anfragen nach created_at */
+  const daily: GtmDailyPoint[] = [];
+  for (let i = 13; i >= 0; i--) {
+    const dayMs = nowMs - i * MS_PER_DAY;
+    const key = utcDayKeyFromMs(dayMs);
+    const count = items.filter((it) => utcDayKeyFromMs(Date.parse(it.created_at)) === key).length;
+    daily.push({ day: key, inquiries: count });
+  }
+
+  /* Wochen: letzte 8 Wochen — qualifiziert nach created_at, Deals nach synced_at */
+  const weekKeys: string[] = [];
+  for (let w = 7; w >= 0; w--) {
+    weekKeys.push(utcWeekStartMondayFromMs(nowMs - w * 7 * MS_PER_DAY));
+  }
+  const uniqWeeks = [...new Set(weekKeys)].sort();
+
+  const qualifiedPerWeek = new Map<string, number>();
+  for (const wk of uniqWeeks) qualifiedPerWeek.set(wk, 0);
+  for (const it of items) {
+    if (!isQualifiedTriage(it.triage_status)) continue;
+    const wk = utcWeekStartMondayFromMs(Date.parse(it.created_at));
+    if (qualifiedPerWeek.has(wk)) qualifiedPerWeek.set(wk, (qualifiedPerWeek.get(wk) ?? 0) + 1);
+  }
+
+  const dealsPerWeek = new Map<string, number>();
+  for (const wk of uniqWeeks) dealsPerWeek.set(wk, 0);
+  for (const j of jobs) {
+    if (!isPipedriveDealCreatedJob(j)) continue;
+    const at = pipedriveDealCreatedAt(j);
+    const wk = utcWeekStartMondayFromMs(Date.parse(at));
+    if (dealsPerWeek.has(wk)) dealsPerWeek.set(wk, (dealsPerWeek.get(wk) ?? 0) + 1);
+  }
+
+  const qualified_and_deals_per_week_utc: GtmWeeklyPoint[] = uniqWeeks.map((week_start) => ({
+    week_start,
+    qualified: qualifiedPerWeek.get(week_start) ?? 0,
+    pipedrive_deals_created: dealsPerWeek.get(week_start) ?? 0,
+  }));
+
+  return {
+    generated_at: now.toISOString(),
+    windows: {
+      "7d": { start: new Date(w7.start).toISOString(), end: new Date(w7.end).toISOString() },
+      "30d": { start: new Date(w30.start).toISOString(), end: new Date(w30.end).toISOString() },
+    },
+    kpis,
+    funnel,
+    segment_table,
+    attention: attentionMerged,
+    trends: {
+      inquiries_per_day_utc: daily,
+      qualified_and_deals_per_week_utc: qualified_and_deals_per_week_utc,
+    },
+    data_notes: {
+      cta_clicks_persisted: false,
+      cta_note_de:
+        "CTA-Klicks werden aktuell nur serverseitig geloggt ([marketing-event]), nicht in einem Query-Store — daher keine zuverlässige Zahl im Dashboard.",
+      funnel_note_de:
+        "Stufen sind absolute Mengen je Zeitraum (Einreichungsdatum). Spätere Stufen können größer wirken als frühere, wenn Leads außerhalb des Fensters qualifiziert wurden; für Steuerung die KPI-Karten und Segmenttabelle nutzen.",
+    },
+  };
+}

--- a/frontend/src/lib/gtmDashboardTime.test.ts
+++ b/frontend/src/lib/gtmDashboardTime.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isoInWindow,
+  utcDayKeyFromMs,
+  utcWeekStartMondayFromMs,
+  windowBoundsMs,
+} from "@/lib/gtmDashboardTime";
+
+describe("gtmDashboardTime", () => {
+  it("windowBoundsMs spans correct length", () => {
+    const now = 1_700_000_000_000;
+    const w = windowBoundsMs(7, now);
+    expect(w.end - w.start).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("isoInWindow respects bounds", () => {
+    const start = Date.parse("2026-04-01T00:00:00.000Z");
+    const end = Date.parse("2026-04-10T23:59:59.999Z");
+    expect(isoInWindow("2026-04-05T12:00:00.000Z", start, end)).toBe(true);
+    expect(isoInWindow("2026-03-01T12:00:00.000Z", start, end)).toBe(false);
+  });
+
+  it("utcDayKeyFromMs", () => {
+    expect(utcDayKeyFromMs(Date.parse("2026-06-15T14:00:00.000Z"))).toBe("2026-06-15");
+  });
+
+  it("utcWeekStartMondayFromMs returns Monday UTC", () => {
+    const wed = Date.parse("2026-04-01T12:00:00.000Z");
+    expect(utcWeekStartMondayFromMs(wed)).toBe("2026-03-30");
+  });
+});

--- a/frontend/src/lib/gtmDashboardTime.ts
+++ b/frontend/src/lib/gtmDashboardTime.ts
@@ -1,0 +1,31 @@
+/** Reine Zeitfenster-Hilfen (ohne server-only) für Tests + Aggregation. */
+
+const MS_PER_DAY = 86_400_000;
+
+export type GtmWindowKey = "7d" | "30d";
+
+export function windowBoundsMs(days: number, nowMs: number): { start: number; end: number } {
+  return { start: nowMs - days * MS_PER_DAY, end: nowMs };
+}
+
+export function isoInWindow(iso: string, startMs: number, endMs: number): boolean {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) return false;
+  return t >= startMs && t <= endMs;
+}
+
+export function utcDayKeyFromMs(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+/** Montag 00:00 UTC der Kalenderwoche. */
+export function utcWeekStartMondayFromMs(ms: number): string {
+  const d = new Date(ms);
+  const day = d.getUTCDay();
+  const mondayOffset = (day + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - mondayOffset);
+  d.setUTCHours(0, 0, 0, 0);
+  return d.toISOString().slice(0, 10);
+}
+
+export { MS_PER_DAY };

--- a/frontend/src/lib/gtmDashboardTypes.ts
+++ b/frontend/src/lib/gtmDashboardTypes.ts
@@ -1,0 +1,64 @@
+import type { GtmWindowKey } from "@/lib/gtmDashboardTime";
+import type { LeadSyncTarget } from "@/lib/leadSyncTypes";
+
+export type { GtmWindowKey } from "@/lib/gtmDashboardTime";
+
+export type GtmSegmentBucket = "industrie_mittelstand" | "kanzlei_wp" | "enterprise_sap" | "other";
+
+export type GtmWindowMetrics = {
+  inbound_inquiries: number;
+  repeated_contact_inquiries: number;
+  qualified_leads: number;
+  contacted_leads: number;
+  failed_webhook_forwards: number;
+  dead_letter_sync_jobs: number;
+  hubspot_synced_jobs: number;
+  pipedrive_deals_created: number;
+  by_segment: Record<GtmSegmentBucket, { inquiries: number; qualified: number }>;
+};
+
+export type GtmFunnelStage = {
+  id: string;
+  label_de: string;
+  counts: Record<GtmWindowKey, number>;
+};
+
+export type GtmAttentionItem = {
+  kind: string;
+  lead_id?: string;
+  job_id?: string;
+  target?: LeadSyncTarget;
+  detail?: string;
+  at: string;
+};
+
+export type GtmDailyPoint = { day: string; inquiries: number };
+export type GtmWeeklyPoint = {
+  week_start: string;
+  qualified: number;
+  pipedrive_deals_created: number;
+};
+
+export type GtmDashboardSnapshot = {
+  generated_at: string;
+  windows: Record<GtmWindowKey, { start: string; end: string }>;
+  kpis: Record<GtmWindowKey, GtmWindowMetrics>;
+  funnel: GtmFunnelStage[];
+  segment_table: {
+    segment: GtmSegmentBucket;
+    label_de: string;
+    inquiries_30d: number;
+    qualified_30d: number;
+    sync_issues_30d: number;
+  }[];
+  attention: GtmAttentionItem[];
+  trends: {
+    inquiries_per_day_utc: GtmDailyPoint[];
+    qualified_and_deals_per_week_utc: GtmWeeklyPoint[];
+  };
+  data_notes: {
+    cta_clicks_persisted: boolean;
+    cta_note_de: string;
+    funnel_note_de: string;
+  };
+};

--- a/frontend/src/lib/leadSyncStore.ts
+++ b/frontend/src/lib/leadSyncStore.ts
@@ -65,6 +65,12 @@ export async function listLeadSyncJobsForLead(leadId: string): Promise<LeadSyncJ
     .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
 }
 
+/** Alle Sync-Jobs (für interne Aggregationen, z. B. GTM-Dashboard). */
+export async function listAllLeadSyncJobs(): Promise<LeadSyncJob[]> {
+  const s = await readLeadSyncStore();
+  return Object.values(s.jobs);
+}
+
 /**
  * Legt einen Job an, wenn für dieselbe idempotency_key noch keiner existiert.
  */


### PR DESCRIPTION
Add internal GTM Command Center with aggregated KPIs (7d/30d), funnel, segment breakdown, attention panel, and lightweight trends via computeGtmDashboardSnapshot and GET /api/admin/gtm/summary.

Link lead inbox to the dashboard; support ?focus= for deep links. Document KPIs and limitations in docs/gtm/wave29-founder-dashboard.md.

Made-with: Cursor