### PR TITLE
feat(advisors): Wave 43 mandant reminders and follow-ups

### DIFF
--- a/docs/advisors/wave41-kanzlei-review-playbook-and-queue.md
+++ b/docs/advisors/wave41-kanzlei-review-playbook-and-queue.md
@@ -64,6 +64,7 @@ Komponente: `frontend/src/components/admin/KanzleiReviewPlaybookHelper.tsx`.
 
 ## Siehe auch
 
+- `docs/advisors/wave43-reminders-and-followups.md`
 - `docs/advisors/wave42-kanzlei-monatsreport.md`
 - `docs/advisors/wave40-kanzlei-review-cadence-and-history.md`
 - `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`

--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -63,5 +63,6 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave43-reminders-and-followups.md`
 - `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`
 - `docs/advisors/wave40-kanzlei-review-cadence-and-history.md`

--- a/docs/advisors/wave43-reminders-and-followups.md
+++ b/docs/advisors/wave43-reminders-and-followups.md
@@ -1,0 +1,74 @@
+# Wave 43 – Mandanten-Reminders & Follow-ups
+
+Leichte **Erinnerungs-Hooks** pro Mandant für wiederkehrende Kanzlei-Arbeit – **kein** Jira/Trello, **kein** Workflow-Engine. Ziel: „Nicht vergessen“ (Review, Export, Follow-up-Notiz) sichtbar machen und mit einem Klick erledigen oder zurückstellen.
+
+## Datenmodell
+
+Persistiert in **`data/advisor-mandant-reminders.json`** (oder `ADVISOR_MANDANT_REMINDERS_PATH`, auf Vercel unter `/tmp`).
+
+| Feld | Bedeutung |
+|------|-----------|
+| `reminder_id` | UUID |
+| `tenant_id` | Mandanten-ID (`client_id`) |
+| `category` | Siehe Kategorien unten |
+| `due_at` | ISO-Zeitpunkt (Fälligkeit) |
+| `status` | `open`, `done`, `dismissed` |
+| `note` | Optional (besonders bei manuellen / Follow-up) |
+| `source` | `auto` (Regel) oder `manual` |
+| `created_at` / `updated_at` | ISO |
+
+### Kategorien
+
+| `category` | Typ | Bedeutung |
+|------------|-----|-----------|
+| `stale_review` | Auto | Review-Kadenz überfällig (wie Wave 40) |
+| `stale_export` | Auto | Export-Kadenz oder kein Export erfasst |
+| `high_gap_count` | Auto | Viele offene Prüfpunkte oder ≥2 mit hoher Dringlichkeit |
+| `portfolio_attention` | Auto | Mandant erfüllt die **Attention-Queue-Kriterien** (Wave 41) |
+| `follow_up_note` | Manuell | Freitext-Follow-up (Notiz Pflicht) |
+| `manual` | Manuell | Kurzer manueller Reminder (Notiz optional) |
+
+## Auto-Generierung
+
+Bei jedem **`computeKanzleiPortfolioPayload`** (also jedem Laden von `GET /api/internal/advisor/kanzlei-portfolio`):
+
+- Für jede Portfolio-Zeile und jede **Auto-Kategorie** wird geprüft, ob die Bedingung aktiv ist.
+- **Neu:** Gibt es noch keinen **offenen** Auto-Reminder für `(tenant_id, category)`, wird einer mit Fälligkeit **Ende der lokalen Kalenderwoche (Sonntag 23:59:59)** angelegt.
+- **Weg:** Ist die Bedingung nicht mehr erfüllt, wird ein offener Auto-Reminder für diese Kategorie auf **`done`** gesetzt (kein Löschen).
+
+Manuelle Reminder werden von der Sync-Logik **nicht** verändert.
+
+## API (intern, Lead-Admin)
+
+| Methode | Pfad | Zweck |
+|---------|------|--------|
+| `GET` | `/api/internal/advisor/mandant-reminders` | Query: `client_id?`, `status?` (`open`/`done`/`dismissed`) |
+| `POST` | `/api/internal/advisor/mandant-reminders` | Manuell anlegen: `client_id`, `category` (`manual` \| `follow_up_note`), `due_at`, optional `note` (bei `follow_up_note` Pflicht) |
+| `PATCH` | `/api/internal/advisor/mandant-reminders` | `{ "reminder_id", "status": "done" \| "dismissed" }` |
+
+Das **Portfolio** liefert zusätzlich eingebettet: `open_reminders`, Zähler **heute/überfällig** und **diese Woche**, sowie pro Zeile `open_reminders_count` und `next_reminder_due_at`.
+
+## UI
+
+- **Kanzlei-Cockpit:** Panel „Fällig heute / diese Woche“, Liste offener Reminder aus dem Portfolio, Aktionen Erledigt/Zurückstellen, kompaktes **manuelles** Anlegen (Mandant wählen, Fälligkeit, Notiz).
+- **Mandanten-Export:** Für gewählte `client_id` offene Reminder listen und dieselben Aktionen.
+
+## Unterschied zur Attention-Queue
+
+| Aspekt | Attention-Queue (Wave 41) | Reminder (Wave 43) |
+|--------|---------------------------|---------------------|
+| Zweck | Priorisierte **Reihenfolge** „wer zuerst“ | **Zeitliche** und **inhaltliche** Erinnerung („bis wann“, Notiz) |
+| Persistenz | Nur berechnet aus Live-Daten | **Gespeichert**, Status done/dismissed |
+| Auto | Nein | Ja (Kadenz, Queue-Kriterium, Lücken) |
+| Manuell | Nein | Ja (Anruf, Termin, Freitext) |
+
+## Empfohlene Nutzung
+
+- Wöchentlich Cockpit öffnen: Panel **diese Woche** abarbeiten, Erledigt setzen.
+- Monatsende: offene Auto-Reminder prüfen; bei dauerhaft zurückgestellten Themen `dismissed` nutzen (erscheint nicht in „open“, Auto kann bei weiterhin gültiger Bedingung neu entstehen – bewusst einfach gehalten).
+
+## Siehe auch
+
+- `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`
+- `docs/advisors/wave40-kanzlei-review-cadence-and-history.md`
+- `frontend/src/lib/advisorMandantReminderRules.ts`

--- a/frontend/src/app/api/internal/advisor/mandant-reminders/route.ts
+++ b/frontend/src/app/api/internal/advisor/mandant-reminders/route.ts
@@ -1,0 +1,160 @@
+import { NextResponse } from "next/server";
+
+import {
+  createAdvisorMandantReminderManual,
+  listAdvisorMandantReminders,
+  updateAdvisorMandantReminderStatus,
+} from "@/lib/advisorMandantReminderStore";
+import type { MandantReminderCategory, MandantReminderStatus } from "@/lib/advisorMandantReminderTypes";
+import { MANDANT_REMINDER_MANUAL_CATEGORIES } from "@/lib/advisorMandantReminderTypes";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+const CLIENT_ID_RE = /^[a-zA-Z0-9._-]{1,255}$/;
+
+function normalizeDueAtIso(input: string): string {
+  const t = input.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(t)) {
+    return new Date(`${t}T23:59:59`).toISOString();
+  }
+  const ms = Date.parse(t);
+  if (Number.isNaN(ms)) throw new Error("invalid_due_at");
+  return new Date(ms).toISOString();
+}
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const clientId = url.searchParams.get("client_id")?.trim() ?? "";
+  const status = url.searchParams.get("status")?.trim() as MandantReminderStatus | undefined;
+
+  const reminders = await listAdvisorMandantReminders({
+    tenant_id: clientId || undefined,
+    status:
+      status === "open" || status === "done" || status === "dismissed" ? status : undefined,
+  });
+
+  return NextResponse.json({ ok: true, reminders });
+}
+
+type PostBody = {
+  client_id?: string;
+  category?: string;
+  note?: string | null;
+  due_at?: string;
+};
+
+export async function POST(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: PostBody = {};
+  try {
+    body = (await req.json()) as PostBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const clientId = typeof body.client_id === "string" ? body.client_id.trim() : "";
+  if (!clientId || !CLIENT_ID_RE.test(clientId)) {
+    return NextResponse.json(
+      { error: "invalid_client_id", detail: "client_id required (alphanumeric, dot, underscore, hyphen)." },
+      { status: 400 },
+    );
+  }
+
+  const cat = body.category as MandantReminderCategory | undefined;
+  if (!cat || !MANDANT_REMINDER_MANUAL_CATEGORIES.includes(cat)) {
+    return NextResponse.json(
+      { error: "invalid_category", detail: "category must be manual or follow_up_note." },
+      { status: 400 },
+    );
+  }
+
+  const dueRaw = typeof body.due_at === "string" ? body.due_at : "";
+  if (!dueRaw.trim()) {
+    return NextResponse.json({ error: "due_at_required" }, { status: 400 });
+  }
+
+  let dueAt: string;
+  try {
+    dueAt = normalizeDueAtIso(dueRaw);
+  } catch {
+    return NextResponse.json({ error: "invalid_due_at" }, { status: 400 });
+  }
+
+  const note =
+    body.note === undefined || body.note === null ? null : String(body.note);
+
+  if (cat === "follow_up_note" && !note?.trim()) {
+    return NextResponse.json(
+      { error: "note_required", detail: "follow_up_note requires a short note." },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const reminder = await createAdvisorMandantReminderManual({
+      tenant_id: clientId,
+      category: cat,
+      note,
+      due_at: dueAt,
+    });
+    return NextResponse.json({ ok: true, reminder });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "error";
+    if (msg === "invalid_manual_category") {
+      return NextResponse.json({ error: "invalid_category" }, { status: 400 });
+    }
+    return NextResponse.json({ error: "server_error" }, { status: 500 });
+  }
+}
+
+type PatchBody = {
+  reminder_id?: string;
+  status?: string;
+};
+
+export async function PATCH(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: PatchBody = {};
+  try {
+    body = (await req.json()) as PatchBody;
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const id = typeof body.reminder_id === "string" ? body.reminder_id.trim() : "";
+  if (!id) {
+    return NextResponse.json({ error: "reminder_id_required" }, { status: 400 });
+  }
+
+  const st = body.status;
+  if (st !== "done" && st !== "dismissed") {
+    return NextResponse.json({ error: "invalid_status" }, { status: 400 });
+  }
+
+  const updated = await updateAdvisorMandantReminderStatus(id, st);
+  if (!updated) {
+    return NextResponse.json({ error: "not_found_or_not_open" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, reminder: updated });
+}

--- a/frontend/src/components/admin/AdvisorMandantExportClient.tsx
+++ b/frontend/src/components/admin/AdvisorMandantExportClient.tsx
@@ -6,6 +6,10 @@ import {
   KanzleiReviewPlaybookHelper,
   type KanzleiPlaybookMandateSnapshot,
 } from "@/components/admin/KanzleiReviewPlaybookHelper";
+import {
+  MANDANT_REMINDER_CATEGORY_LABEL_DE,
+  type MandantReminderRecord,
+} from "@/lib/advisorMandantReminderTypes";
 import type { MandantReadinessAdvisorPayload } from "@/lib/mandantReadinessAdvisorTypes";
 import { naechsterSchrittForRow } from "@/lib/kanzleiAttentionQueue";
 import type { AdvisorMandantHistoryApiDto, KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
@@ -74,6 +78,50 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
   const [reviewBusy, setReviewBusy] = useState(false);
   const [portfolioRow, setPortfolioRow] = useState<KanzleiPortfolioRow | null>(null);
   const [portfolioLoading, setPortfolioLoading] = useState(false);
+  const [tenantReminders, setTenantReminders] = useState<MandantReminderRecord[]>([]);
+  const [remLoading, setRemLoading] = useState(false);
+  const [remPatchId, setRemPatchId] = useState<string | null>(null);
+  const [newRemDue, setNewRemDue] = useState("");
+  const [newRemCat, setNewRemCat] = useState<"manual" | "follow_up_note">("follow_up_note");
+  const [newRemNote, setNewRemNote] = useState("");
+  const [newRemBusy, setNewRemBusy] = useState(false);
+
+  const fetchTenantReminders = useCallback(async () => {
+    const id = clientId.trim();
+    if (!id) {
+      setTenantReminders([]);
+      return;
+    }
+    setRemLoading(true);
+    try {
+      const q = new URLSearchParams({ client_id: id, status: "open" });
+      const r = await fetch(`/api/internal/advisor/mandant-reminders?${q}`, { credentials: "include" });
+      if (!r.ok) {
+        setTenantReminders([]);
+        return;
+      }
+      const data = (await r.json()) as { reminders?: MandantReminderRecord[] };
+      setTenantReminders(data.reminders ?? []);
+    } catch {
+      setTenantReminders([]);
+    } finally {
+      setRemLoading(false);
+    }
+  }, [clientId]);
+
+  useEffect(() => {
+    void fetchTenantReminders();
+  }, [fetchTenantReminders]);
+
+  useEffect(() => {
+    if (!clientId.trim()) return;
+    setNewRemDue((prev) => {
+      if (prev) return prev;
+      const d = new Date();
+      d.setDate(d.getDate() + 7);
+      return d.toISOString().slice(0, 10);
+    });
+  }, [clientId]);
 
   const fetchPortfolioRow = useCallback(async () => {
     const id = clientId.trim();
@@ -177,12 +225,13 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
       setPayload(data.mandant_readiness_export ?? null);
       void fetchHistory();
       void fetchPortfolioRow();
+      void fetchTenantReminders();
     } catch {
       setError("Netzwerkfehler");
     } finally {
       setLoading(false);
     }
-  }, [clientId, fetchHistory, fetchPortfolioRow]);
+  }, [clientId, fetchHistory, fetchPortfolioRow, fetchTenantReminders]);
 
   const copyMd = useCallback(async () => {
     if (!payload?.markdown_de) return;
@@ -245,12 +294,13 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
       setMsg("ZIP-Arbeitspaket geladen.");
       void fetchHistory();
       void fetchPortfolioRow();
+      void fetchTenantReminders();
     } catch {
       setError("Netzwerkfehler");
     } finally {
       setBundleLoading(false);
     }
-  }, [clientId, fetchHistory, fetchPortfolioRow]);
+  }, [clientId, fetchHistory, fetchPortfolioRow, fetchTenantReminders]);
 
   const submitReview = useCallback(async () => {
     const id = clientId.trim();
@@ -284,12 +334,62 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
       setReviewNote("");
       setMsg("Review gespeichert.");
       void fetchPortfolioRow();
+      void fetchTenantReminders();
     } catch {
       setError("Netzwerkfehler");
     } finally {
       setReviewBusy(false);
     }
-  }, [clientId, reviewNote, fetchPortfolioRow]);
+  }, [clientId, reviewNote, fetchPortfolioRow, fetchTenantReminders]);
+
+  const patchTenantReminder = useCallback(
+    async (reminderId: string, status: "done" | "dismissed") => {
+      setRemPatchId(reminderId);
+      try {
+        const r = await fetch("/api/internal/advisor/mandant-reminders", {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reminder_id: reminderId, status }),
+        });
+        if (r.ok) void fetchTenantReminders();
+      } finally {
+        setRemPatchId(null);
+      }
+    },
+    [fetchTenantReminders],
+  );
+
+  const submitNewReminder = useCallback(async () => {
+    const id = clientId.trim();
+    if (!id || !newRemDue.trim()) return;
+    setNewRemBusy(true);
+    try {
+      const r = await fetch("/api/internal/advisor/mandant-reminders", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: id,
+          category: newRemCat,
+          due_at: newRemDue.trim(),
+          ...(newRemNote.trim() ? { note: newRemNote.trim() } : {}),
+        }),
+      });
+      if (r.ok) {
+        setNewRemNote("");
+        void fetchTenantReminders();
+        setMsg("Reminder gespeichert.");
+      } else {
+        const j = (await r.json()) as { detail?: string };
+        setError(j.detail ?? `Reminder HTTP ${r.status}`);
+      }
+    } catch {
+      setError("Netzwerkfehler");
+    } finally {
+      setNewRemBusy(false);
+    }
+  }, [clientId, fetchTenantReminders, newRemCat, newRemDue, newRemNote]);
 
   function formatHist(iso: string | null): string {
     if (!iso) return "—";
@@ -309,7 +409,7 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
   return (
     <div className="space-y-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
       <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 37–41 · Kanzlei / Berater</p>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 37–43 · Kanzlei / Berater</p>
         <h1 className="text-xl font-semibold text-slate-900">Mandanten-Readiness-Export</h1>
         <p className="mt-2 text-sm text-slate-600">
           Kompakter Status für Steuerberater, WP und GRC-Berater – ein Mandant pro Export. Nutzt dieselben
@@ -333,6 +433,11 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
           ·{" "}
           <code className="rounded bg-slate-100 px-1 text-[11px]">
             POST /api/internal/advisor/mandant-review
+          </code>
+          <br />
+          Reminders (Wave 43):{" "}
+          <code className="rounded bg-slate-100 px-1 text-[11px]">
+            GET/POST/PATCH /api/internal/advisor/mandant-reminders
           </code>
         </p>
       </div>
@@ -395,6 +500,85 @@ export function AdvisorMandantExportClient({ adminConfigured }: Props) {
               className="rounded-lg bg-violet-900 px-3 py-1.5 text-xs text-white hover:bg-violet-800 disabled:opacity-50"
             >
               {reviewBusy ? "Speichere…" : "Review durchgeführt"}
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {clientId.trim() ? (
+        <div className="rounded-lg border border-rose-200 bg-rose-50/40 p-3 text-xs text-slate-800">
+          <p className="font-semibold text-rose-950">Offene Reminders (Wave 43)</p>
+          {remLoading ? (
+            <p className="mt-1 text-slate-500">Lade Reminder…</p>
+          ) : tenantReminders.length === 0 ? (
+            <p className="mt-1 text-slate-600">Keine offenen Reminder für diesen Mandanten.</p>
+          ) : (
+            <ul className="mt-2 space-y-2">
+              {tenantReminders.map((r) => (
+                <li key={r.reminder_id} className="rounded border border-rose-100 bg-white/90 p-2">
+                  <div className="font-medium">{MANDANT_REMINDER_CATEGORY_LABEL_DE[r.category]}</div>
+                  <div className="text-slate-600">Fällig: {formatHist(r.due_at)}</div>
+                  {r.note ? <div className="mt-0.5 text-slate-700">{r.note}</div> : null}
+                  <div className="mt-1 flex gap-2">
+                    <button
+                      type="button"
+                      disabled={remPatchId === r.reminder_id}
+                      onClick={() => void patchTenantReminder(r.reminder_id, "done")}
+                      className="text-cyan-800 underline disabled:opacity-50"
+                    >
+                      Erledigt
+                    </button>
+                    <button
+                      type="button"
+                      disabled={remPatchId === r.reminder_id}
+                      onClick={() => void patchTenantReminder(r.reminder_id, "dismissed")}
+                      className="text-slate-600 underline disabled:opacity-50"
+                    >
+                      Zurückstellen
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div className="mt-3 flex flex-wrap items-end gap-2 border-t border-rose-100 pt-2">
+            <label className="text-[11px] font-medium text-slate-700">
+              Neu · Fällig
+              <input
+                type="date"
+                className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                value={newRemDue}
+                onChange={(e) => setNewRemDue(e.target.value)}
+              />
+            </label>
+            <label className="text-[11px] font-medium text-slate-700">
+              Art
+              <select
+                className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                value={newRemCat}
+                onChange={(e) => setNewRemCat(e.target.value as "manual" | "follow_up_note")}
+              >
+                <option value="follow_up_note">Follow-up</option>
+                <option value="manual">Manuell</option>
+              </select>
+            </label>
+            <label className="min-w-[160px] flex-1 text-[11px] font-medium text-slate-700">
+              Notiz
+              <input
+                className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1 text-[11px]"
+                value={newRemNote}
+                onChange={(e) => setNewRemNote(e.target.value)}
+                placeholder="Kurztext"
+                maxLength={500}
+              />
+            </label>
+            <button
+              type="button"
+              disabled={newRemBusy || !newRemDue.trim()}
+              onClick={() => void submitNewReminder()}
+              className="rounded bg-rose-800 px-2 py-1 text-[11px] text-white hover:bg-rose-900 disabled:opacity-50"
+            >
+              {newRemBusy ? "…" : "Reminder anlegen"}
             </button>
           </div>
         </div>

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -6,6 +6,11 @@ import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/board
 import { GTM_READINESS_CLASSES, GTM_READINESS_SHORT_DE } from "@/lib/gtmAccountReadiness";
 import { KanzleiReviewPlaybookHelper } from "@/components/admin/KanzleiReviewPlaybookHelper";
 import type { KanzleiMonthlyReportDto } from "@/lib/kanzleiMonthlyReportTypes";
+import {
+  MANDANT_REMINDER_CATEGORY_LABEL_DE,
+  type MandantReminderApiEntry,
+} from "@/lib/advisorMandantReminderTypes";
+import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
 import type {
   KanzleiAttentionQueueItem,
   KanzleiPortfolioPayload,
@@ -136,6 +141,48 @@ function formatIsoDe(iso: string | null): string {
   return new Date(d).toLocaleDateString("de-DE");
 }
 
+function ReminderRowItem({
+  r,
+  busy,
+  onDone,
+  onDismiss,
+}: {
+  r: MandantReminderApiEntry;
+  busy: boolean;
+  onDone: () => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <li className="rounded border border-rose-100 bg-white/90 p-2 text-[11px] text-slate-800">
+      <div className="font-medium text-slate-900">
+        {r.mandant_label ?? r.tenant_id}{" "}
+        <span className="font-mono text-[10px] text-slate-400">({r.tenant_id})</span>
+      </div>
+      <div className="text-slate-600">{MANDANT_REMINDER_CATEGORY_LABEL_DE[r.category]}</div>
+      <div className="text-slate-500">Fällig: {formatIsoDe(r.due_at)}</div>
+      {r.note ? <div className="mt-0.5 text-slate-600">{r.note}</div> : null}
+      <div className="mt-1 flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onDone}
+          className="text-cyan-800 underline disabled:opacity-50"
+        >
+          Erledigt
+        </button>
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onDismiss}
+          className="text-slate-600 underline disabled:opacity-50"
+        >
+          Zurückstellen
+        </button>
+      </div>
+    </li>
+  );
+}
+
 export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [payload, setPayload] = useState<KanzleiPortfolioPayload | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -158,6 +205,13 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [reportErr, setReportErr] = useState<string | null>(null);
   const [reportMd, setReportMd] = useState<string | null>(null);
   const [reportDto, setReportDto] = useState<KanzleiMonthlyReportDto | null>(null);
+
+  const [reminderPatchBusyId, setReminderPatchBusyId] = useState<string | null>(null);
+  const [manualRemTenantId, setManualRemTenantId] = useState("");
+  const [manualRemDue, setManualRemDue] = useState("");
+  const [manualRemCat, setManualRemCat] = useState<"manual" | "follow_up_note">("follow_up_note");
+  const [manualRemNote, setManualRemNote] = useState("");
+  const [manualRemBusy, setManualRemBusy] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -284,6 +338,72 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     }
   }, [reportMd]);
 
+  const patchReminderStatus = useCallback(
+    async (reminderId: string, status: "done" | "dismissed") => {
+      setReminderPatchBusyId(reminderId);
+      try {
+        const r = await fetch("/api/internal/advisor/mandant-reminders", {
+          method: "PATCH",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ reminder_id: reminderId, status }),
+        });
+        if (r.ok) await load();
+      } finally {
+        setReminderPatchBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  const submitManualReminder = useCallback(async () => {
+    const tid = manualRemTenantId.trim();
+    if (!tid || !manualRemDue.trim()) return;
+    setManualRemBusy(true);
+    try {
+      const r = await fetch("/api/internal/advisor/mandant-reminders", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          client_id: tid,
+          category: manualRemCat,
+          due_at: manualRemDue.trim(),
+          ...(manualRemNote.trim() ? { note: manualRemNote.trim() } : {}),
+        }),
+      });
+      if (r.ok) {
+        setManualRemNote("");
+        await load();
+      }
+    } finally {
+      setManualRemBusy(false);
+    }
+  }, [load, manualRemCat, manualRemDue, manualRemNote, manualRemTenantId]);
+
+  const remindersDueUrgent = useMemo(() => {
+    const list = payload?.open_reminders ?? [];
+    const now = Date.now();
+    return list.filter((r) => isDueTodayOrOverdue(r.due_at, now));
+  }, [payload?.open_reminders]);
+
+  const remindersDueWeekNotUrgent = useMemo(() => {
+    const list = payload?.open_reminders ?? [];
+    const now = Date.now();
+    return list.filter((r) => isDueThisCalendarWeek(r.due_at, now) && !isDueTodayOrOverdue(r.due_at, now));
+  }, [payload?.open_reminders]);
+
+  useEffect(() => {
+    if (!payload?.rows.length) return;
+    setManualRemTenantId((prev) => (prev ? prev : payload.rows[0]!.tenant_id));
+    setManualRemDue((prev) => {
+      if (prev) return prev;
+      const d = new Date();
+      d.setDate(d.getDate() + 7);
+      return d.toISOString().slice(0, 10);
+    });
+  }, [payload?.rows]);
+
   if (!adminConfigured) {
     return (
       <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
@@ -311,12 +431,13 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     <div className="space-y-6">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39–41 · Kanzlei / Berater</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39–43 · Kanzlei / Berater</p>
           <h1 className="text-2xl font-semibold text-slate-900">Mehrmandanten-Kanzlei-Cockpit</h1>
           <p className="mt-1 max-w-3xl text-sm text-slate-600">
             Welcher Mandant braucht jetzt Aufmerksamkeit? Portfolio über gemappte Mandanten mit Readiness,
-            offenen Prüfpunkten, Export-Historie (Readiness / DATEV-ZIP), Review-Kadenz (Wave 40) und
-            Attention-Queue plus Review-Playbook (Wave 41).
+            offenen Prüfpunkten, Export-Historie (Readiness / DATEV-ZIP), Review-Kadenz (Wave 40),
+            Attention-Queue, Review-Playbook (Wave 41), Monatsreport (Wave 42) und Reminders / Follow-ups
+            (Wave 43).
           </p>
           {payload ? (
             <p className="mt-1 font-mono text-xs text-slate-400">
@@ -376,6 +497,125 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             reviewBusyId={reviewBusyId}
           />
         </div>
+      ) : null}
+
+      {payload ? (
+        <section className="rounded-xl border border-rose-200 bg-rose-50/20 p-4 shadow-sm">
+          <h2 className="text-sm font-semibold text-rose-950">Reminders & Follow-ups (Wave 43)</h2>
+          <p className="mt-1 text-[11px] text-slate-600">
+            Gespeichert in{" "}
+            <code className="rounded bg-white px-1">data/advisor-mandant-reminders.json</code> – Auto-Hooks aus
+            Kadenz, Lücken und Attention-Queue; manuell ergänzbar. Kein Ticket-System.
+          </p>
+          <p className="mt-2 text-xs text-slate-700">
+            <span className="font-semibold">Heute / überfällig:</span>{" "}
+            {payload.reminders_due_today_or_overdue_count} ·{" "}
+            <span className="font-semibold">Offen diese Kalenderwoche:</span>{" "}
+            {payload.reminders_due_this_week_open_count} ·{" "}
+            <span className="font-semibold">Offen gesamt:</span> {payload.open_reminders.length}
+          </p>
+          <div className="mt-3 grid gap-4 lg:grid-cols-2">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-rose-800">Heute / überfällig</p>
+              {remindersDueUrgent.length === 0 ? (
+                <p className="mt-1 text-[11px] text-slate-500">Keine offenen Reminder in dieser Kategorie.</p>
+              ) : (
+                <ul className="mt-1 space-y-2">
+                  {remindersDueUrgent.map((r) => (
+                    <ReminderRowItem
+                      key={r.reminder_id}
+                      r={r}
+                      busy={reminderPatchBusyId === r.reminder_id}
+                      onDone={() => void patchReminderStatus(r.reminder_id, "done")}
+                      onDismiss={() => void patchReminderStatus(r.reminder_id, "dismissed")}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">
+                Später diese Woche
+              </p>
+              {remindersDueWeekNotUrgent.length === 0 ? (
+                <p className="mt-1 text-[11px] text-slate-500">Keine weiteren in dieser Woche (außer oben).</p>
+              ) : (
+                <ul className="mt-1 max-h-48 space-y-2 overflow-y-auto">
+                  {remindersDueWeekNotUrgent.map((r) => (
+                    <ReminderRowItem
+                      key={r.reminder_id}
+                      r={r}
+                      busy={reminderPatchBusyId === r.reminder_id}
+                      onDone={() => void patchReminderStatus(r.reminder_id, "done")}
+                      onDismiss={() => void patchReminderStatus(r.reminder_id, "dismissed")}
+                    />
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+          <div className="mt-4 rounded-lg border border-rose-100 bg-white/80 p-3">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-600">Manuell anlegen</p>
+            <div className="mt-2 flex flex-wrap items-end gap-2">
+              <label className="text-[11px] font-medium text-slate-700">
+                Mandant
+                <select
+                  className="mt-0.5 block max-w-[200px] rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                  value={manualRemTenantId}
+                  onChange={(e) => setManualRemTenantId(e.target.value)}
+                >
+                  {payload.rows.map((row) => (
+                    <option key={row.tenant_id} value={row.tenant_id}>
+                      {row.mandant_label ?? row.tenant_id}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="text-[11px] font-medium text-slate-700">
+                Fällig
+                <input
+                  type="date"
+                  className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                  value={manualRemDue}
+                  onChange={(e) => setManualRemDue(e.target.value)}
+                />
+              </label>
+              <label className="text-[11px] font-medium text-slate-700">
+                Art
+                <select
+                  className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                  value={manualRemCat}
+                  onChange={(e) => setManualRemCat(e.target.value as "manual" | "follow_up_note")}
+                >
+                  <option value="follow_up_note">Follow-up (Notiz Pflicht)</option>
+                  <option value="manual">Manuell</option>
+                </select>
+              </label>
+              <label className="block min-w-[180px] flex-1 text-[11px] font-medium text-slate-700">
+                Notiz
+                <input
+                  className="mt-0.5 w-full rounded border border-slate-300 px-2 py-1 text-[11px]"
+                  value={manualRemNote}
+                  onChange={(e) => setManualRemNote(e.target.value)}
+                  placeholder={manualRemCat === "follow_up_note" ? "z. B. ISO-Rollen anrufen" : "optional"}
+                  maxLength={500}
+                />
+              </label>
+              <button
+                type="button"
+                disabled={manualRemBusy || !manualRemTenantId || !manualRemDue}
+                onClick={() => void submitManualReminder()}
+                className="rounded bg-rose-800 px-2 py-1 text-[11px] text-white hover:bg-rose-900 disabled:opacity-50"
+              >
+                {manualRemBusy ? "…" : "Speichern"}
+              </button>
+            </div>
+          </div>
+          <p className="mt-2 text-[10px] text-slate-500">
+            API:{" "}
+            <code className="rounded bg-white px-1">GET/POST/PATCH /api/internal/advisor/mandant-reminders</code>
+          </p>
+        </section>
       ) : null}
 
       {payload ? (
@@ -508,7 +748,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
 
       {payload ? (
         <section className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
-          <table className="min-w-[1100px] w-full border-collapse text-left text-xs">
+          <table className="min-w-[1180px] w-full border-collapse text-left text-xs">
             <thead>
               <tr className="border-b border-slate-200 bg-slate-50 text-slate-600">
                 <th className="px-3 py-2 font-medium">Mandant</th>
@@ -520,13 +760,14 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
                 <th className="px-3 py-2 font-medium">Readiness-Export</th>
                 <th className="px-3 py-2 font-medium">DATEV-ZIP</th>
                 <th className="px-3 py-2 font-medium">Review</th>
+                <th className="px-3 py-2 font-medium">Reminder</th>
                 <th className="px-3 py-2 font-medium">Aktionen</th>
               </tr>
             </thead>
             <tbody>
               {filteredRows.length === 0 ? (
                 <tr>
-                  <td colSpan={10} className="px-3 py-6 text-center text-slate-500">
+                  <td colSpan={11} className="px-3 py-6 text-center text-slate-500">
                     Keine Mandanten für die aktuellen Filter.
                   </td>
                 </tr>
@@ -604,6 +845,16 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
                         </div>
                       ) : null}
                     </td>
+                    <td className="px-3 py-2 align-top text-[10px] text-slate-700">
+                      {row.open_reminders_count > 0 ? (
+                        <>
+                          <div>{formatIsoDe(row.next_reminder_due_at)}</div>
+                          <div className="mt-0.5 font-mono text-slate-500">{row.open_reminders_count} offen</div>
+                        </>
+                      ) : (
+                        <span className="text-slate-400">—</span>
+                      )}
+                    </td>
                     <td className="px-3 py-2 align-top">
                       <div className="flex flex-col gap-1">
                         <button
@@ -639,10 +890,11 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       {payload ? (
         <p className="text-xs text-slate-500">
           Historie: <code className="rounded bg-slate-100 px-1">data/advisor-mandant-history.json</code> (Export-
-          Zeitstempel automatisch; Review per Aktion). Optional weiterlesbar:{" "}
-          <code className="rounded bg-slate-100 px-1">data/advisor-portfolio-touchpoints.json</code> (Wave 39
-          Legacy). Schwellen: Review {payload.constants.review_stale_days} Tage, Export{" "}
-          {payload.constants.any_export_max_age_days} Tage – siehe Wave 40–42 (Doku: Wave 41/42 unter{" "}
+          Zeitstempel automatisch; Review per Aktion). Reminders:{" "}
+          <code className="rounded bg-slate-100 px-1">data/advisor-mandant-reminders.json</code>. Optional
+          weiterlesbar: <code className="rounded bg-slate-100 px-1">data/advisor-portfolio-touchpoints.json</code>{" "}
+          (Wave 39 Legacy). Schwellen: Review {payload.constants.review_stale_days} Tage, Export{" "}
+          {payload.constants.any_export_max_age_days} Tage – siehe Wave 40–43 (
           <code className="rounded bg-slate-100 px-1">docs/advisors/</code>
           ).
         </p>

--- a/frontend/src/lib/advisorMandantReminderRules.test.ts
+++ b/frontend/src/lib/advisorMandantReminderRules.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  autoReminderHighGapActive,
+  autoReminderPortfolioAttentionActive,
+  autoReminderStaleExportActive,
+  autoReminderStaleReviewActive,
+  defaultAutoDueAtIso,
+  isAutoReminderConditionActive,
+} from "@/lib/advisorMandantReminderRules";
+import type { KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+
+function row(p: Partial<KanzleiPortfolioRow>): KanzleiPortfolioRow {
+  return {
+    tenant_id: "t",
+    mandant_label: null,
+    readiness_class: "baseline_governance",
+    readiness_label_de: "Baseline",
+    primary_segment_label_de: null,
+    open_points_count: 0,
+    open_points_hoch: 0,
+    top_gap_pillar_code: "DSGVO",
+    top_gap_pillar_label_de: "DSGVO",
+    pillar_traffic: {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    },
+    board_report_stale: false,
+    api_fetch_ok: true,
+    attention_score: 0,
+    attention_flags_de: [],
+    last_mandant_readiness_export_at: null,
+    last_datev_bundle_export_at: null,
+    last_any_export_at: null,
+    last_review_marked_at: null,
+    last_review_note_de: null,
+    review_stale: false,
+    any_export_stale: false,
+    never_any_export: false,
+    gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
+    links: {
+      mandant_export_page: "/a",
+      datev_bundle_api: "/b",
+      readiness_export_api: "/c",
+      board_readiness_admin: "/d",
+    },
+    ...p,
+  };
+}
+
+describe("advisorMandantReminderRules", () => {
+  it("defaultAutoDueAtIso returns ISO string", () => {
+    const iso = defaultAutoDueAtIso(Date.parse("2026-04-08T12:00:00Z"));
+    expect(iso).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it("stale review and export flags", () => {
+    expect(autoReminderStaleReviewActive(row({ review_stale: true }))).toBe(true);
+    expect(autoReminderStaleExportActive(row({ any_export_stale: true }))).toBe(true);
+    expect(autoReminderStaleExportActive(row({ never_any_export: true }))).toBe(true);
+  });
+
+  it("high gap uses threshold or hoch count", () => {
+    expect(autoReminderHighGapActive(row({ open_points_count: 4 }), 4)).toBe(true);
+    expect(autoReminderHighGapActive(row({ open_points_hoch: 2 }), 99)).toBe(true);
+  });
+
+  it("portfolio attention follows queue qualification", () => {
+    expect(
+      autoReminderPortfolioAttentionActive(row({ review_stale: true, attention_score: 30 }), 4),
+    ).toBe(true);
+  });
+
+  it("isAutoReminderConditionActive maps categories", () => {
+    const r = row({ review_stale: true });
+    expect(isAutoReminderConditionActive(r, "stale_review", 4)).toBe(true);
+    expect(isAutoReminderConditionActive(r, "stale_export", 4)).toBe(false);
+  });
+});

--- a/frontend/src/lib/advisorMandantReminderRules.ts
+++ b/frontend/src/lib/advisorMandantReminderRules.ts
@@ -1,0 +1,87 @@
+/**
+ * Wave 43 – Regeln für automatische Reminder (ohne server-only, testbar).
+ */
+
+import { rowQualifiesForAttentionQueue } from "@/lib/kanzleiAttentionQueue";
+import type { KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import type { MandantReminderCategory } from "@/lib/advisorMandantReminderTypes";
+
+/** Kategorien, die beim Portfolio-Sync gesetzt/aktualisiert werden. */
+export const AUTO_MANDANT_REMINDER_CATEGORIES: MandantReminderCategory[] = [
+  "stale_review",
+  "stale_export",
+  "high_gap_count",
+  "portfolio_attention",
+];
+
+/** Fälligkeit für Auto-Reminder: Ende der lokalen Kalenderwoche (Sonntag 23:59:59). */
+export function defaultAutoDueAtIso(nowMs: number): string {
+  const d = new Date(nowMs);
+  const dow = d.getDay();
+  const daysToSunday = dow === 0 ? 0 : 7 - dow;
+  d.setDate(d.getDate() + daysToSunday);
+  d.setHours(23, 59, 59, 999);
+  return d.toISOString();
+}
+
+export function autoReminderStaleReviewActive(row: KanzleiPortfolioRow): boolean {
+  return row.review_stale;
+}
+
+export function autoReminderStaleExportActive(row: KanzleiPortfolioRow): boolean {
+  return row.any_export_stale || row.never_any_export;
+}
+
+export function autoReminderHighGapActive(row: KanzleiPortfolioRow, manyOpenThreshold: number): boolean {
+  return row.open_points_count >= manyOpenThreshold || row.open_points_hoch >= 2;
+}
+
+export function autoReminderPortfolioAttentionActive(
+  row: KanzleiPortfolioRow,
+  manyOpenThreshold: number,
+): boolean {
+  return rowQualifiesForAttentionQueue(row, manyOpenThreshold);
+}
+
+export function isAutoReminderConditionActive(
+  row: KanzleiPortfolioRow,
+  category: MandantReminderCategory,
+  manyOpenThreshold: number,
+): boolean {
+  switch (category) {
+    case "stale_review":
+      return autoReminderStaleReviewActive(row);
+    case "stale_export":
+      return autoReminderStaleExportActive(row);
+    case "high_gap_count":
+      return autoReminderHighGapActive(row, manyOpenThreshold);
+    case "portfolio_attention":
+      return autoReminderPortfolioAttentionActive(row, manyOpenThreshold);
+    default:
+      return false;
+  }
+}
+
+/** Montag 00:00:00 lokal bis Sonntag 23:59:59 – grobe „diese Woche“-Grenze. */
+export function isDueThisCalendarWeek(dueAtIso: string, nowMs: number): boolean {
+  const due = Date.parse(dueAtIso);
+  if (Number.isNaN(due)) return false;
+  const now = new Date(nowMs);
+  const start = new Date(now);
+  const day = start.getDay();
+  const daysFromMonday = day === 0 ? 6 : day - 1;
+  start.setDate(start.getDate() - daysFromMonday);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 7);
+  end.setMilliseconds(-1);
+  return due >= start.getTime() && due <= end.getTime();
+}
+
+export function isDueTodayOrOverdue(dueAtIso: string, nowMs: number): boolean {
+  const due = Date.parse(dueAtIso);
+  if (Number.isNaN(due)) return false;
+  const endOfToday = new Date(nowMs);
+  endOfToday.setHours(23, 59, 59, 999);
+  return due <= endOfToday.getTime();
+}

--- a/frontend/src/lib/advisorMandantReminderStore.ts
+++ b/frontend/src/lib/advisorMandantReminderStore.ts
@@ -1,0 +1,175 @@
+import "server-only";
+
+import { randomUUID } from "crypto";
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import type { KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import {
+  AUTO_MANDANT_REMINDER_CATEGORIES,
+  defaultAutoDueAtIso,
+  isAutoReminderConditionActive,
+} from "@/lib/advisorMandantReminderRules";
+import type {
+  AdvisorMandantRemindersState,
+  MandantReminderCategory,
+  MandantReminderRecord,
+  MandantReminderStatus,
+} from "@/lib/advisorMandantReminderTypes";
+import { MANDANT_REMINDER_MANUAL_CATEGORIES } from "@/lib/advisorMandantReminderTypes";
+
+function remindersPath(): string {
+  const fromEnv = process.env.ADVISOR_MANDANT_REMINDERS_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-advisor-mandant-reminders.json");
+  }
+  return join(process.cwd(), "data", "advisor-mandant-reminders.json");
+}
+
+function emptyState(): AdvisorMandantRemindersState {
+  return { reminders: [] };
+}
+
+export async function readAdvisorMandantRemindersState(): Promise<AdvisorMandantRemindersState> {
+  const path = remindersPath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const o = JSON.parse(raw) as { reminders?: unknown };
+    if (!o || !Array.isArray(o.reminders)) return emptyState();
+    const reminders: MandantReminderRecord[] = [];
+    for (const e of o.reminders) {
+      if (!e || typeof e !== "object") continue;
+      const r = e as Record<string, unknown>;
+      if (typeof r.reminder_id !== "string" || typeof r.tenant_id !== "string") continue;
+      if (typeof r.category !== "string") continue;
+      if (typeof r.due_at !== "string") continue;
+      if (r.status !== "open" && r.status !== "done" && r.status !== "dismissed") continue;
+      if (r.source !== "auto" && r.source !== "manual") continue;
+      reminders.push({
+        reminder_id: r.reminder_id,
+        tenant_id: r.tenant_id.trim(),
+        category: r.category as MandantReminderCategory,
+        due_at: r.due_at,
+        status: r.status,
+        note: typeof r.note === "string" ? r.note : null,
+        source: r.source,
+        created_at: typeof r.created_at === "string" ? r.created_at : new Date().toISOString(),
+        updated_at: typeof r.updated_at === "string" ? r.updated_at : new Date().toISOString(),
+      });
+    }
+    return { reminders };
+  } catch {
+    return emptyState();
+  }
+}
+
+async function writeAdvisorMandantRemindersState(state: AdvisorMandantRemindersState): Promise<void> {
+  const path = remindersPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(state, null, 2), "utf8");
+}
+
+function findOpenAuto(state: AdvisorMandantRemindersState, tenantId: string, category: MandantReminderCategory) {
+  return state.reminders.find(
+    (x) => x.tenant_id === tenantId && x.category === category && x.status === "open" && x.source === "auto",
+  );
+}
+
+/**
+ * Synchronisiert Auto-Reminder mit Portfolio-Zeilen: anlegen, erledigen wenn Bedingung wegfällt.
+ */
+export async function syncAdvisorMandantRemindersFromPortfolio(
+  rows: KanzleiPortfolioRow[],
+  manyOpenThreshold: number,
+  nowMs: number,
+): Promise<AdvisorMandantRemindersState> {
+  const state = await readAdvisorMandantRemindersState();
+  const isoNow = new Date(nowMs).toISOString();
+
+  for (const row of rows) {
+    for (const category of AUTO_MANDANT_REMINDER_CATEGORIES) {
+      const active = isAutoReminderConditionActive(row, category, manyOpenThreshold);
+      const open = findOpenAuto(state, row.tenant_id, category);
+
+      if (!active && open) {
+        open.status = "done";
+        open.updated_at = isoNow;
+      }
+
+      if (active && !open) {
+        state.reminders.push({
+          reminder_id: randomUUID(),
+          tenant_id: row.tenant_id,
+          category,
+          due_at: defaultAutoDueAtIso(nowMs),
+          status: "open",
+          note: null,
+          source: "auto",
+          created_at: isoNow,
+          updated_at: isoNow,
+        });
+      }
+    }
+  }
+
+  await writeAdvisorMandantRemindersState(state);
+  return state;
+}
+
+export async function createAdvisorMandantReminderManual(input: {
+  tenant_id: string;
+  category: MandantReminderCategory;
+  note: string | null;
+  due_at: string;
+}): Promise<MandantReminderRecord> {
+  if (!MANDANT_REMINDER_MANUAL_CATEGORIES.includes(input.category)) {
+    throw new Error("invalid_manual_category");
+  }
+  const state = await readAdvisorMandantRemindersState();
+  const isoNow = new Date().toISOString();
+  const rec: MandantReminderRecord = {
+    reminder_id: randomUUID(),
+    tenant_id: input.tenant_id.trim(),
+    category: input.category,
+    due_at: input.due_at.trim(),
+    status: "open",
+    note: input.note?.trim() ? input.note.trim().slice(0, 500) : null,
+    source: "manual",
+    created_at: isoNow,
+    updated_at: isoNow,
+  };
+  state.reminders.push(rec);
+  await writeAdvisorMandantRemindersState(state);
+  return rec;
+}
+
+export async function updateAdvisorMandantReminderStatus(
+  reminderId: string,
+  status: MandantReminderStatus,
+): Promise<MandantReminderRecord | null> {
+  if (status !== "done" && status !== "dismissed") return null;
+  const state = await readAdvisorMandantRemindersState();
+  const rec = state.reminders.find((x) => x.reminder_id === reminderId);
+  if (!rec || rec.status !== "open") return null;
+  rec.status = status;
+  rec.updated_at = new Date().toISOString();
+  await writeAdvisorMandantRemindersState(state);
+  return rec;
+}
+
+export async function listAdvisorMandantReminders(filters?: {
+  tenant_id?: string;
+  status?: MandantReminderStatus;
+}): Promise<MandantReminderRecord[]> {
+  const state = await readAdvisorMandantRemindersState();
+  let out = state.reminders;
+  if (filters?.tenant_id?.trim()) {
+    const t = filters.tenant_id.trim();
+    out = out.filter((x) => x.tenant_id === t);
+  }
+  if (filters?.status) {
+    out = out.filter((x) => x.status === filters.status);
+  }
+  return out.sort((a, b) => Date.parse(a.due_at) - Date.parse(b.due_at));
+}

--- a/frontend/src/lib/advisorMandantReminderTypes.ts
+++ b/frontend/src/lib/advisorMandantReminderTypes.ts
@@ -1,0 +1,54 @@
+/**
+ * Wave 43 – Mandanten-Reminders / Follow-ups (intern, kein Task-System).
+ */
+
+/** Regelbasiert + manuell; `portfolio_attention` koppelt an die Attention-Queue. */
+export type MandantReminderCategory =
+  | "stale_review"
+  | "stale_export"
+  | "high_gap_count"
+  | "portfolio_attention"
+  | "follow_up_note"
+  | "manual";
+
+export type MandantReminderStatus = "open" | "done" | "dismissed";
+
+export type MandantReminderSource = "auto" | "manual";
+
+export type MandantReminderRecord = {
+  reminder_id: string;
+  tenant_id: string;
+  category: MandantReminderCategory;
+  due_at: string;
+  status: MandantReminderStatus;
+  note: string | null;
+  source: MandantReminderSource;
+  created_at: string;
+  updated_at: string;
+};
+
+export type AdvisorMandantRemindersState = {
+  reminders: MandantReminderRecord[];
+};
+
+/** In Portfolio-Payload eingebettet (nur offene). */
+export type MandantReminderApiEntry = {
+  reminder_id: string;
+  tenant_id: string;
+  mandant_label: string | null;
+  category: MandantReminderCategory;
+  due_at: string;
+  note: string | null;
+  source: MandantReminderSource;
+};
+
+export const MANDANT_REMINDER_CATEGORY_LABEL_DE: Record<MandantReminderCategory, string> = {
+  stale_review: "Review-Kadenz",
+  stale_export: "Export-Kadenz",
+  high_gap_count: "Viele offene Prüfpunkte",
+  portfolio_attention: "Portfolio-Aufmerksamkeit (Queue)",
+  follow_up_note: "Follow-up / Notiz",
+  manual: "Manuell",
+};
+
+export const MANDANT_REMINDER_MANUAL_CATEGORIES: MandantReminderCategory[] = ["manual", "follow_up_note"];

--- a/frontend/src/lib/kanzleiAttentionQueue.test.ts
+++ b/frontend/src/lib/kanzleiAttentionQueue.test.ts
@@ -40,6 +40,8 @@ function baseRow(over: Partial<KanzleiPortfolioRow> = {}): KanzleiPortfolioRow {
     any_export_stale: false,
     never_any_export: false,
     gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
     links: {
       mandant_export_page: "/admin/advisor-mandant-export?client_id=t-1",
       datev_bundle_api: "/api/x",

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
@@ -39,6 +39,8 @@ function row(partial: Partial<KanzleiPortfolioRow>): KanzleiPortfolioRow {
     any_export_stale: false,
     never_any_export: false,
     gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
     links: {
       mandant_export_page: "/x",
       datev_bundle_api: "/y",
@@ -71,6 +73,9 @@ function payload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
       naechster_schritt_de: "Test-Schritt",
       links: r.links,
     })),
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
   };
 }
 

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -35,6 +35,8 @@ function minimalPayload(): KanzleiPortfolioPayload {
     any_export_stale: false,
     never_any_export: false,
     gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
     links: {
       mandant_export_page: "/a",
       datev_bundle_api: "/b",
@@ -56,6 +58,9 @@ function minimalPayload(): KanzleiPortfolioPayload {
     },
     rows: [row],
     attention_queue: [],
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
   };
 }
 

--- a/frontend/src/lib/kanzleiPortfolioAggregate.ts
+++ b/frontend/src/lib/kanzleiPortfolioAggregate.ts
@@ -2,6 +2,11 @@ import "server-only";
 
 import type { AdvisorMandantHistoryEntry } from "@/lib/advisorMandantHistoryStore";
 import { readAdvisorMandantHistoryMap } from "@/lib/advisorMandantHistoryStore";
+import type { MandantReminderApiEntry } from "@/lib/advisorMandantReminderTypes";
+import {
+  syncAdvisorMandantRemindersFromPortfolio,
+} from "@/lib/advisorMandantReminderStore";
+import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
 import {
   daysSinceValidIso,
   isNonEmptyUnparsableIso,
@@ -245,6 +250,8 @@ function rowFromSnapshot(
     any_export_stale,
     never_any_export,
     gaps_heavy_without_recent_export,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
     links: {
       mandant_export_page: `/admin/advisor-mandant-export?client_id=${tidEnc}`,
       datev_bundle_api: `/api/internal/advisor/datev-export-bundle?client_id=${tidEnc}`,
@@ -271,6 +278,51 @@ export async function computeKanzleiPortfolioPayload(now: Date = new Date()): Pr
 
   const attention_queue = buildAttentionQueue(rows, KANZLEI_MANY_OPEN_POINTS);
 
+  const remState = await syncAdvisorMandantRemindersFromPortfolio(
+    rows,
+    KANZLEI_MANY_OPEN_POINTS,
+    nowMs,
+  );
+  const openReminderRecords = remState.reminders.filter((r) => r.status === "open");
+  const openByTenant = new Map<string, typeof openReminderRecords>();
+  for (const r of openReminderRecords) {
+    const arr = openByTenant.get(r.tenant_id) ?? [];
+    arr.push(r);
+    openByTenant.set(r.tenant_id, arr);
+  }
+  for (const arr of openByTenant.values()) {
+    arr.sort((a, b) => Date.parse(a.due_at) - Date.parse(b.due_at));
+  }
+
+  const labelByTenant = new Map(rows.map((r) => [r.tenant_id, r.mandant_label]));
+  const rowsWithReminders = rows.map((row) => {
+    const list = openByTenant.get(row.tenant_id) ?? [];
+    return {
+      ...row,
+      open_reminders_count: list.length,
+      next_reminder_due_at: list[0]?.due_at ?? null,
+    };
+  });
+
+  const open_reminders: MandantReminderApiEntry[] = [...openReminderRecords]
+    .sort((a, b) => Date.parse(a.due_at) - Date.parse(b.due_at))
+    .map((r) => ({
+      reminder_id: r.reminder_id,
+      tenant_id: r.tenant_id,
+      mandant_label: labelByTenant.get(r.tenant_id) ?? null,
+      category: r.category,
+      due_at: r.due_at,
+      note: r.note,
+      source: r.source,
+    }));
+
+  let reminders_due_today_or_overdue_count = 0;
+  let reminders_due_this_week_open_count = 0;
+  for (const r of openReminderRecords) {
+    if (isDueTodayOrOverdue(r.due_at, nowMs)) reminders_due_today_or_overdue_count += 1;
+    if (isDueThisCalendarWeek(r.due_at, nowMs)) reminders_due_this_week_open_count += 1;
+  }
+
   return {
     version: KANZLEI_PORTFOLIO_VERSION,
     generated_at: bundle.generated_at,
@@ -283,7 +335,10 @@ export async function computeKanzleiPortfolioPayload(now: Date = new Date()): Pr
       many_open_points_threshold: KANZLEI_MANY_OPEN_POINTS,
       gap_heavy_min_open_for_export_rule: KANZLEI_GAP_HEAVY_FOR_EXPORT_RULE,
     },
-    rows,
+    rows: rowsWithReminders,
     attention_queue,
+    open_reminders,
+    reminders_due_today_or_overdue_count,
+    reminders_due_this_week_open_count,
   };
 }

--- a/frontend/src/lib/kanzleiPortfolioTypes.ts
+++ b/frontend/src/lib/kanzleiPortfolioTypes.ts
@@ -1,11 +1,12 @@
 /**
- * Wave 39–41 – Kanzlei-Portfolio-Cockpit (intern, Mehrmandanten-Übersicht).
+ * Wave 39–43 – Kanzlei-Portfolio-Cockpit (intern, Mehrmandanten-Übersicht).
  */
 
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
+import type { MandantReminderApiEntry } from "@/lib/advisorMandantReminderTypes";
 
-export const KANZLEI_PORTFOLIO_VERSION = "wave41-v1";
+export const KANZLEI_PORTFOLIO_VERSION = "wave43-v1";
 
 export type KanzleiPortfolioPillarFilter = BoardReadinessPillarKey | "all";
 
@@ -35,6 +36,8 @@ export type KanzleiPortfolioRow = {
   any_export_stale: boolean;
   never_any_export: boolean;
   gaps_heavy_without_recent_export: boolean;
+  open_reminders_count: number;
+  next_reminder_due_at: string | null;
   links: {
     mandant_export_page: string;
     datev_bundle_api: string;
@@ -67,6 +70,10 @@ export type KanzleiPortfolioPayload = {
   };
   rows: KanzleiPortfolioRow[];
   attention_queue: KanzleiAttentionQueueItem[];
+  /** Offene Reminder (Wave 43), nach Fälligkeit sortiert. */
+  open_reminders: MandantReminderApiEntry[];
+  reminders_due_today_or_overdue_count: number;
+  reminders_due_this_week_open_count: number;
 };
 
 export const KANZLEI_PILLAR_LABEL_DE: Record<string, string> = {


### PR DESCRIPTION
Add lightweight persisted reminders (auto rules + manual), internal API, portfolio aggregate fields, cockpit panel and export-page UI; document model and cross-links in advisor docs.

Made-with: Cursor