### PR TITLE
feat(gtm): Wave 31 health and pipeline readiness

### DIFF
--- a/docs/gtm/wave29-founder-dashboard.md
+++ b/docs/gtm/wave29-founder-dashboard.md
@@ -62,4 +62,4 @@ Kurze Listen (jeweils bis ca. 8 Einträge): fehlgeschlagene Webhooks, Dead-Lette
 - Sehr große JSONL/Job-Stores: Aggregation ist O(n); bei Bedarf später cachen oder Zeitraum begrenzen.
 - Fokus-Link setzt nur die `lead_id` in der Inbox, wenn die Liste geladen ist und die ID existiert.
 
-Siehe auch: [Wave 28 – Lead-Sync](wave28-lead-sync-framework.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 30 – Attribution](wave30-attribution-and-campaign-tracking.md).
+Siehe auch: [Wave 28 – Lead-Sync](wave28-lead-sync-framework.md), [Wave 26 – Lead-Inbox](wave26-internal-lead-inbox.md), [Wave 30 – Attribution](wave30-attribution-and-campaign-tracking.md), [Wave 31 – Health & Readiness](wave31-gtm-health-and-readiness.md).

--- a/docs/gtm/wave31-gtm-health-and-readiness.md
+++ b/docs/gtm/wave31-gtm-health-and-readiness.md
@@ -1,0 +1,71 @@
+# Wave 31 – GTM Health & Pipeline Readiness
+
+## Zweck
+
+Auf dem [Founder Dashboard (Wave 29)](wave29-founder-dashboard.md) und der [Attribution-Schicht (Wave 30)](wave30-attribution-and-campaign-tracking.md) aufbauend: eine **ehrliche, regelbasierte Kompass-Ansicht** für frühe GTM-Phase — **kein** OKR-System, **kein** Board-BI.
+
+Fragen, die in 1–2 Minuten beantwortet werden sollen:
+
+- Wie stabil ist der **Eingang** (Webhooks, Noise)?
+- Hängt **Triage**?
+- Wie gesund ist der **CRM-Sync**?
+- Passt **Pipeline** (qualifiziert → Deal) grob?
+- Welche **Segmente** und **Kanäle** wirken ausgewogen vs. riskant?
+
+## Wo im Produkt?
+
+- **`/admin/gtm`** (oben): Block **GTM Health** (Kacheln), **Operative Hinweise**, erweiterte **Segment-Readiness-Tabelle**, **Attribution & Signalqualität (Top 3)**.
+- Zugriff wie bisher: `LEAD_ADMIN_SECRET` / Session wie Lead-Inbox.
+
+## Health-Indikatoren (Kacheln)
+
+| Kachel | Signale | Status-Logik (Kurz) |
+|--------|---------|---------------------|
+| **Lead-Eingang** | Webhook-Fehlerquote & Spam-Anteil (30 Tage) | Schwellen in `gtmHealthThresholds.ts` (`GTM_HEALTH_WEBHOOK_RATE_*`, `GTM_HEALTH_SPAM_RATE_*`). Formular-Uptime wird **nicht** gemessen — Hinweis in der Kachel. |
+| **Triage** | Anzahl Leads mit Status „Neu“, **älter als 3 Tage** (Einreichungsdatum) | ≥ 5 → issue, ≥ 2 → watch. |
+| **CRM-Sync** | Anteil **Dead Letter + fehlgeschlagen** vs. **gesendet** (HubSpot/Pipedrive, 30 Tage, echte Connectors) | Nur ab Mindestdenominator (`GTM_HEALTH_CRM_BAD_RATIO_MIN_DENOM`). |
+| **Pipeline** | Verhältnis **Pipedrive-Deals neu** / **qualifiziert** (30 Tage) | Nur wenn qualifiziert ≥ `GTM_HEALTH_PIPELINE_QUALIFIED_MIN`. |
+
+Status je Kachel: **`good` | `watch` | `issue`** — qualitativ, keine gewichtete Gesamtnote.
+
+## Operative Hinweise (SLA-Stil)
+
+Aggregierte **Zähler** mit sachlichen Formulierungen (keine Zuschreibungen an Personen):
+
+| Hint-ID | Bedeutung |
+|---------|-----------|
+| `untriaged_3d` | „Neu“-Leads älter als 3 Tage |
+| `stuck_sync` | CRM-Job `failed`, letzter Versuch **> 24 h** her (`GTM_HEALTH_STUCK_SYNC_HOURS`) |
+| `qualified_no_deal` | Triage qualifiziert / Abschluss-Interesse, **kein** Pipedrive-Deal (Sync), Einreichung **> 7 Tage** — **Proxy**, siehe Caveats |
+| `attrib_noise` | Unter den Top-3-Quellen nach Volumen: Kanäle mit vielen Leads und sehr niedriger Qualifikationsquote (Heuristik) |
+
+## Segment-Readiness
+
+Pro Segment (inkl. „Sonstiges“): Anfragen und Qualifikation (30 Tage), **HubSpot gesendet**, **Pipedrive Touch** (gesendete Pipedrive-Jobs im Fenster), **Sync-Issues** (wie Wave 29), **dominante Attributions-Quellen** (Top 2 nach Volumen).
+
+**Readiness-Hinweis (watch):**
+
+- Kernsegmente mit **sehr wenig** Volumen (`GTM_HEALTH_SEGMENT_VOLUME_VERY_LOW`).
+- **Viel Volumen**, aber **Qualifikationsquote** unter `GTM_HEALTH_SEGMENT_QUAL_RATIO_LOW` (ab `GTM_HEALTH_SEGMENT_VOLUME_MIN` Anfragen).
+
+## Attribution Top 3 & Noise
+
+Die drei stärksten Quellen (nach Leads 30 Tage) mit Qualifikationsquote. **Noise-Verdacht** ab Mindest-Leads und maximaler Qual-Quote (`GTM_HEALTH_ATTRIB_NOISE_*`).
+
+## Technische Referenz
+
+- Schwellen: `frontend/src/lib/gtmHealthThresholds.ts`
+- Regeln & Texte: `frontend/src/lib/gtmHealthEngine.ts`
+- Metrik-Vorbereitung: `frontend/src/lib/gtmDashboardAggregate.ts` (ruft `evaluateGtmHealth`)
+- UI: `frontend/src/components/admin/GtmCommandCenterClient.tsx`
+
+## Interpretation & Caveats
+
+- **Frühphase:** Wenig Daten → viele Kacheln bleiben „OK“; Hinweise sind **advisory**.
+- **Kein Qualifizierungszeitpunkt:** „Qualifiziert ohne Deal > 7 Tage“ nutzt **Einreichungsalter**, nicht das Datum der Triage-Änderung — kann **über- oder unterschätzen**.
+- **Deals:** nur **Pipedrive-Sync** mit `deal_action === "created"` im 30-Tage-Fenster (wie bestehendes Dashboard).
+- **Retries:** „Stuck sync“ zählt Jobs im Status `failed` mit altem `last_attempt_at` — Dispatcher-Verhalten kann abweichen.
+
+## Ausblick
+
+Schwellen anpassen, wenn Volumen steigt; optional später echte **Triage-Timestamps** oder **HubSpot-Property-Mapping** aus Wave 30/28 — weiterhin ohne Drittanbieter-Attribution-Stack.

--- a/frontend/src/components/admin/GtmCommandCenterClient.tsx
+++ b/frontend/src/components/admin/GtmCommandCenterClient.tsx
@@ -2,9 +2,25 @@
 
 import { useCallback, useEffect, useState } from "react";
 
-import type { GtmDashboardSnapshot, GtmWindowKey } from "@/lib/gtmDashboardTypes";
+import type {
+  GtmDashboardSnapshot,
+  GtmHealthStatus,
+  GtmWindowKey,
+} from "@/lib/gtmDashboardTypes";
 
 type Props = { adminConfigured: boolean };
+
+function healthStatusClass(s: GtmHealthStatus): string {
+  if (s === "good") return "border-emerald-200 bg-emerald-50/90 text-emerald-950";
+  if (s === "watch") return "border-amber-200 bg-amber-50/90 text-amber-950";
+  return "border-rose-200 bg-rose-50/90 text-rose-950";
+}
+
+function healthStatusLabel(s: GtmHealthStatus): string {
+  if (s === "good") return "OK";
+  if (s === "watch") return "Beobachten";
+  return "Handeln";
+}
 
 function KpiCard({
   title,
@@ -148,6 +164,53 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
 
       {snapshot ? (
         <>
+          <section id="gtm-health" className="rounded-xl border border-slate-200 bg-slate-50/80 p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-900">GTM Health</h2>
+            <p className="mt-1 text-xs text-slate-600">{snapshot.data_notes.health_note_de}</p>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+              {snapshot.health.tiles.map((t) => (
+                <div
+                  key={t.id}
+                  className={`rounded-lg border p-3 text-sm ${healthStatusClass(t.status)}`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium">{t.label_de}</span>
+                    <span className="rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide opacity-90">
+                      {healthStatusLabel(t.status)}
+                    </span>
+                  </div>
+                  <p className="mt-2 text-xs leading-relaxed opacity-95">{t.explanation_de}</p>
+                  <a
+                    href={t.href}
+                    className="mt-2 inline-block text-xs font-medium text-cyan-900 underline underline-offset-2"
+                  >
+                    {t.link_label_de} →
+                  </a>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          {snapshot.health.ops_hints.length > 0 ? (
+            <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-800">Operative Hinweise (SLA‑Stil)</h2>
+              <p className="mt-1 text-xs text-slate-500">
+                Orientierung für den Alltag — keine verbindlichen SLAs, keine Personenbewertung.
+              </p>
+              <ul className="mt-3 space-y-2 text-sm text-slate-800">
+                {snapshot.health.ops_hints.map((h) => (
+                  <li key={h.id} className="flex flex-wrap items-baseline gap-2">
+                    <span className="font-mono text-xs text-slate-500">×{h.count}</span>
+                    <span>{h.message_de}</span>
+                    <a href={h.href} className="text-xs text-cyan-800 underline">
+                      Öffnen
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
           <section>
             <h2 className="mb-3 text-sm font-semibold text-slate-800">Kern-KPIs</h2>
             <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
@@ -200,34 +263,62 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
             </div>
           </section>
 
-          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
-            <h2 className="text-sm font-semibold text-slate-800">Segmente (30 Tage)</h2>
+          <section
+            id="gtm-segment-readiness"
+            className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          >
+            <h2 className="text-sm font-semibold text-slate-800">Segment-Readiness (30 Tage)</h2>
+            <p className="mt-1 text-xs text-slate-500">
+              Volumen, Qualifikation, CRM-Touches (gesendete Jobs) und dominante Attributions-Quellen.
+              Sync-Probleme: fehlgeschlagen oder Dead Letter (letztes Update im Fenster).
+            </p>
             <div className="mt-3 overflow-x-auto">
-              <table className="w-full min-w-[520px] border-collapse text-left text-sm">
+              <table className="w-full min-w-[860px] border-collapse text-left text-sm">
                 <thead>
                   <tr className="border-b border-slate-200 text-xs text-slate-500">
                     <th className="py-2 pr-2">Segment</th>
-                    <th className="py-2 pr-2">Anfragen</th>
-                    <th className="py-2 pr-2">Qualifiziert</th>
-                    <th className="py-2">CRM-Sync-Probleme</th>
+                    <th className="py-2 pr-2">Anfr.</th>
+                    <th className="py-2 pr-2">Qual.</th>
+                    <th className="py-2 pr-2">HubSpot OK</th>
+                    <th className="py-2 pr-2">PD Touch</th>
+                    <th className="py-2 pr-2">Sync-Issues</th>
+                    <th className="py-2 pr-2">Top-Quellen</th>
+                    <th className="py-2 pr-2">Status</th>
+                    <th className="py-2">Hinweis</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {snapshot.segment_table.map((row) => (
-                    <tr key={row.segment} className="border-b border-slate-100">
-                      <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
-                      <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
-                      <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
-                      <td className="py-2 font-mono text-amber-800">{row.sync_issues_30d}</td>
-                    </tr>
-                  ))}
+                  {snapshot.health.segment_readiness.map((row) => {
+                    const syncRow = snapshot.segment_table.find((s) => s.segment === row.segment);
+                    return (
+                      <tr key={row.segment} className="border-b border-slate-100">
+                        <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
+                        <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
+                        <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
+                        <td className="py-2 pr-2 font-mono text-slate-700">{row.hubspot_sent_30d}</td>
+                        <td className="py-2 pr-2 font-mono text-slate-700">
+                          {row.pipedrive_touch_30d}
+                        </td>
+                        <td className="py-2 pr-2 font-mono text-amber-800">
+                          {syncRow?.sync_issues_30d ?? 0}
+                        </td>
+                        <td className="max-w-[200px] py-2 pr-2 text-xs text-slate-600">
+                          {row.dominant_sources_de}
+                        </td>
+                        <td className="py-2 pr-2">
+                          <span
+                            className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${healthStatusClass(row.status)}`}
+                          >
+                            {healthStatusLabel(row.status)}
+                          </span>
+                        </td>
+                        <td className="max-w-[220px] py-2 text-xs text-slate-600">{row.note_de}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
-            <p className="mt-2 text-xs text-slate-500">
-              Sync-Probleme: fehlgeschlagen oder Dead Letter bei HubSpot/Pipedrive (letztes Update im
-              30-Tage-Fenster).
-            </p>
           </section>
 
           <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -311,6 +402,61 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
             </div>
           </section>
 
+          <section
+            id="gtm-attribution-health"
+            className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          >
+            <h2 className="text-sm font-semibold text-slate-800">Attribution &amp; Signalqualität (Top 3)</h2>
+            <p className="mt-1 text-xs text-slate-500">
+              Stärkste Quellen nach Volumen; „Noise“ = viele Leads, sehr wenig Qualifikation
+              (heuristisch, kein Bot-Nachweis).
+            </p>
+            <div className="mt-3 overflow-x-auto">
+              <table className="w-full min-w-[480px] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-b border-slate-200 text-xs text-slate-500">
+                    <th className="py-2 pr-2">Quelle</th>
+                    <th className="py-2 pr-2">Leads</th>
+                    <th className="py-2 pr-2">Qual.</th>
+                    <th className="py-2 pr-2">Deals</th>
+                    <th className="py-2 pr-2">Qual.-Quote</th>
+                    <th className="py-2">Hinweis</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {snapshot.health.attribution_health_top3.length === 0 ? (
+                    <tr>
+                      <td colSpan={6} className="py-3 text-xs text-slate-500">
+                        Keine Daten.
+                      </td>
+                    </tr>
+                  ) : (
+                    snapshot.health.attribution_health_top3.map((row) => (
+                      <tr key={row.key} className="border-b border-slate-100">
+                        <td className="py-2 pr-2 text-slate-800">{row.label_de}</td>
+                        <td className="py-2 pr-2 font-mono">{row.inquiries_30d}</td>
+                        <td className="py-2 pr-2 font-mono">{row.qualified_30d}</td>
+                        <td className="py-2 pr-2 font-mono">{row.pipedrive_deals_created_30d}</td>
+                        <td className="py-2 pr-2 font-mono text-slate-600">
+                          {row.inquiries_30d > 0
+                            ? `${Math.round(row.qual_ratio * 100)}%`
+                            : "—"}
+                        </td>
+                        <td className="py-2 text-xs">
+                          {row.noise_suspected ? (
+                            <span className="text-amber-800">Viel Volumen, wenig Qual. prüfen</span>
+                          ) : (
+                            <span className="text-slate-500">—</span>
+                          )}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
           <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
             <h2 className="text-sm font-semibold text-slate-800">Trichter (absolute Zahlen)</h2>
             <p className="mt-1 text-xs text-slate-500">{snapshot.data_notes.funnel_note_de}</p>
@@ -337,7 +483,7 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
             </div>
           </section>
 
-          <section className="rounded-xl border border-slate-200 bg-amber-50/80 p-4 shadow-sm">
+          <section id="gtm-attention" className="rounded-xl border border-slate-200 bg-amber-50/80 p-4 shadow-sm">
             <h2 className="text-sm font-semibold text-amber-950">Aufmerksamkeit</h2>
             <ul className="mt-3 max-h-64 space-y-2 overflow-auto text-xs">
               {snapshot.attention.length === 0 ? (

--- a/frontend/src/lib/gtmDashboardAggregate.ts
+++ b/frontend/src/lib/gtmDashboardAggregate.ts
@@ -14,6 +14,12 @@ import { readAllLeadRecordsMerged } from "@/lib/leadPersistence";
 import { listAllLeadSyncJobs } from "@/lib/leadSyncStore";
 import type { LeadAttributionSource } from "@/lib/leadAttribution";
 import { LEAD_ATTRIBUTION_SOURCE_LABELS_DE } from "@/lib/leadAttributionLabels";
+import { evaluateGtmHealth } from "@/lib/gtmHealthEngine";
+import {
+  GTM_HEALTH_QUALIFIED_NO_DEAL_DAYS,
+  GTM_HEALTH_STUCK_SYNC_HOURS,
+  GTM_HEALTH_UNTRIAGED_DAYS,
+} from "@/lib/gtmHealthThresholds";
 import type {
   GtmAttentionItem,
   GtmAttributionBreakdownRow,
@@ -29,10 +35,17 @@ import type { LeadSyncJob, LeadSyncTarget } from "@/lib/leadSyncTypes";
 export type { GtmWindowKey } from "@/lib/gtmDashboardTime";
 export type {
   GtmAttentionItem,
+  GtmAttributionBreakdownRow,
+  GtmAttributionHealthRow,
   GtmDailyPoint,
   GtmDashboardSnapshot,
   GtmFunnelStage,
+  GtmHealthLayer,
+  GtmHealthStatus,
+  GtmHealthTile,
+  GtmOpsHint,
   GtmSegmentBucket,
+  GtmSegmentReadinessRow,
   GtmWeeklyPoint,
   GtmWindowMetrics,
 } from "@/lib/gtmDashboardTypes";
@@ -111,6 +124,16 @@ function syncJobBad(j: LeadSyncJob): boolean {
 
 function isCrmTarget(t: LeadSyncTarget): boolean {
   return t === "hubspot" || t === "pipedrive";
+}
+
+/** Nur echte Connectors (keine Stubs) für Health-Zähler. */
+function isProductionCrmTarget(t: LeadSyncTarget): boolean {
+  return t === "hubspot" || t === "pipedrive";
+}
+
+function isPipedriveSentInWindow(j: LeadSyncJob, startMs: number, endMs: number): boolean {
+  if (j.target !== "pipedrive" || j.status !== "sent") return false;
+  return isoInWindow(jobTimestampForStatus(j), startMs, endMs);
 }
 
 export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promise<GtmDashboardSnapshot> {
@@ -421,6 +444,114 @@ export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promi
     k === "(ohne_campaign)" ? "Ohne utm_campaign" : k,
   );
 
+  const MS_UNTRIAGED = GTM_HEALTH_UNTRIAGED_DAYS * MS_PER_DAY;
+  const MS_QUAL_NO_DEAL = GTM_HEALTH_QUALIFIED_NO_DEAL_DAYS * MS_PER_DAY;
+  const MS_STUCK_SYNC = GTM_HEALTH_STUCK_SYNC_HOURS * 60 * 60 * 1000;
+
+  const spam_30d = items30d.filter((it) => it.triage_status === "spam").length;
+
+  const untriaged_over_3d = items.filter((it) => {
+    if (it.triage_status !== "received") return false;
+    const age = nowMs - Date.parse(it.created_at);
+    return age > MS_UNTRIAGED;
+  }).length;
+
+  let crm_dead_letter_30d = 0;
+  let crm_failed_30d = 0;
+  let crm_sent_ok_30d = 0;
+  for (const j of jobs) {
+    if (!isProductionCrmTarget(j.target)) continue;
+    const ts = jobTimestampForStatus(j);
+    if (!isoInWindow(ts, w30.start, w30.end)) continue;
+    if (j.status === "dead_letter") crm_dead_letter_30d += 1;
+    else if (j.status === "failed") crm_failed_30d += 1;
+    else if (j.status === "sent") crm_sent_ok_30d += 1;
+  }
+
+  let stuck_failed_crm_sync_24h = 0;
+  for (const j of jobs) {
+    if (!isProductionCrmTarget(j.target) || j.status !== "failed") continue;
+    const last = Date.parse(j.last_attempt_at ?? j.updated_at);
+    if (Number.isFinite(last) && nowMs - last > MS_STUCK_SYNC) stuck_failed_crm_sync_24h += 1;
+  }
+
+  const leadIdHasPipedriveDeal = new Set<string>();
+  for (const j of jobs) {
+    if (isPipedriveDealCreatedJob(j)) leadIdHasPipedriveDeal.add(j.lead_id);
+  }
+
+  const qualified_no_pipedrive_deal_old_7d = items.filter((it) => {
+    if (!isQualifiedTriage(it.triage_status)) return false;
+    if (leadIdHasPipedriveDeal.has(it.lead_id)) return false;
+    const age = nowMs - Date.parse(it.created_at);
+    return age > MS_QUAL_NO_DEAL;
+  }).length;
+
+  const hubspotBySegment: Record<GtmSegmentBucket, number> = {
+    industrie_mittelstand: 0,
+    kanzlei_wp: 0,
+    enterprise_sap: 0,
+    other: 0,
+  };
+  const pipedriveTouchBySegment: Record<GtmSegmentBucket, number> = {
+    industrie_mittelstand: 0,
+    kanzlei_wp: 0,
+    enterprise_sap: 0,
+    other: 0,
+  };
+  for (const j of jobs) {
+    if (!isoInWindow(jobTimestampForStatus(j), w30.start, w30.end)) continue;
+    const seg = leadIdToSegment.get(j.lead_id) ?? "other";
+    if (j.target === "hubspot" && j.status === "sent") hubspotBySegment[seg] += 1;
+    if (isPipedriveSentInWindow(j, w30.start, w30.end)) pipedriveTouchBySegment[seg] += 1;
+  }
+
+  function dominantSourcesForSegment(seg: GtmSegmentBucket): string {
+    const counts = new Map<string, number>();
+    for (const it of items30d) {
+      if (segmentBucket(it.segment) !== seg) continue;
+      const k = it.attribution_source;
+      counts.set(k, (counts.get(k) ?? 0) + 1);
+    }
+    const top = [...counts.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
+    if (top.length === 0) return "—";
+    return top
+      .map(([k, n]) => `${LEAD_ATTRIBUTION_SOURCE_LABELS_DE[k as LeadAttributionSource] ?? k} (${n})`)
+      .join(", ");
+  }
+
+  const segmentKeys: GtmSegmentBucket[] = [
+    "industrie_mittelstand",
+    "kanzlei_wp",
+    "enterprise_sap",
+    "other",
+  ];
+  const healthSegments = segmentKeys.map((segment) => ({
+    segment,
+    label_de: SEGMENT_LABELS_DE[segment],
+    inquiries_30d: kpis["30d"].by_segment[segment].inquiries,
+    qualified_30d: kpis["30d"].by_segment[segment].qualified,
+    hubspot_sent_30d: hubspotBySegment[segment],
+    pipedrive_touch_30d: pipedriveTouchBySegment[segment],
+    dominant_sources_de: dominantSourcesForSegment(segment),
+  }));
+
+  const health = evaluateGtmHealth({
+    inbound_30d: kpis["30d"].inbound_inquiries,
+    webhook_failed_30d: kpis["30d"].failed_webhook_forwards,
+    spam_30d,
+    untriaged_over_3d,
+    crm_dead_letter_30d,
+    crm_failed_30d,
+    crm_sent_ok_30d,
+    qualified_30d: kpis["30d"].qualified_leads,
+    deals_created_30d: kpis["30d"].pipedrive_deals_created,
+    stuck_failed_crm_sync_24h,
+    qualified_no_pipedrive_deal_old_7d,
+    segments: healthSegments,
+    attribution_top_sources: attribution_by_source_30d,
+  });
+
   return {
     generated_at: now.toISOString(),
     windows: {
@@ -437,6 +568,7 @@ export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promi
     },
     attribution_by_source_30d,
     attribution_by_campaign_30d,
+    health,
     data_notes: {
       cta_clicks_persisted: false,
       cta_note_de:
@@ -445,6 +577,8 @@ export async function computeGtmDashboardSnapshot(now: Date = new Date()): Promi
         "Stufen sind absolute Mengen je Zeitraum (Einreichungsdatum). Spätere Stufen können größer wirken als frühere, wenn Leads außerhalb des Fensters qualifiziert wurden; für Steuerung die KPI-Karten und Segmenttabelle nutzen.",
       attribution_note_de:
         "Attribution: first-touch-UTM (Tab-Session) plus Server-Referer-Heuristik beim Absenden — keine Multi-Touch-Zuordnung. „Deals“ = Pipedrive-Sync mit deal_action created im 30-Tage-Fenster.",
+      health_note_de:
+        "Health ist regelbasiert (Schwellen in gtmHealthThresholds.ts) — kein Board-BI. „Qualifiziert ohne Deal“ nutzt Einreichungsalter statt echtem Qualifizierungszeitpunkt.",
     },
   };
 }

--- a/frontend/src/lib/gtmDashboardTypes.ts
+++ b/frontend/src/lib/gtmDashboardTypes.ts
@@ -47,6 +47,49 @@ export type GtmAttributionBreakdownRow = {
   pipedrive_deals_created_30d: number;
 };
 
+/** Wave 31 – qualitative Health-Stufen */
+export type GtmHealthStatus = "good" | "watch" | "issue";
+
+export type GtmHealthTile = {
+  id: string;
+  label_de: string;
+  status: GtmHealthStatus;
+  explanation_de: string;
+  href: string;
+  link_label_de: string;
+};
+
+export type GtmOpsHint = {
+  id: string;
+  count: number;
+  message_de: string;
+  href: string;
+};
+
+export type GtmSegmentReadinessRow = {
+  segment: GtmSegmentBucket;
+  label_de: string;
+  inquiries_30d: number;
+  qualified_30d: number;
+  hubspot_sent_30d: number;
+  pipedrive_touch_30d: number;
+  dominant_sources_de: string;
+  status: GtmHealthStatus;
+  note_de: string;
+};
+
+export type GtmAttributionHealthRow = GtmAttributionBreakdownRow & {
+  qual_ratio: number;
+  noise_suspected: boolean;
+};
+
+export type GtmHealthLayer = {
+  tiles: GtmHealthTile[];
+  ops_hints: GtmOpsHint[];
+  segment_readiness: GtmSegmentReadinessRow[];
+  attribution_health_top3: GtmAttributionHealthRow[];
+};
+
 export type GtmDashboardSnapshot = {
   generated_at: string;
   windows: Record<GtmWindowKey, { start: string; end: string }>;
@@ -67,10 +110,13 @@ export type GtmDashboardSnapshot = {
   /** Wave 30 – letzte 30 Tage, keine Multi-Touch-Modelle */
   attribution_by_source_30d: GtmAttributionBreakdownRow[];
   attribution_by_campaign_30d: GtmAttributionBreakdownRow[];
+  /** Wave 31 – regelbasierte Health / Readiness */
+  health: GtmHealthLayer;
   data_notes: {
     cta_clicks_persisted: boolean;
     cta_note_de: string;
     funnel_note_de: string;
     attribution_note_de: string;
+    health_note_de: string;
   };
 };

--- a/frontend/src/lib/gtmHealthEngine.test.ts
+++ b/frontend/src/lib/gtmHealthEngine.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluateGtmHealth } from "@/lib/gtmHealthEngine";
+
+const emptySeg = (
+  segment: "industrie_mittelstand" | "kanzlei_wp" | "enterprise_sap" | "other",
+  label_de: string,
+) => ({
+  segment,
+  label_de,
+  inquiries_30d: 0,
+  qualified_30d: 0,
+  hubspot_sent_30d: 0,
+  pipedrive_touch_30d: 0,
+  dominant_sources_de: "—",
+});
+
+describe("evaluateGtmHealth", () => {
+  it("returns four tiles and empty hints for quiet zero-data input", () => {
+    const h = evaluateGtmHealth({
+      inbound_30d: 0,
+      webhook_failed_30d: 0,
+      spam_30d: 0,
+      untriaged_over_3d: 0,
+      crm_dead_letter_30d: 0,
+      crm_failed_30d: 0,
+      crm_sent_ok_30d: 0,
+      qualified_30d: 0,
+      deals_created_30d: 0,
+      stuck_failed_crm_sync_24h: 0,
+      qualified_no_pipedrive_deal_old_7d: 0,
+      segments: [
+        emptySeg("industrie_mittelstand", "Industrie"),
+        emptySeg("kanzlei_wp", "Kanzlei"),
+        emptySeg("enterprise_sap", "Enterprise"),
+        emptySeg("other", "Sonstiges"),
+      ],
+      attribution_top_sources: [],
+    });
+    expect(h.tiles).toHaveLength(4);
+    expect(h.ops_hints.length).toBe(0);
+    expect(h.attribution_health_top3).toHaveLength(0);
+  });
+
+  it("flags issue when many old untriaged leads", () => {
+    const h = evaluateGtmHealth({
+      inbound_30d: 10,
+      webhook_failed_30d: 0,
+      spam_30d: 0,
+      untriaged_over_3d: 6,
+      crm_dead_letter_30d: 0,
+      crm_failed_30d: 0,
+      crm_sent_ok_30d: 2,
+      qualified_30d: 1,
+      deals_created_30d: 0,
+      stuck_failed_crm_sync_24h: 0,
+      qualified_no_pipedrive_deal_old_7d: 0,
+      segments: [
+        emptySeg("industrie_mittelstand", "Industrie"),
+        emptySeg("kanzlei_wp", "Kanzlei"),
+        emptySeg("enterprise_sap", "Enterprise"),
+        emptySeg("other", "Sonstiges"),
+      ],
+      attribution_top_sources: [],
+    });
+    const triage = h.tiles.find((t) => t.id === "triage");
+    expect(triage?.status).toBe("issue");
+    expect(h.ops_hints.some((x) => x.id === "untriaged_3d")).toBe(true);
+  });
+});

--- a/frontend/src/lib/gtmHealthEngine.ts
+++ b/frontend/src/lib/gtmHealthEngine.ts
@@ -1,0 +1,238 @@
+/**
+ * Wave 31 – regelbasierte GTM Health / Readiness (kein Scoring-Modell).
+ */
+
+import type {
+  GtmAttributionBreakdownRow,
+  GtmAttributionHealthRow,
+  GtmHealthLayer,
+  GtmHealthStatus,
+  GtmHealthTile,
+  GtmOpsHint,
+  GtmSegmentBucket,
+  GtmSegmentReadinessRow,
+} from "@/lib/gtmDashboardTypes";
+
+import {
+  GTM_HEALTH_ATTRIB_NOISE_MAX_QUAL_RATIO,
+  GTM_HEALTH_ATTRIB_NOISE_MIN_LEADS,
+  GTM_HEALTH_CRM_BAD_RATIO_ISSUE,
+  GTM_HEALTH_CRM_BAD_RATIO_MIN_DENOM,
+  GTM_HEALTH_CRM_BAD_RATIO_WATCH,
+  GTM_HEALTH_DEAL_TO_QUALIFIED_ISSUE,
+  GTM_HEALTH_DEAL_TO_QUALIFIED_WATCH,
+  GTM_HEALTH_PIPELINE_QUALIFIED_MIN,
+  GTM_HEALTH_SEGMENT_QUAL_RATIO_LOW,
+  GTM_HEALTH_SEGMENT_VOLUME_MIN,
+  GTM_HEALTH_SEGMENT_VOLUME_VERY_LOW,
+  GTM_HEALTH_SPAM_RATE_ISSUE,
+  GTM_HEALTH_SPAM_RATE_MIN_INBOUND,
+  GTM_HEALTH_SPAM_RATE_WATCH,
+  GTM_HEALTH_UNTRIAGED_COUNT_ISSUE,
+  GTM_HEALTH_UNTRIAGED_COUNT_WATCH,
+  GTM_HEALTH_WEBHOOK_RATE_ISSUE,
+  GTM_HEALTH_WEBHOOK_RATE_WATCH,
+} from "@/lib/gtmHealthThresholds";
+
+export type GtmHealthEngineInput = {
+  inbound_30d: number;
+  webhook_failed_30d: number;
+  spam_30d: number;
+  untriaged_over_3d: number;
+  crm_dead_letter_30d: number;
+  crm_failed_30d: number;
+  crm_sent_ok_30d: number;
+  qualified_30d: number;
+  deals_created_30d: number;
+  stuck_failed_crm_sync_24h: number;
+  qualified_no_pipedrive_deal_old_7d: number;
+  segments: {
+    segment: GtmSegmentBucket;
+    label_de: string;
+    inquiries_30d: number;
+    qualified_30d: number;
+    hubspot_sent_30d: number;
+    pipedrive_touch_30d: number;
+    dominant_sources_de: string;
+  }[];
+  attribution_top_sources: GtmAttributionBreakdownRow[];
+};
+
+export function evaluateGtmHealth(input: GtmHealthEngineInput): GtmHealthLayer {
+  const whRate = input.inbound_30d > 0 ? input.webhook_failed_30d / input.inbound_30d : 0;
+  const spamRate =
+    input.inbound_30d >= GTM_HEALTH_SPAM_RATE_MIN_INBOUND
+      ? input.spam_30d / input.inbound_30d
+      : 0;
+
+  let intakeStatus: GtmHealthStatus = "good";
+  if (input.inbound_30d > 0) {
+    const spamBad =
+      input.inbound_30d >= GTM_HEALTH_SPAM_RATE_MIN_INBOUND &&
+      spamRate >= GTM_HEALTH_SPAM_RATE_ISSUE;
+    const spamWarn =
+      input.inbound_30d >= GTM_HEALTH_SPAM_RATE_MIN_INBOUND &&
+      spamRate >= GTM_HEALTH_SPAM_RATE_WATCH;
+    if (whRate >= GTM_HEALTH_WEBHOOK_RATE_ISSUE || spamBad) intakeStatus = "issue";
+    else if (whRate >= GTM_HEALTH_WEBHOOK_RATE_WATCH || spamWarn) intakeStatus = "watch";
+  }
+
+  let triageStatus: GtmHealthStatus = "good";
+  if (input.untriaged_over_3d >= GTM_HEALTH_UNTRIAGED_COUNT_ISSUE) triageStatus = "issue";
+  else if (input.untriaged_over_3d >= GTM_HEALTH_UNTRIAGED_COUNT_WATCH) triageStatus = "watch";
+
+  const crmDenom =
+    input.crm_dead_letter_30d + input.crm_failed_30d + input.crm_sent_ok_30d;
+  const crmBad = input.crm_dead_letter_30d + input.crm_failed_30d;
+  const crmBadRatio = crmDenom >= GTM_HEALTH_CRM_BAD_RATIO_MIN_DENOM ? crmBad / crmDenom : 0;
+  let syncHealthStatus: GtmHealthStatus = "good";
+  if (crmDenom >= GTM_HEALTH_CRM_BAD_RATIO_MIN_DENOM) {
+    if (crmBadRatio >= GTM_HEALTH_CRM_BAD_RATIO_ISSUE) syncHealthStatus = "issue";
+    else if (crmBadRatio >= GTM_HEALTH_CRM_BAD_RATIO_WATCH) syncHealthStatus = "watch";
+  }
+
+  let pipelineStatus: GtmHealthStatus = "good";
+  let pipelineExplanation =
+    "Qualifizierte Leads und Pipedrive-Deals (30 Tage) stehen in einem plausiblen Verhältnis — oder es gibt noch zu wenig Daten.";
+  if (input.qualified_30d >= GTM_HEALTH_PIPELINE_QUALIFIED_MIN) {
+    const ratio = input.deals_created_30d / input.qualified_30d;
+    if (ratio < GTM_HEALTH_DEAL_TO_QUALIFIED_ISSUE) {
+      pipelineStatus = "issue";
+      pipelineExplanation =
+        "Relativ viele qualifizierte Leads, aber wenige neue Pipedrive-Deals im gleichen Fenster — Pipeline-Übergang prüfen.";
+    } else if (ratio < GTM_HEALTH_DEAL_TO_QUALIFIED_WATCH) {
+      pipelineStatus = "watch";
+      pipelineExplanation =
+        "Einige qualifizierte Leads ohne entsprechende Deal-Anlage im 30-Tage-Fenster — kein Vorwurf, nur Orientierung.";
+    }
+  }
+
+  const tiles: GtmHealthTile[] = [
+    {
+      id: "intake",
+      label_de: "Lead-Eingang",
+      status: intakeStatus,
+      explanation_de:
+        intakeStatus === "good"
+          ? "Webhook-Fehlerquote und Spam-Anteil (30 Tage) wirken unkritisch. Formular-Uptime wird hier nicht gemessen."
+          : intakeStatus === "watch"
+            ? "Erhöhte Webhook-Fehler oder Spam-Anteil möglich — Inbox und n8n/Webhook prüfen."
+            : "Auffällige Webhook-Fehler oder Spam — technische Route und Dubletten/Noise klären.",
+      href: "/admin/leads?forwarding_status=failed",
+      link_label_de: "Fehlgeschlagene Weiterleitungen",
+    },
+    {
+      id: "triage",
+      label_de: "Triage",
+      status: triageStatus,
+      explanation_de:
+        triageStatus === "good"
+          ? "Keine unbearbeiteten „Neu“-Leads älter als 3 Tage."
+          : triageStatus === "watch"
+            ? "Einige „Neu“-Leads warten länger — kurz durchgehen."
+            : "Mehrere „Neu“-Leads hängen — Rückstand droht Chancen zu kosten.",
+      href: "/admin/leads?triage_status=received",
+      link_label_de: "Neu / unbearbeitet",
+    },
+    {
+      id: "sync",
+      label_de: "CRM-Sync",
+      status: syncHealthStatus,
+      explanation_de:
+        syncHealthStatus === "good"
+          ? "Anteil fehlgeschlagener/Dead-Letter-CRM-Jobs (30 Tage) ist gering oder es gibt kaum Volumen."
+          : syncHealthStatus === "watch"
+            ? "CRM-Sync stolpert merklich — Jobs und Secrets prüfen."
+            : "Viele fehlgeschlagene oder terminale Sync-Jobs — Downstream stabilisieren.",
+      href: "/admin/gtm#gtm-attention",
+      link_label_de: "Aufmerksamkeit",
+    },
+    {
+      id: "pipeline",
+      label_de: "Pipeline",
+      status: pipelineStatus,
+      explanation_de: pipelineExplanation,
+      href: "/admin/gtm#gtm-segment-readiness",
+      link_label_de: "Segment-Readiness",
+    },
+  ];
+
+  const ops_hints: GtmOpsHint[] = [];
+  if (input.untriaged_over_3d > 0) {
+    ops_hints.push({
+      id: "untriaged_3d",
+      count: input.untriaged_over_3d,
+      message_de: `${input.untriaged_over_3d} Lead(s) mit Status „Neu“ seit über 3 Tagen — Triage vorschlagen.`,
+      href: "/admin/leads?triage_status=received",
+    });
+  }
+  if (input.stuck_failed_crm_sync_24h > 0) {
+    ops_hints.push({
+      id: "stuck_sync",
+      count: input.stuck_failed_crm_sync_24h,
+      message_de: `${input.stuck_failed_crm_sync_24h} CRM-Sync-Job(s) fehlgeschlagen, letzter Versuch vor über 24 Stunden — Retry oder Dead Letter prüfen.`,
+      href: "/admin/gtm#gtm-attention",
+    });
+  }
+  if (input.qualified_no_pipedrive_deal_old_7d > 0) {
+    ops_hints.push({
+      id: "qualified_no_deal",
+      count: input.qualified_no_pipedrive_deal_old_7d,
+      message_de: `${input.qualified_no_pipedrive_deal_old_7d} qualifizierter Lead ohne Pipedrive-Deal, Einreichung älter als 7 Tage (Proxy — Qualifizierungsdatum nicht separat gespeichert).`,
+      href: "/admin/leads",
+    });
+  }
+
+  const segment_readiness: GtmSegmentReadinessRow[] = input.segments.map((s) => {
+    const qualRatio = s.inquiries_30d > 0 ? s.qualified_30d / s.inquiries_30d : 0;
+    let status: GtmHealthStatus = "good";
+    let note_de =
+      "Volumen und Qualifikation wirken ausgewogen für die Phase — oder es gibt noch wenig Daten.";
+
+    if (s.segment !== "other" && s.inquiries_30d <= GTM_HEALTH_SEGMENT_VOLUME_VERY_LOW) {
+      status = "watch";
+      note_de = "Sehr wenige Eingänge — strategischer GTM-Fokus oder Reichweite prüfen.";
+    } else if (
+      s.inquiries_30d >= GTM_HEALTH_SEGMENT_VOLUME_MIN &&
+      qualRatio < GTM_HEALTH_SEGMENT_QUAL_RATIO_LOW
+    ) {
+      status = "watch";
+      note_de = "Viele Eingänge, aber wenig Qualifikation — Angebot, ICP oder Erwartungsmanagement prüfen.";
+    }
+
+    return {
+      segment: s.segment,
+      label_de: s.label_de,
+      inquiries_30d: s.inquiries_30d,
+      qualified_30d: s.qualified_30d,
+      hubspot_sent_30d: s.hubspot_sent_30d,
+      pipedrive_touch_30d: s.pipedrive_touch_30d,
+      dominant_sources_de: s.dominant_sources_de,
+      status,
+      note_de,
+    };
+  });
+
+  const attribution_health_top3: GtmAttributionHealthRow[] = input.attribution_top_sources
+    .slice(0, 3)
+    .map((row) => {
+      const qual_ratio =
+        row.inquiries_30d > 0 ? row.qualified_30d / row.inquiries_30d : 0;
+      const noise_suspected =
+        row.inquiries_30d >= GTM_HEALTH_ATTRIB_NOISE_MIN_LEADS &&
+        qual_ratio <= GTM_HEALTH_ATTRIB_NOISE_MAX_QUAL_RATIO;
+      return { ...row, qual_ratio, noise_suspected };
+    });
+
+  const noiseChannels = attribution_health_top3.filter((r) => r.noise_suspected);
+  if (noiseChannels.length > 0) {
+    ops_hints.push({
+      id: "attrib_noise",
+      count: noiseChannels.length,
+      message_de: `${noiseChannels.length} starke(r) Kanal(e) mit vielen Leads aber wenig Qualifikation — Zielgruppe oder Bots prüfen (heuristisch).`,
+      href: "/admin/gtm#gtm-attribution-health",
+    });
+  }
+
+  return { tiles, ops_hints, segment_readiness, attribution_health_top3 };
+}

--- a/frontend/src/lib/gtmHealthThresholds.ts
+++ b/frontend/src/lib/gtmHealthThresholds.ts
@@ -1,0 +1,45 @@
+/**
+ * Wave 31 – Schwellen für GTM Health (regelbasiert, bewusst grob).
+ * Anpassungen hier statt in UI-Komponenten.
+ */
+
+/** Webhook-Fehlerquote (fehlgeschlagen / Inbound 30d) */
+export const GTM_HEALTH_WEBHOOK_RATE_WATCH = 0.05;
+export const GTM_HEALTH_WEBHOOK_RATE_ISSUE = 0.12;
+
+/** Spam-Anteil (Triage spam / Inbound 30d), nur ab Mindestvolumen */
+export const GTM_HEALTH_SPAM_RATE_MIN_INBOUND = 5;
+export const GTM_HEALTH_SPAM_RATE_WATCH = 0.08;
+export const GTM_HEALTH_SPAM_RATE_ISSUE = 0.18;
+
+/** „Neu“-Leads älter als X Tage (Triage received) */
+export const GTM_HEALTH_UNTRIAGED_DAYS = 3;
+export const GTM_HEALTH_UNTRIAGED_COUNT_WATCH = 2;
+export const GTM_HEALTH_UNTRIAGED_COUNT_ISSUE = 5;
+
+/** CRM: fehlgeschlagene + Dead-Letter-Jobs 30d vs. erfolgreiche Sends */
+export const GTM_HEALTH_CRM_BAD_RATIO_MIN_DENOM = 4;
+export const GTM_HEALTH_CRM_BAD_RATIO_WATCH = 0.25;
+export const GTM_HEALTH_CRM_BAD_RATIO_ISSUE = 0.45;
+
+/** Pipeline: Deals / qualifiziert (30d) */
+export const GTM_HEALTH_PIPELINE_QUALIFIED_MIN = 3;
+export const GTM_HEALTH_DEAL_TO_QUALIFIED_WATCH = 0.15;
+export const GTM_HEALTH_DEAL_TO_QUALIFIED_ISSUE = 0.05;
+
+/** Sync: letzter Versuch älter als X h, Status failed (CRM) */
+export const GTM_HEALTH_STUCK_SYNC_HOURS = 24;
+
+/** Qualifiziert ohne Pipedrive-Deal, Proxy: Einreichung > X Tage */
+export const GTM_HEALTH_QUALIFIED_NO_DEAL_DAYS = 7;
+
+/** Segment: „viel rein, wenig qualifiziert“ */
+export const GTM_HEALTH_SEGMENT_VOLUME_MIN = 6;
+export const GTM_HEALTH_SEGMENT_QUAL_RATIO_LOW = 0.12;
+
+/** Segment: GTM-Fokus-Lücke */
+export const GTM_HEALTH_SEGMENT_VOLUME_VERY_LOW = 2;
+
+/** Attribution: Noise-Verdacht */
+export const GTM_HEALTH_ATTRIB_NOISE_MIN_LEADS = 4;
+export const GTM_HEALTH_ATTRIB_NOISE_MAX_QUAL_RATIO = 0.12;


### PR DESCRIPTION
Add rule-based GTM Health tiles, SLA-style ops hints, segment readiness with CRM touches and dominant sources, and attribution top-3 noise hints. Centralize thresholds in gtmHealthThresholds; evaluate in gtmHealthEngine; extend computeGtmDashboardSnapshot. Document in wave31 doc.

Made-with: Cursor