### PR TITLE
feat(advisor): Kanzlei portfolio cockpit (Wave 39)

### DIFF
--- a/docs/advisors/wave39-kanzlei-portfolio-cockpit.md
+++ b/docs/advisors/wave39-kanzlei-portfolio-cockpit.md
@@ -1,0 +1,88 @@
+# Wave 39 – Mehrmandanten-Kanzlei-Cockpit
+
+Interne **Portfolio-Übersicht** für **Steuerberater, Wirtschaftsprüfer und GRC-Berater**: alle **gemappten Mandanten** (wie Board Readiness) in **einer Tabelle**, mit Fokus auf die Frage **„Welcher Mandant braucht jetzt Kanzlei-Aufmerksamkeit?“** – ohne zusätzliches „Executive-Dashboard“-Design.
+
+## Zielnutzer
+
+- Kanzlei-Teams, die **viele Mandanten** in ComplianceHub begleiten.
+- Advisor- und CS-Interna, die **Check-ins, Exporte und Nachsteuerung** planen.
+
+## Wo finden?
+
+- **UI:** `/admin/advisor-portfolio`
+- **API:** `GET /api/internal/advisor/kanzlei-portfolio`
+- **Auth:** wie Mandanten-Export / Board Readiness (`LEAD_ADMIN_SECRET` + Session über Lead-Inbox).
+
+## Spalten (kompakt)
+
+| Spalte | Inhalt |
+|--------|--------|
+| Mandant | Anzeigename aus GTM-Map, technische `tenant_id`, optional dominantes Segment (30-Tage-Leads) |
+| Readiness | Wave-33-Klasse (`early_pilot` … `advanced_governance`) + Mini-Ampeln je Säule |
+| Fokus-Säule | Säule mit den **gewichtet dringlichsten offenen Prüfpunkten**; ohne offene Punkte: **schlechteste Säule** aus Board-Readiness-Ampel |
+| Bericht | **Überfällig**, wenn Hochrisiko-Systeme existieren und der Mandanten-/Board-Report nicht im Frischefenster liegt (wie Wave 37) |
+| Offen | Anzahl **offener Prüfpunkte** (`computeMandantOffenePunkte`), in Klammern Anzahl **hoch** |
+| Signale | Kurzliste **Kanzlei-Hinweise** (Export-Stale, Bericht, viele Punkte, Pilot-Baseline, API) + numerischer **Attention-Score** |
+| Letzter Export / Review | Aus optionaler Datei `data/advisor-portfolio-touchpoints.json` (siehe unten); sonst **—** |
+| Aktionen | Links zu **Mandanten-Export-UI** (mit `client_id`), **ZIP-Bundle-API**, **Board Readiness** |
+
+## Filter
+
+- **Readiness-Klasse** (alle oder eine Klasse).
+- **Säule:** Mandanten, bei denen diese Säule **nicht grün** ist **oder** die Fokus-Säule der offenen Punkte entspricht.
+- **Nur überfälliger Mandantenbericht.**
+- **Viele offene Punkte** (Schwelle aus Payload, Standard **4**).
+
+## Priorisierung (Sortierung)
+
+Serverseitig absteigend nach **Attention-Score**, dann nach **Anzahl offener Punkte**, dann alphabetisch nach Mandantenbezeichnung.
+
+Score (vereinfacht): gewichtet **hohe** vs. **mittlere** Prüfpunkte, **überfälliger Bericht**, **kein Export** im konfigurierten Zeitraum, **Pilot/Baseline**, **API nicht lesbar**, plus Zuschläge für **rote/gelbe Säulen**. Obergrenze 999 für stabile Darstellung.
+
+**Export-Stale:** kein Eintrag `last_export_iso` **oder** älter als **45 Tage** (Konstante `KANZLEI_EXPORT_STALE_DAYS` im Code).
+
+## Touchpoints (optional)
+
+Datei **`data/advisor-portfolio-touchpoints.json`** (oder `ADVISOR_PORTFOLIO_TOUCHPOINTS_PATH`), Schema:
+
+```json
+{
+  "entries": [
+    {
+      "tenant_id": "mein-mandant-001",
+      "last_export_iso": "2026-03-15T10:00:00.000Z",
+      "last_review_iso": "2026-03-20T14:00:00.000Z",
+      "note_de": "Quartals-Check geplant"
+    }
+  ]
+}
+```
+
+Keine automatische Befüllung in Wave 39: Kanzlei trägt manuell nach (oder späterer Hook nach Export).
+
+## Aggregation (zentrale Logik)
+
+- **Gemeinsame Mandanten-Ladung** mit Board Readiness: `loadMappedTenantPillarSnapshots` in `boardReadinessAggregate.ts` (eine API-Runde pro Mandant wie zuvor).
+- **Portfolio-Zeilen:** `computeKanzleiPortfolioPayload` in `kanzleiPortfolioAggregate.ts`.
+- **Offene Punkte / Säule:** `computeMandantOffenePunkte` + `pillarCodeForOpenPoint` in `tenantBoardReadinessGaps.ts`.
+
+## Nutzung in wiederkehrenden Mandanten-Reviews
+
+1. Cockpit laden, nach **höchstem Score** oben arbeiten.
+2. **ZIP** oder **Readiness-Export** für den Mandanten ziehen und im DMS ablegen; optional Touchpoints-Datei pflegen.
+3. **Board Readiness** für Portfolio-Ampel und Briefing nutzen; Cockpit für **operative Priorenliste** je Mandant.
+
+## Unterschied zu Wave 37 / 38 / Board Readiness
+
+| Wave | Fokus |
+|------|--------|
+| 37 | Ein Mandant, narrativer Export |
+| 38 | Ein Mandant, ZIP-Arbeitspaket |
+| 34–36 | Board-/Portfolio-Ampeln, Segmente, Pack |
+| **39** | **Tabellarische Mehrmandanten-Priorität** für Kanzlei-Alltag |
+
+## Siehe auch
+
+- `docs/advisors/wave37-mandant-readiness-export.md`
+- `docs/advisors/wave38-datev-export-bundle.md`
+- `docs/board/wave34-board-readiness-dashboard.md`

--- a/frontend/src/app/admin/advisor-portfolio/page.tsx
+++ b/frontend/src/app/admin/advisor-portfolio/page.tsx
@@ -1,0 +1,15 @@
+import { KanzleiPortfolioCockpitClient } from "@/components/admin/KanzleiPortfolioCockpitClient";
+
+export const dynamic = "force-dynamic";
+
+export default function AdminAdvisorPortfolioPage() {
+  const adminConfigured = Boolean(process.env.LEAD_ADMIN_SECRET?.trim());
+
+  return (
+    <div className="min-h-screen bg-slate-100 px-4 py-10">
+      <div className="mx-auto max-w-7xl">
+        <KanzleiPortfolioCockpitClient adminConfigured={adminConfigured} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/api/internal/advisor/kanzlei-portfolio/route.ts
+++ b/frontend/src/app/api/internal/advisor/kanzlei-portfolio/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+
+import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const payload = await computeKanzleiPortfolioPayload(new Date());
+  return NextResponse.json({ ok: true, kanzlei_portfolio: payload });
+}

--- a/frontend/src/components/admin/AdvisorMandantExportClient.tsx
+++ b/frontend/src/components/admin/AdvisorMandantExportClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import type { MandantReadinessAdvisorPayload } from "@/lib/mandantReadinessAdvisorTypes";
 
@@ -13,6 +13,12 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
   const [error, setError] = useState<string | null>(null);
   const [msg, setMsg] = useState<string | null>(null);
   const [bundleLoading, setBundleLoading] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const c = new URLSearchParams(window.location.search).get("client_id")?.trim();
+    if (c) setClientId(c);
+  }, []);
 
   const load = useCallback(async () => {
     const id = clientId.trim();
@@ -182,8 +188,12 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
       </div>
 
       <p className="text-xs text-slate-500">
+        <a className="text-cyan-700 underline" href="/admin/advisor-portfolio">
+          Kanzlei-Cockpit
+        </a>
+        {" · "}
         <a className="text-cyan-700 underline" href="/admin/board-readiness">
-          ← Board Readiness
+          Board Readiness
         </a>
       </p>
 

--- a/frontend/src/components/admin/BoardReadinessClient.tsx
+++ b/frontend/src/components/admin/BoardReadinessClient.tsx
@@ -102,6 +102,12 @@ export function BoardReadinessClient({ adminConfigured }: Props) {
         </div>
         <div className="flex flex-wrap gap-2">
           <a
+            href="/admin/advisor-portfolio"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Kanzlei-Cockpit
+          </a>
+          <a
             href="/admin/advisor-mandant-export"
             className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
           >

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -1,0 +1,342 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+import { GTM_READINESS_CLASSES, GTM_READINESS_SHORT_DE } from "@/lib/gtmAccountReadiness";
+import type {
+  KanzleiPortfolioPayload,
+  KanzleiPortfolioPillarFilter,
+  KanzleiPortfolioReadinessFilter,
+  KanzleiPortfolioRow,
+} from "@/lib/kanzleiPortfolioTypes";
+
+type Props = { adminConfigured: boolean };
+
+function trafficPill(s: BoardReadinessTraffic): string {
+  if (s === "green") return "border-emerald-300 bg-emerald-50 text-emerald-950";
+  if (s === "amber") return "border-amber-300 bg-amber-50 text-amber-950";
+  return "border-rose-300 bg-rose-50 text-rose-950";
+}
+
+function trafficLabel(s: BoardReadinessTraffic): string {
+  if (s === "green") return "OK";
+  if (s === "amber") return "Beobachten";
+  return "Handeln";
+}
+
+const PILLAR_KEYS: BoardReadinessPillarKey[] = ["eu_ai_act", "iso_42001", "nis2", "dsgvo"];
+
+const PILLAR_FILTER_LABELS: Record<BoardReadinessPillarKey, string> = {
+  eu_ai_act: "EU AI Act",
+  iso_42001: "ISO 42001",
+  nis2: "NIS2",
+  dsgvo: "DSGVO",
+};
+
+function topGapMatchesPillar(row: KanzleiPortfolioRow, pk: BoardReadinessPillarKey): boolean {
+  const map: Record<string, BoardReadinessPillarKey> = {
+    EU_AI_Act: "eu_ai_act",
+    ISO_42001: "iso_42001",
+    NIS2: "nis2",
+    DSGVO: "dsgvo",
+  };
+  return map[row.top_gap_pillar_code] === pk;
+}
+
+function formatIsoDe(iso: string | null): string {
+  if (!iso) return "—";
+  const d = Date.parse(iso);
+  if (Number.isNaN(d)) return iso.slice(0, 10);
+  return new Date(d).toLocaleDateString("de-DE");
+}
+
+export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
+  const [payload, setPayload] = useState<KanzleiPortfolioPayload | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const [readinessFilter, setReadinessFilter] = useState<KanzleiPortfolioReadinessFilter>("all");
+  const [pillarFilter, setPillarFilter] = useState<KanzleiPortfolioPillarFilter>("all");
+  const [staleOnly, setStaleOnly] = useState(false);
+  const [manyOpenOnly, setManyOpenOnly] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const r = await fetch("/api/internal/advisor/kanzlei-portfolio", { credentials: "include" });
+      if (r.status === 401) {
+        setPayload(null);
+        setLoadError("unauthorized");
+        return;
+      }
+      if (!r.ok) {
+        setLoadError(`HTTP ${r.status}`);
+        return;
+      }
+      const data = (await r.json()) as { ok?: boolean; kanzlei_portfolio?: KanzleiPortfolioPayload };
+      setPayload(data.kanzlei_portfolio ?? null);
+    } catch {
+      setLoadError("Netzwerkfehler");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!adminConfigured) return;
+    void load();
+  }, [adminConfigured, load]);
+
+  const filteredRows = useMemo(() => {
+    if (!payload) return [];
+    const thr = payload.constants.many_open_points_threshold;
+    return payload.rows.filter((row) => {
+      if (readinessFilter !== "all" && row.readiness_class !== readinessFilter) return false;
+      if (pillarFilter !== "all") {
+        const st = row.pillar_traffic[pillarFilter];
+        const gapMatch = topGapMatchesPillar(row, pillarFilter);
+        if (st === "green" && !gapMatch) return false;
+      }
+      if (staleOnly && !row.board_report_stale) return false;
+      if (manyOpenOnly && row.open_points_count < thr) return false;
+      return true;
+    });
+  }, [payload, readinessFilter, pillarFilter, staleOnly, manyOpenOnly]);
+
+  if (!adminConfigured) {
+    return (
+      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+        Kanzlei-Cockpit nicht konfiguriert (<code className="font-mono">LEAD_ADMIN_SECRET</code>).
+      </div>
+    );
+  }
+
+  if (loadError === "unauthorized") {
+    return (
+      <div className="mx-auto max-w-lg rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">Kanzlei-Portfolio</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Bitte zuerst unter{" "}
+          <a className="text-cyan-700 underline" href="/admin/leads">
+            Lead-Inbox
+          </a>{" "}
+          mit dem Admin-Secret anmelden, dann diese Seite neu laden.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39 · Kanzlei / Berater</p>
+          <h1 className="text-2xl font-semibold text-slate-900">Mehrmandanten-Kanzlei-Cockpit</h1>
+          <p className="mt-1 max-w-3xl text-sm text-slate-600">
+            Welcher Mandant braucht jetzt Aufmerksamkeit? Kompakte Portfolio-Sicht über gemappte Mandanten
+            (gtm-product-account-map), dieselben Readiness-Signale wie Board Readiness, plus offene Prüfpunkte
+            und optionale Touchpoints (Export/Review).
+          </p>
+          {payload ? (
+            <p className="mt-1 font-mono text-xs text-slate-400">
+              Stand: {new Date(payload.generated_at).toLocaleString("de-DE")} · Mandanten:{" "}
+              {payload.mapped_tenant_count}
+              {payload.tenants_partial ? ` · API teilweise: ${payload.tenants_partial}` : ""}
+            </p>
+          ) : null}
+          <p className="mt-2 text-xs text-slate-500">
+            API:{" "}
+            <code className="rounded bg-slate-100 px-1 text-[11px]">
+              GET /api/internal/advisor/kanzlei-portfolio
+            </code>
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <a
+            href="/admin/advisor-mandant-export"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Mandanten-Export
+          </a>
+          <a
+            href="/admin/board-readiness"
+            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+          >
+            Board Readiness
+          </a>
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+          >
+            {loading ? "Laden…" : "Aktualisieren"}
+          </button>
+        </div>
+      </div>
+
+      {loadError && loadError !== "unauthorized" ? (
+        <p className="text-sm text-red-600">{loadError}</p>
+      ) : null}
+
+      {payload ? (
+        <div className="flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+          <label className="text-xs font-medium text-slate-700">
+            Readiness-Klasse
+            <select
+              className="mt-1 block rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              value={readinessFilter}
+              onChange={(e) => setReadinessFilter(e.target.value as KanzleiPortfolioReadinessFilter)}
+            >
+              <option value="all">Alle</option>
+              {GTM_READINESS_CLASSES.map((c) => (
+                <option key={c} value={c}>
+                  {GTM_READINESS_SHORT_DE[c]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="text-xs font-medium text-slate-700">
+            Säule (Lücke)
+            <select
+              className="mt-1 block rounded-lg border border-slate-300 bg-white px-2 py-1.5 text-sm"
+              value={pillarFilter}
+              onChange={(e) => setPillarFilter(e.target.value as KanzleiPortfolioPillarFilter)}
+            >
+              <option value="all">Alle</option>
+              {PILLAR_KEYS.map((k) => (
+                <option key={k} value={k}>
+                  {PILLAR_FILTER_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-700">
+            <input type="checkbox" checked={staleOnly} onChange={(e) => setStaleOnly(e.target.checked)} />
+            Nur überfälliger Mandantenbericht
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-700">
+            <input
+              type="checkbox"
+              checked={manyOpenOnly}
+              onChange={(e) => setManyOpenOnly(e.target.checked)}
+            />
+            Viele offene Punkte (≥{payload.constants.many_open_points_threshold})
+          </label>
+          <p className="text-xs text-slate-500">
+            Sortierung: Kanzlei-Aufmerksamkeit (Score) absteigend, wie vom Server geliefert.
+          </p>
+        </div>
+      ) : null}
+
+      {loading && !payload ? <p className="text-sm text-slate-500">Portfolio wird geladen …</p> : null}
+
+      {payload ? (
+        <section className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-[960px] w-full border-collapse text-left text-xs">
+            <thead>
+              <tr className="border-b border-slate-200 bg-slate-50 text-slate-600">
+                <th className="px-3 py-2 font-medium">Mandant</th>
+                <th className="px-3 py-2 font-medium">Readiness</th>
+                <th className="px-3 py-2 font-medium">Fokus-Säule</th>
+                <th className="px-3 py-2 font-medium">Bericht</th>
+                <th className="px-3 py-2 font-medium">Offen</th>
+                <th className="px-3 py-2 font-medium">Signale</th>
+                <th className="px-3 py-2 font-medium">Letzter Export</th>
+                <th className="px-3 py-2 font-medium">Review</th>
+                <th className="px-3 py-2 font-medium">Aktionen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredRows.length === 0 ? (
+                <tr>
+                  <td colSpan={9} className="px-3 py-6 text-center text-slate-500">
+                    Keine Mandanten für die aktuellen Filter.
+                  </td>
+                </tr>
+              ) : (
+                filteredRows.map((row) => (
+                  <tr key={row.tenant_id} className="border-b border-slate-100 hover:bg-slate-50/80">
+                    <td className="px-3 py-2 align-top">
+                      <div className="font-medium text-slate-900">{row.mandant_label ?? row.tenant_id}</div>
+                      <div className="font-mono text-[10px] text-slate-500">{row.tenant_id}</div>
+                      {row.primary_segment_label_de ? (
+                        <div className="mt-0.5 text-[10px] text-slate-500">{row.primary_segment_label_de}</div>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-2 align-top">
+                      <span className="text-slate-800">{row.readiness_label_de}</span>
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {PILLAR_KEYS.map((k) => (
+                          <span
+                            key={k}
+                            title={PILLAR_FILTER_LABELS[k]}
+                            className={`inline-block rounded border px-1 py-0.5 text-[9px] font-semibold ${trafficPill(row.pillar_traffic[k])}`}
+                          >
+                            {trafficLabel(row.pillar_traffic[k]).charAt(0)}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-3 py-2 align-top text-slate-800">{row.top_gap_pillar_label_de}</td>
+                    <td className="px-3 py-2 align-top">
+                      {row.board_report_stale ? (
+                        <span className="rounded border border-rose-200 bg-rose-50 px-1.5 py-0.5 text-[10px] font-medium text-rose-900">
+                          Überfällig
+                        </span>
+                      ) : (
+                        <span className="text-slate-600">OK / n.a.</span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 align-top font-mono text-slate-800">
+                      {row.open_points_count}
+                      {row.open_points_hoch > 0 ? (
+                        <span className="ml-1 text-rose-700">({row.open_points_hoch} hoch)</span>
+                      ) : null}
+                    </td>
+                    <td className="px-3 py-2 align-top text-[10px] text-slate-600">
+                      <ul className="max-w-[200px] list-inside list-disc">
+                        {row.attention_flags_de.slice(0, 3).map((f) => (
+                          <li key={f}>{f}</li>
+                        ))}
+                      </ul>
+                      <div className="mt-1 font-mono text-slate-400">Score {row.attention_score}</div>
+                    </td>
+                    <td className="px-3 py-2 align-top text-slate-700">{formatIsoDe(row.last_export_iso)}</td>
+                    <td className="px-3 py-2 align-top text-slate-700">{formatIsoDe(row.last_review_iso)}</td>
+                    <td className="px-3 py-2 align-top">
+                      <div className="flex flex-col gap-1">
+                        <a
+                          className="text-cyan-700 underline"
+                          href={row.links.mandant_export_page}
+                        >
+                          Readiness-Export (UI)
+                        </a>
+                        <a className="text-cyan-700 underline" href={row.links.datev_bundle_api}>
+                          ZIP-Bundle
+                        </a>
+                        <a className="text-cyan-700 underline" href={row.links.board_readiness_admin}>
+                          Board Readiness
+                        </a>
+                      </div>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </section>
+      ) : null}
+
+      {payload ? (
+        <p className="text-xs text-slate-500">
+          Touchpoints (letzter Export / Review): optional{" "}
+          <code className="rounded bg-slate-100 px-1">data/advisor-portfolio-touchpoints.json</code> – siehe
+          Dokumentation Wave 39.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/lib/advisorPortfolioTouchpointsStore.ts
+++ b/frontend/src/lib/advisorPortfolioTouchpointsStore.ts
@@ -1,0 +1,71 @@
+import "server-only";
+
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+/**
+ * Optionale manuelle Touchpoints (letzter Export / Review) pro Mandant.
+ * Leere Datei oder fehlende Datei: alle Felder null im Portfolio.
+ */
+
+export type AdvisorPortfolioTouchpointEntry = {
+  tenant_id: string;
+  last_export_iso?: string | null;
+  last_review_iso?: string | null;
+  note_de?: string | null;
+};
+
+export type AdvisorPortfolioTouchpointsState = {
+  entries: AdvisorPortfolioTouchpointEntry[];
+};
+
+function resolvePath(): string {
+  const fromEnv = process.env.ADVISOR_PORTFOLIO_TOUCHPOINTS_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-advisor-portfolio-touchpoints.json");
+  }
+  return join(process.cwd(), "data", "advisor-portfolio-touchpoints.json");
+}
+
+function emptyState(): AdvisorPortfolioTouchpointsState {
+  return { entries: [] };
+}
+
+export async function readAdvisorPortfolioTouchpoints(): Promise<AdvisorPortfolioTouchpointsState> {
+  const path = resolvePath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const o = JSON.parse(raw) as { entries?: unknown };
+    if (!o || typeof o !== "object") return emptyState();
+    const entries: AdvisorPortfolioTouchpointEntry[] = [];
+    if (Array.isArray(o.entries)) {
+      for (const e of o.entries) {
+        if (!e || typeof e !== "object") continue;
+        const rec = e as Record<string, unknown>;
+        const tenant_id = typeof rec.tenant_id === "string" ? rec.tenant_id.trim() : "";
+        if (!tenant_id) continue;
+        entries.push({
+          tenant_id,
+          last_export_iso:
+            typeof rec.last_export_iso === "string" ? rec.last_export_iso.trim() || null : null,
+          last_review_iso:
+            typeof rec.last_review_iso === "string" ? rec.last_review_iso.trim() || null : null,
+          note_de: typeof rec.note_de === "string" ? rec.note_de.trim() || null : null,
+        });
+      }
+    }
+    return { entries };
+  } catch {
+    return emptyState();
+  }
+}
+
+/** Für spätere Waves (z. B. Hook nach Export); aktuell kaum genutzt. */
+export async function writeAdvisorPortfolioTouchpoints(
+  state: AdvisorPortfolioTouchpointsState,
+): Promise<void> {
+  const path = resolvePath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify({ entries: state.entries }, null, 2)}\n`, "utf8");
+}

--- a/frontend/src/lib/boardReadinessAggregate.ts
+++ b/frontend/src/lib/boardReadinessAggregate.ts
@@ -111,7 +111,8 @@ function nis2RoleOk(setup: TenantBoardReadinessRaw["ai_governance_setup"]): bool
   });
 }
 
-type TenantPillarSnapshot = {
+/** Pro-Mandant-Pillar-Snapshot für Board Readiness und Kanzlei-Portfolio (Wave 39). */
+export type TenantPillarSnapshot = {
   tenant_id: string;
   tenant_label: string | null;
   pilot: boolean;
@@ -712,14 +713,26 @@ function mapEntryForTenant(
   return map.entries.find((e) => e.tenant_id === tid);
 }
 
-export async function computeBoardReadinessPayload(now: Date = new Date()): Promise<BoardReadinessPayload> {
+export type MappedTenantPillarSnapshotBundle = {
+  generated_at: string;
+  nowMs: number;
+  map: Awaited<ReturnType<typeof readGtmProductAccountMap>>;
+  tenantIds: string[];
+  leads30d: LeadInboxItem[];
+  snapshots: TenantPillarSnapshot[];
+  backend_reachable: boolean;
+  tenants_partial: number;
+};
+
+/**
+ * Lädt alle gemappten Mandanten mit Pillar-Snapshots (eine API-Runde pro Mandant).
+ * Wird von Board Readiness und Kanzlei-Portfolio (Wave 39) gemeinsam genutzt.
+ */
+export async function loadMappedTenantPillarSnapshots(now: Date = new Date()): Promise<MappedTenantPillarSnapshotBundle> {
   const nowMs = now.getTime();
   const map = await readGtmProductAccountMap();
   const tenantIds = [...new Set(map.entries.map((e) => e.tenant_id))];
   const leads30d = await loadLeads30d(nowMs);
-
-  const { computeProductBridgePayload } = await import("@/lib/gtmProductBridgeAggregate");
-  const product_bridge = await computeProductBridgePayload(now);
 
   const snapshots: TenantPillarSnapshot[] = [];
   let backendReachable = false;
@@ -736,6 +749,25 @@ export async function computeBoardReadinessPayload(now: Date = new Date()): Prom
     const primary_segment = primarySegmentForTenant(tid, map, leads30d);
     snapshots.push(buildTenantSnapshot(tid, entry, primary_segment, raw, govSnap, nowMs));
   }
+
+  return {
+    generated_at: now.toISOString(),
+    nowMs,
+    map,
+    tenantIds,
+    leads30d,
+    snapshots,
+    backend_reachable: backendReachable,
+    tenants_partial: partial,
+  };
+}
+
+export async function computeBoardReadinessPayload(now: Date = new Date()): Promise<BoardReadinessPayload> {
+  const bundle = await loadMappedTenantPillarSnapshots(now);
+  const { snapshots, backend_reachable: backendReachable, tenants_partial: partial, nowMs } = bundle;
+
+  const { computeProductBridgePayload } = await import("@/lib/gtmProductBridgeAggregate");
+  const product_bridge = await computeProductBridgePayload(now);
 
   const pillarMap = aggregatePillarsFromTenants(snapshots);
   const pillars = [
@@ -793,7 +825,7 @@ export async function computeBoardReadinessPayload(now: Date = new Date()): Prom
   return {
     generated_at: now.toISOString(),
     backend_reachable: backendReachable,
-    mapped_tenant_count: tenantIds.length,
+    mapped_tenant_count: bundle.tenantIds.length,
     tenants_partial: partial,
     overall: { status: overallStatus, label_de: overallLabel },
     pillars,

--- a/frontend/src/lib/datevKanzleiBundleGenerate.ts
+++ b/frontend/src/lib/datevKanzleiBundleGenerate.ts
@@ -5,8 +5,11 @@
 
 import JSZip from "jszip";
 
-import { boardComplianceReportFresh } from "@/lib/tenantBoardReadinessGaps";
-import type { MandantOffenerPunkt } from "@/lib/tenantBoardReadinessGaps";
+import {
+  boardComplianceReportFresh,
+  pillarCodeForOpenPoint,
+  type MandantOffenerPunkt,
+} from "@/lib/tenantBoardReadinessGaps";
 import type { TenantBoardReadinessRaw } from "@/lib/tenantBoardReadinessRawTypes";
 
 export const DATEV_KANZLEI_BUNDLE_VERSION = "wave38-v1";
@@ -16,14 +19,7 @@ const CSV_SEP = ";";
 /** UTF-8 BOM so Excel (DE) opens UTF-8 correctly. */
 export const EXCEL_UTF8_BOM = "\uFEFF";
 
-export function pillarCodeForOpenPoint(p: MandantOffenerPunkt): string {
-  if (p.id.startsWith("board:")) return "EU_AI_Act";
-  const t = p.pruefpunkt_de.toLowerCase();
-  if (t.includes("nis2")) return "NIS2";
-  if (t.includes("dsgvo") || t.includes("datenschutz")) return "DSGVO";
-  if (t.includes("iso")) return "ISO_42001";
-  return "EU_AI_Act";
-}
+export { pillarCodeForOpenPoint };
 
 export function objectTypeForOpenPoint(p: MandantOffenerPunkt): string {
   if (p.id.startsWith("owner:")) return "AI_System";

--- a/frontend/src/lib/kanzleiPortfolioAggregate.ts
+++ b/frontend/src/lib/kanzleiPortfolioAggregate.ts
@@ -1,0 +1,235 @@
+import "server-only";
+
+import type { TenantPillarSnapshot } from "@/lib/boardReadinessAggregate";
+import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
+import { worstTraffic } from "@/lib/boardReadinessThresholds";
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+import { readAdvisorPortfolioTouchpoints } from "@/lib/advisorPortfolioTouchpointsStore";
+import type { GtmSegmentBucket } from "@/lib/gtmDashboardTypes";
+import { GTM_READINESS_LABELS_DE } from "@/lib/gtmAccountReadiness";
+import {
+  KANZLEI_EXPORT_STALE_DAYS,
+  KANZLEI_MANY_OPEN_POINTS,
+  kanzleiAttentionScore,
+} from "@/lib/kanzleiPortfolioScoring";
+import {
+  computeMandantOffenePunkte,
+  pillarCodeForOpenPoint,
+} from "@/lib/tenantBoardReadinessGaps";
+import {
+  KANZLEI_PILLAR_LABEL_DE,
+  KANZLEI_PORTFOLIO_VERSION,
+  type KanzleiPortfolioPayload,
+  type KanzleiPortfolioRow,
+} from "@/lib/kanzleiPortfolioTypes";
+
+export { KANZLEI_EXPORT_STALE_DAYS, KANZLEI_MANY_OPEN_POINTS } from "@/lib/kanzleiPortfolioScoring";
+
+const SEGMENT_LABELS_DE: Record<GtmSegmentBucket, string> = {
+  industrie_mittelstand: "Industrie / Mittelstand",
+  kanzlei_wp: "Kanzlei / WP",
+  enterprise_sap: "Enterprise / SAP",
+  other: "Sonstiges",
+};
+
+const PILLAR_ORDER: BoardReadinessPillarKey[] = ["eu_ai_act", "iso_42001", "nis2", "dsgvo"];
+
+const PILLAR_KEY_TO_CODE: Record<BoardReadinessPillarKey, string> = {
+  eu_ai_act: "EU_AI_Act",
+  iso_42001: "ISO_42001",
+  nis2: "NIS2",
+  dsgvo: "DSGVO",
+};
+
+function trafficRank(s: BoardReadinessTraffic): number {
+  if (s === "red") return 0;
+  if (s === "amber") return 1;
+  return 2;
+}
+
+function segmentLabel(seg: GtmSegmentBucket | null): string | null {
+  if (!seg) return null;
+  return SEGMENT_LABELS_DE[seg] ?? null;
+}
+
+function worstPillarFromSnapshot(t: TenantPillarSnapshot): {
+  key: BoardReadinessPillarKey;
+  code: string;
+  label_de: string;
+} {
+  let best: BoardReadinessPillarKey = "eu_ai_act";
+  let bestRank = 99;
+  for (const key of PILLAR_ORDER) {
+    const st =
+      key === "eu_ai_act"
+        ? t.eu.status
+        : key === "iso_42001"
+          ? t.iso.status
+          : key === "nis2"
+            ? t.nis2.status
+            : t.dsgvo.status;
+    const r = trafficRank(st);
+    if (r < bestRank) {
+      bestRank = r;
+      best = key;
+    }
+  }
+  const code = PILLAR_KEY_TO_CODE[best];
+  return { key: best, code, label_de: KANZLEI_PILLAR_LABEL_DE[code] ?? code };
+}
+
+const OPEN_PILLAR_PRIORITY = ["EU_AI_Act", "ISO_42001", "NIS2", "DSGVO"] as const;
+
+function weightedTopPillarFromOpenPoints(
+  punkte: ReturnType<typeof computeMandantOffenePunkte>,
+): { code: string; weight: number } | null {
+  const weights: Record<string, number> = {};
+  for (const p of punkte) {
+    const c = pillarCodeForOpenPoint(p);
+    const w = p.dringlichkeit === "hoch" ? 3 : 1;
+    weights[c] = (weights[c] ?? 0) + w;
+  }
+  let bestCode: string | null = null;
+  let bestW = 0;
+  for (const c of OPEN_PILLAR_PRIORITY) {
+    const w = weights[c] ?? 0;
+    if (w > bestW) {
+      bestW = w;
+      bestCode = c;
+    }
+  }
+  if (!bestCode || bestW <= 0) return null;
+  return { code: bestCode, weight: bestW };
+}
+
+function daysSinceIso(iso: string | null | undefined, nowMs: number): number | null {
+  if (!iso?.trim()) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return Math.floor((nowMs - t) / (24 * 60 * 60 * 1000));
+}
+
+function rowFromSnapshot(
+  t: TenantPillarSnapshot,
+  nowMs: number,
+  touchByTenant: Map<string, { last_export_iso?: string | null; last_review_iso?: string | null; note_de?: string | null }>,
+): KanzleiPortfolioRow {
+  const punkte = computeMandantOffenePunkte(t.tenant_id, t.raw, nowMs);
+  const open_points_count = punkte.length;
+  const open_points_hoch = punkte.filter((p) => p.dringlichkeit === "hoch").length;
+
+  const weighted = weightedTopPillarFromOpenPoints(punkte);
+  const worst = worstPillarFromSnapshot(t);
+  const top_gap_pillar_code = weighted?.code ?? worst.code;
+  const top_gap_pillar_label_de =
+    KANZLEI_PILLAR_LABEL_DE[top_gap_pillar_code] ?? top_gap_pillar_code;
+
+  const pillar_traffic: Record<BoardReadinessPillarKey, BoardReadinessTraffic> = {
+    eu_ai_act: t.eu.status,
+    iso_42001: t.iso.status,
+    nis2: t.nis2.status,
+    dsgvo: t.dsgvo.status,
+  };
+
+  const hr = t.eu.hr_total > 0;
+  const board_report_stale = hr && !t.eu.board_fresh;
+
+  const touch = touchByTenant.get(t.tenant_id);
+  const last_export_iso = touch?.last_export_iso ?? null;
+  const last_review_iso = touch?.last_review_iso ?? null;
+  const dExport = daysSinceIso(last_export_iso, nowMs);
+  const export_stale = dExport === null || dExport > KANZLEI_EXPORT_STALE_DAYS;
+
+  const baseline_gap = t.readiness_class === "early_pilot";
+
+  const attention_flags_de: string[] = [];
+  if (export_stale) attention_flags_de.push("Kein aktueller Export (Kanzlei) im Zeitraum");
+  if (board_report_stale) attention_flags_de.push("Mandanten-/Board-Report überfällig");
+  if (open_points_count >= KANZLEI_MANY_OPEN_POINTS) attention_flags_de.push("Viele offene Prüfpunkte");
+  if (baseline_gap) attention_flags_de.push("Governance-Baseline noch dünn (Pilot)");
+  if (!t.raw.fetch_ok) attention_flags_de.push("API teilweise nicht lesbar");
+
+  const worstOverall = PILLAR_ORDER.reduce(
+    (acc, k) => worstTraffic(acc, pillar_traffic[k]),
+    "green" as BoardReadinessTraffic,
+  );
+  if (worstOverall === "red" && !attention_flags_de.some((x) => x.includes("überfällig"))) {
+    attention_flags_de.push("Mindestens eine Säule rot");
+  }
+
+  const attention_score = kanzleiAttentionScore({
+    open_points_count,
+    open_points_hoch,
+    board_report_stale,
+    export_stale,
+    baseline_gap,
+    api_fetch_ok: t.raw.fetch_ok,
+    pillar_traffic,
+  });
+
+  const tidEnc = encodeURIComponent(t.tenant_id);
+  return {
+    tenant_id: t.tenant_id,
+    mandant_label: t.tenant_label,
+    readiness_class: t.readiness_class,
+    readiness_label_de: GTM_READINESS_LABELS_DE[t.readiness_class],
+    primary_segment_label_de: segmentLabel(t.primary_segment),
+    open_points_count,
+    open_points_hoch,
+    top_gap_pillar_code,
+    top_gap_pillar_label_de,
+    pillar_traffic,
+    board_report_stale,
+    api_fetch_ok: t.raw.fetch_ok,
+    attention_score,
+    attention_flags_de,
+    last_export_iso,
+    last_review_iso,
+    touchpoint_note_de: touch?.note_de ?? null,
+    links: {
+      mandant_export_page: `/admin/advisor-mandant-export?client_id=${tidEnc}`,
+      datev_bundle_api: `/api/internal/advisor/datev-export-bundle?client_id=${tidEnc}`,
+      readiness_export_api: `/api/internal/advisor/mandant-readiness-export?client_id=${tidEnc}`,
+      board_readiness_admin: "/admin/board-readiness",
+    },
+  };
+}
+
+export async function computeKanzleiPortfolioPayload(now: Date = new Date()): Promise<KanzleiPortfolioPayload> {
+  const [bundle, touchState] = await Promise.all([
+    loadMappedTenantPillarSnapshots(now),
+    readAdvisorPortfolioTouchpoints(),
+  ]);
+  const nowMs = bundle.nowMs;
+  const touchByTenant = new Map(
+    touchState.entries.map((e) => [
+      e.tenant_id,
+      {
+        last_export_iso: e.last_export_iso,
+        last_review_iso: e.last_review_iso,
+        note_de: e.note_de,
+      },
+    ]),
+  );
+
+  const rows = bundle.snapshots
+    .map((s) => rowFromSnapshot(s, nowMs, touchByTenant))
+    .sort((a, b) => {
+      if (b.attention_score !== a.attention_score) return b.attention_score - a.attention_score;
+      if (b.open_points_count !== a.open_points_count) return b.open_points_count - a.open_points_count;
+      return (a.mandant_label ?? a.tenant_id).localeCompare(b.mandant_label ?? b.tenant_id, "de");
+    });
+
+  return {
+    version: KANZLEI_PORTFOLIO_VERSION,
+    generated_at: bundle.generated_at,
+    backend_reachable: bundle.backend_reachable,
+    mapped_tenant_count: bundle.tenantIds.length,
+    tenants_partial: bundle.tenants_partial,
+    constants: {
+      export_stale_days: KANZLEI_EXPORT_STALE_DAYS,
+      many_open_points_threshold: KANZLEI_MANY_OPEN_POINTS,
+    },
+    rows,
+  };
+}

--- a/frontend/src/lib/kanzleiPortfolioScoring.test.ts
+++ b/frontend/src/lib/kanzleiPortfolioScoring.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { kanzleiAttentionScore } from "@/lib/kanzleiPortfolioScoring";
+
+describe("kanzleiPortfolioScoring", () => {
+  it("ranks higher attention when board stale and many open points", () => {
+    const base = {
+      open_points_count: 2,
+      open_points_hoch: 0,
+      board_report_stale: false,
+      export_stale: false,
+      baseline_gap: false,
+      api_fetch_ok: true,
+      pillar_traffic: {
+        eu_ai_act: "green" as const,
+        iso_42001: "green" as const,
+        nis2: "green" as const,
+        dsgvo: "green" as const,
+      },
+    };
+    const low = kanzleiAttentionScore(base);
+    const high = kanzleiAttentionScore({
+      ...base,
+      open_points_count: 6,
+      open_points_hoch: 2,
+      board_report_stale: true,
+      export_stale: true,
+      baseline_gap: true,
+      api_fetch_ok: false,
+      pillar_traffic: {
+        eu_ai_act: "red",
+        iso_42001: "amber",
+        nis2: "green",
+        dsgvo: "green",
+      },
+    });
+    expect(high).toBeGreaterThan(low);
+  });
+});

--- a/frontend/src/lib/kanzleiPortfolioScoring.ts
+++ b/frontend/src/lib/kanzleiPortfolioScoring.ts
@@ -1,0 +1,34 @@
+/**
+ * Reine Scoring-Hilfen für Kanzlei-Portfolio (Wave 39); ohne server-only für Tests.
+ */
+
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+
+export const KANZLEI_EXPORT_STALE_DAYS = 45;
+export const KANZLEI_MANY_OPEN_POINTS = 4;
+
+const PILLAR_ORDER: BoardReadinessPillarKey[] = ["eu_ai_act", "iso_42001", "nis2", "dsgvo"];
+
+export function kanzleiAttentionScore(input: {
+  open_points_count: number;
+  open_points_hoch: number;
+  board_report_stale: boolean;
+  export_stale: boolean;
+  baseline_gap: boolean;
+  api_fetch_ok: boolean;
+  pillar_traffic: Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+}): number {
+  let s = 0;
+  s += input.open_points_hoch * 22;
+  s += Math.max(0, input.open_points_count - input.open_points_hoch) * 9;
+  if (input.board_report_stale) s += 38;
+  if (input.export_stale) s += 28;
+  if (input.baseline_gap) s += 18;
+  if (!input.api_fetch_ok) s += 24;
+  for (const k of PILLAR_ORDER) {
+    const st = input.pillar_traffic[k];
+    if (st === "red") s += 16;
+    else if (st === "amber") s += 7;
+  }
+  return Math.min(999, s);
+}

--- a/frontend/src/lib/kanzleiPortfolioTypes.ts
+++ b/frontend/src/lib/kanzleiPortfolioTypes.ts
@@ -1,0 +1,61 @@
+/**
+ * Wave 39 – Kanzlei-Portfolio-Cockpit (intern, Mehrmandanten-Übersicht).
+ * JSON-Schema für API-Antwort; filterbar/sortierbar im Client.
+ */
+
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
+
+export const KANZLEI_PORTFOLIO_VERSION = "wave39-v1";
+
+export type KanzleiPortfolioPillarFilter = BoardReadinessPillarKey | "all";
+
+export type KanzleiPortfolioReadinessFilter = GtmReadinessClass | "all";
+
+export type KanzleiPortfolioRow = {
+  tenant_id: string;
+  mandant_label: string | null;
+  readiness_class: GtmReadinessClass;
+  readiness_label_de: string;
+  primary_segment_label_de: string | null;
+  open_points_count: number;
+  open_points_hoch: number;
+  /** Säule mit den gewichtet dringendsten offenen Punkten; sonst Ampel-Fokus. */
+  top_gap_pillar_code: string;
+  top_gap_pillar_label_de: string;
+  pillar_traffic: Record<BoardReadinessPillarKey, BoardReadinessTraffic>;
+  board_report_stale: boolean;
+  api_fetch_ok: boolean;
+  attention_score: number;
+  attention_flags_de: string[];
+  last_export_iso: string | null;
+  last_review_iso: string | null;
+  touchpoint_note_de: string | null;
+  links: {
+    mandant_export_page: string;
+    datev_bundle_api: string;
+    readiness_export_api: string;
+    board_readiness_admin: string;
+  };
+};
+
+export type KanzleiPortfolioPayload = {
+  version: typeof KANZLEI_PORTFOLIO_VERSION;
+  generated_at: string;
+  backend_reachable: boolean;
+  mapped_tenant_count: number;
+  tenants_partial: number;
+  constants: {
+    export_stale_days: number;
+    many_open_points_threshold: number;
+  };
+  rows: KanzleiPortfolioRow[];
+};
+
+export const KANZLEI_PILLAR_LABEL_DE: Record<string, string> = {
+  EU_AI_Act: "EU AI Act",
+  ISO_42001: "ISO 42001",
+  NIS2: "NIS2",
+  DSGVO: "DSGVO",
+  none: "—",
+};

--- a/frontend/src/lib/tenantBoardReadinessGaps.ts
+++ b/frontend/src/lib/tenantBoardReadinessGaps.ts
@@ -49,6 +49,16 @@ export type MandantOffenerPunkt = {
   letzte_aenderung_iso?: string | null;
 };
 
+/** Säulen-Code für offene Punkte (Kanzlei-Export / Portfolio). */
+export function pillarCodeForOpenPoint(p: MandantOffenerPunkt): string {
+  if (p.id.startsWith("board:")) return "EU_AI_Act";
+  const t = p.pruefpunkt_de.toLowerCase();
+  if (t.includes("nis2")) return "NIS2";
+  if (t.includes("dsgvo") || t.includes("datenschutz")) return "DSGVO";
+  if (t.includes("iso")) return "ISO_42001";
+  return "EU_AI_Act";
+}
+
 function refKi(sysId: string): string {
   return `HR-AI-${sysId}`;
 }


### PR DESCRIPTION
- Add /admin/advisor-portfolio and GET /api/internal/advisor/kanzlei-portfolio
- Centralize mapped-tenant snapshot load in loadMappedTenantPillarSnapshots
- Portfolio rows: open points, pillars, attention score, optional touchpoints file
- Move pillarCodeForOpenPoint to tenantBoardReadinessGaps; re-export from datev bundle
- Link cockpit from board readiness and mandant export; prefill client_id from query

Made-with: Cursor