### PR TITLE
feat(gtm): Wave 30 attribution and campaign tracking

### DIFF
--- a/docs/gtm/wave29-founder-dashboard.md
+++ b/docs/gtm/wave29-founder-dashboard.md
@@ -62,4 +62,4 @@ Kurze Listen (jeweils bis ca. 8 Einträge): fehlgeschlagene Webhooks, Dead-Lette
 - Sehr große JSONL/Job-Stores: Aggregation ist O(n); bei Bedarf später cachen oder Zeitraum begrenzen.
 - Fokus-Link setzt nur die `lead_id` in der Inbox, wenn die Liste geladen ist und die ID existiert.
 
-Siehe auch: [Wave 28 – Lead-Sync](wave28-lead-sync-framework.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md).
+Siehe auch: [Wave 28 – Lead-Sync](wave28-lead-sync-framework.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 30 – Attribution](wave30-attribution-and-campaign-tracking.md).

--- a/docs/gtm/wave30-attribution-and-campaign-tracking.md
+++ b/docs/gtm/wave30-attribution-and-campaign-tracking.md
@@ -1,0 +1,52 @@
+# Wave 30 – Attribution & Campaign Tracking (DSGVO-orientiert)
+
+## Zweck
+
+ComplianceHub erfasst **minimale, intern nutzbare** Hinweise dazu, **welcher Kanal und welche Kampagne** zu einer Kontaktanfrage geführt haben. Ziel ist operative Steuerung („Was lohnt sich?“), **kein** vollwertiges Ad-Attribution-Produkt und **keine** nutzerbezogenen Werbeprofile.
+
+## Was wird erfasst?
+
+| Datenpunkt | Herkunft | Speicherort |
+|------------|----------|-------------|
+| **utm_source**, **utm_medium**, **utm_campaign** | URL-Parameter beim ersten Auftreten in der **Browser-Tab-Session** (`sessionStorage`, first-party) + Fallback aus der aktuellen Kontakt-URL beim Absenden | Lead-Outbound (`schema_version` 1.2), JSONL |
+| **document.referrer** (gekürzt) | Vom Browser beim Absenden des Formulars im Request-Body | Lead-Outbound |
+| **HTTP Referer** (nur **Hostname**) | `Referer`-Header der POST-Anfrage an `/api/lead-inquiry` | Lead-Outbound (`referrer_host`) |
+| **cta_id**, **cta_label** | Query-Parameter auf `/kontakt` (von CTAs, z. B. `contactPageHref`) | Lead-Outbound |
+| **Abgeleitete Felder** `source`, `medium`, `campaign` | Serverseitige Heuristik aus UTM + Referrer (siehe `buildLeadAttribution`) | Lead-Outbound, Sync-Payload optional |
+
+Die bestehende **Sales-„Quelle“** (`source_page` / Query `quelle`) bleibt unverändert; sie beschreibt **wo auf der Site** der Kontakt ausgelöst wurde, nicht den Marketing-Kanal.
+
+## Was wird bewusst **nicht** gemacht?
+
+- Keine **Drittanbieter-Pixel** oder Social-Pixel auf der Anfrage-Strecke.
+- Keine **Cross-Site-Tracking**-IDs, keine **Fingerprinting**-Logik.
+- Keine **dauerhaften Marketing-Cookies** für Attribution; nur **sessionStorage** für UTM-First-Touch (Tab-Sitzung).
+- Kein **Multi-Touch-Attribution-Modell** (keine gewichteten Journeys).
+- Keine automatische **Zuordnung zu Einzelpersonen** über Drittanbieter-Daten.
+
+## Rechtliche Einordnung (Kurz)
+
+- Verarbeitung erfolgt zur **Bearbeitung der Anfrage** und internen **Vertriebs-/Organisationssteuerung**; UTM/Referrer sind typischerweise **Kontext der Anfrage**, keine zusätzliche „Profiling“-Ebene über das hinaus, was ohnehin bei Server-Logs oder Formularübermittlung anfällt.
+- **Transparenz:** Datenschutzhinweise sollten erwähnen, dass bei Bedarf **Referrer- und Kampagnenparameter** mitübermittelt werden können (wie üblich bei Webformularen).
+- Speicherdauer richtet sich nach den **internen Aufbewahrungsregeln** für Leads (siehe allgemeine Privacy-Dokumentation).
+
+## Interne Nutzung
+
+- **`/admin/gtm`:** Tabellen „Attribution (30 Tage)“: Anfragen, qualifizierte Leads und Pipedrive-Deals (neu angelegt, Sync) **pro abgeleiteter Quelle** bzw. **pro Campaign-Slug** — ohne Conversion-Raten aus unvollständigen Daten.
+- **`/admin/leads`:** Spalte Attribution, Detailkasten, Filter nach Quelle/Campaign/Medium.
+- **Sync-Payload (optional):** Feld `attribution` im Lead-Sync-JSON für spätere **HubSpot-Feldzuordnung** (manuell in n8n/Connector konfigurierbar).
+
+## Zukünftige Erweiterungen (ohne Tracker-Inflation)
+
+- Mapping der gespeicherten Felder auf **HubSpot custom properties** oder Pipedrive-Felder.
+- Einfache **Campaign-ROI-Ansichten** auf Basis qualifizierter Leads und Deals (weiterhin ohne Third-Party-Attribution).
+- Serverseitiges **Landing-Log** nur bei Bedarf (z. B. anonymisierte Zähler), weiterhin ohne Cookies.
+
+## Technische Referenz
+
+- `frontend/src/lib/leadAttribution.ts` – Ableitung und Grenzen.
+- `frontend/src/lib/attributionSessionClient.ts` – sessionStorage First-Touch.
+- `frontend/src/components/marketing/SessionAttributionCapture.tsx` – Einbindung im Root-Layout.
+- `frontend/src/app/api/lead-inquiry/route.ts` – Persistenz beim POST.
+
+Siehe auch: [Wave 29 – Founder Dashboard](wave29-founder-dashboard.md).

--- a/frontend/src/app/api/admin/lead-inquiries/route.ts
+++ b/frontend/src/app/api/admin/lead-inquiries/route.ts
@@ -49,6 +49,9 @@ export async function GET(req: Request) {
   const forwarding = url.searchParams.get("forwarding_status")?.trim();
   const repeated = url.searchParams.get("repeated_contacts")?.trim();
   const unresolvedRep = url.searchParams.get("unresolved_repeated")?.trim();
+  const attributionSource = url.searchParams.get("attribution_source")?.trim();
+  const attributionCampaign = url.searchParams.get("attribution_campaign")?.trim();
+  const attributionMedium = url.searchParams.get("attribution_medium")?.trim();
 
   if (triage) {
     items = items.filter((i) => i.triage_status === triage);
@@ -67,6 +70,25 @@ export async function GET(req: Request) {
   }
   if (unresolvedRep === "1" || unresolvedRep === "true") {
     items = items.filter((i) => i.contact_has_unresolved_repeat);
+  }
+  if (attributionSource) {
+    items = items.filter((i) => i.attribution_source === attributionSource);
+  }
+  if (attributionCampaign) {
+    const needle = attributionCampaign.toLowerCase();
+    items = items.filter(
+      (i) =>
+        i.attribution_campaign.toLowerCase().includes(needle) ||
+        i.attribution.utm_campaign_raw.toLowerCase().includes(needle),
+    );
+  }
+  if (attributionMedium) {
+    const needle = attributionMedium.toLowerCase();
+    items = items.filter(
+      (i) =>
+        i.attribution_medium.toLowerCase().includes(needle) ||
+        i.attribution.utm_medium_raw.toLowerCase().includes(needle),
+    );
   }
 
   return NextResponse.json({

--- a/frontend/src/app/api/lead-inquiry/route.ts
+++ b/frontend/src/app/api/lead-inquiry/route.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { NextResponse } from "next/server";
 
+import { buildLeadAttribution } from "@/lib/leadAttribution";
 import { validateBusinessEmailDomain, validateFormTiming } from "@/lib/leadAntiAbuse";
 import {
   checkLeadEmailCooldown,
@@ -43,6 +44,14 @@ type Incoming = {
   company_website?: string;
   /** ms seit Epoch – Formular geöffnet (Client) */
   form_opened_at?: number;
+  /** Wave 30 – optional, aus Session-UTM + Formular / Kontext */
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  /** document.referrer (gekürzt), first-party */
+  page_referrer?: string;
+  cta_id?: string;
+  cta_label?: string;
 };
 
 function trimStr(v: unknown, max: number): string {
@@ -91,6 +100,7 @@ export async function POST(req: Request) {
   const company = trimStr(body.company, LEAD_FIELD_LIMITS.company);
   const message = trimStr(body.message ?? "", LEAD_FIELD_LIMITS.message);
   const source_page = trimStr(body.source_page, LEAD_FIELD_LIMITS.source_page);
+  const httpReferer = req.headers.get("referer");
 
   if (!name || !work_email || !company || !source_page) {
     return NextResponse.json({ ok: false, error: "validation" }, { status: 400 });
@@ -145,6 +155,16 @@ export async function POST(req: Request) {
     lead_contact_key,
   );
 
+  const attribution = buildLeadAttribution({
+    utm_source: body.utm_source,
+    utm_medium: body.utm_medium,
+    utm_campaign: body.utm_campaign,
+    page_referrer: body.page_referrer,
+    cta_id: body.cta_id,
+    cta_label: body.cta_label,
+    http_referer: httpReferer,
+  });
+
   const outbound = buildLeadOutboundPayload({
     lead_id,
     trace_id,
@@ -164,6 +184,7 @@ export async function POST(req: Request) {
       contact_latest_seen_at,
       duplicate_hint,
     },
+    attribution,
   });
 
   const storeRecord: LeadStoreRecord = {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata } from "next";
-import React from "react";
+import React, { Suspense } from "react";
 
 import { DemoContextualHint } from "@/components/demo/DemoContextualHint";
 import { DemoEnvironmentBanner } from "@/components/demo/DemoEnvironmentBanner";
 import { DemoGuide } from "@/components/demo/DemoGuide";
+import { SessionAttributionCapture } from "@/components/marketing/SessionAttributionCapture";
 import { SbsFooter } from "@/components/sbs/SbsFooter";
 import { SbsHeader } from "@/components/sbs/SbsHeader";
 import { isDemoUiDesiredForTenant } from "@/lib/workspaceDemoServer";
@@ -28,6 +29,9 @@ export default async function RootLayout({
   return (
     <html lang="de" className="scroll-smooth scroll-pt-[7.5rem]">
       <body className="sbs-body flex min-h-screen flex-col bg-slate-50 antialiased">
+        <Suspense fallback={null}>
+          <SessionAttributionCapture />
+        </Suspense>
         <SbsHeader />
         <DemoEnvironmentBanner visible={showDemoUi} />
         <main

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -64,7 +64,11 @@ export default function HomePage() {
             </p>
             <div className="mt-7 flex flex-wrap gap-3">
               <TrackedContactLink
-                href={contactPageHref("home-hero")}
+                href={contactPageHref({
+                  quelle: "home-hero",
+                  ctaId: "home-hero-demo",
+                  ctaLabel: "Demo anfragen",
+                })}
                 ctaId="home-hero-demo"
                 quelle="home-hero"
                 className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-emerald-600 to-emerald-500 px-5 py-2.5 text-sm font-semibold text-white shadow-md shadow-emerald-900/15 transition hover:from-emerald-700 hover:to-emerald-600"
@@ -251,7 +255,11 @@ export default function HomePage() {
           <p className="mt-6 text-center text-xs text-slate-500">
             Ihre Plattform fehlt?{" "}
             <TrackedContactLink
-              href={contactPageHref("home-integrations")}
+              href={contactPageHref({
+                quelle: "home-integrations",
+                ctaId: "home-integrations-kontakt",
+                ctaLabel: "Kontakt aufnehmen",
+              })}
               ctaId="home-integrations-kontakt"
               quelle="home-integrations"
               className="font-medium text-cyan-700 underline-offset-2 hover:underline"
@@ -278,7 +286,11 @@ export default function HomePage() {
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
             <TrackedContactLink
-              href={contactPageHref("home-mid-cta")}
+              href={contactPageHref({
+                quelle: "home-mid-cta",
+                ctaId: "home-mid-cta-demo",
+                ctaLabel: "Demo anfragen",
+              })}
               ctaId="home-mid-cta-demo"
               quelle="home-mid-cta"
               className="inline-flex items-center justify-center rounded-xl bg-gradient-to-r from-emerald-600 to-emerald-500 px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:from-emerald-700 hover:to-emerald-600"

--- a/frontend/src/components/admin/AdminLeadInboxClient.tsx
+++ b/frontend/src/components/admin/AdminLeadInboxClient.tsx
@@ -3,6 +3,8 @@
 import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { LEAD_ATTRIBUTION_SOURCES } from "@/lib/leadAttribution";
+import { LEAD_ATTRIBUTION_SOURCE_LABELS_DE } from "@/lib/leadAttributionLabels";
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
 import type { LeadContactHistoryEntry, LeadInboxItem } from "@/lib/leadInboxTypes";
 import { describePipedriveDealEligibility } from "@/lib/pipedriveDealEligibility";
@@ -133,6 +135,9 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     triage_status: "",
     segment: "",
     source_page: "",
+    attribution_source: "",
+    attribution_campaign: "",
+    attribution_medium: "",
     forwarding_status: "",
     repeated_contacts: false,
     unresolved_repeated: false,
@@ -176,6 +181,9 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
     if (filters.triage_status) p.set("triage_status", filters.triage_status);
     if (filters.segment) p.set("segment", filters.segment);
     if (filters.source_page) p.set("source_page", filters.source_page);
+    if (filters.attribution_source) p.set("attribution_source", filters.attribution_source);
+    if (filters.attribution_campaign) p.set("attribution_campaign", filters.attribution_campaign);
+    if (filters.attribution_medium) p.set("attribution_medium", filters.attribution_medium);
     if (filters.forwarding_status) p.set("forwarding_status", filters.forwarding_status);
     if (filters.repeated_contacts) p.set("repeated_contacts", "1");
     if (filters.unresolved_repeated) p.set("unresolved_repeated", "1");
@@ -528,6 +536,39 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
           />
         </label>
         <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Attr. Quelle</span>
+          <select
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.attribution_source}
+            onChange={(e) => setFilters((f) => ({ ...f, attribution_source: e.target.value }))}
+          >
+            <option value="">Alle</option>
+            {LEAD_ATTRIBUTION_SOURCES.map((s) => (
+              <option key={s} value={s}>
+                {LEAD_ATTRIBUTION_SOURCE_LABELS_DE[s]}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Campaign (enthält)</span>
+          <input
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.attribution_campaign}
+            onChange={(e) => setFilters((f) => ({ ...f, attribution_campaign: e.target.value }))}
+            placeholder="utm_campaign"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-slate-600">Medium (enthält)</span>
+          <input
+            className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
+            value={filters.attribution_medium}
+            onChange={(e) => setFilters((f) => ({ ...f, attribution_medium: e.target.value }))}
+            placeholder="utm_medium"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
           <span className="text-slate-600">Weiterleitung</span>
           <select
             className="rounded-lg border border-slate-300 bg-white px-2 py-1.5"
@@ -641,6 +682,22 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 <td className="max-w-[90px] truncate px-3 py-2" title={row.source_page}>
                   {row.source_page}
                 </td>
+                <td
+                  className="max-w-[130px] px-3 py-2 text-xs text-slate-700"
+                  title={`${row.attribution_source} · ${row.attribution_medium || "—"} · ${row.attribution_campaign || "—"} · CTA ${row.attribution_cta_label || "—"}`}
+                >
+                  <div className="font-medium">
+                    {LEAD_ATTRIBUTION_SOURCE_LABELS_DE[row.attribution_source]}
+                  </div>
+                  {row.attribution_campaign ? (
+                    <div className="truncate font-mono text-[10px] text-slate-500">
+                      {row.attribution_campaign}
+                    </div>
+                  ) : null}
+                  {row.attribution_cta_label ? (
+                    <div className="truncate text-[10px] text-slate-500">{row.attribution_cta_label}</div>
+                  ) : null}
+                </td>
                 <td className="max-w-[140px] truncate px-3 py-2 text-slate-600" title={row.queue_label}>
                   {row.route_key}
                 </td>
@@ -668,6 +725,49 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                 Kontakt #{displayLead.contact_inquiry_sequence} von {displayLead.contact_submission_count}{" "}
                 (Schlüssel: <span className="font-mono">{displayLead.lead_contact_key.slice(0, 18)}…</span>)
               </p>
+              <div className="mt-3 rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2 text-xs text-slate-700">
+                <p className="font-semibold text-slate-800">Attribution (Wave 30)</p>
+                <p className="mt-1">
+                  Quelle: {LEAD_ATTRIBUTION_SOURCE_LABELS_DE[displayLead.attribution_source]}
+                  {displayLead.attribution_medium ? (
+                    <>
+                      {" "}
+                      · Medium: <span className="font-mono">{displayLead.attribution_medium}</span>
+                    </>
+                  ) : null}
+                  {displayLead.attribution_campaign ? (
+                    <>
+                      {" "}
+                      · Campaign:{" "}
+                      <span className="font-mono">{displayLead.attribution_campaign}</span>
+                    </>
+                  ) : null}
+                </p>
+                <p className="mt-1">
+                  CTA: {displayLead.attribution_cta_label || "—"}
+                  {displayLead.attribution_cta_id ? (
+                    <>
+                      {" "}
+                      (<span className="font-mono">{displayLead.attribution_cta_id}</span>)
+                    </>
+                  ) : null}
+                </p>
+                {(displayLead.attribution.utm_source_raw ||
+                  displayLead.attribution.utm_medium_raw ||
+                  displayLead.attribution.utm_campaign_raw) ? (
+                  <p className="mt-1 font-mono text-[10px] text-slate-500">
+                    UTM: {displayLead.attribution.utm_source_raw || "—"} /{" "}
+                    {displayLead.attribution.utm_medium_raw || "—"} /{" "}
+                    {displayLead.attribution.utm_campaign_raw || "—"}
+                  </p>
+                ) : null}
+                {displayLead.attribution.referrer_host ? (
+                  <p className="mt-1 text-[10px] text-slate-500">
+                    Referrer-Host:{" "}
+                    <span className="font-mono">{displayLead.attribution.referrer_host}</span>
+                  </p>
+                ) : null}
+              </div>
             </div>
             <div className="flex flex-wrap gap-2">
               <button
@@ -750,6 +850,11 @@ export function AdminLeadInboxClient({ adminConfigured }: Props) {
                   <p className="mt-1 text-xs text-slate-600">
                     {forwardingLabel(h.forwarding_status)} · {LEAD_TRIAGE_LABELS_DE[h.triage_status]}
                     {h.owner ? ` · Owner: ${h.owner}` : ""}
+                  </p>
+                  <p className="mt-0.5 text-[10px] text-slate-500">
+                    {LEAD_ATTRIBUTION_SOURCE_LABELS_DE[h.attribution_source]}
+                    {h.attribution_campaign ? ` · ${h.attribution_campaign}` : ""}
+                    {h.attribution_cta_label ? ` · CTA ${h.attribution_cta_label}` : ""}
                   </p>
                   <p className="mt-1 line-clamp-2 text-xs text-slate-700">{h.message_preview}</p>
                 </li>

--- a/frontend/src/components/admin/GtmCommandCenterClient.tsx
+++ b/frontend/src/components/admin/GtmCommandCenterClient.tsx
@@ -231,6 +231,87 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
           </section>
 
           <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-800">Attribution (30 Tage)</h2>
+            <p className="mt-1 text-xs text-slate-500">{snapshot.data_notes.attribution_note_de}</p>
+            <div className="mt-4 grid gap-6 lg:grid-cols-2">
+              <div>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  Nach Quelle (heuristisch)
+                </h3>
+                <div className="mt-2 overflow-x-auto">
+                  <table className="w-full min-w-[320px] border-collapse text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-200 text-xs text-slate-500">
+                        <th className="py-2 pr-2">Quelle</th>
+                        <th className="py-2 pr-2">Anfr.</th>
+                        <th className="py-2 pr-2">Qual.</th>
+                        <th className="py-2">PD neu</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {snapshot.attribution_by_source_30d.length === 0 ? (
+                        <tr>
+                          <td colSpan={4} className="py-3 text-xs text-slate-500">
+                            Keine Daten im Fenster.
+                          </td>
+                        </tr>
+                      ) : (
+                        snapshot.attribution_by_source_30d.map((row) => (
+                          <tr key={row.key} className="border-b border-slate-100">
+                            <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
+                            <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
+                            <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
+                            <td className="py-2 font-mono text-slate-700">
+                              {row.pipedrive_deals_created_30d}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+              <div>
+                <h3 className="text-xs font-medium uppercase tracking-wide text-slate-500">
+                  Nach Campaign (utm_campaign)
+                </h3>
+                <div className="mt-2 overflow-x-auto">
+                  <table className="w-full min-w-[320px] border-collapse text-left text-sm">
+                    <thead>
+                      <tr className="border-b border-slate-200 text-xs text-slate-500">
+                        <th className="py-2 pr-2">Campaign</th>
+                        <th className="py-2 pr-2">Anfr.</th>
+                        <th className="py-2 pr-2">Qual.</th>
+                        <th className="py-2">PD neu</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {snapshot.attribution_by_campaign_30d.length === 0 ? (
+                        <tr>
+                          <td colSpan={4} className="py-3 text-xs text-slate-500">
+                            Keine Daten im Fenster.
+                          </td>
+                        </tr>
+                      ) : (
+                        snapshot.attribution_by_campaign_30d.map((row) => (
+                          <tr key={row.key} className="border-b border-slate-100">
+                            <td className="py-2 pr-2 font-mono text-slate-800">{row.label_de}</td>
+                            <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
+                            <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
+                            <td className="py-2 font-mono text-slate-700">
+                              {row.pipedrive_deals_created_30d}
+                            </td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="text-sm font-semibold text-slate-800">Trichter (absolute Zahlen)</h2>
             <p className="mt-1 text-xs text-slate-500">{snapshot.data_notes.funnel_note_de}</p>
             <p className="mt-2 text-xs text-amber-800">{snapshot.data_notes.cta_note_de}</p>

--- a/frontend/src/components/contact/ContactLeadForm.tsx
+++ b/frontend/src/components/contact/ContactLeadForm.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 
+import { readSessionAttribution } from "@/lib/attributionSessionClient";
+import { LEAD_ATTRIBUTION_LIMITS } from "@/lib/leadAttribution";
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY } from "@/lib/boardLayout";
 import { LEAD_SEGMENTS } from "@/lib/leadCapture";
 import { sendMarketingEvent } from "@/lib/marketingTelemetryClient";
@@ -17,6 +19,11 @@ export function ContactLeadForm() {
   const quelleRaw = sp.get("quelle");
   const quelle =
     quelleRaw && quelleRaw.trim() ? quelleRaw.trim().slice(0, 120) : "kontakt-direct";
+  const ctaIdFromUrl = (sp.get("cta_id")?.trim() ?? "").slice(0, LEAD_ATTRIBUTION_LIMITS.cta_id);
+  const ctaLabelFromUrl = (sp.get("cta_label")?.trim() ?? "").slice(
+    0,
+    LEAD_ATTRIBUTION_LIMITS.cta_label,
+  );
 
   const [formOpenedAt] = useState(() => Date.now());
   const startedRef = useRef(false);
@@ -49,6 +56,21 @@ export function ContactLeadForm() {
 
     const fd = new FormData(e.currentTarget);
     const company_website = (fd.get("company_website") as string) || "";
+    const sessionAttr = readSessionAttribution();
+    const uSrc =
+      sessionAttr?.utm_source ||
+      (sp.get("utm_source")?.trim() ?? "").slice(0, LEAD_ATTRIBUTION_LIMITS.utm);
+    const uMed =
+      sessionAttr?.utm_medium ||
+      (sp.get("utm_medium")?.trim() ?? "").slice(0, LEAD_ATTRIBUTION_LIMITS.utm);
+    const uCamp =
+      sessionAttr?.utm_campaign ||
+      (sp.get("utm_campaign")?.trim() ?? "").slice(0, LEAD_ATTRIBUTION_LIMITS.utm);
+    const pageReferrer =
+      typeof document !== "undefined"
+        ? document.referrer.trim().slice(0, LEAD_ATTRIBUTION_LIMITS.referrer)
+        : "";
+
     const payload = {
       name: (fd.get("name") as string) || "",
       work_email: (fd.get("work_email") as string) || "",
@@ -58,6 +80,12 @@ export function ContactLeadForm() {
       source_page: quelle,
       company_website,
       form_opened_at: formOpenedAt,
+      ...(uSrc ? { utm_source: uSrc } : {}),
+      ...(uMed ? { utm_medium: uMed } : {}),
+      ...(uCamp ? { utm_campaign: uCamp } : {}),
+      ...(pageReferrer ? { page_referrer: pageReferrer } : {}),
+      ...(ctaIdFromUrl ? { cta_id: ctaIdFromUrl } : {}),
+      ...(ctaLabelFromUrl ? { cta_label: ctaLabelFromUrl } : {}),
     };
 
     try {

--- a/frontend/src/components/marketing/SessionAttributionCapture.tsx
+++ b/frontend/src/components/marketing/SessionAttributionCapture.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { usePathname, useSearchParams } from "next/navigation";
+import { useEffect } from "react";
+
+import { tryCaptureUtmFromSearchParams } from "@/lib/attributionSessionClient";
+
+/**
+ * Legt bei erstem Auftreten von utm_* in der Tab-Session einen sessionStorage-Eintrag an.
+ * Keine Cookies; kein Cross-Site-Tracking.
+ */
+export function SessionAttributionCapture() {
+  const pathname = usePathname() ?? "/";
+  const sp = useSearchParams();
+
+  useEffect(() => {
+    tryCaptureUtmFromSearchParams(sp, pathname);
+  }, [pathname, sp]);
+
+  return null;
+}

--- a/frontend/src/components/sbs/SbsFooter.tsx
+++ b/frontend/src/components/sbs/SbsFooter.tsx
@@ -28,7 +28,11 @@ export function SbsFooter() {
             Supplier
           </Link>
           <Link
-            href={contactPageHref("footer")}
+            href={contactPageHref({
+              quelle: "footer",
+              ctaId: "footer-kontakt",
+              ctaLabel: "Kontakt",
+            })}
             className="font-medium text-slate-600 hover:text-slate-900"
           >
             Kontakt

--- a/frontend/src/lib/attributionSessionClient.ts
+++ b/frontend/src/lib/attributionSessionClient.ts
@@ -1,0 +1,56 @@
+/**
+ * First-Touch-UTM in sessionStorage (Tab-Session), first-party, kein Cookie.
+ * Nur aus URL-Parametern; wird beim Absenden der Kontaktanfrage mitgeschickt.
+ */
+
+import { LEAD_ATTRIBUTION_LIMITS } from "@/lib/leadAttribution";
+
+export const SESSION_ATTRIBUTION_STORAGE_KEY = "ch_gtm_attr_v1";
+
+export type SessionAttributionPayload = {
+  utm_source: string;
+  utm_medium: string;
+  utm_campaign: string;
+  first_landing_path: string;
+  captured_at: string;
+};
+
+export function tryCaptureUtmFromSearchParams(sp: URLSearchParams, pathname: string): void {
+  if (typeof window === "undefined") return;
+  const u = sp.get("utm_source")?.trim() ?? "";
+  const m = sp.get("utm_medium")?.trim() ?? "";
+  const c = sp.get("utm_campaign")?.trim() ?? "";
+  if (!u && !m && !c) return;
+  if (sessionStorage.getItem(SESSION_ATTRIBUTION_STORAGE_KEY)) return;
+  const payload: SessionAttributionPayload = {
+    utm_source: u.slice(0, LEAD_ATTRIBUTION_LIMITS.utm),
+    utm_medium: m.slice(0, LEAD_ATTRIBUTION_LIMITS.utm),
+    utm_campaign: c.slice(0, LEAD_ATTRIBUTION_LIMITS.utm),
+    first_landing_path: pathname.slice(0, 200),
+    captured_at: new Date().toISOString(),
+  };
+  try {
+    sessionStorage.setItem(SESSION_ATTRIBUTION_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    /* Speicher voll / private mode */
+  }
+}
+
+export function readSessionAttribution(): SessionAttributionPayload | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = sessionStorage.getItem(SESSION_ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+    const o = JSON.parse(raw) as Partial<SessionAttributionPayload>;
+    if (typeof o !== "object" || !o) return null;
+    return {
+      utm_source: typeof o.utm_source === "string" ? o.utm_source : "",
+      utm_medium: typeof o.utm_medium === "string" ? o.utm_medium : "",
+      utm_campaign: typeof o.utm_campaign === "string" ? o.utm_campaign : "",
+      first_landing_path: typeof o.first_landing_path === "string" ? o.first_landing_path : "",
+      captured_at: typeof o.captured_at === "string" ? o.captured_at : "",
+    };
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/lib/gtmDashboardAggregate.ts
+++ b/frontend/src/lib/gtmDashboardAggregate.ts
@@ -12,8 +12,11 @@ import type { LeadInboxItem } from "@/lib/leadInboxTypes";
 import { readLeadOpsState } from "@/lib/leadOpsState";
 import { readAllLeadRecordsMerged } from "@/lib/leadPersistence";
 import { listAllLeadSyncJobs } from "@/lib/leadSyncStore";
+import type { LeadAttributionSource } from "@/lib/leadAttribution";
+import { LEAD_ATTRIBUTION_SOURCE_LABELS_DE } from "@/lib/leadAttributionLabels";
 import type {
   GtmAttentionItem,
+  GtmAttributionBreakdownRow,
   GtmDailyPoint,
   GtmDashboardSnapshot,
   GtmFunnelStage,
@@ -368,6 +371,56 @@ export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promi
     pipedrive_deals_created: dealsPerWeek.get(week_start) ?? 0,
   }));
 
+  type Agg = { inquiries: number; qualified: number; deals: number };
+  function bumpAgg(m: Map<string, Agg>, key: string, qualified: boolean, deal: boolean) {
+    const cur = m.get(key) ?? { inquiries: 0, qualified: 0, deals: 0 };
+    cur.inquiries += 1;
+    if (qualified) cur.qualified += 1;
+    if (deal) cur.deals += 1;
+    m.set(key, cur);
+  }
+
+  const leadDeal30d = new Set<string>();
+  for (const j of jobs) {
+    if (pipedriveDealCreatedInWindow(j, w30.start, w30.end)) leadDeal30d.add(j.lead_id);
+  }
+
+  const items30d = items.filter((it) => isoInWindow(it.created_at, w30.start, w30.end));
+  const bySource = new Map<string, Agg>();
+  const byCampaign = new Map<string, Agg>();
+  for (const it of items30d) {
+    const q = isQualifiedTriage(it.triage_status);
+    const deal = leadDeal30d.has(it.lead_id);
+    bumpAgg(bySource, it.attribution_source, q, deal);
+    const camp = it.attribution_campaign || "(ohne_campaign)";
+    bumpAgg(byCampaign, camp, q, deal);
+  }
+
+  function rowsFromMap(
+    m: Map<string, Agg>,
+    labelForKey: (k: string) => string,
+  ): GtmAttributionBreakdownRow[] {
+    return [...m.entries()]
+      .sort((a, b) => b[1].inquiries - a[1].inquiries)
+      .slice(0, 14)
+      .map(([key, v]) => ({
+        key,
+        label_de: labelForKey(key),
+        inquiries_30d: v.inquiries,
+        qualified_30d: v.qualified,
+        pipedrive_deals_created_30d: v.deals,
+      }));
+  }
+
+  const attribution_by_source_30d = rowsFromMap(bySource, (k) => {
+    const label = LEAD_ATTRIBUTION_SOURCE_LABELS_DE[k as LeadAttributionSource];
+    return label ?? k;
+  });
+
+  const attribution_by_campaign_30d = rowsFromMap(byCampaign, (k) =>
+    k === "(ohne_campaign)" ? "Ohne utm_campaign" : k,
+  );
+
   return {
     generated_at: now.toISOString(),
     windows: {
@@ -382,12 +435,16 @@ export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promi
       inquiries_per_day_utc: daily,
       qualified_and_deals_per_week_utc: qualified_and_deals_per_week_utc,
     },
+    attribution_by_source_30d,
+    attribution_by_campaign_30d,
     data_notes: {
       cta_clicks_persisted: false,
       cta_note_de:
         "CTA-Klicks werden aktuell nur serverseitig geloggt ([marketing-event]), nicht in einem Query-Store — daher keine zuverlässige Zahl im Dashboard.",
       funnel_note_de:
         "Stufen sind absolute Mengen je Zeitraum (Einreichungsdatum). Spätere Stufen können größer wirken als frühere, wenn Leads außerhalb des Fensters qualifiziert wurden; für Steuerung die KPI-Karten und Segmenttabelle nutzen.",
+      attribution_note_de:
+        "Attribution: first-touch-UTM (Tab-Session) plus Server-Referer-Heuristik beim Absenden — keine Multi-Touch-Zuordnung. „Deals“ = Pipedrive-Sync mit deal_action created im 30-Tage-Fenster.",
     },
   };
 }

--- a/frontend/src/lib/gtmDashboardTypes.ts
+++ b/frontend/src/lib/gtmDashboardTypes.ts
@@ -39,6 +39,14 @@ export type GtmWeeklyPoint = {
   pipedrive_deals_created: number;
 };
 
+export type GtmAttributionBreakdownRow = {
+  key: string;
+  label_de: string;
+  inquiries_30d: number;
+  qualified_30d: number;
+  pipedrive_deals_created_30d: number;
+};
+
 export type GtmDashboardSnapshot = {
   generated_at: string;
   windows: Record<GtmWindowKey, { start: string; end: string }>;
@@ -56,9 +64,13 @@ export type GtmDashboardSnapshot = {
     inquiries_per_day_utc: GtmDailyPoint[];
     qualified_and_deals_per_week_utc: GtmWeeklyPoint[];
   };
+  /** Wave 30 – letzte 30 Tage, keine Multi-Touch-Modelle */
+  attribution_by_source_30d: GtmAttributionBreakdownRow[];
+  attribution_by_campaign_30d: GtmAttributionBreakdownRow[];
   data_notes: {
     cta_clicks_persisted: boolean;
     cta_note_de: string;
     funnel_note_de: string;
+    attribution_note_de: string;
   };
 };

--- a/frontend/src/lib/leadAttribution.test.ts
+++ b/frontend/src/lib/leadAttribution.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { attributionFromOutbound, buildLeadAttribution, emptyLeadAttribution } from "@/lib/leadAttribution";
+
+describe("buildLeadAttribution", () => {
+  it("classifies paid search from UTM", () => {
+    const a = buildLeadAttribution({
+      utm_source: "google",
+      utm_medium: "cpc",
+      utm_campaign: "ai-act-q2-2026",
+      http_referer: null,
+    });
+    expect(a.source).toBe("paid_search");
+    expect(a.medium).toBe("cpc");
+    expect(a.campaign).toBe("ai-act-q2-2026");
+  });
+
+  it("uses LinkedIn source token", () => {
+    const a = buildLeadAttribution({
+      utm_source: "linkedin",
+      utm_medium: "social",
+      http_referer: null,
+    });
+    expect(a.source).toBe("linkedin");
+  });
+
+  it("treats empty UTM and referrers as direct", () => {
+    const a = buildLeadAttribution({
+      http_referer: null,
+      page_referrer: "",
+    });
+    expect(a.source).toBe("direct");
+  });
+
+  it("infers organic search from Google referer host", () => {
+    const a = buildLeadAttribution({
+      http_referer: "https://www.google.com/search?q=compliance",
+    });
+    expect(a.source).toBe("organic_search");
+    expect(a.referrer_host).toBe("www.google.com");
+  });
+
+  it("stores CTA fields", () => {
+    const a = buildLeadAttribution({
+      cta_id: "home-hero-demo",
+      cta_label: "Demo anfragen",
+      http_referer: null,
+    });
+    expect(a.cta_id).toBe("home-hero-demo");
+    expect(a.cta_label).toBe("Demo anfragen");
+  });
+});
+
+describe("attributionFromOutbound", () => {
+  it("returns unknown when outbound has no attribution", () => {
+    expect(attributionFromOutbound({})).toEqual(emptyLeadAttribution());
+  });
+});

--- a/frontend/src/lib/leadAttribution.ts
+++ b/frontend/src/lib/leadAttribution.ts
@@ -1,0 +1,231 @@
+/**
+ * Wave 30 – leichte Attribution (UTM, Referrer, CTA) ohne Multi-Touch-Engine.
+ * Ableitung ist heuristisch; Werte sind interne Steuerungsgrößen, keine „Wahrheit“.
+ */
+
+export const LEAD_ATTRIBUTION_SOURCES = [
+  "direct",
+  "organic_search",
+  "referral",
+  "linkedin",
+  "newsletter",
+  "paid_search",
+  "paid_social",
+  "email",
+  "other",
+  "unknown",
+] as const;
+
+export type LeadAttributionSource = (typeof LEAD_ATTRIBUTION_SOURCES)[number];
+
+/** Gespeichert in Outbound (schema ≥ 1.2) und gespiegelt in Inbox. */
+export type LeadAttributionSnapshot = {
+  source: LeadAttributionSource;
+  /** Normalisiertes Medium (z. B. cpc, email, paid_social) oder leer */
+  medium: string;
+  /** Kurzcode aus utm_campaign, Kleinbuchstaben/Zahlen/_/- */
+  campaign: string;
+  /** Technischer CTA-Bezeichner (Link/Event) */
+  cta_id: string;
+  /** Anzeige-Label für Menschen (z. B. „Demo“) */
+  cta_label: string;
+  utm_source_raw: string;
+  utm_medium_raw: string;
+  utm_campaign_raw: string;
+  /** Host der HTTP-Referer-URL (serverseitig), nicht die volle URL */
+  referrer_host: string;
+};
+
+export const LEAD_ATTRIBUTION_LIMITS = {
+  utm: 120,
+  medium: 64,
+  campaign: 120,
+  cta_id: 80,
+  cta_label: 120,
+  referrer: 500,
+  referrer_host: 253,
+} as const;
+
+function slugMedium(s: string): string {
+  const t = s.trim().toLowerCase().slice(0, LEAD_ATTRIBUTION_LIMITS.medium);
+  return t.replace(/[^a-z0-9_+-]+/g, "_").replace(/_+/g, "_").replace(/^_|_$/g, "");
+}
+
+function slugCampaign(s: string): string {
+  const t = s.trim().toLowerCase().slice(0, LEAD_ATTRIBUTION_LIMITS.campaign);
+  return t.replace(/[^a-z0-9_+-]+/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+}
+
+function trimField(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  return s.trim().slice(0, max);
+}
+
+function parseUrlHost(raw: string): string {
+  const t = raw.trim().slice(0, LEAD_ATTRIBUTION_LIMITS.referrer);
+  if (!t) return "";
+  try {
+    const u = new URL(t);
+    return u.hostname.toLowerCase().slice(0, LEAD_ATTRIBUTION_LIMITS.referrer_host);
+  } catch {
+    return "";
+  }
+}
+
+function hostFromReferrerHeader(header: string | null): string {
+  if (!header) return "";
+  return parseUrlHost(header);
+}
+
+function hostFromPageReferrer(clientRef: string): string {
+  return parseUrlHost(clientRef);
+}
+
+const SEARCH_HOST_FRAGMENTS = [
+  "google.",
+  "bing.",
+  "duckduckgo.",
+  "ecosia.",
+  "startpage.",
+  "yahoo.",
+  "qwant.",
+];
+
+function isSearchHost(host: string): boolean {
+  if (!host) return false;
+  return SEARCH_HOST_FRAGMENTS.some((f) => host.includes(f));
+}
+
+function normalizeSourceToken(s: string): string {
+  return s.trim().toLowerCase();
+}
+
+function deriveSourceFromUtm(
+  utmSource: string,
+  utmMedium: string,
+): LeadAttributionSource | null {
+  const src = normalizeSourceToken(utmSource);
+  const med = normalizeSourceToken(utmMedium);
+  if (!src && !med) return null;
+
+  if (med === "cpc" || med === "ppc" || med === "paidsearch" || med === "paid_search") {
+    return "paid_search";
+  }
+  if (med === "paid_social" || med === "paidsocial" || med === "social_paid") {
+    return "paid_social";
+  }
+  if (med === "email" || med === "e-mail") {
+    return "email";
+  }
+  if (med === "newsletter" || src.includes("newsletter") || src.includes("mailchimp")) {
+    return "newsletter";
+  }
+  if (src.includes("linkedin") || src === "lnkd.in") {
+    return "linkedin";
+  }
+  if (src === "google" && (med === "organic" || med === "referral" || !med)) {
+    return "organic_search";
+  }
+  if (
+    (src === "google" || src === "bing") &&
+    (med === "organic" || med === "referral" || !med)
+  ) {
+    return "organic_search";
+  }
+  if (src && (med === "organic" || med === "natural")) {
+    return "organic_search";
+  }
+  return null;
+}
+
+function deriveSourceFromHosts(
+  httpReferrerHost: string,
+  pageReferrerHost: string,
+): LeadAttributionSource {
+  const hosts = [httpReferrerHost, pageReferrerHost].filter(Boolean);
+  if (hosts.length === 0) return "direct";
+  for (const h of hosts) {
+    if (isSearchHost(h)) return "organic_search";
+    if (h.includes("linkedin")) return "linkedin";
+  }
+  return "referral";
+}
+
+export function buildLeadAttribution(input: {
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  page_referrer?: string;
+  cta_id?: string;
+  cta_label?: string;
+  http_referer?: string | null;
+}): LeadAttributionSnapshot {
+  const utm_source_raw = trimField(input.utm_source, LEAD_ATTRIBUTION_LIMITS.utm);
+  const utm_medium_raw = trimField(input.utm_medium, LEAD_ATTRIBUTION_LIMITS.utm);
+  const utm_campaign_raw = trimField(input.utm_campaign, LEAD_ATTRIBUTION_LIMITS.utm);
+  const cta_id = trimField(input.cta_id, LEAD_ATTRIBUTION_LIMITS.cta_id);
+  const cta_label = trimField(input.cta_label, LEAD_ATTRIBUTION_LIMITS.cta_label);
+
+  const httpHost = hostFromReferrerHeader(input.http_referer ?? null);
+  const pageHost = hostFromPageReferrer(trimField(input.page_referrer, LEAD_ATTRIBUTION_LIMITS.referrer));
+  const referrer_host = httpHost || pageHost;
+
+  const hasUtm = Boolean(utm_source_raw || utm_medium_raw);
+  const fromUtm = deriveSourceFromUtm(utm_source_raw, utm_medium_raw);
+  let source: LeadAttributionSource;
+  if (hasUtm) {
+    source = fromUtm ?? (utm_source_raw || utm_medium_raw ? "other" : "unknown");
+  } else {
+    source = deriveSourceFromHosts(httpHost, pageHost);
+  }
+
+  const medium = slugMedium(utm_medium_raw);
+  const campaign = slugCampaign(utm_campaign_raw);
+
+  return {
+    source,
+    medium,
+    campaign,
+    cta_id,
+    cta_label,
+    utm_source_raw,
+    utm_medium_raw,
+    utm_campaign_raw,
+    referrer_host,
+  };
+}
+
+export function emptyLeadAttribution(): LeadAttributionSnapshot {
+  return {
+    source: "unknown",
+    medium: "",
+    campaign: "",
+    cta_id: "",
+    cta_label: "",
+    utm_source_raw: "",
+    utm_medium_raw: "",
+    utm_campaign_raw: "",
+    referrer_host: "",
+  };
+}
+
+export function attributionFromOutbound(
+  ob: { attribution?: LeadAttributionSnapshot | null } | null | undefined,
+): LeadAttributionSnapshot {
+  const a = ob?.attribution;
+  if (!a || typeof a !== "object") return emptyLeadAttribution();
+  const src = LEAD_ATTRIBUTION_SOURCES.includes(a.source as LeadAttributionSource)
+    ? (a.source as LeadAttributionSource)
+    : "unknown";
+  return {
+    source: src,
+    medium: typeof a.medium === "string" ? a.medium : "",
+    campaign: typeof a.campaign === "string" ? a.campaign : "",
+    cta_id: typeof a.cta_id === "string" ? a.cta_id : "",
+    cta_label: typeof a.cta_label === "string" ? a.cta_label : "",
+    utm_source_raw: typeof a.utm_source_raw === "string" ? a.utm_source_raw : "",
+    utm_medium_raw: typeof a.utm_medium_raw === "string" ? a.utm_medium_raw : "",
+    utm_campaign_raw: typeof a.utm_campaign_raw === "string" ? a.utm_campaign_raw : "",
+    referrer_host: typeof a.referrer_host === "string" ? a.referrer_host : "",
+  };
+}

--- a/frontend/src/lib/leadAttributionLabels.ts
+++ b/frontend/src/lib/leadAttributionLabels.ts
@@ -1,0 +1,14 @@
+import type { LeadAttributionSource } from "@/lib/leadAttribution";
+
+export const LEAD_ATTRIBUTION_SOURCE_LABELS_DE: Record<LeadAttributionSource, string> = {
+  direct: "Direkt",
+  organic_search: "Organische Suche",
+  referral: "Referral / Website",
+  linkedin: "LinkedIn",
+  newsletter: "Newsletter / Liste",
+  paid_search: "Bezahlte Suche",
+  paid_social: "Paid Social",
+  email: "E-Mail (UTM)",
+  other: "Sonstige Quelle (UTM)",
+  unknown: "Unbekannt (Legacy)",
+};

--- a/frontend/src/lib/leadInboxMerge.ts
+++ b/frontend/src/lib/leadInboxMerge.ts
@@ -1,3 +1,4 @@
+import { attributionFromOutbound } from "@/lib/leadAttribution";
 import {
   deriveLeadAccountKeyFromStoredRecord,
   deriveLeadContactKeyFromStoredRecord,
@@ -34,6 +35,7 @@ export function mergeLeadsWithOps(rows: LeadAdminRow[], ops: LeadOpsFile): LeadI
     const contact_latest_seen_at =
       r.contact_latest_seen_at ?? ob.contact_latest_seen_at ?? r.created_at;
     const duplicate_hint = r.duplicate_hint ?? ob.duplicate_hint ?? "none";
+    const attr = attributionFromOutbound(ob);
     return {
       lead_id: r.lead_id,
       trace_id: r.trace_id,
@@ -49,6 +51,12 @@ export function mergeLeadsWithOps(rows: LeadAdminRow[], ops: LeadOpsFile): LeadI
       priority: ob.route.priority,
       sla_bucket: ob.route.sla_bucket,
       source_page: ob.source_page,
+      attribution_source: attr.source,
+      attribution_medium: attr.medium,
+      attribution_campaign: attr.campaign,
+      attribution_cta_id: attr.cta_id,
+      attribution_cta_label: attr.cta_label,
+      attribution: attr,
       company: ob.company,
       business_email: ob.business_email,
       name: ob.name,
@@ -169,6 +177,7 @@ export function buildContactHistoryItems(
     const o = getOpsEntryForLead(ops, r.lead_id);
     const fw = forwardingStatus(r);
     const ob = r.outbound;
+    const attr = attributionFromOutbound(ob);
     return {
       lead_id: r.lead_id,
       trace_id: r.trace_id,
@@ -179,6 +188,10 @@ export function buildContactHistoryItems(
       owner: o.owner,
       internal_note: o.internal_note,
       source_page: ob.source_page,
+      attribution_source: attr.source,
+      attribution_medium: attr.medium,
+      attribution_campaign: attr.campaign,
+      attribution_cta_label: attr.cta_label,
       segment: ob.segment,
       message_preview: ob.message.slice(0, 200),
       contact_inquiry_sequence:

--- a/frontend/src/lib/leadInboxTypes.ts
+++ b/frontend/src/lib/leadInboxTypes.ts
@@ -1,3 +1,4 @@
+import type { LeadAttributionSnapshot, LeadAttributionSource } from "@/lib/leadAttribution";
 import type { LeadSegment } from "@/lib/leadCapture";
 import type { LeadDuplicateHint } from "@/lib/leadIdentity";
 import type { LeadDuplicateReviewStatus, LeadOpsActivity } from "@/lib/leadOpsTypes";
@@ -21,6 +22,12 @@ export type LeadInboxItem = {
   priority: string;
   sla_bucket: string;
   source_page: string;
+  /** Wave 30 – kanonische Attribution (aus Outbound, gespiegelt). */
+  attribution_source: LeadAttributionSource;
+  attribution_medium: string;
+  attribution_campaign: string;
+  attribution_cta_id: string;
+  attribution_cta_label: string;
   company: string;
   business_email: string;
   name: string;
@@ -45,6 +52,8 @@ export type LeadInboxItem = {
   other_contacts_on_same_account: number;
   manual_related_lead_ids: string[];
   duplicate_review: LeadDuplicateReviewStatus;
+  /** Rohfelder für Detailansicht (optional leer bei alten Leads). */
+  attribution: LeadAttributionSnapshot;
 };
 
 /** Timeline-Eintrag für Kontakt-Historie (Detail). */
@@ -58,6 +67,10 @@ export type LeadContactHistoryEntry = {
   owner: string;
   internal_note: string;
   source_page: string;
+  attribution_source: LeadAttributionSource;
+  attribution_medium: string;
+  attribution_campaign: string;
+  attribution_cta_label: string;
   segment: LeadSegment;
   message_preview: string;
   contact_inquiry_sequence: number;

--- a/frontend/src/lib/leadOutbound.ts
+++ b/frontend/src/lib/leadOutbound.ts
@@ -1,15 +1,16 @@
+import type { LeadAttributionSnapshot } from "@/lib/leadAttribution";
 import type { LeadSegment } from "@/lib/leadCapture";
 import type { LeadDuplicateHint } from "@/lib/leadIdentity";
 import type { LeadRoute } from "@/lib/leadRouting";
 
 /** Stabile Webhook-/CRM-Version – bei Breaking Changes hochzählen. */
-export const LEAD_OUTBOUND_SCHEMA_VERSION = "1.1" as const;
+export const LEAD_OUTBOUND_SCHEMA_VERSION = "1.2" as const;
 
-export type LeadOutboundSchemaVersion = "1.0" | "1.1";
+export type LeadOutboundSchemaVersion = "1.0" | "1.1" | "1.2";
 
 /**
- * n8n-/CRM-freundlicher Outbound-Vertrag (Wave 25, erweitert Wave 27).
- * Neue Anfragen nutzen `1.1` inkl. Identity-Feldern; ältere JSONL-Zeilen können `1.0` sein.
+ * n8n-/CRM-freundlicher Outbound-Vertrag (Wave 25, erweitert Wave 27/30).
+ * Neue Anfragen nutzen `1.2` inkl. Identity + Attribution; ältere JSONL-Zeilen können `1.0`/`1.1` sein.
  */
 export type LeadOutboundPayloadV1 = {
   schema_version: LeadOutboundSchemaVersion;
@@ -28,13 +29,15 @@ export type LeadOutboundPayloadV1 = {
     priority: LeadRoute["priority"];
     sla_bucket: LeadRoute["sla_bucket"];
   };
-  /** Wave 27 – nur bei schema_version 1.1 gesetzt (CRM/n8n Dedup-Vorbereitung). */
+  /** Wave 27 – ab schema_version 1.1 (CRM/n8n Dedup-Vorbereitung). */
   lead_contact_key?: string;
   lead_account_key?: string | null;
   contact_inquiry_sequence?: number;
   contact_first_seen_at?: string;
   contact_latest_seen_at?: string;
   duplicate_hint?: LeadDuplicateHint;
+  /** Wave 30 – Attribution (UTM, Referrer, CTA); nur ab 1.2. */
+  attribution?: LeadAttributionSnapshot;
 };
 
 export type LeadOutboundIdentitySnapshot = {
@@ -59,6 +62,7 @@ export function buildLeadOutboundPayload(input: {
   identity: LeadOutboundIdentitySnapshot;
   /** Optional: gleicher Zeitstempel wie JSONL-Zeile (Persistenz/Webhook konsistent). */
   timestamp?: string;
+  attribution?: LeadAttributionSnapshot;
 }): LeadOutboundPayloadV1 {
   const { identity } = input;
   return {
@@ -84,5 +88,6 @@ export function buildLeadOutboundPayload(input: {
     contact_first_seen_at: identity.contact_first_seen_at,
     contact_latest_seen_at: identity.contact_latest_seen_at,
     duplicate_hint: identity.duplicate_hint,
+    ...(input.attribution ? { attribution: input.attribution } : {}),
   };
 }

--- a/frontend/src/lib/leadSyncPayload.ts
+++ b/frontend/src/lib/leadSyncPayload.ts
@@ -81,5 +81,6 @@ export function buildLeadSyncPayloadV1(input: {
     pipeline_status: row.status,
     forwarding_status,
     legacy_inbound_webhook_delivery: legacyInboundDelivery,
+    ...(ob.attribution ? { attribution: ob.attribution } : {}),
   };
 }

--- a/frontend/src/lib/leadSyncTypes.ts
+++ b/frontend/src/lib/leadSyncTypes.ts
@@ -2,6 +2,8 @@
  * Wave 28 – Lead-Sync-Jobs (getrennt von Roh-Anfrage / JSONL lead_inquiry).
  */
 
+import type { LeadAttributionSnapshot } from "@/lib/leadAttribution";
+
 export type LeadSyncTarget =
   | "n8n_webhook"
   | "hubspot"
@@ -52,6 +54,8 @@ export type LeadSyncPayloadV1 = {
   forwarding_status: string;
   /** Hinweis: separates Legacy-Webhook (Wave 25) vs. Sync-Framework */
   legacy_inbound_webhook_delivery: "forwarded" | "stored" | "stored_forward_failed" | "not_configured";
+  /** Wave 30 – optional; Downstream (HubSpot/n8n) kann Felder mappen. */
+  attribution?: LeadAttributionSnapshot;
 };
 
 export type LeadSyncJob = {

--- a/frontend/src/lib/publicContact.ts
+++ b/frontend/src/lib/publicContact.ts
@@ -7,8 +7,26 @@ export const PUBLIC_CONTACT_EMAIL = "kontakt@complywithai.de";
 export const PUBLIC_CONTACT_MAILTO = `mailto:${PUBLIC_CONTACT_EMAIL}`;
 export const PUBLIC_CONTACT_PATH = "/kontakt" as const;
 
+export type ContactPageHrefOpts = {
+  quelle: string;
+  /** Technischer CTA-Code (z. B. home-hero-demo) */
+  ctaId?: string;
+  /** Kurzes Anzeige-Label (z. B. Demo, Kontakt) */
+  ctaLabel?: string;
+};
+
 /** `quelle` = Query-Parameter für Sales-Triage (z. B. home-hero, footer). */
-export function contactPageHref(quelle: string): string {
-  const q = quelle.trim() || "unbekannt";
-  return `${PUBLIC_CONTACT_PATH}?quelle=${encodeURIComponent(q)}`;
+export function contactPageHref(quelle: string): string;
+export function contactPageHref(opts: ContactPageHrefOpts): string;
+export function contactPageHref(quelleOrOpts: string | ContactPageHrefOpts): string {
+  const opts: ContactPageHrefOpts =
+    typeof quelleOrOpts === "string"
+      ? { quelle: quelleOrOpts }
+      : { ...quelleOrOpts, quelle: quelleOrOpts.quelle };
+  const q = (opts.quelle.trim() || "unbekannt").slice(0, 120);
+  const p = new URLSearchParams();
+  p.set("quelle", q);
+  if (opts.ctaId?.trim()) p.set("cta_id", opts.ctaId.trim().slice(0, 80));
+  if (opts.ctaLabel?.trim()) p.set("cta_label", opts.ctaLabel.trim().slice(0, 120));
+  return `${PUBLIC_CONTACT_PATH}?${p.toString()}`;
 }


### PR DESCRIPTION
Add privacy-conscious first-touch UTM (sessionStorage), referrer/CTA enrichment on lead ingest, outbound schema 1.2, and optional attribution on sync payloads.

Extend /admin/gtm with 30d source/campaign tables; inbox filters, column, and detail. Document scope and DSGVO stance in wave30 doc.

Made-with: Cursor