### PR TITLE
feat(admin): Wave 34 Board Readiness dashboard and GTM banner

### DIFF
--- a/app/board_readiness_models.py
+++ b/app/board_readiness_models.py
@@ -1,0 +1,77 @@
+"""Board Readiness (Wave 34) – governance-side DTOs for executive / internal dashboards.
+
+Aggregations are primarily computed in the Next.js admin layer via tenant-scoped APIs;
+these models document the contract and support future FastAPI endpoints or imports.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+
+class BoardReadinessTraffic(StrEnum):
+    """Coarse RAG-style signal (no numeric vanity score at pillar level)."""
+
+    green = "green"
+    amber = "amber"
+    red = "red"
+
+
+class BoardReadinessPillarKey(StrEnum):
+    eu_ai_act = "eu_ai_act"
+    iso_42001 = "iso_42001"
+    nis2 = "nis2"
+    dsgvo = "dsgvo"
+
+
+class BoardReadinessSubIndicator(BaseModel):
+    """Single auditable metric within a pillar."""
+
+    key: str = Field(description="Stable machine key, e.g. high_risk_art9_complete_ratio")
+    label_de: str
+    value_percent: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=100.0,
+        description="0–100 where applicable; None if not computable.",
+    )
+    value_count: int | None = Field(default=None, ge=0, description="Numerator or absolute count.")
+    value_denominator: int | None = Field(default=None, ge=0)
+    status: BoardReadinessTraffic
+    source_api_paths: list[str] = Field(
+        default_factory=list,
+        description="Underlying REST paths used to derive the indicator.",
+    )
+
+
+class BoardReadinessPillarBlock(BaseModel):
+    pillar: BoardReadinessPillarKey
+    title_de: str
+    summary_de: str
+    status: BoardReadinessTraffic
+    indicators: list[BoardReadinessSubIndicator] = Field(default_factory=list)
+
+
+class BoardAttentionItem(BaseModel):
+    """Row for the Board Attention list (governance debt)."""
+
+    id: str
+    severity: BoardReadinessTraffic
+    tenant_id: str
+    tenant_label: str | None = None
+    segment_tag: str | None = Field(default=None, description="GTM segment bucket or ICP label.")
+    readiness_class: str | None = Field(default=None, description="Wave 33 readiness class.")
+    subject_type: str = Field(description="ai_system | tenant")
+    subject_id: str | None = None
+    subject_name: str | None = None
+    missing_artefact_de: str
+    last_change_at: str | None = Field(
+        default=None,
+        description="ISO-8601 from underlying entity when available.",
+    )
+    deep_links: dict[str, str] = Field(
+        default_factory=dict,
+        description="workspace_path / api_path keys for drill-down.",
+    )

--- a/docs/board/wave34-board-readiness-dashboard.md
+++ b/docs/board/wave34-board-readiness-dashboard.md
@@ -1,0 +1,102 @@
+# Wave 34 – Board Readiness Dashboard
+
+Interne Executive-Ansicht unter `/admin/board-readiness` (Next.js Admin, `LEAD_ADMIN_SECRET`). Sie bündelt **wenige, nachvollziehbare** Governance-Signale aus den bestehenden FastAPI-Endpunkten – ohne zusammengesetzten „Compliance-Score“.
+
+## Ziele
+
+- Beantwortung: **Wie AI-Act-/ISO-42001-/NIS2-/DSGVO-ready sind wir produktseitig** über die in `data/gtm-product-account-map.json` gemappten Mandanten?
+- **Auditierbarkeit:** Jede Teilmetrik nennt die **API-Pfade**, aus denen sie abgeleitet wird; Attention Items enthalten **Workspace-Pfade** und **API-Pfade** für Nachweise.
+- **GTM-Bezug:** Segment- und Readiness-Klassen-Rollups knüpfen an **Wave 33** (Product–GTM Bridge) und die gleiche 30-Tage-Fensterlogik wie `/admin/gtm`.
+
+## Governance-Datenmodell (Python)
+
+Strukturelle DTOs (für Vertrag/Dokumentation, zukünftige APIs): `app/board_readiness_models.py` (`BoardReadinessPillarBlock`, `BoardReadinessSubIndicator`, `BoardAttentionItem`, …).
+
+## Indikatoren je Säule
+
+Schwellen (Ampel) sind zentral in `frontend/src/lib/boardReadinessThresholds.ts` definiert:
+
+| Ampel  | Bedingung (Ratio 0–1)      |
+|--------|----------------------------|
+| Grün   | Ratio ≥ 0,75               |
+| Amber  | 0,45 ≤ Ratio < 0,75 oder Ratio nicht berechenbar |
+| Rot    | Ratio < 0,45               |
+
+Zusätzlich gelten **harte Rot-Signale** dort, wo ein fachliches Minimum fehlt (z. B. fehlender aktueller Board-Report trotz High-Risk-Systemen).
+
+### EU AI Act
+
+| Key | Bedeutung | Datenquellen |
+|-----|-----------|--------------|
+| `high_risk_art9_complete_ratio` | Anteil der **klassifizierten High-Risk**-Systeme mit Compliance-Status **Art. 9 (Risikomanagement)** = `completed` | `GET /api/v1/compliance/dashboard` (Filter `risk_level == high_risk`), `GET /api/v1/ai-systems/{id}/compliance` |
+| `high_risk_evidence_bundle_ratio` | Anteil High-Risk mit **Art. 11 abgeschlossen** oder **≥ 2 gespeicherte AI-Act-Doc-Sektionen** (`status == saved`) | `.../compliance`, `GET /api/v1/ai-systems/{id}/ai-act-docs` (Feature-Flag; bei Fehler zählt nur Art. 11) |
+| `board_report_recency` | Mindestens ein Eintrag in `GET /api/v1/tenants/{tid}/board/ai-compliance-reports` mit `created_at` innerhalb von **90 Tagen** (`BOARD_REPORT_FRESH_DAYS`), sofern der Mandant High-Risk-Systeme hat | Board-Report-Liste |
+
+Portfolio-Säule: **schlechteste** Ampel der drei Teilindikatoren über alle gemappten Mandanten; Teil-Prozente werden **gemittelt** (nur Mandanten mit Wert).
+
+### ISO 42001 (AI-Managementsystem, pragmatisch)
+
+| Key | Bedeutung | Datenquellen |
+|-----|-----------|--------------|
+| `iso42001_scope_framework` | `active_frameworks` oder `compliance_scopes` enthält ISO-42001-Hinweis (Substring `42001`) | `GET /api/v1/tenants/{tid}/ai-governance-setup` |
+| `iso42001_roles` | Mindestens **zwei** nicht-leere Einträge in `governance_roles` | Setup |
+| `iso42001_policies` | `policies_published` im Guided Setup | `GET /api/v1/tenants/{tid}/setup-status` |
+
+### NIS2 / KRITIS (operative Mindestsignale)
+
+| Key | Bedeutung | Datenquellen |
+|-----|-----------|--------------|
+| `nis2_obligations_kpi_seed` | `nis2_kpis_seeded` **oder** `nis2_kritis_kpi_mean_percent > 0` | Setup-Status, `GET /api/v1/ai-governance/compliance/overview` |
+| `nis2_contact_roles` | Rolle mit Schlüssel passend zu CISO/DPO/NIS2/Incident/Security/KRITIS und nicht-leerer Kontakt | Setup |
+| `nis2_incident_runbook_high_risk` | Anteil High-Risk-Systeme mit `has_incident_runbook` | `GET /api/v1/ai-systems` |
+
+### DSGVO / Aufzeichnungen
+
+| Key | Bedeutung | Datenquellen |
+|-----|-----------|--------------|
+| `dsgvo_dpia_flag_high_risk` | Anteil High-Risk-Systeme mit `gdpr_dpia_required == true` (Proxy für dokumentierten DSFA-Pfad, konsistent mit EU-AI-Act-Readiness-Heuristik) | AI-Systeme |
+| `dsgvo_records_evidence` | `evidence_attached` oder `classification_completed` im Setup-Status | Setup-Status |
+
+## Segment- und Readiness-Klassen-Rollups
+
+- **Segment:** Dominantes Lead-Segment (30 Tage) pro Mandant über `findGtmProductMapEntry` – gleiche Logik wie Wave 33.
+- **Readiness-Klasse:** `classifyMappedTenantReadiness` aus `frontend/src/lib/gtmAccountReadiness.ts` (Wave 33) auf Basis von `fetchTenantGovernanceSnapshot` + Pilot-Flag aus der Map.
+- **Score-Proxy in Tabellen:** Mittelwert der Mandanten-Pillar-Scores (`eu.score` aus Art.9/Evidenz/Board-Mix; ISO/NIS2/DSGVO aus booleschen Teilscores 0–100).
+
+## Board Attention Items
+
+Kriterien (Auszug):
+
+1. **High-Risk-System** ohne `owner_email`.
+2. **High-Risk** ohne abgeschlossenes **Art. 9** (`completed`).
+3. **High-Risk** ohne Evidenzbündel (Art. 11 / AI-Act-Docs-Proxy).
+4. Mandant mit **High-Risk-Systemen**, aber **kein** Board-Report in den letzten 90 Tagen.
+5. **GTM:** Segment mit **≥ 3 qualifizierten** Leads (30 Tage) und **dominanter Readiness-Klasse** `early_pilot` → Portfolio-Hinweis (Nachfrage vs. Governance).
+
+Items sind auf **80 Zeilen** begrenzt; zuerst GTM-Hinweise, dann mandantenspezifische Lücken.
+
+## Beziehung zu `/admin/gtm`
+
+- `GET /api/admin/gtm/summary` liefert `board_readiness_banner` (gesamte Ampel + Kurztext), berechnet mit derselben Pipeline wie das Board-Dashboard.
+- Auf `/admin/gtm` verlinkt eine Kachel nach `/admin/board-readiness`.
+
+## Konfiguration
+
+- **Admin-Auth:** `LEAD_ADMIN_SECRET` (wie Lead-Inbox).
+- **Backend:** `COMPLIANCEHUB_API_BASE_URL`, `COMPLIANCEHUB_API_KEY` (oder `NEXT_PUBLIC_*` Fallbacks wie bei der GTM-Brücke).
+- **Account-Mapping:** `data/gtm-product-account-map.json` bzw. `GTM_PRODUCT_ACCOUNT_MAP_PATH`.
+
+## Interpretation
+
+- **Internes Governance-Steering:** Attention Items priorisieren konkrete Artefakt-Lücken; Säulen-Ampeln zeigen **wo** der Portfolio-Schwerpunkt liegt (EU AI Act vs. ISO vs. NIS2 vs. DSGVO).
+- **Board-Vorbereitung:** Vor einem Board-Termin zuerst **rote** EU-AI-Act- und Board-Report-Signale schließen, dann ISO/NIS2-Mindestnachweise (Rollen, Policies, KPI-Saat).
+
+## Implementierungsreferenz
+
+| Teil | Pfad |
+|------|------|
+| Rohdaten-Fetch | `frontend/src/lib/fetchTenantBoardReadinessRaw.ts` |
+| Aggregation | `frontend/src/lib/boardReadinessAggregate.ts` |
+| Schwellen | `frontend/src/lib/boardReadinessThresholds.ts` |
+| API | `frontend/src/app/api/admin/board-readiness/route.ts` |
+| UI | `frontend/src/components/admin/BoardReadinessClient.tsx` |

--- a/frontend/src/app/admin/board-readiness/page.tsx
+++ b/frontend/src/app/admin/board-readiness/page.tsx
@@ -1,0 +1,15 @@
+import { BoardReadinessClient } from "@/components/admin/BoardReadinessClient";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminBoardReadinessPage() {
+  const adminConfigured = Boolean(process.env.LEAD_ADMIN_SECRET?.trim());
+
+  return (
+    <div className="min-h-screen bg-slate-100 px-4 py-10">
+      <div className="mx-auto max-w-7xl">
+        <BoardReadinessClient adminConfigured={adminConfigured} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/api/admin/board-readiness/route.ts
+++ b/frontend/src/app/api/admin/board-readiness/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { boardReadinessBannerFromPayload, computeBoardReadinessPayload } from "@/lib/boardReadinessAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const bannerOnly = url.searchParams.get("banner") === "1";
+
+  const payload = await computeBoardReadinessPayload();
+  if (bannerOnly) {
+    return NextResponse.json({ ok: true, board_readiness_banner: boardReadinessBannerFromPayload(payload) });
+  }
+  return NextResponse.json({ ok: true, board_readiness: payload });
+}

--- a/frontend/src/app/api/admin/gtm/summary/route.ts
+++ b/frontend/src/app/api/admin/gtm/summary/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { boardReadinessBannerFromPayload, computeBoardReadinessPayload } from "@/lib/boardReadinessAggregate";
 import { computeGtmDashboardSnapshot } from "@/lib/gtmDashboardAggregate";
 import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
 import { computeProductBridgePayload } from "@/lib/gtmProductBridgeAggregate";
@@ -15,14 +16,22 @@ export async function GET(req: Request) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  const [snapshot, product_bridge] = await Promise.all([
+  const [snapshot, product_bridge, board_payload] = await Promise.all([
     computeGtmDashboardSnapshot(),
     computeProductBridgePayload(),
+    computeBoardReadinessPayload(),
   ]);
+  const board_readiness_banner = boardReadinessBannerFromPayload(board_payload);
   const wr = await readGtmWeeklyReviewState();
   const weekly_review = {
     last_reviewed_at: wr.last_reviewed_at,
     recent_notes: sliceRecentNotes(wr, 3),
   };
-  return NextResponse.json({ ok: true, snapshot, weekly_review, product_bridge });
+  return NextResponse.json({
+    ok: true,
+    snapshot,
+    weekly_review,
+    product_bridge,
+    board_readiness_banner,
+  });
 }

--- a/frontend/src/components/admin/BoardReadinessClient.tsx
+++ b/frontend/src/components/admin/BoardReadinessClient.tsx
@@ -1,0 +1,365 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { BoardReadinessPayload, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+
+type Props = { adminConfigured: boolean };
+
+function trafficPill(s: BoardReadinessTraffic): string {
+  if (s === "green") return "border-emerald-300 bg-emerald-50 text-emerald-950";
+  if (s === "amber") return "border-amber-300 bg-amber-50 text-amber-950";
+  return "border-rose-300 bg-rose-50 text-rose-950";
+}
+
+function trafficLabel(s: BoardReadinessTraffic): string {
+  if (s === "green") return "OK";
+  if (s === "amber") return "Beobachten";
+  return "Handeln";
+}
+
+export function BoardReadinessClient({ adminConfigured }: Props) {
+  const [payload, setPayload] = useState<BoardReadinessPayload | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const r = await fetch("/api/admin/board-readiness", { credentials: "include" });
+      if (r.status === 401) {
+        setPayload(null);
+        setLoadError("unauthorized");
+        return;
+      }
+      if (!r.ok) {
+        setLoadError(`HTTP ${r.status}`);
+        return;
+      }
+      const data = (await r.json()) as { ok?: boolean; board_readiness?: BoardReadinessPayload };
+      setPayload(data.board_readiness ?? null);
+    } catch {
+      setLoadError("Netzwerkfehler");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!adminConfigured) return;
+    void load();
+  }, [adminConfigured, load]);
+
+  const sortedAttention = useMemo(() => {
+    const rank: Record<BoardReadinessTraffic, number> = { red: 0, amber: 1, green: 2 };
+    return [...(payload?.attention_items ?? [])].sort((a, b) => rank[a.severity] - rank[b.severity]);
+  }, [payload?.attention_items]);
+
+  if (!adminConfigured) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+        Board Readiness ist nicht konfiguriert (<code className="font-mono">LEAD_ADMIN_SECRET</code>).
+      </div>
+    );
+  }
+
+  if (loadError === "unauthorized") {
+    return (
+      <div className="mx-auto max-w-lg rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">Board Readiness</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Bitte zuerst unter{" "}
+          <a className="text-cyan-700 underline" href="/admin/leads">
+            Lead-Inbox
+          </a>{" "}
+          mit dem Admin-Secret anmelden, dann diese Seite neu laden.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 34 · Intern</p>
+          <h1 className="text-2xl font-semibold text-slate-900">Board Readiness</h1>
+          <p className="mt-1 max-w-3xl text-sm text-slate-600">
+            Governance-Signale je Säule (EU AI Act, ISO 42001, NIS2, DSGVO) über gemappte Mandanten –
+            anschlussfähig an GTM-Segmente und Wave-33-Readiness-Klassen.
+          </p>
+          {payload ? (
+            <p className="mt-1 font-mono text-xs text-slate-400">
+              Stand: {new Date(payload.generated_at).toLocaleString("de-DE")} · Backend:{" "}
+              {payload.backend_reachable ? "erreichbar" : "teilweise nicht erreichbar"} · Mandanten (Map):{" "}
+              {payload.mapped_tenant_count}
+              {payload.tenants_partial ? ` · ohne vollständige API: ${payload.tenants_partial}` : ""}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href="/admin/gtm"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            GTM Command Center
+          </a>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {loading ? "Laden…" : "Aktualisieren"}
+          </button>
+        </div>
+      </div>
+
+      {loadError && loadError !== "unauthorized" ? (
+        <p className="text-sm text-red-600">{loadError}</p>
+      ) : null}
+
+      {loading && !payload ? <p className="text-sm text-slate-500">Daten werden geladen …</p> : null}
+
+      {payload ? (
+        <>
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-900">Portfolio-Ampel</h2>
+            <div className="mt-3 flex flex-wrap items-center gap-3">
+              <span
+                className={`inline-flex items-center rounded-full border px-3 py-1 text-sm font-medium ${trafficPill(payload.overall.status)}`}
+              >
+                {trafficLabel(payload.overall.status)}
+              </span>
+              <p className="text-sm text-slate-700">{payload.overall.label_de}</p>
+            </div>
+            <ul className="mt-3 list-inside list-disc text-xs text-slate-600">
+              {payload.notes_de.map((n) => (
+                <li key={n}>{n}</li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="grid gap-4 lg:grid-cols-2">
+            {payload.pillars.map((p) => (
+              <div key={p.pillar} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <h3 className="text-sm font-semibold text-slate-900">{p.title_de}</h3>
+                    <p className="mt-1 text-xs text-slate-600">{p.summary_de}</p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase ${trafficPill(p.status)}`}
+                  >
+                    {trafficLabel(p.status)}
+                  </span>
+                </div>
+                <ul className="mt-4 space-y-3">
+                  {p.indicators.map((ind) => (
+                    <li key={ind.key} className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <span className="text-xs font-medium text-slate-800">{ind.label_de}</span>
+                        <span
+                          className={`rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${trafficPill(ind.status)}`}
+                        >
+                          {trafficLabel(ind.status)}
+                        </span>
+                      </div>
+                      <p className="mt-1 font-mono text-[11px] text-slate-600">
+                        {ind.value_percent !== null
+                          ? `${ind.value_percent}%`
+                          : "—"}
+                        {ind.value_count !== null && ind.value_denominator !== null
+                          ? ` · ${ind.value_count}/${ind.value_denominator}`
+                          : ""}
+                      </p>
+                      {ind.source_api_paths.length ? (
+                        <p className="mt-1 text-[10px] text-slate-500">
+                          Quellen: {ind.source_api_paths.join(", ")}
+                        </p>
+                      ) : null}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-900">Segment × Governance (gemappte Mandanten)</h2>
+            <p className="mt-1 text-xs text-slate-600">
+              Nachfrage-Spalten aus GTM (30 Tage); Ampeln aus Mandanten, die diesem Segment über dominante Leads
+              zugeordnet sind.
+            </p>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full border-collapse text-left text-xs">
+                <thead>
+                  <tr className="border-b border-slate-200 text-slate-500">
+                    <th className="py-2 pr-3 font-medium">Segment</th>
+                    <th className="py-2 pr-3 font-medium">Anfragen 30d</th>
+                    <th className="py-2 pr-3 font-medium">Qualifiziert</th>
+                    <th className="py-2 pr-3 font-medium">Mandanten</th>
+                    <th className="py-2 pr-3 font-medium">EU AI Act</th>
+                    <th className="py-2 pr-3 font-medium">ISO 42001</th>
+                    <th className="py-2 pr-3 font-medium">NIS2</th>
+                    <th className="py-2 pr-3 font-medium">DSGVO</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {payload.segment_rollups.map((r) => (
+                    <tr key={r.segment} className="border-b border-slate-100">
+                      <td className="py-2 pr-3 text-slate-800">{r.label_de}</td>
+                      <td className="py-2 pr-3 font-mono text-slate-700">{r.inquiries_30d}</td>
+                      <td className="py-2 pr-3 font-mono text-slate-700">{r.qualified_30d}</td>
+                      <td className="py-2 pr-3 font-mono text-slate-700">{r.mapped_tenant_count}</td>
+                      {(["eu_ai_act", "iso_42001", "nis2", "dsgvo"] as const).map((k) => (
+                        <td key={k} className="py-2 pr-3">
+                          <span
+                            className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold ${trafficPill(r.pillar_status[k])}`}
+                          >
+                            {trafficLabel(r.pillar_status[k])}
+                          </span>
+                          {r.pillar_score_proxy[k] !== null ? (
+                            <span className="ml-1 font-mono text-[10px] text-slate-500">
+                              {Math.round(r.pillar_score_proxy[k] as number)}%
+                            </span>
+                          ) : null}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-900">Readiness-Klasse (Wave 33)</h2>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full border-collapse text-left text-xs">
+                <thead>
+                  <tr className="border-b border-slate-200 text-slate-500">
+                    <th className="py-2 pr-3 font-medium">Klasse</th>
+                    <th className="py-2 pr-3 font-medium">Mandanten</th>
+                    <th className="py-2 pr-3 font-medium">EU AI Act</th>
+                    <th className="py-2 pr-3 font-medium">ISO 42001</th>
+                    <th className="py-2 pr-3 font-medium">NIS2</th>
+                    <th className="py-2 pr-3 font-medium">DSGVO</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {payload.readiness_class_rollups.map((r) => (
+                    <tr key={r.readiness_class} className="border-b border-slate-100">
+                      <td className="py-2 pr-3 text-slate-800">{r.label_de}</td>
+                      <td className="py-2 pr-3 font-mono text-slate-700">{r.tenant_count}</td>
+                      {(["eu_ai_act", "iso_42001", "nis2", "dsgvo"] as const).map((k) => (
+                        <td key={k} className="py-2 pr-3">
+                          <span
+                            className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold ${trafficPill(r.pillar_status[k])}`}
+                          >
+                            {trafficLabel(r.pillar_status[k])}
+                          </span>
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          {payload.gtm_demand_strip ? (
+            <section className="rounded-xl border border-cyan-200 bg-cyan-50/40 p-4 shadow-sm">
+              <h2 className="text-sm font-semibold text-slate-900">GTM-Nachfrage vs. dominante Readiness</h2>
+              <p className="mt-1 text-xs text-slate-600">
+                Kompakte Wave-33-Sicht (gleiche Fensterlogik wie /admin/gtm).
+              </p>
+              <ul className="mt-3 space-y-2 text-xs text-slate-800">
+                {payload.gtm_demand_strip.segment_rows.map((s) => (
+                  <li key={s.segment}>
+                    <span className="font-medium">{s.label_de}</span>
+                    <span className="ml-2 font-mono text-slate-600">
+                      {s.inquiries_30d} Anfragen · {s.qualified_30d} qualifiziert · dominant:{" "}
+                      {s.dominant_readiness}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          <section className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <h2 className="text-sm font-semibold text-slate-900">Board Attention Items</h2>
+            <p className="mt-1 text-xs text-slate-600">
+              Konkrete Lücken mit Deep-Links (Workspace-Pfade und API-Pfade für Audit).
+            </p>
+            <div className="mt-4 overflow-x-auto">
+              <table className="min-w-full border-collapse text-left text-xs">
+                <thead>
+                  <tr className="border-b border-slate-200 text-slate-500">
+                    <th className="py-2 pr-2 font-medium">Ampel</th>
+                    <th className="py-2 pr-2 font-medium">Mandant</th>
+                    <th className="py-2 pr-2 font-medium">System / Ebene</th>
+                    <th className="py-2 pr-2 font-medium">Fehlend</th>
+                    <th className="py-2 pr-2 font-medium">Segment</th>
+                    <th className="py-2 pr-2 font-medium">Letzte Änderung</th>
+                    <th className="py-2 pr-2 font-medium">Links</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedAttention.map((a) => (
+                    <tr key={a.id} className="border-b border-slate-100 align-top">
+                      <td className="py-2 pr-2">
+                        <span
+                          className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold ${trafficPill(a.severity)}`}
+                        >
+                          {trafficLabel(a.severity)}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-2 text-slate-800">
+                        {a.tenant_label ?? a.tenant_id}
+                        <div className="font-mono text-[10px] text-slate-500">{a.tenant_id}</div>
+                      </td>
+                      <td className="py-2 pr-2 text-slate-700">
+                        {a.subject_type === "ai_system" ? (
+                          <>
+                            KI-System
+                            <div className="font-mono text-[10px] text-slate-500">{a.subject_id}</div>
+                            {a.subject_name ? <div>{a.subject_name}</div> : null}
+                          </>
+                        ) : (
+                          <>Mandant / Portfolio</>
+                        )}
+                      </td>
+                      <td className="py-2 pr-2 text-slate-800">{a.missing_artefact_de}</td>
+                      <td className="py-2 pr-2 text-slate-600">{a.segment_tag ?? "—"}</td>
+                      <td className="py-2 pr-2 font-mono text-[10px] text-slate-600">
+                        {a.last_change_at
+                          ? new Date(a.last_change_at).toLocaleString("de-DE")
+                          : "—"}
+                      </td>
+                      <td className="py-2 pr-2 text-[10px]">
+                        {Object.entries(a.deep_links).map(([k, v]) => (
+                          <div key={k} className="text-cyan-800">
+                            <span className="text-slate-500">{k}: </span>
+                            <code className="break-all">{v}</code>
+                          </div>
+                        ))}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <p className="text-center text-[11px] text-slate-500">
+            Dokumentation:{" "}
+            <code className="rounded bg-slate-200/80 px-1">docs/board/wave34-board-readiness-dashboard.md</code>
+          </p>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/GtmCommandCenterClient.tsx
+++ b/frontend/src/components/admin/GtmCommandCenterClient.tsx
@@ -9,6 +9,7 @@ import type {
   GtmWeeklyReviewNote,
   GtmWindowKey,
 } from "@/lib/gtmDashboardTypes";
+import type { BoardReadinessBanner } from "@/lib/boardReadinessTypes";
 import type { GtmProductBridgePayload } from "@/lib/gtmProductBridgeTypes";
 
 type Props = { adminConfigured: boolean };
@@ -84,6 +85,7 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
   const [weeklyNoteDraft, setWeeklyNoteDraft] = useState("");
   const [weeklySaving, setWeeklySaving] = useState(false);
   const [weeklyMsg, setWeeklyMsg] = useState<string | null>(null);
+  const [boardReadinessBanner, setBoardReadinessBanner] = useState<BoardReadinessBanner | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -94,6 +96,7 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
         setSnapshot(null);
         setProductBridge(null);
         setWeeklyReview(null);
+        setBoardReadinessBanner(null);
         setLoadError("unauthorized");
         return;
       }
@@ -106,9 +109,11 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
         snapshot?: GtmDashboardSnapshot;
         weekly_review?: WeeklyReviewPayload;
         product_bridge?: GtmProductBridgePayload;
+        board_readiness_banner?: BoardReadinessBanner;
       };
       setSnapshot(data.snapshot ?? null);
       setProductBridge(data.product_bridge ?? null);
+      setBoardReadinessBanner(data.board_readiness_banner ?? null);
       setWeeklyReview(
         data.weekly_review ?? { last_reviewed_at: null, recent_notes: [] },
       );
@@ -232,6 +237,38 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
 
       {loading && !snapshot ? (
         <p className="text-sm text-slate-500">Daten werden geladen …</p>
+      ) : null}
+
+      {boardReadinessBanner ? (
+        <a
+          href="/admin/board-readiness"
+          className={`block rounded-xl border p-4 shadow-sm transition hover:opacity-95 ${
+            boardReadinessBanner.status === "green"
+              ? "border-emerald-200 bg-emerald-50/90"
+              : boardReadinessBanner.status === "amber"
+                ? "border-amber-200 bg-amber-50/90"
+                : "border-rose-200 bg-rose-50/90"
+          }`}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-semibold text-slate-900">Board Readiness</h2>
+            <span className="rounded-full border border-slate-300 bg-white/80 px-2 py-0.5 text-[10px] font-semibold uppercase text-slate-800">
+              {boardReadinessBanner.status === "green"
+                ? "OK"
+                : boardReadinessBanner.status === "amber"
+                  ? "Beobachten"
+                  : "Handeln"}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-slate-700">{boardReadinessBanner.label_de}</p>
+          <p className="mt-2 font-mono text-[10px] text-slate-600">
+            Mandanten (Map): {boardReadinessBanner.mapped_tenant_count} · Backend:{" "}
+            {boardReadinessBanner.backend_reachable ? "OK" : "teilweise offline"}
+          </p>
+          <p className="mt-2 text-xs font-medium text-cyan-900 underline underline-offset-2">
+            Details anzeigen →
+          </p>
+        </a>
       ) : null}
 
       {snapshot ? (

--- a/frontend/src/lib/boardReadinessAggregate.ts
+++ b/frontend/src/lib/boardReadinessAggregate.ts
@@ -1,0 +1,820 @@
+import "server-only";
+
+import {
+  classifyMappedTenantReadiness,
+  GTM_READINESS_LABELS_DE,
+  type GtmGovernanceSignalsInput,
+  type GtmReadinessClass,
+} from "@/lib/gtmAccountReadiness";
+import type {
+  BoardAttentionItem,
+  BoardReadinessBanner,
+  BoardReadinessClassRollupRow,
+  BoardReadinessPayload,
+  BoardReadinessPillarBlock,
+  BoardReadinessPillarKey,
+  BoardReadinessSegmentRollupRow,
+  BoardReadinessTraffic,
+  BoardReadinessGtmDemandStrip,
+} from "@/lib/boardReadinessTypes";
+import type { GtmProductBridgePayload } from "@/lib/gtmProductBridgeTypes";
+import { BOARD_REPORT_FRESH_DAYS, trafficFromRatio, worstTraffic } from "@/lib/boardReadinessThresholds";
+import { isoInWindow, windowBoundsMs } from "@/lib/gtmDashboardTime";
+import type { GtmSegmentBucket } from "@/lib/gtmDashboardTypes";
+import { attachContactRollups, mergeLeadsWithOps } from "@/lib/leadInboxMerge";
+import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import { readLeadOpsState } from "@/lib/leadOpsState";
+import { readAllLeadRecordsMerged } from "@/lib/leadPersistence";
+import {
+  findGtmProductMapEntry,
+  readGtmProductAccountMap,
+  type GtmProductMapEntry,
+} from "@/lib/gtmProductAccountMapStore";
+import { fetchTenantGovernanceSnapshot } from "@/lib/gtmProductGovernanceFetch";
+import {
+  fetchTenantBoardReadinessRaw,
+  type TenantBoardReadinessRaw,
+} from "@/lib/fetchTenantBoardReadinessRaw";
+
+const ART9 = "art9_risk_management";
+const ART11 = "art11_technical_documentation";
+
+const SEGMENT_LABELS_DE: Record<GtmSegmentBucket, string> = {
+  industrie_mittelstand: "Industrie / Mittelstand",
+  kanzlei_wp: "Kanzlei / WP",
+  enterprise_sap: "Enterprise / SAP",
+  other: "Sonstiges",
+};
+
+function segmentBucket(seg: string): GtmSegmentBucket {
+  if (seg === "industrie_mittelstand") return "industrie_mittelstand";
+  if (seg === "kanzlei_wp") return "kanzlei_wp";
+  if (seg === "enterprise_sap") return "enterprise_sap";
+  return "other";
+}
+
+function signalsToInput(
+  snap: Awaited<ReturnType<typeof fetchTenantGovernanceSnapshot>>,
+  pilot_flag: boolean,
+): GtmGovernanceSignalsInput {
+  return {
+    ai_systems_count: snap.ai_systems_count,
+    progress_steps: snap.progress_steps,
+    active_frameworks: snap.active_frameworks,
+    fetch_ok: snap.fetch_ok,
+    pilot_flag,
+  };
+}
+
+function complianceStatus(
+  rows: { requirement_id: string; status: string }[] | undefined,
+  reqId: string,
+): string | undefined {
+  return rows?.find((r) => r.requirement_id === reqId)?.status;
+}
+
+function countSavedAiActSections(raw: TenantBoardReadinessRaw, sysId: string): number {
+  const items = raw.ai_act_doc_items_by_system[sysId] ?? [];
+  return items.filter((it) => it.status === "saved").length;
+}
+
+function evidenceBundleOk(raw: TenantBoardReadinessRaw, sysId: string): boolean {
+  const st = complianceStatus(raw.compliance_by_system[sysId], ART11);
+  if (st === "completed") return true;
+  return countSavedAiActSections(raw, sysId) >= 2;
+}
+
+function boardReportFresh(raw: TenantBoardReadinessRaw, nowMs: number): boolean {
+  const latest = raw.board_reports[0];
+  if (!latest?.created_at) return false;
+  const w = windowBoundsMs(BOARD_REPORT_FRESH_DAYS, nowMs);
+  return isoInWindow(latest.created_at, w.start, w.end);
+}
+
+function isoFrameworksScopes(setup: TenantBoardReadinessRaw["ai_governance_setup"]): {
+  fw: string[];
+  scopes: string[];
+} {
+  const fw = (setup?.active_frameworks ?? []).map((x) => x.toLowerCase());
+  const scopes = (setup?.compliance_scopes ?? []).map((x) => x.toLowerCase());
+  return { fw, scopes };
+}
+
+function iso42001ScopeOk(setup: TenantBoardReadinessRaw["ai_governance_setup"]): boolean {
+  const { fw, scopes } = isoFrameworksScopes(setup);
+  return fw.some((x) => x.includes("42001") || x.includes("iso_42001")) || scopes.some((x) => x.includes("42001"));
+}
+
+function nis2RoleOk(setup: TenantBoardReadinessRaw["ai_governance_setup"]): boolean {
+  const roles = setup?.governance_roles ?? {};
+  return Object.entries(roles).some(([k, v]) => {
+    if (!String(v || "").trim()) return false;
+    return /ciso|dpo|nis2|incident|security|kritis/i.test(k);
+  });
+}
+
+type TenantPillarSnapshot = {
+  tenant_id: string;
+  tenant_label: string | null;
+  pilot: boolean;
+  primary_segment: GtmSegmentBucket | null;
+  readiness_class: GtmReadinessClass;
+  raw: TenantBoardReadinessRaw;
+  eu: {
+    hr_total: number;
+    art9_ratio: number | null;
+    evidence_ratio: number | null;
+    board_fresh: boolean;
+    score: number | null;
+    status: BoardReadinessTraffic;
+    indicators: BoardReadinessPillarBlock["indicators"];
+  };
+  iso: { score: number | null; status: BoardReadinessTraffic; indicators: BoardReadinessPillarBlock["indicators"] };
+  nis2: { score: number | null; status: BoardReadinessTraffic; indicators: BoardReadinessPillarBlock["indicators"] };
+  dsgvo: { score: number | null; status: BoardReadinessTraffic; indicators: BoardReadinessPillarBlock["indicators"] };
+};
+
+function buildTenantSnapshot(
+  tenantId: string,
+  mapEntry: GtmProductMapEntry | undefined,
+  primary_segment: GtmSegmentBucket | null,
+  raw: TenantBoardReadinessRaw,
+  govSnap: Awaited<ReturnType<typeof fetchTenantGovernanceSnapshot>>,
+  nowMs: number,
+): TenantPillarSnapshot {
+  const readiness_class = classifyMappedTenantReadiness(
+    signalsToInput(govSnap, mapEntry?.pilot === true),
+  );
+
+  const hasComplianceDashboard = raw.compliance_dashboard != null;
+  const hrIds = hasComplianceDashboard
+    ? (raw.compliance_dashboard?.systems ?? [])
+        .filter((s) => s.risk_level === "high_risk")
+        .map((s) => s.ai_system_id)
+    : [];
+  const hr_total = hrIds.length;
+
+  let art9_ok = 0;
+  let ev_ok = 0;
+  for (const id of hrIds) {
+    if (complianceStatus(raw.compliance_by_system[id], ART9) === "completed") art9_ok += 1;
+    if (evidenceBundleOk(raw, id)) ev_ok += 1;
+  }
+
+  const art9_ratio = hr_total ? art9_ok / hr_total : null;
+  const evidence_ratio = hr_total ? ev_ok / hr_total : null;
+  const board_fresh = hr_total > 0 ? boardReportFresh(raw, nowMs) : true;
+
+  const eu_sub_board: BoardReadinessTraffic = !hasComplianceDashboard
+    ? "amber"
+    : hr_total === 0
+      ? "green"
+      : board_fresh
+        ? "green"
+        : "red";
+
+  const eu_core = worstTraffic(trafficFromRatio(art9_ratio), trafficFromRatio(evidence_ratio));
+  const eu_status: BoardReadinessTraffic = !hasComplianceDashboard ? "amber" : worstTraffic(eu_core, eu_sub_board);
+
+  const eu_score =
+    !hasComplianceDashboard
+      ? null
+      : hr_total > 0
+        ? Math.round(
+            (((art9_ratio ?? 0) + (evidence_ratio ?? 0) + (board_fresh ? 1 : 0)) / 3) * 1000,
+          ) / 10
+        : null;
+
+  const eu_indicators: BoardReadinessPillarBlock["indicators"] = [
+    {
+      key: "high_risk_art9_complete_ratio",
+      label_de: "High-Risk: Risikomanagement (Art. 9) abgeschlossen",
+      value_percent:
+        !hasComplianceDashboard ? null : art9_ratio !== null ? Math.round(art9_ratio * 1000) / 10 : null,
+      value_count: hr_total ? art9_ok : null,
+      value_denominator: hasComplianceDashboard ? hr_total || null : null,
+      status: !hasComplianceDashboard ? "amber" : trafficFromRatio(art9_ratio),
+      source_api_paths: ["/api/v1/compliance/dashboard", "/api/v1/ai-systems/{id}/compliance"],
+    },
+    {
+      key: "high_risk_evidence_bundle_ratio",
+      label_de: "High-Risk: Nachweis-/Doku-Bündel (Art. 11 oder AI-Act-Docs)",
+      value_percent:
+        !hasComplianceDashboard ? null : evidence_ratio !== null ? Math.round(evidence_ratio * 1000) / 10 : null,
+      value_count: hr_total ? ev_ok : null,
+      value_denominator: hasComplianceDashboard ? hr_total || null : null,
+      status: !hasComplianceDashboard ? "amber" : trafficFromRatio(evidence_ratio),
+      source_api_paths: [
+        "/api/v1/ai-systems/{id}/compliance",
+        "/api/v1/ai-systems/{id}/ai-act-docs",
+      ],
+    },
+    {
+      key: "board_report_recency",
+      label_de: `Board-Report (${BOARD_REPORT_FRESH_DAYS} Tage)`,
+      value_percent:
+        !hasComplianceDashboard ? null : hr_total === 0 ? null : board_fresh ? 100 : 0,
+      value_count: !hasComplianceDashboard ? null : hr_total > 0 ? (board_fresh ? 1 : 0) : null,
+      value_denominator: hasComplianceDashboard && hr_total > 0 ? 1 : null,
+      status: eu_sub_board,
+      source_api_paths: [`/api/v1/tenants/{tid}/board/ai-compliance-reports`],
+    },
+  ];
+
+  const scope_ok = iso42001ScopeOk(raw.ai_governance_setup);
+  const roles_ok =
+    Object.values(raw.ai_governance_setup?.governance_roles ?? {}).filter((v) => String(v || "").trim()).length >= 2;
+  const policies_ok = raw.setup_status?.policies_published === true;
+  const iso_parts = [scope_ok, roles_ok, policies_ok];
+  const iso_score = raw.fetch_ok ? (iso_parts.filter(Boolean).length / 3) * 100 : null;
+  const iso_status = trafficFromRatio(iso_score !== null ? iso_score / 100 : null);
+
+  const iso_indicators: BoardReadinessPillarBlock["indicators"] = [
+    {
+      key: "iso42001_scope_framework",
+      label_de: "AI-MS Scope (ISO 42001 Framework/Scope)",
+      value_percent: scope_ok ? 100 : 0,
+      value_count: scope_ok ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: scope_ok ? "green" : "red",
+      source_api_paths: ["/api/v1/tenants/{tid}/ai-governance-setup"],
+    },
+    {
+      key: "iso42001_roles",
+      label_de: "Rollen im Setup hinterlegt (≥2 befüllt)",
+      value_percent: roles_ok ? 100 : 0,
+      value_count: roles_ok ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: roles_ok ? "green" : "amber",
+      source_api_paths: ["/api/v1/tenants/{tid}/ai-governance-setup"],
+    },
+    {
+      key: "iso42001_policies",
+      label_de: "Policy-Set veröffentlicht (Guided Setup)",
+      value_percent: policies_ok ? 100 : 0,
+      value_count: policies_ok ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: policies_ok ? "green" : "red",
+      source_api_paths: ["/api/v1/tenants/{tid}/setup-status"],
+    },
+  ];
+
+  const nis2_obl = raw.setup_status?.nis2_kpis_seeded === true;
+  const mean = raw.ai_compliance_overview?.nis2_kritis_kpi_mean_percent;
+  const cov = raw.ai_compliance_overview?.nis2_kritis_systems_full_coverage_ratio ?? 0;
+  const obligations_ok = nis2_obl || (mean != null && mean > 0);
+  let hr_inc = 0;
+  let hr_inc_ok = 0;
+  for (const id of hrIds) {
+    const row = raw.ai_systems.find((s) => s.id === id);
+    if (!row) continue;
+    hr_inc += 1;
+    if (row.has_incident_runbook) hr_inc_ok += 1;
+  }
+  const incident_ratio = hr_inc ? hr_inc_ok / hr_inc : null;
+  const nis2_parts = [
+    obligations_ok,
+    nis2RoleOk(raw.ai_governance_setup),
+    (incident_ratio ?? 1) >= 0.75 || hr_inc === 0,
+  ];
+  const nis2_score = raw.fetch_ok ? (nis2_parts.filter(Boolean).length / 3) * 100 : null;
+  const nis2_status = trafficFromRatio(nis2_score !== null ? nis2_score / 100 : null);
+
+  const nis2_indicators: BoardReadinessPillarBlock["indicators"] = [
+    {
+      key: "nis2_obligations_kpi_seed",
+      label_de: "NIS2-Pflichten / KPI-Grundlage (gesät oder KPI-Mittelwert)",
+      value_percent: obligations_ok ? 100 : 0,
+      value_count: obligations_ok ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: obligations_ok ? "green" : "amber",
+      source_api_paths: [
+        "/api/v1/tenants/{tid}/setup-status",
+        "/api/v1/ai-governance/compliance/overview",
+      ],
+    },
+    {
+      key: "nis2_contact_roles",
+      label_de: "Kontakt-Rollen (CISO/DPO/Incident o.ä.)",
+      value_percent: nis2RoleOk(raw.ai_governance_setup) ? 100 : 0,
+      value_count: nis2RoleOk(raw.ai_governance_setup) ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: nis2RoleOk(raw.ai_governance_setup) ? "green" : "amber",
+      source_api_paths: ["/api/v1/tenants/{tid}/ai-governance-setup"],
+    },
+    {
+      key: "nis2_incident_runbook_high_risk",
+      label_de: "Incident-Runbook bei High-Risk-Systemen (Anteil)",
+      value_percent: incident_ratio !== null ? Math.round(incident_ratio * 1000) / 10 : null,
+      value_count: hr_inc ? hr_inc_ok : null,
+      value_denominator: hr_inc || null,
+      status: trafficFromRatio(incident_ratio),
+      source_api_paths: ["/api/v1/ai-systems"],
+    },
+  ];
+
+  let dpia_ok = 0;
+  for (const id of hrIds) {
+    const row = raw.ai_systems.find((s) => s.id === id);
+    if (row?.gdpr_dpia_required) dpia_ok += 1;
+  }
+  const dpia_ratio = hr_total ? dpia_ok / hr_total : null;
+  const records_ok =
+    raw.setup_status?.evidence_attached === true || raw.setup_status?.classification_completed === true;
+  const dsgvo_parts = [
+    hr_total === 0 ? true : (dpia_ratio ?? 0) >= 0.85,
+    records_ok,
+  ];
+  const dsgvo_score = raw.fetch_ok ? (dsgvo_parts.filter(Boolean).length / 2) * 100 : null;
+  const dsgvo_status = trafficFromRatio(dsgvo_score !== null ? dsgvo_score / 100 : null);
+
+  const dsgvo_indicators: BoardReadinessPillarBlock["indicators"] = [
+    {
+      key: "dsgvo_dpia_flag_high_risk",
+      label_de: "DSFA-Pflicht / Nachweis-Flag bei High-Risk (Anteil mit gdpr_dpia_required)",
+      value_percent: dpia_ratio !== null ? Math.round(dpia_ratio * 1000) / 10 : null,
+      value_count: hr_total ? dpia_ok : null,
+      value_denominator: hr_total || null,
+      status: trafficFromRatio(dpia_ratio),
+      source_api_paths: ["/api/v1/ai-systems"],
+    },
+    {
+      key: "dsgvo_records_evidence",
+      label_de: "Grundaufzeichnungen (Evidenz/Klassifikation laut Setup-Status)",
+      value_percent: records_ok ? 100 : 0,
+      value_count: records_ok ? 1 : 0,
+      value_denominator: raw.fetch_ok ? 1 : null,
+      status: records_ok ? "green" : "amber",
+      source_api_paths: ["/api/v1/tenants/{tid}/setup-status"],
+    },
+  ];
+
+  return {
+    tenant_id: tenantId,
+    tenant_label: mapEntry?.label ?? null,
+    pilot: mapEntry?.pilot === true,
+    primary_segment,
+    readiness_class,
+    raw,
+    eu: {
+      hr_total,
+      art9_ratio,
+      evidence_ratio,
+      board_fresh,
+      score: eu_score,
+      status: eu_status,
+      indicators: eu_indicators,
+    },
+    iso: { score: iso_score, status: iso_status, indicators: iso_indicators },
+    nis2: { score: nis2_score, status: nis2_status, indicators: nis2_indicators },
+    dsgvo: { score: dsgvo_score, status: dsgvo_status, indicators: dsgvo_indicators },
+  };
+}
+
+function aggregatePillarsFromTenants(
+  tenants: TenantPillarSnapshot[],
+): Record<BoardReadinessPillarKey, BoardReadinessPillarBlock> {
+  const keys: BoardReadinessPillarKey[] = ["eu_ai_act", "iso_42001", "nis2", "dsgvo"];
+  const titles: Record<BoardReadinessPillarKey, string> = {
+    eu_ai_act: "EU AI Act",
+    iso_42001: "ISO 42001",
+    nis2: "NIS2 / KRITIS",
+    dsgvo: "DSGVO / Aufzeichnungen",
+  };
+
+  const pickIndicators = (
+    pillar: "eu" | "iso" | "nis2" | "dsgvo",
+  ): BoardReadinessPillarBlock["indicators"] => {
+    const first = tenants[0];
+    const template = first ? first[pillar].indicators : [];
+    return template.map((ind) => {
+      const vals: number[] = [];
+      let st: BoardReadinessTraffic = "green";
+      for (const t of tenants) {
+        const match = t[pillar].indicators.find((x) => x.key === ind.key);
+        if (!match) continue;
+        if (match.value_percent !== null && match.value_percent !== undefined) {
+          vals.push(match.value_percent);
+        }
+        st = worstTraffic(st, match.status);
+      }
+      const avg = vals.length ? Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 10) / 10 : null;
+      const stFromAvg = trafficFromRatio(avg !== null ? avg / 100 : null);
+      return {
+        ...ind,
+        value_percent: avg,
+        value_count: null,
+        value_denominator: tenants.length ? tenants.length : null,
+        status: worstTraffic(st, stFromAvg),
+      };
+    });
+  };
+
+  const blocks: Record<BoardReadinessPillarKey, BoardReadinessPillarBlock> = {} as Record<
+    BoardReadinessPillarKey,
+    BoardReadinessPillarBlock
+  >;
+
+  if (!tenants.length) {
+    for (const k of keys) {
+      blocks[k] = {
+        pillar: k,
+        title_de: titles[k],
+        summary_de: "Keine gemappten Mandanten im GTM-Product-Map.",
+        status: "amber",
+        indicators: [],
+      };
+    }
+    return blocks;
+  }
+
+  const euInd = pickIndicators("eu");
+  const isoInd = pickIndicators("iso");
+  const nisInd = pickIndicators("nis2");
+  const dsgInd = pickIndicators("dsgvo");
+
+  const pillarStatus = (inds: BoardReadinessPillarBlock["indicators"]): BoardReadinessTraffic =>
+    inds.reduce((a, x) => worstTraffic(a, x.status), "green" as BoardReadinessTraffic);
+
+  blocks.eu_ai_act = {
+    pillar: "eu_ai_act",
+    title_de: titles.eu_ai_act,
+    summary_de:
+      "High-Risk-Stichprobe: Art. 9, Nachweisbündel (Art. 11 / AI-Act-Docs), Board-Report-Recency.",
+    status: pillarStatus(euInd),
+    indicators: euInd,
+  };
+  blocks.iso_42001 = {
+    pillar: "iso_42001",
+    title_de: titles.iso_42001,
+    summary_de: "AI-Managementsystem: Scope/Framework, Rollen, Policies (reale Setup-Artefakte).",
+    status: pillarStatus(isoInd),
+    indicators: isoInd,
+  };
+  blocks.nis2 = {
+    pillar: "nis2",
+    title_de: titles.nis2,
+    summary_de: "Grundpflichten/KPIs, Kontakte, Incident-Runbooks an High-Risk-Systemen.",
+    status: pillarStatus(nisInd),
+    indicators: nisInd,
+  };
+  blocks.dsgvo = {
+    pillar: "dsgvo",
+    title_de: titles.dsgvo,
+    summary_de: "DSFA-Flag / Pfad für High-Risk und Basis-Evidenz aus Guided Setup.",
+    status: pillarStatus(dsgInd),
+    indicators: dsgInd,
+  };
+
+  return blocks;
+}
+
+function attentionItemsForTenant(t: TenantPillarSnapshot): BoardAttentionItem[] {
+  const items: BoardAttentionItem[] = [];
+  const seg = t.primary_segment ? SEGMENT_LABELS_DE[t.primary_segment] : null;
+
+  const hrIds =
+    t.raw.compliance_dashboard?.systems.filter((s) => s.risk_level === "high_risk").map((s) => s.ai_system_id) ??
+    [];
+
+  for (const id of hrIds) {
+    const sys = t.raw.ai_systems.find((s) => s.id === id);
+    const name = sys?.name ?? id;
+    const updated = sys?.updated_at_utc ?? null;
+
+    if (!String(sys?.owner_email || "").trim()) {
+      items.push({
+        id: `owner:${t.tenant_id}:${id}`,
+        severity: "red",
+        tenant_id: t.tenant_id,
+        tenant_label: t.tenant_label,
+        segment_tag: seg,
+        readiness_class: t.readiness_class,
+        subject_type: "ai_system",
+        subject_id: id,
+        subject_name: name,
+        missing_artefact_de: "Verantwortlicher (owner_email) fehlt",
+        last_change_at: updated ?? null,
+        deep_links: {
+          workspace_path: `/tenant/ai-systems/${id}`,
+          api_path: `/api/v1/ai-systems/${id}`,
+        },
+      });
+    }
+
+    if (complianceStatus(t.raw.compliance_by_system[id], ART9) !== "completed") {
+      items.push({
+        id: `art9:${t.tenant_id}:${id}`,
+        severity: "amber",
+        tenant_id: t.tenant_id,
+        tenant_label: t.tenant_label,
+        segment_tag: seg,
+        readiness_class: t.readiness_class,
+        subject_type: "ai_system",
+        subject_id: id,
+        subject_name: name,
+        missing_artefact_de: "Risikomanagement (Art. 9) nicht abgeschlossen",
+        last_change_at: updated ?? null,
+        deep_links: {
+          workspace_path: `/tenant/eu-ai-act`,
+          api_path: `/api/v1/ai-systems/${id}/compliance`,
+        },
+      });
+    }
+
+    if (!evidenceBundleOk(t.raw, id)) {
+      items.push({
+        id: `evidence:${t.tenant_id}:${id}`,
+        severity: "amber",
+        tenant_id: t.tenant_id,
+        tenant_label: t.tenant_label,
+        segment_tag: seg,
+        readiness_class: t.readiness_class,
+        subject_type: "ai_system",
+        subject_id: id,
+        subject_name: name,
+        missing_artefact_de: "Konformitätsnachweis/Doku-Bündel unvollständig (Art. 11 oder AI-Act-Docs)",
+        last_change_at: updated ?? null,
+        deep_links: {
+          workspace_path: `/tenant/ai-systems/${id}`,
+          api_path: `/api/v1/ai-systems/${id}/ai-act-docs`,
+        },
+      });
+    }
+  }
+
+  if (hrIds.length && !t.eu.board_fresh) {
+    const br = t.raw.board_reports[0];
+    items.push({
+      id: `board:${t.tenant_id}`,
+      severity: "red",
+      tenant_id: t.tenant_id,
+      tenant_label: t.tenant_label,
+      segment_tag: seg,
+      readiness_class: t.readiness_class,
+      subject_type: "tenant",
+      subject_id: t.tenant_id,
+      subject_name: t.tenant_label ?? t.tenant_id,
+      missing_artefact_de: `Aktueller Board-Report fehlt (letzte ${BOARD_REPORT_FRESH_DAYS} Tage)`,
+      last_change_at: br?.created_at ?? null,
+      deep_links: {
+        workspace_path: "/board/ai-compliance-report",
+        api_path: `/api/v1/tenants/${t.tenant_id}/board/ai-compliance-reports`,
+      },
+    });
+  }
+
+  return items;
+}
+
+function rollupBySegment(
+  tenants: TenantPillarSnapshot[],
+  overlay: GtmProductBridgePayload["segment_overlay"],
+): BoardReadinessSegmentRollupRow[] {
+  const buckets: GtmSegmentBucket[] = [
+    "industrie_mittelstand",
+    "kanzlei_wp",
+    "enterprise_sap",
+    "other",
+  ];
+
+  const bySeg = new Map<GtmSegmentBucket, TenantPillarSnapshot[]>();
+  for (const b of buckets) bySeg.set(b, []);
+  for (const t of tenants) {
+    const s = t.primary_segment ?? "other";
+    bySeg.get(s)?.push(t);
+  }
+
+  return buckets.map((segment) => {
+    const group = bySeg.get(segment) ?? [];
+    const ov = overlay.find((r) => r.segment === segment);
+
+    const pillar_score_proxy: Record<BoardReadinessPillarKey, number | null> = {
+      eu_ai_act: null,
+      iso_42001: null,
+      nis2: null,
+      dsgvo: null,
+    };
+    const pillar_status: Record<BoardReadinessPillarKey, BoardReadinessTraffic> = {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    };
+
+    for (const pk of Object.keys(pillar_score_proxy) as BoardReadinessPillarKey[]) {
+      const key = pk === "eu_ai_act" ? "eu" : pk === "iso_42001" ? "iso" : pk === "nis2" ? "nis2" : "dsgvo";
+      const scores: number[] = [];
+      let st: BoardReadinessTraffic = "green";
+      for (const tn of group) {
+        const sc = tn[key].score;
+        if (sc !== null && sc !== undefined) scores.push(sc);
+        st = worstTraffic(st, tn[key].status);
+      }
+      pillar_score_proxy[pk] = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+      pillar_status[pk] = st;
+    }
+
+    return {
+      segment,
+      label_de: SEGMENT_LABELS_DE[segment],
+      inquiries_30d: ov?.inquiries_30d ?? 0,
+      qualified_30d: ov?.qualified_30d ?? 0,
+      pillar_status,
+      pillar_score_proxy,
+      mapped_tenant_count: group.length,
+    };
+  });
+}
+
+function rollupByReadinessClass(tenants: TenantPillarSnapshot[]): BoardReadinessClassRollupRow[] {
+  const classes: GtmReadinessClass[] = [
+    "no_footprint",
+    "early_pilot",
+    "baseline_governance",
+    "advanced_governance",
+  ];
+
+  return classes.map((readiness_class) => {
+    const group = tenants.filter((t) => t.readiness_class === readiness_class);
+    const pillar_score_proxy: Record<BoardReadinessPillarKey, number | null> = {
+      eu_ai_act: null,
+      iso_42001: null,
+      nis2: null,
+      dsgvo: null,
+    };
+    const pillar_status: Record<BoardReadinessPillarKey, BoardReadinessTraffic> = {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    };
+    for (const pk of Object.keys(pillar_score_proxy) as BoardReadinessPillarKey[]) {
+      const key = pk === "eu_ai_act" ? "eu" : pk === "iso_42001" ? "iso" : pk === "nis2" ? "nis2" : "dsgvo";
+      const scores: number[] = [];
+      let st: BoardReadinessTraffic = "green";
+      for (const tn of group) {
+        const sc = tn[key].score;
+        if (sc !== null && sc !== undefined) scores.push(sc);
+        st = worstTraffic(st, tn[key].status);
+      }
+      pillar_score_proxy[pk] = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : null;
+      pillar_status[pk] = st;
+    }
+    return {
+      readiness_class,
+      label_de: GTM_READINESS_LABELS_DE[readiness_class],
+      tenant_count: group.length,
+      pillar_status,
+      pillar_score_proxy,
+    };
+  });
+}
+
+async function loadLeads30d(nowMs: number): Promise<LeadInboxItem[]> {
+  const allRows = await readAllLeadRecordsMerged();
+  const ops = await readLeadOpsState();
+  const merged = mergeLeadsWithOps(allRows, ops);
+  const items = attachContactRollups(merged, allRows, ops);
+  const w = windowBoundsMs(30, nowMs);
+  return items.filter((it) => isoInWindow(it.created_at, w.start, w.end));
+}
+
+function primarySegmentForTenant(
+  tenantId: string,
+  map: Awaited<ReturnType<typeof readGtmProductAccountMap>>,
+  items: LeadInboxItem[],
+): GtmSegmentBucket | null {
+  const counts: Record<GtmSegmentBucket, number> = {
+    industrie_mittelstand: 0,
+    kanzlei_wp: 0,
+    enterprise_sap: 0,
+    other: 0,
+  };
+  for (const it of items) {
+    const e = findGtmProductMapEntry(map, it);
+    if (!e || e.tenant_id !== tenantId) continue;
+    counts[segmentBucket(it.segment)] += 1;
+  }
+  let best: GtmSegmentBucket | null = null;
+  let max = 0;
+  (Object.keys(counts) as GtmSegmentBucket[]).forEach((k) => {
+    if (counts[k] > max) {
+      max = counts[k];
+      best = k;
+    }
+  });
+  return max > 0 ? best : null;
+}
+
+function mapEntryForTenant(
+  tid: string,
+  map: Awaited<ReturnType<typeof readGtmProductAccountMap>>,
+): GtmProductMapEntry | undefined {
+  return map.entries.find((e) => e.tenant_id === tid);
+}
+
+export async function computeBoardReadinessPayload(now: Date = new Date()): Promise<BoardReadinessPayload> {
+  const nowMs = now.getTime();
+  const map = await readGtmProductAccountMap();
+  const tenantIds = [...new Set(map.entries.map((e) => e.tenant_id))];
+  const leads30d = await loadLeads30d(nowMs);
+
+  const { computeProductBridgePayload } = await import("@/lib/gtmProductBridgeAggregate");
+  const product_bridge = await computeProductBridgePayload(now);
+
+  const snapshots: TenantPillarSnapshot[] = [];
+  let backendReachable = false;
+  let partial = 0;
+
+  for (const tid of tenantIds) {
+    const [raw, govSnap] = await Promise.all([
+      fetchTenantBoardReadinessRaw(tid),
+      fetchTenantGovernanceSnapshot(tid),
+    ]);
+    if (raw.fetch_ok) backendReachable = true;
+    else partial += 1;
+    const entry = mapEntryForTenant(tid, map);
+    const primary_segment = primarySegmentForTenant(tid, map, leads30d);
+    snapshots.push(buildTenantSnapshot(tid, entry, primary_segment, raw, govSnap, nowMs));
+  }
+
+  const pillarMap = aggregatePillarsFromTenants(snapshots);
+  const pillars = [
+    pillarMap.eu_ai_act,
+    pillarMap.iso_42001,
+    pillarMap.nis2,
+    pillarMap.dsgvo,
+  ];
+
+  const overallStatus = pillars.reduce((a, p) => worstTraffic(a, p.status), "green" as BoardReadinessTraffic);
+  const overallLabel =
+    overallStatus === "green"
+      ? "Portfolio insgesamt im Zielkorridor"
+      : overallStatus === "amber"
+        ? "Gezielte Nachsteuerung empfohlen"
+        : "Kritische Governance-Lücken – Board-Vorbereitung anstoßen";
+
+  const gtmAttention: BoardAttentionItem[] = [];
+  for (const row of product_bridge.segment_overlay) {
+    if (row.qualified_30d >= 3 && row.dominant_readiness === "early_pilot") {
+      gtmAttention.push({
+        id: `gtm-demand:${row.segment}`,
+        severity: "amber",
+        tenant_id: "_portfolio",
+        tenant_label: null,
+        segment_tag: row.label_de,
+        readiness_class: row.dominant_readiness,
+        subject_type: "tenant",
+        subject_id: null,
+        subject_name: row.label_de,
+        missing_artefact_de:
+          "Hohe qualifizierte Nachfrage im Segment bei dominanter Pilot-Readiness – Produkt-Governance nachziehen.",
+        last_change_at: new Date(nowMs).toISOString(),
+        deep_links: {
+          workspace_path: "/admin/gtm",
+          api_path: "/api/admin/gtm/summary",
+        },
+      });
+    }
+  }
+
+  const attention_items = [...gtmAttention, ...snapshots.flatMap(attentionItemsForTenant)].slice(0, 80);
+
+  const gtm_demand_strip: BoardReadinessGtmDemandStrip = {
+    window_days: 30,
+    segment_rows: product_bridge.segment_overlay.map((r) => ({
+      segment: r.segment,
+      label_de: r.label_de,
+      inquiries_30d: r.inquiries_30d,
+      qualified_30d: r.qualified_30d,
+      dominant_readiness: r.dominant_readiness,
+    })),
+  };
+
+  return {
+    generated_at: now.toISOString(),
+    backend_reachable: backendReachable,
+    mapped_tenant_count: tenantIds.length,
+    tenants_partial: partial,
+    overall: { status: overallStatus, label_de: overallLabel },
+    pillars,
+    segment_rollups: rollupBySegment(snapshots, product_bridge.segment_overlay),
+    readiness_class_rollups: rollupByReadinessClass(snapshots),
+    attention_items,
+    gtm_demand_strip,
+    notes_de: [
+      "Indikatoren bewusst grob; Ampeln leiten aus echten API-Artefakten ab (kein Composite-Score).",
+      "Scope: Mandanten aus gtm-product-account-map.json; Segment aus dominanten Leads (30 Tage).",
+    ],
+  };
+}
+
+export function boardReadinessBannerFromPayload(p: BoardReadinessPayload): BoardReadinessBanner {
+  return {
+    status: p.overall.status,
+    label_de: p.overall.label_de,
+    mapped_tenant_count: p.mapped_tenant_count,
+    backend_reachable: p.backend_reachable,
+  };
+}

--- a/frontend/src/lib/boardReadinessThresholds.test.ts
+++ b/frontend/src/lib/boardReadinessThresholds.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import { trafficFromRatio, worstTraffic } from "@/lib/boardReadinessThresholds";
+
+describe("boardReadinessThresholds", () => {
+  it("marks green at or above 0.75", () => {
+    expect(trafficFromRatio(0.75)).toBe("green");
+    expect(trafficFromRatio(0.9)).toBe("green");
+  });
+
+  it("marks red below 0.45", () => {
+    expect(trafficFromRatio(0.44)).toBe("red");
+    expect(trafficFromRatio(0)).toBe("red");
+  });
+
+  it("marks amber in the band", () => {
+    expect(trafficFromRatio(0.5)).toBe("amber");
+    expect(trafficFromRatio(0.74)).toBe("amber");
+  });
+
+  it("treats null ratio as amber", () => {
+    expect(trafficFromRatio(null)).toBe("amber");
+  });
+
+  it("picks worst traffic", () => {
+    expect(worstTraffic("green", "amber")).toBe("amber");
+    expect(worstTraffic("amber", "red")).toBe("red");
+    expect(worstTraffic("green", "green")).toBe("green");
+  });
+});

--- a/frontend/src/lib/boardReadinessThresholds.ts
+++ b/frontend/src/lib/boardReadinessThresholds.ts
@@ -1,0 +1,16 @@
+import type { BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+
+/** Schwellen bewusst grob (Wave 34); siehe docs/board/wave34-board-readiness-dashboard.md */
+export const BOARD_REPORT_FRESH_DAYS = 90;
+
+export function trafficFromRatio(ratio: number | null): BoardReadinessTraffic {
+  if (ratio === null || Number.isNaN(ratio)) return "amber";
+  if (ratio >= 0.75) return "green";
+  if (ratio < 0.45) return "red";
+  return "amber";
+}
+
+export function worstTraffic(a: BoardReadinessTraffic, b: BoardReadinessTraffic): BoardReadinessTraffic {
+  const rank: Record<BoardReadinessTraffic, number> = { green: 0, amber: 1, red: 2 };
+  return rank[a] >= rank[b] ? a : b;
+}

--- a/frontend/src/lib/boardReadinessTypes.ts
+++ b/frontend/src/lib/boardReadinessTypes.ts
@@ -1,0 +1,94 @@
+/**
+ * Wave 34 – Board Readiness Dashboard (internal).
+ * Aligns conceptually with `app/board_readiness_models.py`.
+ */
+
+export type BoardReadinessTraffic = "green" | "amber" | "red";
+
+export type BoardReadinessPillarKey = "eu_ai_act" | "iso_42001" | "nis2" | "dsgvo";
+
+export type BoardReadinessSubIndicator = {
+  key: string;
+  label_de: string;
+  value_percent: number | null;
+  value_count: number | null;
+  value_denominator: number | null;
+  status: BoardReadinessTraffic;
+  source_api_paths: string[];
+};
+
+export type BoardReadinessPillarBlock = {
+  pillar: BoardReadinessPillarKey;
+  title_de: string;
+  summary_de: string;
+  status: BoardReadinessTraffic;
+  indicators: BoardReadinessSubIndicator[];
+};
+
+export type BoardAttentionItem = {
+  id: string;
+  severity: BoardReadinessTraffic;
+  tenant_id: string;
+  tenant_label?: string | null;
+  segment_tag?: string | null;
+  readiness_class?: string | null;
+  subject_type: "ai_system" | "tenant";
+  subject_id?: string | null;
+  subject_name?: string | null;
+  missing_artefact_de: string;
+  last_change_at?: string | null;
+  deep_links: Record<string, string>;
+};
+
+export type BoardReadinessSegmentRollupRow = {
+  segment: import("@/lib/gtmDashboardTypes").GtmSegmentBucket;
+  label_de: string;
+  /** Demand proxy from GTM (30d window, same as Wave 33 bridge). */
+  inquiries_30d: number;
+  qualified_30d: number;
+  pillar_status: Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+  /** Mean of numeric sub-indicators where defined (0–100). */
+  pillar_score_proxy: Record<BoardReadinessPillarKey, number | null>;
+  mapped_tenant_count: number;
+};
+
+export type BoardReadinessClassRollupRow = {
+  readiness_class: import("@/lib/gtmAccountReadiness").GtmReadinessClass;
+  label_de: string;
+  tenant_count: number;
+  pillar_status: Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+  pillar_score_proxy: Record<BoardReadinessPillarKey, number | null>;
+};
+
+export type BoardReadinessGtmDemandStrip = {
+  window_days: number;
+  segment_rows: Array<{
+    segment: import("@/lib/gtmDashboardTypes").GtmSegmentBucket;
+    label_de: string;
+    inquiries_30d: number;
+    qualified_30d: number;
+    dominant_readiness: import("@/lib/gtmAccountReadiness").GtmReadinessClass;
+  }>;
+};
+
+export type BoardReadinessPayload = {
+  generated_at: string;
+  backend_reachable: boolean;
+  mapped_tenant_count: number;
+  tenants_partial: number;
+  overall: {
+    status: BoardReadinessTraffic;
+    label_de: string;
+  };
+  pillars: BoardReadinessPillarBlock[];
+  segment_rollups: BoardReadinessSegmentRollupRow[];
+  readiness_class_rollups: BoardReadinessClassRollupRow[];
+  attention_items: BoardAttentionItem[];
+  gtm_demand_strip: BoardReadinessGtmDemandStrip | null;
+  notes_de: string[];
+};
+
+export type BoardReadinessBanner = BoardReadinessPayload["overall"] & {
+  mapped_tenant_count: number;
+  backend_reachable: boolean;
+};

--- a/frontend/src/lib/fetchTenantBoardReadinessRaw.ts
+++ b/frontend/src/lib/fetchTenantBoardReadinessRaw.ts
@@ -1,0 +1,237 @@
+import "server-only";
+
+/** Raw backend payloads for Board Readiness (Wave 34). Kept loose for API evolution. */
+
+export type RawAISystemRow = {
+  id: string;
+  name: string;
+  owner_email?: string | null;
+  gdpr_dpia_required?: boolean;
+  has_incident_runbook?: boolean;
+  has_backup_runbook?: boolean;
+  has_supplier_risk_register?: boolean;
+  updated_at_utc?: string;
+};
+
+export type RawComplianceStatusEntry = {
+  requirement_id: string;
+  status: string;
+};
+
+export type RawSystemReadiness = {
+  ai_system_id: string;
+  ai_system_name: string;
+  risk_level: string;
+  readiness_score?: number;
+};
+
+export type RawComplianceDashboard = {
+  tenant_id: string;
+  systems: RawSystemReadiness[];
+};
+
+export type RawAIComplianceOverview = {
+  tenant_id: string;
+  overall_readiness?: number;
+  nis2_kritis_kpi_mean_percent?: number | null;
+  nis2_kritis_systems_full_coverage_ratio?: number;
+};
+
+export type RawEuAIActReadinessOverview = {
+  tenant_id: string;
+  overall_readiness?: number;
+  high_risk_systems_essential_complete?: number;
+  high_risk_systems_essential_incomplete?: number;
+};
+
+export type RawTenantSetupStatus = {
+  tenant_id: string;
+  policies_published?: boolean;
+  nis2_kpis_seeded?: boolean;
+  evidence_attached?: boolean;
+  classification_completed?: boolean;
+  completed_steps?: number;
+  total_steps?: number;
+};
+
+export type RawTenantAIGovernanceSetup = {
+  tenant_id?: string;
+  compliance_scopes?: string[];
+  governance_roles?: Record<string, string>;
+  active_frameworks?: string[];
+  progress_steps?: number[];
+};
+
+export type RawBoardReportListItem = {
+  id: string;
+  title: string;
+  created_at: string;
+};
+
+export type RawAIActDocListItem = {
+  section_key: string;
+  status: string;
+  doc?: { version?: number; updated_at?: string } | null;
+};
+
+export type RawAIActDocListResponse = {
+  ai_system_id: string;
+  items?: RawAIActDocListItem[];
+};
+
+export type TenantBoardReadinessRaw = {
+  tenant_id: string;
+  fetch_ok: boolean;
+  ai_systems: RawAISystemRow[];
+  compliance_by_system: Record<string, RawComplianceStatusEntry[]>;
+  ai_act_doc_items_by_system: Record<string, RawAIActDocListItem[]>;
+  compliance_dashboard: RawComplianceDashboard | null;
+  eu_ai_act_readiness: RawEuAIActReadinessOverview | null;
+  ai_compliance_overview: RawAIComplianceOverview | null;
+  setup_status: RawTenantSetupStatus | null;
+  ai_governance_setup: RawTenantAIGovernanceSetup | null;
+  board_reports: RawBoardReportListItem[];
+  ai_act_docs_errors: Record<string, boolean>;
+};
+
+function apiBase(): string {
+  return (
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+function tenantHeaders(tenantId: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey(),
+    "x-tenant-id": tenantId,
+    "Content-Type": "application/json",
+  };
+}
+
+async function getJson<T>(
+  tenantId: string,
+  path: string,
+): Promise<{ ok: boolean; data: T | null; status: number }> {
+  const base = apiBase();
+  const url = `${base}${path}`;
+  try {
+    const res = await fetch(url, { headers: tenantHeaders(tenantId), cache: "no-store" });
+    if (!res.ok) return { ok: false, data: null, status: res.status };
+    const data = (await res.json()) as T;
+    return { ok: true, data, status: res.status };
+  } catch {
+    return { ok: false, data: null, status: 0 };
+  }
+}
+
+/**
+ * Loads tenant-scoped governance artefacts for Board Readiness.
+ * Best-effort: partial data still returns `fetch_ok` if any core call succeeded.
+ */
+export async function fetchTenantBoardReadinessRaw(tenantId: string): Promise<TenantBoardReadinessRaw> {
+  const tid = encodeURIComponent(tenantId);
+  let fetch_ok = false;
+
+  const systemsRes = await getJson<RawAISystemRow[]>(tenantId, "/api/v1/ai-systems");
+  if (systemsRes.ok && Array.isArray(systemsRes.data)) fetch_ok = true;
+  const ai_systems = systemsRes.ok && Array.isArray(systemsRes.data) ? systemsRes.data : [];
+
+  const dashRes = await getJson<RawComplianceDashboard>(
+    tenantId,
+    "/api/v1/compliance/dashboard",
+  );
+  if (dashRes.ok) fetch_ok = true;
+  const compliance_dashboard = dashRes.ok ? dashRes.data : null;
+
+  const euRes = await getJson<RawEuAIActReadinessOverview>(
+    tenantId,
+    "/api/v1/ai-governance/readiness/eu-ai-act",
+  );
+  if (euRes.ok) fetch_ok = true;
+  const eu_ai_act_readiness = euRes.ok ? euRes.data : null;
+
+  const overviewRes = await getJson<RawAIComplianceOverview>(
+    tenantId,
+    "/api/v1/ai-governance/compliance/overview",
+  );
+  if (overviewRes.ok) fetch_ok = true;
+  const ai_compliance_overview = overviewRes.ok ? overviewRes.data : null;
+
+  const setupRes = await getJson<RawTenantSetupStatus>(
+    tenantId,
+    `/api/v1/tenants/${tid}/setup-status`,
+  );
+  if (setupRes.ok) fetch_ok = true;
+  const setup_status = setupRes.ok ? setupRes.data : null;
+
+  const agRes = await getJson<RawTenantAIGovernanceSetup>(
+    tenantId,
+    `/api/v1/tenants/${tid}/ai-governance-setup`,
+  );
+  if (agRes.ok) fetch_ok = true;
+  const ai_governance_setup = agRes.ok ? agRes.data : null;
+
+  const brRes = await getJson<RawBoardReportListItem[]>(
+    tenantId,
+    `/api/v1/tenants/${tid}/board/ai-compliance-reports?limit=20`,
+  );
+  const board_reports = brRes.ok && Array.isArray(brRes.data) ? brRes.data : [];
+  if (brRes.ok) fetch_ok = true;
+
+  const highRiskIds = new Set<string>();
+  for (const row of compliance_dashboard?.systems ?? []) {
+    if (row.risk_level === "high_risk") highRiskIds.add(row.ai_system_id);
+  }
+
+  const compliance_by_system: Record<string, RawComplianceStatusEntry[]> = {};
+  const ai_act_doc_items_by_system: Record<string, RawAIActDocListItem[]> = {};
+  const ai_act_docs_errors: Record<string, boolean> = {};
+
+  for (const sysId of highRiskIds) {
+    const sid = encodeURIComponent(sysId);
+    const cRes = await getJson<RawComplianceStatusEntry[]>(
+      tenantId,
+      `/api/v1/ai-systems/${sid}/compliance`,
+    );
+    if (cRes.ok && Array.isArray(cRes.data)) {
+      fetch_ok = true;
+      compliance_by_system[sysId] = cRes.data;
+    }
+
+    const docRes = await getJson<RawAIActDocListResponse>(
+      tenantId,
+      `/api/v1/ai-systems/${sid}/ai-act-docs`,
+    );
+    if (!docRes.ok) {
+      ai_act_docs_errors[sysId] = true;
+      continue;
+    }
+    fetch_ok = true;
+    ai_act_doc_items_by_system[sysId] = docRes.data?.items ?? [];
+  }
+
+  return {
+    tenant_id: tenantId,
+    fetch_ok,
+    ai_systems,
+    compliance_by_system,
+    ai_act_doc_items_by_system,
+    compliance_dashboard,
+    eu_ai_act_readiness,
+    ai_compliance_overview,
+    setup_status,
+    ai_governance_setup,
+    board_reports,
+    ai_act_docs_errors,
+  };
+}

--- a/tests/test_board_readiness_models.py
+++ b/tests/test_board_readiness_models.py
@@ -1,0 +1,46 @@
+"""Sanity checks for board readiness DTOs (Wave 34)."""
+
+from __future__ import annotations
+
+from app.board_readiness_models import (
+    BoardAttentionItem,
+    BoardReadinessPillarBlock,
+    BoardReadinessPillarKey,
+    BoardReadinessSubIndicator,
+    BoardReadinessTraffic,
+)
+
+
+def test_board_readiness_pillar_roundtrip() -> None:
+    b = BoardReadinessPillarBlock(
+        pillar=BoardReadinessPillarKey.eu_ai_act,
+        title_de="EU AI Act",
+        summary_de="Test",
+        status=BoardReadinessTraffic.amber,
+        indicators=[
+            BoardReadinessSubIndicator(
+                key="k",
+                label_de="L",
+                value_percent=50.0,
+                value_count=1,
+                value_denominator=2,
+                status=BoardReadinessTraffic.amber,
+                source_api_paths=["/api/v1/example"],
+            ),
+        ],
+    )
+    assert b.pillar == BoardReadinessPillarKey.eu_ai_act
+    assert b.indicators[0].value_percent == 50.0
+
+
+def test_board_attention_item() -> None:
+    a = BoardAttentionItem(
+        id="x",
+        severity=BoardReadinessTraffic.red,
+        tenant_id="t1",
+        subject_type="ai_system",
+        subject_id="s1",
+        missing_artefact_de="Fehlt",
+        deep_links={"workspace_path": "/tenant/ai-systems/s1"},
+    )
+    assert a.deep_links["workspace_path"].endswith("s1")


### PR DESCRIPTION
Add internal /admin/board-readiness with EU AI Act, ISO 42001, NIS2, and DSGVO indicators derived from tenant APIs; segment and Wave 33 readiness rollups; attention items with audit deep links. Extend GTM summary with board_readiness_banner and link tile. Document in docs/board/; add app/board_readiness_models.py and tests.

Made-with: Cursor