### PR TITLE
feat(admin): Wave 35 Board Readiness Briefing

### DIFF
--- a/docs/board/wave35-board-readiness-briefing.md
+++ b/docs/board/wave35-board-readiness-briefing.md
@@ -1,0 +1,59 @@
+# Wave 35 – Board Readiness Briefing
+
+Internes Hilfsmittel für **Quartals- oder Ad-hoc-Updates** an Board/Advisory: ein **strukturiertes Text-/Markdown-Gerüst**, gespeist aus dem bestehenden Board-Readiness-Dashboard (Wave 34). Kein Ersatz für juristische Prüfung oder vollständige Compliance-Berichte.
+
+## Gliederung (Outline)
+
+Die logische Struktur ist in Code als `BOARD_READINESS_BRIEFING_OUTLINE_DE` in `frontend/src/lib/boardReadinessBriefingTypes.ts` dokumentiert:
+
+1. **Executive Summary** – Portfolio-Ampel, Säulen in Kurzform, optional Delta zur gespeicherten Baseline.
+2. **Säulenüberblick** – EU AI Act, ISO 42001, NIS2, DSGVO: je bis zu drei Indikator-Zeilen (Ampel + Kennzahl, falls vorhanden).
+3. **High-Risk / Attention Items** – Top-Auswahl aus dem Dashboard mit **Referenz-IDs** (`HR-AI-…`, `TENANT-…`, `GTM-…`).
+4. **GTM vs. Governance** – Heuristiken zum 30-Tage-Fenster (z. B. qualifizierte Nachfrage bei dominanter Pilot-Readiness).
+5. **Nächste Governance-Prioritäten** – bis zu drei Vorschläge mit **Owner-Platzhalter** und Zeithorizont (manuell zu verfeinern).
+
+## API
+
+| Methode | Pfad | Zweck |
+|--------|------|--------|
+| `GET` | `/api/admin/board-readiness/briefing` | Liefert `briefing` (JSON: `sections`, `markdown_de`, `delta_bullets_de`, `meta_de`). Nutzt aktuelle Board-Readiness-Berechnung und optional `data/board-readiness-briefing-baseline.json`. |
+| `POST` | `/api/admin/board-readiness/briefing/baseline` | Speichert eine **Baseline** (Ampeln + Attention-Zähler) für **Delta-Hinweise** beim nächsten Briefing. |
+
+Auth wie andere Admin-Routen: Session über `LEAD_ADMIN_SECRET` (siehe Lead-Inbox).
+
+Baseline-Pfad: `data/board-readiness-briefing-baseline.json` oder `BOARD_READINESS_BRIEFING_BASELINE_PATH` (z. B. `/tmp` auf Vercel).
+
+## UI
+
+Auf `/admin/board-readiness`:
+
+- Button **„Board Readiness Briefing erzeugen“** (lädt `GET …/briefing`).
+- Darstellung der **Abschnitte und Bullets** zum Überfliegen.
+- **Markdown** in einem Textfeld (copy-paste) plus **Kopieren** und **Download** als `.md`.
+
+## Nutzung für Decks oder Memos
+
+1. Dashboard aktualisieren, Briefing erzeugen.
+2. Optional **Baseline speichern** nach einem Board-Termin, damit das nächste Briefing **Änderungen** in Kurzform nennt.
+3. Markdown in Google Docs, Notion, oder Folien **manuell** einteilen (Titel pro Abschnitt = Folie oder Memo-Kapitel).
+4. Referenz-IDs nutzen, um in ComplianceHub dieselben Mandanten/Systeme zu öffnen (Pfade siehe Attention-Tabelle im Dashboard).
+
+## Grenzen und Caveats
+
+- **Keine automatischen Rechtsfolgen** – nur Fakten, Lücken und Vorschläge aus vorhandenen API-Signalen.
+- **Heuristiken** (GTM vs. Governance, Prioritäten) sind **Startpunkte**; Owner, Termine und Formulierung sind extern zu finalisieren.
+- **Baseline** ist bewusst schlank (Ampeln + Zähler), keine tiefe Versionshistorie – für echte Trendanalyse später erweiterbar.
+- Sprache der Generierung: **Deutsch**, board-tauglich knapp; redaktionelle Feinarbeit bleibt beim Menschen.
+
+## Implementierung
+
+| Teil | Pfad |
+|------|------|
+| Typen & Outline | `frontend/src/lib/boardReadinessBriefingTypes.ts` |
+| Generierung & Markdown | `frontend/src/lib/boardReadinessBriefingGenerate.ts` |
+| Baseline-Store | `frontend/src/lib/boardReadinessBriefingSnapshotStore.ts` |
+| API Briefing | `frontend/src/app/api/admin/board-readiness/briefing/route.ts` |
+| API Baseline | `frontend/src/app/api/admin/board-readiness/briefing/baseline/route.ts` |
+| UI | `frontend/src/components/admin/BoardReadinessBriefingPanel.tsx` (eingebunden in `BoardReadinessClient`) |
+
+Siehe ergänzend: `docs/board/wave34-board-readiness-dashboard.md` (Datenquellen der Indikatoren).

--- a/frontend/src/app/api/admin/board-readiness/briefing/baseline/route.ts
+++ b/frontend/src/app/api/admin/board-readiness/briefing/baseline/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { computeBoardReadinessPayload } from "@/lib/boardReadinessAggregate";
+import { baselineFromPayload } from "@/lib/boardReadinessBriefingGenerate";
+import {
+  readBoardReadinessBriefingBaseline,
+  writeBoardReadinessBriefingBaseline,
+} from "@/lib/boardReadinessBriefingSnapshotStore";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+/**
+ * POST: Speichert eine Baseline für Delta-Hinweise im nächsten Briefing (optional Wave 35).
+ */
+export async function POST(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const payload = await computeBoardReadinessPayload();
+  const baseline = baselineFromPayload(payload);
+  await writeBoardReadinessBriefingBaseline(baseline);
+
+  const stored = await readBoardReadinessBriefingBaseline();
+  return NextResponse.json({
+    ok: true,
+    baseline: stored,
+    message_de: "Baseline für Board-Readiness-Briefing gespeichert.",
+  });
+}

--- a/frontend/src/app/api/admin/board-readiness/briefing/route.ts
+++ b/frontend/src/app/api/admin/board-readiness/briefing/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { computeBoardReadinessPayload } from "@/lib/boardReadinessAggregate";
+import { generateBoardReadinessBriefing } from "@/lib/boardReadinessBriefingGenerate";
+import { readBoardReadinessBriefingBaseline } from "@/lib/boardReadinessBriefingSnapshotStore";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const [payload, baseline] = await Promise.all([
+    computeBoardReadinessPayload(),
+    readBoardReadinessBriefingBaseline(),
+  ]);
+  const briefing = generateBoardReadinessBriefing(payload, baseline);
+
+  return NextResponse.json({ ok: true, briefing });
+}

--- a/frontend/src/components/admin/BoardReadinessBriefingPanel.tsx
+++ b/frontend/src/components/admin/BoardReadinessBriefingPanel.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { BOARD_READINESS_BRIEFING_OUTLINE_DE } from "@/lib/boardReadinessBriefingTypes";
+import type { BoardReadinessBriefingPayload } from "@/lib/boardReadinessBriefingTypes";
+
+export function BoardReadinessBriefingPanel() {
+  const [briefing, setBriefing] = useState<BoardReadinessBriefingPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [baselineMsg, setBaselineMsg] = useState<string | null>(null);
+
+  const generate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setBaselineMsg(null);
+    try {
+      const r = await fetch("/api/admin/board-readiness/briefing", { credentials: "include" });
+      if (r.status === 401) {
+        setError("Nicht angemeldet (Admin-Secret).");
+        setBriefing(null);
+        return;
+      }
+      if (!r.ok) {
+        setError(`HTTP ${r.status}`);
+        return;
+      }
+      const data = (await r.json()) as { ok?: boolean; briefing?: BoardReadinessBriefingPayload };
+      setBriefing(data.briefing ?? null);
+    } catch {
+      setError("Netzwerkfehler");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const saveBaseline = useCallback(async () => {
+    setBaselineMsg(null);
+    try {
+      const r = await fetch("/api/admin/board-readiness/briefing/baseline", {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!r.ok) {
+        setBaselineMsg(`Baseline speichern fehlgeschlagen (${r.status}).`);
+        return;
+      }
+      const data = (await r.json()) as { message_de?: string };
+      setBaselineMsg(data.message_de ?? "Gespeichert.");
+    } catch {
+      setBaselineMsg("Netzwerkfehler beim Speichern der Baseline.");
+    }
+  }, []);
+
+  const copyMd = useCallback(async () => {
+    if (!briefing?.markdown_de) return;
+    try {
+      await navigator.clipboard.writeText(briefing.markdown_de);
+      setBaselineMsg("Markdown in die Zwischenablage kopiert.");
+    } catch {
+      setBaselineMsg("Kopieren nicht möglich (Browser-Berechtigung).");
+    }
+  }, [briefing?.markdown_de]);
+
+  const downloadMd = useCallback(() => {
+    if (!briefing?.markdown_de) return;
+    const blob = new Blob([briefing.markdown_de], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `board-readiness-briefing-${briefing.generated_at.slice(0, 10)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [briefing]);
+
+  return (
+    <section className="rounded-xl border border-indigo-200 bg-indigo-50/40 p-4 shadow-sm">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-indigo-800">Wave 35</p>
+          <h2 className="text-sm font-semibold text-slate-900">Board Readiness Briefing</h2>
+          <p className="mt-1 max-w-3xl text-xs text-slate-600">
+            Strukturiertes Memo-/Deck-Gerüst aus Live-Dashboard-Daten. Redaktion und rechtliche Prüfung
+            erfolgen außerhalb der App.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => void generate()}
+            disabled={loading}
+            className="rounded-lg bg-indigo-900 px-3 py-1.5 text-sm text-white hover:bg-indigo-800 disabled:opacity-50"
+          >
+            {loading ? "Erzeuge…" : "Briefing erzeugen"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void saveBaseline()}
+            className="rounded-lg border border-indigo-300 bg-white px-3 py-1.5 text-sm text-indigo-950 hover:bg-indigo-50"
+          >
+            Baseline für Deltas speichern
+          </button>
+        </div>
+      </div>
+
+      <details className="mt-3 rounded-lg border border-indigo-100 bg-white/70 px-3 py-2 text-xs text-slate-700">
+        <summary className="cursor-pointer font-medium text-slate-800">Gliederung (Outline)</summary>
+        <ul className="mt-2 list-inside list-decimal space-y-1">
+          {BOARD_READINESS_BRIEFING_OUTLINE_DE.map((o) => (
+            <li key={o.id}>
+              <span className="font-medium">{o.title_de}</span> – {o.purpose_de}
+            </li>
+          ))}
+        </ul>
+      </details>
+
+      {error ? <p className="mt-2 text-sm text-red-600">{error}</p> : null}
+      {baselineMsg ? <p className="mt-2 text-sm text-indigo-900">{baselineMsg}</p> : null}
+
+      {briefing ? (
+        <div className="mt-4 space-y-4 border-t border-indigo-100 pt-4">
+          <p className="font-mono text-[10px] text-slate-500">
+            Briefing: {new Date(briefing.generated_at).toLocaleString("de-DE")} · Quelle Dashboard:{" "}
+            {new Date(briefing.source_board_readiness_generated_at).toLocaleString("de-DE")}
+            {briefing.baseline_saved_at
+              ? ` · Baseline: ${new Date(briefing.baseline_saved_at).toLocaleString("de-DE")}`
+              : " · Keine Baseline-Datei"}
+          </p>
+
+          {briefing.delta_bullets_de.length ? (
+            <div>
+              <h3 className="text-xs font-semibold text-slate-900">Delta (Kurz)</h3>
+              <ul className="mt-1 list-inside list-disc text-xs text-slate-700">
+                {briefing.delta_bullets_de.map((d) => (
+                  <li key={d}>{d}</li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
+          <div className="space-y-3">
+            {briefing.sections.map((s) => (
+              <div key={s.id} className="rounded-lg border border-slate-200 bg-white p-3">
+                <h3 className="text-xs font-semibold text-slate-900">{s.heading_de}</h3>
+                <ul className="mt-2 list-inside list-disc space-y-1 text-xs text-slate-800">
+                  {s.bullets.map((b, i) => (
+                    <li key={i} className="whitespace-pre-wrap">
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+                {s.references?.length ? (
+                  <div className="mt-2 border-t border-slate-100 pt-2 text-[10px] text-slate-600">
+                    <span className="font-medium text-slate-700">Referenzen: </span>
+                    {s.references.map((r) => (
+                      <span key={r.ref_id} className="mr-2 font-mono">
+                        {r.ref_id}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+            ))}
+          </div>
+
+          <div>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <h3 className="text-xs font-semibold text-slate-900">Markdown (Export)</h3>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => void copyMd()}
+                  className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-800 hover:bg-slate-50"
+                >
+                  Kopieren
+                </button>
+                <button
+                  type="button"
+                  onClick={() => downloadMd()}
+                  className="rounded border border-slate-300 bg-white px-2 py-1 text-xs text-slate-800 hover:bg-slate-50"
+                >
+                  .md laden
+                </button>
+              </div>
+            </div>
+            <textarea
+              readOnly
+              className="mt-2 h-64 w-full resize-y rounded-lg border border-slate-200 bg-slate-50 p-2 font-mono text-[11px] text-slate-800"
+              value={briefing.markdown_de}
+              aria-label="Board Readiness Briefing als Markdown"
+            />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/admin/BoardReadinessClient.tsx
+++ b/frontend/src/components/admin/BoardReadinessClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { BoardReadinessBriefingPanel } from "@/components/admin/BoardReadinessBriefingPanel";
 import type { BoardReadinessPayload, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 
 type Props = { adminConfigured: boolean };
@@ -83,7 +84,7 @@ export function BoardReadinessClient({ adminConfigured }: Props) {
     <div className="space-y-8">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 34 · Intern</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 34–35 · Intern</p>
           <h1 className="text-2xl font-semibold text-slate-900">Board Readiness</h1>
           <p className="mt-1 max-w-3xl text-sm text-slate-600">
             Governance-Signale je Säule (EU AI Act, ISO 42001, NIS2, DSGVO) über gemappte Mandanten –
@@ -121,6 +122,8 @@ export function BoardReadinessClient({ adminConfigured }: Props) {
       ) : null}
 
       {loading && !payload ? <p className="text-sm text-slate-500">Daten werden geladen …</p> : null}
+
+      <BoardReadinessBriefingPanel />
 
       {payload ? (
         <>

--- a/frontend/src/lib/boardReadinessBriefingGenerate.test.ts
+++ b/frontend/src/lib/boardReadinessBriefingGenerate.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  baselineFromPayload,
+  briefingRefIdForAttentionItem,
+  buildBriefingMarkdownDe,
+  computeDeltaBulletsDe,
+  generateBoardReadinessBriefing,
+} from "@/lib/boardReadinessBriefingGenerate";
+import type { BoardReadinessPayload } from "@/lib/boardReadinessTypes";
+
+function minimalPayload(overrides: Partial<BoardReadinessPayload> = {}): BoardReadinessPayload {
+  const base: BoardReadinessPayload = {
+    generated_at: "2026-04-01T12:00:00.000Z",
+    backend_reachable: true,
+    mapped_tenant_count: 2,
+    tenants_partial: 0,
+    overall: { status: "amber", label_de: "Test" },
+    pillars: [
+      {
+        pillar: "eu_ai_act",
+        title_de: "EU AI Act",
+        summary_de: "s",
+        status: "amber",
+        indicators: [
+          {
+            key: "k1",
+            label_de: "Indikator 1",
+            value_percent: 50,
+            value_count: 1,
+            value_denominator: 2,
+            status: "amber",
+            source_api_paths: ["/x"],
+          },
+        ],
+      },
+      {
+        pillar: "iso_42001",
+        title_de: "ISO 42001",
+        summary_de: "s",
+        status: "green",
+        indicators: [],
+      },
+      {
+        pillar: "nis2",
+        title_de: "NIS2",
+        summary_de: "s",
+        status: "green",
+        indicators: [],
+      },
+      {
+        pillar: "dsgvo",
+        title_de: "DSGVO",
+        summary_de: "s",
+        status: "green",
+        indicators: [],
+      },
+    ],
+    segment_rollups: [],
+    readiness_class_rollups: [],
+    attention_items: [
+      {
+        id: "a1",
+        severity: "red",
+        tenant_id: "t-acme",
+        tenant_label: "ACME EU",
+        subject_type: "ai_system",
+        subject_id: "sys-1",
+        subject_name: "Credit Bot",
+        missing_artefact_de: "Board-Report fehlt",
+        deep_links: {},
+      },
+    ],
+    gtm_demand_strip: {
+      window_days: 30,
+      segment_rows: [
+        {
+          segment: "industrie_mittelstand",
+          label_de: "Mittelstand",
+          inquiries_30d: 10,
+          qualified_30d: 4,
+          dominant_readiness: "early_pilot",
+        },
+      ],
+    },
+    notes_de: [],
+  };
+  return { ...base, ...overrides };
+}
+
+describe("boardReadinessBriefingGenerate", () => {
+  it("formats HR-AI ref for ai_system attention items", () => {
+    expect(
+      briefingRefIdForAttentionItem({
+        id: "x",
+        severity: "red",
+        tenant_id: "t1",
+        subject_type: "ai_system",
+        subject_id: "my-sys",
+        missing_artefact_de: "m",
+        deep_links: {},
+      }),
+    ).toBe("HR-AI-my-sys");
+  });
+
+  it("formats TENANT ref for tenant-level items", () => {
+    expect(
+      briefingRefIdForAttentionItem({
+        id: "x",
+        severity: "amber",
+        tenant_id: "tenant-acme",
+        subject_type: "tenant",
+        missing_artefact_de: "m",
+        deep_links: {},
+      }),
+    ).toBe("TENANT-tenant-acme");
+  });
+
+  it("computes deltas when baseline differs", () => {
+    const cur = minimalPayload({
+      overall: { status: "red", label_de: "X" },
+    });
+    const baseline = baselineFromPayload(minimalPayload());
+    const bullets = computeDeltaBulletsDe(cur, baseline);
+    expect(bullets.some((b) => b.includes("Portfolio-Ampel"))).toBe(true);
+  });
+
+  it("generates briefing with five sections and markdown", () => {
+    const b = generateBoardReadinessBriefing(minimalPayload(), null);
+    expect(b.sections.length).toBe(5);
+    expect(b.markdown_de).toContain("# Board Readiness Briefing");
+    expect(b.markdown_de).toContain("HR-AI-sys-1");
+  });
+
+  it("buildBriefingMarkdownDe includes delta block", () => {
+    const md = buildBriefingMarkdownDe(
+      "T",
+      "2026-01-01T00:00:00.000Z",
+      [{ id: "1", heading_de: "H", bullets: ["a"] }],
+      ["Delta eins"],
+      null,
+    );
+    expect(md).toContain("Delta eins");
+    expect(md).toContain("## H");
+  });
+});

--- a/frontend/src/lib/boardReadinessBriefingGenerate.ts
+++ b/frontend/src/lib/boardReadinessBriefingGenerate.ts
@@ -1,0 +1,337 @@
+import type {
+  BoardAttentionItem,
+  BoardReadinessPayload,
+  BoardReadinessPillarBlock,
+  BoardReadinessPillarKey,
+  BoardReadinessTraffic,
+} from "@/lib/boardReadinessTypes";
+import type {
+  BoardReadinessBriefingBaselineFile,
+  BoardReadinessBriefingPayload,
+  BoardReadinessBriefingSection,
+  BriefingReference,
+} from "@/lib/boardReadinessBriefingTypes";
+
+const PILLAR_TITLES: Record<BoardReadinessPillarKey, string> = {
+  eu_ai_act: "EU AI Act",
+  iso_42001: "ISO 42001",
+  nis2: "NIS2 / KRITIS",
+  dsgvo: "DSGVO / Aufzeichnungen",
+};
+
+function trafficWort(s: BoardReadinessTraffic): string {
+  if (s === "green") return "Grün";
+  if (s === "amber") return "Amber";
+  return "Rot";
+}
+
+/** Referenz-ID für Briefing / Deck (Rückverfolgung im Dashboard). */
+export function briefingRefIdForAttentionItem(it: BoardAttentionItem): string {
+  if (it.subject_type === "ai_system" && it.subject_id) {
+    return `HR-AI-${it.subject_id}`;
+  }
+  if (it.tenant_id && it.tenant_id !== "_portfolio") {
+    return `TENANT-${it.tenant_id}`;
+  }
+  return `GTM-${it.id.replace(/[^a-zA-Z0-9_-]/g, "_")}`;
+}
+
+export function baselineFromPayload(payload: BoardReadinessPayload): BoardReadinessBriefingBaselineFile {
+  const pillar_status = {} as Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+  for (const p of payload.pillars) {
+    pillar_status[p.pillar] = p.status;
+  }
+  const red_attention_count = payload.attention_items.filter((a) => a.severity === "red").length;
+  const amber_attention_count = payload.attention_items.filter((a) => a.severity === "amber").length;
+  return {
+    saved_at: new Date().toISOString(),
+    source_board_readiness_generated_at: payload.generated_at,
+    overall_status: payload.overall.status,
+    pillar_status,
+    red_attention_count,
+    amber_attention_count,
+    attention_total: payload.attention_items.length,
+  };
+}
+
+export function computeDeltaBulletsDe(
+  current: BoardReadinessPayload,
+  baseline: BoardReadinessBriefingBaselineFile | null,
+): string[] {
+  if (!baseline) return [];
+  const out: string[] = [];
+
+  if (baseline.overall_status !== current.overall.status) {
+    out.push(
+      `Portfolio-Ampel von „${trafficWort(baseline.overall_status)}“ auf „${trafficWort(current.overall.status)}“ (Baseline: ${new Date(baseline.saved_at).toLocaleDateString("de-DE")}).`,
+    );
+  }
+
+  for (const p of current.pillars) {
+    const prev = baseline.pillar_status[p.pillar];
+    if (prev && prev !== p.status) {
+      out.push(
+        `${PILLAR_TITLES[p.pillar]}: Ampel ${trafficWort(prev)} → ${trafficWort(p.status)}.`,
+      );
+    }
+  }
+
+  const redNow = current.attention_items.filter((a) => a.severity === "red").length;
+  if (redNow !== baseline.red_attention_count) {
+    out.push(
+      `Anzahl roter Attention-Items: ${baseline.red_attention_count} → ${redNow}.`,
+    );
+  }
+
+  if (out.length === 0) {
+    out.push(
+      `Keine Änderung der groben Ampeln gegenüber der Baseline vom ${new Date(baseline.saved_at).toLocaleDateString("de-DE")} (Detailkennzahlen können sich dennoch bewegt haben).`,
+    );
+  }
+
+  return out.slice(0, 5);
+}
+
+function sortIndicatorsForBriefing(p: BoardReadinessPillarBlock): BoardReadinessPillarBlock["indicators"] {
+  const rank: Record<BoardReadinessTraffic, number> = { red: 0, amber: 1, green: 2 };
+  return [...p.indicators].sort((a, b) => rank[a.status] - rank[b.status]);
+}
+
+function pillarBullets(p: BoardReadinessPillarBlock): string[] {
+  const sorted = sortIndicatorsForBriefing(p);
+  const pick = sorted.slice(0, 3);
+  return pick.map((ind) => {
+    const pct =
+      ind.value_percent !== null && ind.value_percent !== undefined
+        ? `${Math.round(ind.value_percent * 10) / 10}%`
+        : "n. v.";
+    return `${ind.label_de}: ${pct}, Ampel ${trafficWort(ind.status)}.`;
+  });
+}
+
+function attentionBullets(items: BoardAttentionItem[], limit: number): { bullets: string[]; refs: BriefingReference[] } {
+  const rank: Record<BoardReadinessTraffic, number> = { red: 0, amber: 1, green: 2 };
+  const sorted = [...items].sort((a, b) => rank[a.severity] - rank[b.severity]);
+  const slice = sorted.slice(0, limit);
+  const refs: BriefingReference[] = [];
+  const bullets = slice.map((it) => {
+    const rid = briefingRefIdForAttentionItem(it);
+    const tenant = it.tenant_label?.trim() || it.tenant_id;
+    const seg = it.segment_tag ? ` · Segment ${it.segment_tag}` : "";
+    const sys = it.subject_type === "ai_system" && it.subject_name ? ` · „${it.subject_name}“` : "";
+    refs.push({
+      ref_id: rid,
+      context_de: `${it.missing_artefact_de} (${tenant})`,
+    });
+    return `[${rid}] ${it.missing_artefact_de} · Mandant ${tenant}${sys}${seg} · Ampel ${trafficWort(it.severity)}.`;
+  });
+  return { bullets, refs };
+}
+
+function gtmGovernanceBullets(payload: BoardReadinessPayload): string[] {
+  const rows = payload.gtm_demand_strip?.segment_rows ?? [];
+  const out: string[] = [];
+  for (const r of rows) {
+    if (r.qualified_30d >= 3 && r.dominant_readiness === "early_pilot") {
+      out.push(
+        `${r.label_de}: qualifizierte Nachfrage (${r.qualified_30d} / ${r.inquiries_30d} Anfragen 30d) bei dominanter Readiness „${r.dominant_readiness}“ – Governance nachziehen.`,
+      );
+    }
+    if (r.dominant_readiness === "advanced_governance" && r.qualified_30d <= 1 && r.inquiries_30d >= 4) {
+      out.push(
+        `${r.label_de}: hohe Eingangslautstärke, wenig Qualifizierung – Pipeline-Thema; Governance-Seite wirkt vorbereitet („${r.dominant_readiness}“).`,
+      );
+    }
+  }
+  if (out.length === 0) {
+    out.push(
+      "Keine automatisch erkannten Extrem-Mismatches im 30-Tage-GTM-Fenster; Details siehe Segment-Tabelle im Dashboard.",
+    );
+  }
+  return out.slice(0, 6);
+}
+
+function nextPriorityBullets(payload: BoardReadinessPayload): string[] {
+  const rank: Record<BoardReadinessTraffic, number> = { red: 0, amber: 1, green: 2 };
+  const sorted = [...payload.attention_items].sort((a, b) => rank[a.severity] - rank[b.severity]);
+  const priorities: string[] = [];
+
+  const nextFromItem = (it: BoardAttentionItem): string | null => {
+    const rid = briefingRefIdForAttentionItem(it);
+    const owner = "Owner: [CCO/CISO – zuweisen]";
+    const horizon = "Horizont: bis nächstes Quartals-Update";
+    if (it.missing_artefact_de.includes("Board-Report")) {
+      return `${owner} · Board-Report aktualisieren (${rid}) · ${horizon}.`;
+    }
+    if (it.missing_artefact_de.includes("owner_email") || it.missing_artefact_de.includes("Verantwortlicher")) {
+      return `${owner} · Verantwortlichen im KI-Register setzen (${rid}) · ${horizon}.`;
+    }
+    if (it.missing_artefact_de.includes("Art. 9")) {
+      return `${owner} · Risikomanagement Art. 9 abschließen (${rid}) · ${horizon}.`;
+    }
+    if (it.missing_artefact_de.includes("Nachweis") || it.missing_artefact_de.includes("Doku")) {
+      return `${owner} · Konformitätsnachweis/Dokumentation schließen (${rid}) · ${horizon}.`;
+    }
+    if (it.missing_artefact_de.includes("Governance nachziehen")) {
+      return `${owner} · Pilot-Mandanten mit Playbook/Setup hochziehen · ${horizon}.`;
+    }
+    return `${owner} · Lücke schließen: ${it.missing_artefact_de} (${rid}) · ${horizon}.`;
+  };
+
+  for (const it of sorted) {
+    const line = nextFromItem(it);
+    if (line && !priorities.includes(line)) priorities.push(line);
+    if (priorities.length >= 3) break;
+  }
+
+  if (priorities.length < 3) {
+    const redPillars = payload.pillars.filter((p) => p.status === "red").map((p) => PILLAR_TITLES[p.pillar]);
+    if (redPillars.length) {
+      priorities.push(
+        `Owner: [CCO/CISO – zuweisen] · Säulen mit Rot-Ampel gezielt entzerren: ${redPillars.join(", ")} · Horizont: bis nächstes Quartals-Update.`,
+      );
+    }
+  }
+
+  if (priorities.length < 3) {
+    priorities.push(
+      "Owner: [CCO/CISO – zuweisen] · Kurzes Review der Segment-Rollups im Board-Readiness-Dashboard · Horizont: ad hoc.",
+    );
+  }
+
+  return priorities.slice(0, 3);
+}
+
+export function buildBriefingMarkdownDe(
+  title: string,
+  generatedAtIso: string,
+  sections: BoardReadinessBriefingSection[],
+  deltaBullets: string[],
+  baselineHint: string | null,
+): string {
+  const lines: string[] = [`# ${title}`, "", `_Erzeugt: ${generatedAtIso}_`, ""];
+  if (baselineHint) {
+    lines.push(`> ${baselineHint}`, "");
+  }
+  if (deltaBullets.length) {
+    lines.push("## Delta (gegenüber Baseline)", "");
+    for (const d of deltaBullets) lines.push(`- ${d}`);
+    lines.push("");
+  }
+  for (const s of sections) {
+    lines.push(`## ${s.heading_de}`, "");
+    for (const b of s.bullets) lines.push(`- ${b}`);
+    lines.push("");
+    if (s.references?.length) {
+      lines.push("**Referenzen:**", "");
+      for (const r of s.references) lines.push(`- \`${r.ref_id}\`: ${r.context_de}`);
+      lines.push("");
+    }
+  }
+  lines.push(
+    "---",
+    "",
+    "_Hinweis: Ausgangspunkt für Redaktion; keine Rechtsberatung. Fachlich und sprachlich vor Board-Einsatz prüfen._",
+    "",
+  );
+  return lines.join("\n");
+}
+
+const ATTENTION_LIMIT = 8;
+
+export function generateBoardReadinessBriefing(
+  payload: BoardReadinessPayload,
+  baseline: BoardReadinessBriefingBaselineFile | null,
+): BoardReadinessBriefingPayload {
+  const delta_bullets_de = computeDeltaBulletsDe(payload, baseline);
+
+  const execBullets: string[] = [
+    `Portfolio: ${trafficWort(payload.overall.status)} – ${payload.overall.label_de}`,
+    `Gemappte Mandanten: ${payload.mapped_tenant_count}; Backend-Datenlage: ${payload.backend_reachable ? "überwiegend lesbar" : "teilweise eingeschränkt"}.`,
+  ];
+  for (const p of payload.pillars) {
+    execBullets.push(`${PILLAR_TITLES[p.pillar]}: ${trafficWort(p.status)}.`);
+  }
+  if (baseline && delta_bullets_de.length) {
+    execBullets.push("Änderungen vs. gespeicherter Baseline siehe Abschnitt „Delta“ im Markdown-Export.");
+  }
+
+  const pillarBulletLines: string[] = [];
+  for (const p of payload.pillars) {
+    const label = PILLAR_TITLES[p.pillar];
+    const lines = pillarBullets(p);
+    if (!lines.length) {
+      pillarBulletLines.push(
+        `[${label} · ${trafficWort(p.status)}] Keine Indikator-Detailzeilen im aktuellen Schnappschuss.`,
+      );
+      continue;
+    }
+    for (const line of lines) {
+      pillarBulletLines.push(`[${label} · ${trafficWort(p.status)}] ${line}`);
+    }
+  }
+
+  const pillarSections: BoardReadinessBriefingSection = {
+    id: "pillar_overview",
+    heading_de: "2. Säulenüberblick",
+    bullets: pillarBulletLines,
+  };
+
+  const { bullets: attBullets, refs: attRefs } = attentionBullets(payload.attention_items, ATTENTION_LIMIT);
+
+  const sections: BoardReadinessBriefingSection[] = [
+    {
+      id: "executive_summary",
+      heading_de: "1. Executive Summary",
+      bullets: execBullets,
+    },
+    pillarSections,
+    {
+      id: "attention_high_risk",
+      heading_de: "3. High-Risk / Attention Items (Auswahl)",
+      bullets:
+        attBullets.length > 0
+          ? attBullets
+          : ["Keine Attention Items im aktuellen Dashboard-Schnappschuss."],
+      references: attRefs.length ? attRefs : undefined,
+    },
+    {
+      id: "gtm_governance",
+      heading_de: "4. GTM vs. Governance",
+      bullets: gtmGovernanceBullets(payload),
+    },
+    {
+      id: "next_priorities",
+      heading_de: "5. Nächste Governance-Prioritäten",
+      bullets: nextPriorityBullets(payload),
+    },
+  ];
+
+  const baselineHint = baseline
+    ? `Baseline gespeichert am ${new Date(baseline.saved_at).toLocaleString("de-DE")} (Board-Readiness-Stand ${baseline.source_board_readiness_generated_at}).`
+    : null;
+
+  const generated_at = new Date().toISOString();
+  const markdown_de = buildBriefingMarkdownDe(
+    "Board Readiness Briefing",
+    generated_at,
+    sections,
+    delta_bullets_de,
+    baselineHint,
+  );
+
+  return {
+    generated_at,
+    source_board_readiness_generated_at: payload.generated_at,
+    outline_version: "wave35-v1",
+    sections,
+    markdown_de,
+    delta_bullets_de,
+    baseline_saved_at: baseline?.saved_at ?? null,
+    meta_de: {
+      mapped_tenant_count: payload.mapped_tenant_count,
+      backend_reachable: payload.backend_reachable,
+      attention_items_included: Math.min(ATTENTION_LIMIT, payload.attention_items.length),
+    },
+  };
+}

--- a/frontend/src/lib/boardReadinessBriefingSnapshotStore.ts
+++ b/frontend/src/lib/boardReadinessBriefingSnapshotStore.ts
@@ -1,0 +1,37 @@
+import "server-only";
+
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import type { BoardReadinessBriefingBaselineFile } from "@/lib/boardReadinessBriefingTypes";
+
+function resolvePath(): string {
+  const fromEnv = process.env.BOARD_READINESS_BRIEFING_BASELINE_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-board-readiness-briefing-baseline.json");
+  }
+  return join(process.cwd(), "data", "board-readiness-briefing-baseline.json");
+}
+
+export async function readBoardReadinessBriefingBaseline(): Promise<BoardReadinessBriefingBaselineFile | null> {
+  const path = resolvePath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const o = JSON.parse(raw) as BoardReadinessBriefingBaselineFile;
+    if (!o || typeof o !== "object") return null;
+    if (typeof o.saved_at !== "string" || typeof o.overall_status !== "string") return null;
+    if (!o.pillar_status || typeof o.pillar_status !== "object") return null;
+    return o;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeBoardReadinessBriefingBaseline(
+  baseline: BoardReadinessBriefingBaselineFile,
+): Promise<void> {
+  const path = resolvePath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+}

--- a/frontend/src/lib/boardReadinessBriefingTypes.ts
+++ b/frontend/src/lib/boardReadinessBriefingTypes.ts
@@ -1,0 +1,79 @@
+/**
+ * Wave 35 – Board Readiness Briefing (structured narrative from dashboard data).
+ */
+
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+
+/** Template outline (documentation + UI legend). */
+export const BOARD_READINESS_BRIEFING_OUTLINE_DE: readonly {
+  id: string;
+  title_de: string;
+  purpose_de: string;
+}[] = [
+  {
+    id: "executive_summary",
+    title_de: "Executive Summary",
+    purpose_de:
+      "Gesamt-Ampel, Säulen auf einen Blick, optional Delta zur letzten gespeicherten Baseline (kein Rechtsurteil).",
+  },
+  {
+    id: "pillar_overview",
+    title_de: "Säulenüberblick",
+    purpose_de: "EU AI Act, ISO 42001, NIS2, DSGVO – jeweils 2–3 faktenbasierte Kernaussagen aus Indikatoren.",
+  },
+  {
+    id: "attention_high_risk",
+    title_de: "High-Risk / Attention Items",
+    purpose_de: "Top-Lücken aus dem Dashboard mit Referenz-IDs für Rückverfolgung in UI/API.",
+  },
+  {
+    id: "gtm_governance",
+    title_de: "GTM vs. Governance",
+    purpose_de: "Wo Nachfrage (30-Tage-Fenster) und Readiness auseinanderlaufen – und wo Governance vor Demand liegt.",
+  },
+  {
+    id: "next_priorities",
+    title_de: "Nächste Governance-Prioritäten",
+    purpose_de: "1–3 konkrete nächste Schritte (Aktion, Owner-Platzhalter, Zeithorizont) – zur Freitext-Bearbeitung außerhalb der App.",
+  },
+] as const;
+
+export type BriefingReference = {
+  /** Stable tag, e.g. HR-AI-credit-scoring-v1 */
+  ref_id: string;
+  context_de: string;
+};
+
+export type BoardReadinessBriefingSection = {
+  id: string;
+  heading_de: string;
+  bullets: string[];
+  /** Evidence-style anchors for audit trail */
+  references?: BriefingReference[];
+};
+
+export type BoardReadinessBriefingPayload = {
+  generated_at: string;
+  source_board_readiness_generated_at: string;
+  outline_version: "wave35-v1";
+  sections: BoardReadinessBriefingSection[];
+  markdown_de: string;
+  /** German sentences; empty if no baseline file */
+  delta_bullets_de: string[];
+  baseline_saved_at: string | null;
+  meta_de: {
+    mapped_tenant_count: number;
+    backend_reachable: boolean;
+    attention_items_included: number;
+  };
+};
+
+export type BoardReadinessBriefingBaselineFile = {
+  saved_at: string;
+  source_board_readiness_generated_at: string;
+  overall_status: BoardReadinessTraffic;
+  pillar_status: Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+  red_attention_count: number;
+  amber_attention_count: number;
+  attention_total: number;
+};


### PR DESCRIPTION
Add GET /api/admin/board-readiness/briefing and POST …/baseline for Markdown-ready narrative from dashboard data; optional delta vs saved baseline. UI panel on /admin/board-readiness with copy/download .md. Document in docs/board/wave35-board-readiness-briefing.md; Vitest for briefing generation helpers.

Made-with: Cursor