### PR TITLE
feat(advisors): Wave 45 Kanzlei KPI layer

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -25,8 +25,10 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | `compare` | `1` (an) | `compare=0` schaltet Abschnitt 3 ab (Snapshot trotzdem nutzbar) |
 | `update_baseline` | `0` | `update_baseline=1` **überschreibt** die Baseline-Datei mit dem **aktuellen** Portfolio-Snapshot |
 | `top_n` | `10` | Anzahl Zeilen in Abschnitt 2 (3–25) |
+| `kpi_window_days` | `90` | Wave 45: Fenster für KPI-Abschnitt 5 (7–365) |
+| `kpi` | `1` | `kpi=0` schaltet Abschnitt 5 ab |
 
-**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (`wave42-v1`), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
+**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (`wave45-v1` inkl. optionalem Abschnitt 5), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
 
 ## Baseline & Change-Logik
 
@@ -63,6 +65,7 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave44-partner-review-package.md`
 - `docs/advisors/wave43-reminders-and-followups.md`
 - `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -19,7 +19,8 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
     - `compare=0` – kein Vergleich mit Baseline (Teil C ohne Inhalt außer Hinweis).
     - `top_n` – Anzahl Top-Mandanten in Teil B (3–15, Standard 8).
     - `format=markdown` – Antwort als **Markdown-Datei** (`Content-Disposition: attachment`) statt JSON.
-  - JSON-Antwort: `partner_review_package` (strukturiert), `markdown_de`, kompaktes `meta`.
+    - `kpi_window_days` / `kpi=0` – Wave 45: KPI-Teil E wie beim Monatsreport.
+  - JSON-Antwort: `partner_review_package` (strukturiert, Schema `wave45-v1`), `markdown_de`, kompaktes `meta`.
 
 ## Priorisierung (transparent)
 
@@ -51,6 +52,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave43-reminders-and-followups.md`
 - `docs/advisors/wave42-kanzlei-monatsreport.md`
 - `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`

--- a/docs/advisors/wave45-advisor-kpis.md
+++ b/docs/advisors/wave45-advisor-kpis.md
@@ -1,0 +1,57 @@
+# Wave 45 – Advisor-KPIs / Kanzlei Performance Metrics
+
+Interne, **erklärbare** Kennzahlen für operatives Kanzlei-Steering (Regelmäßigkeit von Reviews und Exporten, Reaktion auf Reminder-Signale, Portfolio-Hygiene). **Kein** öffentliches Dashboard und **kein** Analytics-Cube.
+
+## KPI-Überblick (Strip + JSON)
+
+| KPI | Bedeutung | Datenquelle |
+|-----|-----------|-------------|
+| **Review aktuell** | Anteil Mandanten ohne überfälliges Kanzlei-Review (Schwelle wie Cockpit, z. B. 90 Tage) | Portfolio-Zeilen + Historie (`review_stale`) |
+| **Export-Kadenz OK** | Anteil Mandanten mit gültigem letztem Readiness-/DATEV-Export | Portfolio (`any_export_stale`) |
+| **Reminder-Reaktionszeit (Median)** | Median Stunden von `created_at` bis `updated_at` bei Remindern mit Status done/dismissed, deren Abschluss im gewählten Fenster liegt | `data/advisor-mandant-reminders.json` |
+| **Queue-Reminder (Median)** | Wie oben, nur Kategorie `portfolio_attention` (Proxy für Bearbeitung von Queue-Signalen) | Reminder-Store |
+| **Ohne rote Säule** | Anteil Mandanten ohne rote Board-Readiness-Säule (EU AI Act, ISO 42001, NIS2, DSGVO) | Portfolio `pillar_traffic` |
+
+Zusätzlich im JSON (nicht immer im Strip): **Mittleres Review-Alter** (Tage seit `last_review_marked_at` für Mandanten mit gültigem Datum), **Export-Aktivität im Fenster** (Anteil Mandanten, deren letzter Export-Zeitstempel in die letzten *N* Tage fällt), **Segment-Breakdown** nach Readiness-Klasse oder Primärsegment (Branchenlabel).
+
+## Trend-Pfeile (↑ / ↓ / → / ○)
+
+- **Review:** Vergleich der *Aktivität*: Anteil Mandanten mit Review-Zeitstempel im aktuellen Fenster vs. der Vorperiode (gleiche Länge).
+- **Export-Aktivität:** Anteil Mandanten mit Export-Zeitstempel im Fenster vs. Vorperiode.
+- **Median-Stunden (Reminder / Queue-Proxy):** niedrigere Mediane in der aktuellen Periode = Verbesserung (↑).
+- **Ohne rote Säule:** Trend `unknown` (kein historischer Querschnitt ohne zusätzliche Persistenz).
+
+## API
+
+`GET /api/internal/advisor/kpi-portfolio` (Lead-Admin wie andere Advisor-Interna)
+
+| Parameter | Standard | Bedeutung |
+|-----------|----------|-----------|
+| `window_days` | `90` | Auswertungsfenster und Länge der Vorperiode (7–365) |
+| `segment_by` | `readiness` | `readiness` oder `primary_segment` (Branchencluster aus GTM-Segment) |
+
+Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `strip`, `segments`, `interpretation_notes_de`.
+
+## Einbindung Monatsreport & Partner-Paket
+
+- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab.
+- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional.
+
+## Grenzen (bewusst)
+
+- **Keine Export-Event-Historie:** „Wie viele Exporte in einem Monat“ ist ohne separates Log nicht exakt; genutzt wird der **letzte** Zeitstempel pro Mandant und ob er im Fenster liegt.
+- **Attention-Queue ohne Zeitstempel:** Es gibt kein „Eintrag in Queue um T0“. Der Median für `portfolio_attention`-Reminder ist ein **Proxy** (Bedingung erkannt → Auto-Reminder angelegt → erledigt).
+- **Ein Kanzlei-Workspace:** Die APIs beziehen sich auf das **gemappte Mandantenportfolio** dieser Umgebung, nicht auf mandantenübergreifende SaaS-Analytics.
+
+## Interpretation für Kanzleien (Beispiele)
+
+- **Review aktuell unter 50 %, Trend ↓:** Review-Rhythmus mit Partnerterminen oder Playbook-Zyklen schärfen; Historie im Cockpit pflegen.
+- **Median Reminder &gt; 168 h:** Follow-ups stauen sich – wöchentliche Queue-Durcharbeitung oder Delegation klären.
+- **Viele rote Säulen:** Priorisierung über Attention-Queue und Mandanten-Exports, nicht über KPI-Strip alleine.
+
+## Siehe auch
+
+- `docs/advisors/wave44-partner-review-package.md`
+- `docs/advisors/wave42-kanzlei-monatsreport.md`
+- `docs/advisors/wave43-reminders-and-followups.md`
+- `frontend/src/lib/advisorKpiPortfolioBuild.ts`

--- a/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
+++ b/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { readKanzleiMonthlyReportBaseline, writeKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
@@ -29,14 +30,23 @@ export async function GET(req: Request) {
   const updateBaseline = url.searchParams.get("update_baseline") === "1";
   const topNRaw = url.searchParams.get("top_n");
   const attentionTopN = Math.min(25, Math.max(3, Number.parseInt(topNRaw ?? "10", 10) || 10));
+  const kpiWindowRaw = url.searchParams.get("kpi_window_days");
+  const kpiWindowDays = Math.min(365, Math.max(7, Number.parseInt(kpiWindowRaw ?? "90", 10) || 90));
+  const kpiOff = url.searchParams.get("kpi") === "0";
 
-  const payload = await computeKanzleiPortfolioPayload(new Date());
+  const now = new Date();
+  const payload = await computeKanzleiPortfolioPayload(now);
   const baseline = await readKanzleiMonthlyReportBaseline();
+
+  const advisorKpiSnapshot = kpiOff
+    ? null
+    : await attachAdvisorKpiToPayload(payload, now.getTime(), kpiWindowDays);
 
   const report = buildKanzleiMonthlyReport(payload, baseline, {
     periodLabel: period,
     compareToBaseline: compare,
     attentionTopN,
+    advisorKpiSnapshot,
   });
   const markdown_de = kanzleiMonthlyReportMarkdownDe(report);
 

--- a/frontend/src/app/api/internal/advisor/kpi-portfolio/route.ts
+++ b/frontend/src/app/api/internal/advisor/kpi-portfolio/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+
+import { computeAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const wRaw = url.searchParams.get("window_days");
+  const windowDays = Math.min(365, Math.max(7, Number.parseInt(wRaw ?? "90", 10) || 90));
+  const seg = url.searchParams.get("segment_by")?.trim().toLowerCase();
+  const segmentBy: "readiness" | "primary_segment" =
+    seg === "primary_segment" || seg === "segment" ? "primary_segment" : "readiness";
+
+  const snapshot = await computeAdvisorKpiPortfolioSnapshot(new Date(), windowDays, segmentBy);
+
+  return NextResponse.json({
+    ok: true,
+    advisor_kpi_portfolio: snapshot,
+  });
+}

--- a/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
+++ b/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 
+import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { readKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildPartnerReviewPackage } from "@/lib/partnerReviewPackageBuild";
@@ -21,13 +22,22 @@ export async function GET(req: Request) {
   const topNRaw = url.searchParams.get("top_n");
   const attentionTopN = Math.min(15, Math.max(3, Number.parseInt(topNRaw ?? "8", 10) || 8));
   const format = url.searchParams.get("format")?.trim().toLowerCase();
+  const kpiWindowRaw = url.searchParams.get("kpi_window_days");
+  const kpiWindowDays = Math.min(365, Math.max(7, Number.parseInt(kpiWindowRaw ?? "90", 10) || 90));
+  const kpiOff = url.searchParams.get("kpi") === "0";
 
-  const payload = await computeKanzleiPortfolioPayload(new Date());
+  const now = new Date();
+  const payload = await computeKanzleiPortfolioPayload(now);
   const baseline = await readKanzleiMonthlyReportBaseline();
+
+  const advisorKpiSnapshot = kpiOff
+    ? null
+    : await attachAdvisorKpiToPayload(payload, now.getTime(), kpiWindowDays);
 
   const partner_review_package = buildPartnerReviewPackage(payload, baseline, {
     compareToBaseline: compare,
     attentionTopN,
+    advisorKpiSnapshot,
   });
   const markdown_de = partnerReviewPackageMarkdownDe(partner_review_package);
 

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import { GTM_READINESS_CLASSES, GTM_READINESS_SHORT_DE } from "@/lib/gtmAccountReadiness";
 import { KanzleiReviewPlaybookHelper } from "@/components/admin/KanzleiReviewPlaybookHelper";
+import type { AdvisorKpiPortfolioSnapshot, AdvisorKpiTrend, AdvisorKpiTraffic } from "@/lib/advisorKpiTypes";
 import type { KanzleiMonthlyReportDto } from "@/lib/kanzleiMonthlyReportTypes";
 import type { PartnerReviewPackageDto } from "@/lib/partnerReviewPackageTypes";
 import {
@@ -22,6 +23,20 @@ import type {
 import { isNonEmptyUnparsableIso } from "@/lib/mandantHistoryMerge";
 
 type Props = { adminConfigured: boolean };
+
+function kpiTrendSymbol(t: AdvisorKpiTrend): string {
+  if (t === "up") return "↑";
+  if (t === "down") return "↓";
+  if (t === "flat") return "→";
+  return "○";
+}
+
+function kpiTileBorder(t: AdvisorKpiTraffic): string {
+  if (t === "green") return "border-emerald-300 bg-emerald-50/70";
+  if (t === "amber") return "border-amber-300 bg-amber-50/70";
+  if (t === "red") return "border-rose-300 bg-rose-50/70";
+  return "border-slate-200 bg-slate-50/80";
+}
 
 function trafficPill(s: BoardReadinessTraffic): string {
   if (s === "green") return "border-emerald-300 bg-emerald-50 text-emerald-950";
@@ -214,6 +229,11 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [partnerCompare, setPartnerCompare] = useState(true);
   const [partnerTopN, setPartnerTopN] = useState(8);
 
+  const [kpiSnapshot, setKpiSnapshot] = useState<AdvisorKpiPortfolioSnapshot | null>(null);
+  const [kpiLoading, setKpiLoading] = useState(false);
+  const [kpiErr, setKpiErr] = useState<string | null>(null);
+  const [kpiWindowDays, setKpiWindowDays] = useState(90);
+
   const [reminderPatchBusyId, setReminderPatchBusyId] = useState<string | null>(null);
   const [manualRemTenantId, setManualRemTenantId] = useState("");
   const [manualRemDue, setManualRemDue] = useState("");
@@ -248,6 +268,39 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     if (!adminConfigured) return;
     void load();
   }, [adminConfigured, load]);
+
+  const fetchKpi = useCallback(async () => {
+    setKpiLoading(true);
+    setKpiErr(null);
+    try {
+      const w = Math.min(365, Math.max(7, kpiWindowDays));
+      const r = await fetch(`/api/internal/advisor/kpi-portfolio?window_days=${w}`, {
+        credentials: "include",
+      });
+      if (r.status === 401) {
+        setKpiErr("KPI: nicht angemeldet.");
+        setKpiSnapshot(null);
+        return;
+      }
+      if (!r.ok) {
+        setKpiErr(`KPI: HTTP ${r.status}`);
+        setKpiSnapshot(null);
+        return;
+      }
+      const data = (await r.json()) as { advisor_kpi_portfolio?: AdvisorKpiPortfolioSnapshot };
+      setKpiSnapshot(data.advisor_kpi_portfolio ?? null);
+    } catch {
+      setKpiErr("KPI: Netzwerkfehler");
+      setKpiSnapshot(null);
+    } finally {
+      setKpiLoading(false);
+    }
+  }, [kpiWindowDays]);
+
+  useEffect(() => {
+    if (!adminConfigured || !payload?.generated_at) return;
+    void fetchKpi();
+  }, [adminConfigured, payload?.generated_at, fetchKpi]);
 
   const filteredRows = useMemo(() => {
     if (!payload) return [];
@@ -498,13 +551,13 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     <div className="space-y-6">
       <div className="flex flex-wrap items-end justify-between gap-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39–44 · Kanzlei / Berater</p>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39–45 · Kanzlei / Berater</p>
           <h1 className="text-2xl font-semibold text-slate-900">Mehrmandanten-Kanzlei-Cockpit</h1>
           <p className="mt-1 max-w-3xl text-sm text-slate-600">
             Welcher Mandant braucht jetzt Aufmerksamkeit? Portfolio über gemappte Mandanten mit Readiness,
             offenen Prüfpunkten, Export-Historie (Readiness / DATEV-ZIP), Review-Kadenz (Wave 40),
             Attention-Queue, Review-Playbook (Wave 41), Monatsreport (Wave 42), Reminders / Follow-ups
-            (Wave 43) und Partner-Review-Paket (Wave 44) für interne Steuerung.
+            (Wave 43), Partner-Review-Paket (Wave 44) und Kanzlei-KPIs (Wave 45) für internes Steering.
           </p>
           {payload ? (
             <p className="mt-1 font-mono text-xs text-slate-400">
@@ -521,6 +574,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             ·{" "}
             <code className="rounded bg-slate-100 px-1 text-[11px]">
               GET /api/internal/advisor/partner-review-package
+            </code>{" "}
+            ·{" "}
+            <code className="rounded bg-slate-100 px-1 text-[11px]">
+              GET /api/internal/advisor/kpi-portfolio
             </code>
           </p>
         </div>
@@ -553,6 +610,68 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       ) : null}
 
       {payload ? (
+        <section
+          id="kanzlei-kpi-strip"
+          className="rounded-xl border border-teal-200 bg-teal-50/40 p-4 shadow-sm"
+        >
+          <div className="flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <h2 className="text-sm font-semibold text-teal-950">Kanzlei-KPIs (Wave 45)</h2>
+              <p className="mt-1 text-[11px] text-slate-600">
+                Operative Kennzahlen für Regelmäßigkeit (Review, Export, Reminder-Reaktion). Kein BI-System –{" "}
+                <code className="rounded bg-white px-1">GET /api/internal/advisor/kpi-portfolio</code>.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="text-[11px] font-medium text-slate-700">
+                Fenster (Tage)
+                <select
+                  className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                  value={kpiWindowDays}
+                  onChange={(e) => setKpiWindowDays(Number.parseInt(e.target.value, 10) || 90)}
+                >
+                  <option value={30}>30</option>
+                  <option value={60}>60</option>
+                  <option value={90}>90</option>
+                </select>
+              </label>
+              <button
+                type="button"
+                disabled={kpiLoading}
+                onClick={() => void fetchKpi()}
+                className="rounded-lg border border-teal-700 bg-teal-800 px-2 py-1 text-[11px] text-white hover:bg-teal-900 disabled:opacity-50"
+              >
+                {kpiLoading ? "…" : "KPI aktualisieren"}
+              </button>
+            </div>
+          </div>
+          {kpiErr ? <p className="mt-2 text-[11px] text-red-600">{kpiErr}</p> : null}
+          {kpiSnapshot ? (
+            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+              {kpiSnapshot.strip.map((tile) => (
+                <a
+                  key={tile.id}
+                  href={tile.href ?? "#"}
+                  className={`block rounded-lg border p-2.5 text-[11px] shadow-sm transition hover:opacity-95 ${kpiTileBorder(tile.traffic_light)}`}
+                >
+                  <div className="font-semibold text-slate-900">{tile.label_de}</div>
+                  <div className="mt-1 flex items-baseline gap-1.5 tabular-nums">
+                    <span className="text-base font-bold text-slate-900">{tile.value_display_de}</span>
+                    <span className="text-slate-600" title="Trend vs. Vorperiode (wo verfügbar)">
+                      {kpiTrendSymbol(tile.trend)}
+                    </span>
+                  </div>
+                  <p className="mt-1 leading-snug text-slate-600">{tile.hint_de}</p>
+                </a>
+              ))}
+            </div>
+          ) : !kpiLoading ? (
+            <p className="mt-2 text-[11px] text-slate-500">KPI werden nach Portfolio-Laden geladen …</p>
+          ) : null}
+        </section>
+      ) : null}
+
+      {payload ? (
         <div className="grid gap-4 lg:grid-cols-2">
           <KanzleiReviewPlaybookHelper
             variant="full"
@@ -562,16 +681,18 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
                 : "Keine Mandanten in der Queue – Playbook trotzdem für Stichproben nutzen."
             }
           />
-          <AttentionQueuePanel
-            items={payload.attention_queue ?? []}
-            onMarkReview={(tid) => void markReviewDone(tid)}
-            reviewBusyId={reviewBusyId}
-          />
+          <section id="kanzlei-kpi-queue" className="min-w-0">
+            <AttentionQueuePanel
+              items={payload.attention_queue ?? []}
+              onMarkReview={(tid) => void markReviewDone(tid)}
+              reviewBusyId={reviewBusyId}
+            />
+          </section>
         </div>
       ) : null}
 
       {payload ? (
-        <section className="rounded-xl border border-rose-200 bg-rose-50/20 p-4 shadow-sm">
+        <section id="kanzlei-kpi-reminders" className="rounded-xl border border-rose-200 bg-rose-50/20 p-4 shadow-sm">
           <h2 className="text-sm font-semibold text-rose-950">Reminders & Follow-ups (Wave 43)</h2>
           <p className="mt-1 text-[11px] text-slate-600">
             Gespeichert in{" "}
@@ -691,13 +812,15 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
 
       {payload ? (
         <section className="rounded-xl border border-cyan-200 bg-cyan-50/30 p-4 shadow-sm">
-          <h2 className="text-sm font-semibold text-slate-900">Monatsreport / Sammelreport (Wave 42)</h2>
+          <h2 className="text-sm font-semibold text-slate-900">Monatsreport / Sammelreport (Wave 42–45)</h2>
           <p className="mt-1 text-[11px] text-slate-600">
             Portfolio-weiter Überblick für interne Kanzlei-Reviews und Status-Mails. JSON + Markdown über{" "}
             <code className="rounded bg-white px-1">GET /api/internal/advisor/kanzlei-monthly-report</code>.
             Vergleich nutzt optional{" "}
             <code className="rounded bg-white px-1">data/kanzlei-monthly-report-baseline.json</code> (siehe
-            Doku).
+            Doku). Abschnitt 5 (KPIs):{" "}
+            <code className="rounded bg-white px-1">kpi_window_days</code>, abschalten mit{" "}
+            <code className="rounded bg-white px-1">kpi=0</code>.
           </p>
           <div className="mt-3 flex flex-wrap items-end gap-3">
             <label className="text-xs font-medium text-slate-700">
@@ -759,12 +882,14 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
 
       {payload ? (
         <section className="rounded-xl border border-indigo-200 bg-indigo-50/30 p-4 shadow-sm">
-          <h2 className="text-sm font-semibold text-slate-900">Partner-Review-Paket (Wave 44)</h2>
+          <h2 className="text-sm font-semibold text-slate-900">Partner-Review-Paket (Wave 44–45)</h2>
           <p className="mt-1 text-[11px] text-slate-600">
             Kompaktes Sammelpaket für Partnerrunden und Portfolio-Steuerung (nicht Mandanten-Einzel, nicht
-            Board-Pack). Teil C nutzt dieselbe Baseline wie der Monatsreport.{" "}
+            Board-Pack). Teil C nutzt dieselbe Baseline wie der Monatsreport; Teil E enthält Kanzlei-KPIs
+            (Wave 45).{" "}
             <code className="rounded bg-white px-1">GET /api/internal/advisor/partner-review-package</code> ·{" "}
-            <code className="rounded bg-white px-1">?format=markdown</code> für Datei-Download.
+            <code className="rounded bg-white px-1">?format=markdown</code> · optional{" "}
+            <code className="rounded bg-white px-1">kpi=0</code>.
           </p>
           <div className="mt-3 flex flex-wrap items-end gap-3">
             <label className="text-xs font-medium text-slate-700">
@@ -830,7 +955,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       ) : null}
 
       {payload ? (
-        <div className="flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div
+          id="kanzlei-kpi-filters"
+          className="flex flex-wrap items-end gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+        >
           <label className="text-xs font-medium text-slate-700">
             Readiness-Klasse
             <select
@@ -873,7 +1001,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             />
             Viele offene Punkte (≥{payload.constants.many_open_points_threshold})
           </label>
-          <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-700">
+          <label
+            id="kanzlei-kpi-review"
+            className="flex cursor-pointer items-center gap-2 text-xs text-slate-700"
+          >
             <input
               type="checkbox"
               checked={reviewStaleOnly}
@@ -890,7 +1021,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       {loading && !payload ? <p className="text-sm text-slate-500">Portfolio wird geladen …</p> : null}
 
       {payload ? (
-        <section className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+        <section
+          id="kanzlei-kpi-table"
+          className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm"
+        >
           <table className="min-w-[1180px] w-full border-collapse text-left text-xs">
             <thead>
               <tr className="border-b border-slate-200 bg-slate-50 text-slate-600">
@@ -900,7 +1034,9 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
                 <th className="px-3 py-2 font-medium">Bericht</th>
                 <th className="px-3 py-2 font-medium">Offen</th>
                 <th className="px-3 py-2 font-medium">Signale</th>
-                <th className="px-3 py-2 font-medium">Readiness-Export</th>
+                <th id="kanzlei-kpi-export" className="px-3 py-2 font-medium">
+                  Readiness-Export
+                </th>
                 <th className="px-3 py-2 font-medium">DATEV-ZIP</th>
                 <th className="px-3 py-2 font-medium">Review</th>
                 <th className="px-3 py-2 font-medium">Reminder</th>
@@ -1036,7 +1172,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
           Zeitstempel automatisch; Review per Aktion). Reminders:{" "}
           <code className="rounded bg-slate-100 px-1">data/advisor-mandant-reminders.json</code>. Optional
           weiterlesbar: <code className="rounded bg-slate-100 px-1">data/advisor-portfolio-touchpoints.json</code>{" "}
-          (Wave 39–44). Schwellen: Review {payload.constants.review_stale_days} Tage, Export{" "}
+          (Wave 39–45). Schwellen: Review {payload.constants.review_stale_days} Tage, Export{" "}
           {payload.constants.any_export_max_age_days} Tage – siehe Wave 40–43 (
           <code className="rounded bg-slate-100 px-1">docs/advisors/</code>
           ).

--- a/frontend/src/lib/advisorKpiPortfolioAggregate.ts
+++ b/frontend/src/lib/advisorKpiPortfolioAggregate.ts
@@ -1,0 +1,32 @@
+import "server-only";
+
+import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
+import { readAdvisorMandantRemindersState } from "@/lib/advisorMandantReminderStore";
+import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+
+/** KPIs zu bereits geladenem Portfolio (ein Portfolio-Compute pro Request). */
+export async function attachAdvisorKpiToPayload(
+  payload: KanzleiPortfolioPayload,
+  nowMs: number,
+  windowDays: number = 90,
+  segmentBy: "readiness" | "primary_segment" = "readiness",
+) {
+  const { reminders } = await readAdvisorMandantRemindersState();
+  return buildAdvisorKpiPortfolioSnapshot({
+    payload,
+    reminders,
+    nowMs,
+    windowDays,
+    segmentBy,
+  });
+}
+
+export async function computeAdvisorKpiPortfolioSnapshot(
+  now: Date = new Date(),
+  windowDays: number = 90,
+  segmentBy: "readiness" | "primary_segment" = "readiness",
+) {
+  const payload = await computeKanzleiPortfolioPayload(now);
+  return attachAdvisorKpiToPayload(payload, now.getTime(), windowDays, segmentBy);
+}

--- a/frontend/src/lib/advisorKpiPortfolioBuild.test.ts
+++ b/frontend/src/lib/advisorKpiPortfolioBuild.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
+import type { MandantReminderRecord } from "@/lib/advisorMandantReminderTypes";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import { KANZLEI_PORTFOLIO_VERSION } from "@/lib/kanzleiPortfolioTypes";
+
+function row(partial: Partial<KanzleiPortfolioRow> = {}): KanzleiPortfolioRow {
+  return {
+    tenant_id: "t-1",
+    mandant_label: "Acme",
+    readiness_class: "baseline_governance",
+    readiness_label_de: "Baseline",
+    primary_segment_label_de: "Kanzlei / WP",
+    open_points_count: 0,
+    open_points_hoch: 0,
+    top_gap_pillar_code: "DSGVO",
+    top_gap_pillar_label_de: "DSGVO",
+    pillar_traffic: {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    },
+    board_report_stale: false,
+    api_fetch_ok: true,
+    attention_score: 2,
+    attention_flags_de: [],
+    last_mandant_readiness_export_at: "2026-04-01T10:00:00Z",
+    last_datev_bundle_export_at: null,
+    last_any_export_at: "2026-04-01T10:00:00Z",
+    last_review_marked_at: "2026-04-01T10:00:00Z",
+    last_review_note_de: null,
+    review_stale: false,
+    any_export_stale: false,
+    never_any_export: false,
+    gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
+    links: {
+      mandant_export_page: "/a",
+      datev_bundle_api: "/b",
+      readiness_export_api: "/c",
+      board_readiness_admin: "/d",
+    },
+    ...partial,
+  };
+}
+
+function payload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
+  return {
+    version: KANZLEI_PORTFOLIO_VERSION,
+    generated_at: "2026-04-10T12:00:00Z",
+    backend_reachable: true,
+    mapped_tenant_count: rows.length,
+    tenants_partial: 0,
+    constants: {
+      review_stale_days: 90,
+      any_export_max_age_days: 90,
+      many_open_points_threshold: 4,
+      gap_heavy_min_open_for_export_rule: 5,
+    },
+    rows,
+    attention_queue: [],
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
+  };
+}
+
+describe("advisorKpiPortfolioBuild", () => {
+  it("computes strip and review share", () => {
+    const nowMs = Date.parse("2026-04-10T12:00:00Z");
+    const kpi = buildAdvisorKpiPortfolioSnapshot({
+      payload: payload([row(), row({ tenant_id: "t-2", review_stale: true })]),
+      reminders: [],
+      nowMs,
+      windowDays: 30,
+      segmentBy: "readiness",
+    });
+    expect(kpi.version).toBe("wave45-v1");
+    expect(kpi.review.current_share).toBe(0.5);
+    expect(kpi.strip.length).toBe(5);
+    expect(kpi.segments.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("median reminder resolution from closed reminders in window", () => {
+    const nowMs = Date.parse("2026-04-10T12:00:00Z");
+    const closed: MandantReminderRecord = {
+      reminder_id: "r1",
+      tenant_id: "t-1",
+      category: "manual",
+      due_at: "2026-04-09T12:00:00Z",
+      status: "done",
+      note: null,
+      source: "manual",
+      created_at: "2026-04-09T10:00:00Z",
+      updated_at: "2026-04-09T14:00:00Z",
+    };
+    const kpi = buildAdvisorKpiPortfolioSnapshot({
+      payload: payload([row()]),
+      reminders: [closed],
+      nowMs,
+      windowDays: 90,
+    });
+    expect(kpi.responsiveness.reminder_median_resolution_hours).toBe(4);
+    expect(kpi.responsiveness.closed_reminders_in_window).toBe(1);
+  });
+});

--- a/frontend/src/lib/advisorKpiPortfolioBuild.ts
+++ b/frontend/src/lib/advisorKpiPortfolioBuild.ts
@@ -1,0 +1,322 @@
+/**
+ * Wave 45 – KPI-Aggregation aus Portfolio, Historie-Zeilen und Reminder-Store (ohne server-only).
+ */
+
+import { GTM_READINESS_LABELS_DE, type GtmReadinessClass } from "@/lib/gtmAccountReadiness";
+import type { BoardReadinessPillarKey } from "@/lib/boardReadinessTypes";
+import type { MandantReminderRecord } from "@/lib/advisorMandantReminderTypes";
+import type {
+  AdvisorKpiPortfolioSnapshot,
+  AdvisorKpiSegmentBreakdown,
+  AdvisorKpiStripItem,
+  AdvisorKpiTraffic,
+  AdvisorKpiTrend,
+  BuildAdvisorKpiPortfolioInput,
+} from "@/lib/advisorKpiTypes";
+import { ADVISOR_KPI_PORTFOLIO_VERSION } from "@/lib/advisorKpiTypes";
+import type { KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import { daysSinceValidIso, isParseableIso, maxIsoTimestamps } from "@/lib/mandantHistoryMerge";
+
+const PILLAR_KEYS: BoardReadinessPillarKey[] = ["eu_ai_act", "iso_42001", "nis2", "dsgvo"];
+
+function median(nums: number[]): number | null {
+  if (nums.length === 0) return null;
+  const s = [...nums].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 === 1 ? s[m]! : (s[m - 1]! + s[m]!) / 2;
+}
+
+function rowHasRedPillar(row: KanzleiPortfolioRow): boolean {
+  return PILLAR_KEYS.some((k) => row.pillar_traffic[k] === "red");
+}
+
+function lastExportIso(row: KanzleiPortfolioRow): string | null {
+  return maxIsoTimestamps(row.last_mandant_readiness_export_at, row.last_datev_bundle_export_at);
+}
+
+function inMsRange(iso: string, startMs: number, endMs: number): boolean {
+  if (!isParseableIso(iso)) return false;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return false;
+  return t >= startMs && t <= endMs;
+}
+
+function resolutionHoursMs(r: MandantReminderRecord): number | null {
+  const u = Date.parse(r.updated_at);
+  const c = Date.parse(r.created_at);
+  if (Number.isNaN(u) || Number.isNaN(c) || u < c) return null;
+  return (u - c) / (60 * 60 * 1000);
+}
+
+function closedInWindow(
+  reminders: MandantReminderRecord[],
+  startMs: number,
+  endMs: number,
+  categoryFilter?: MandantReminderRecord["category"],
+): number[] {
+  const hours: number[] = [];
+  for (const r of reminders) {
+    if (r.status === "open") continue;
+    if (categoryFilter !== undefined && r.category !== categoryFilter) continue;
+    const u = Date.parse(r.updated_at);
+    if (Number.isNaN(u) || u < startMs || u > endMs) continue;
+    const h = resolutionHoursMs(r);
+    if (h !== null) hours.push(h);
+  }
+  return hours;
+}
+
+function shareTraffic(share: number, greenAt: number, amberAt: number): AdvisorKpiTraffic {
+  if (share >= greenAt) return "green";
+  if (share >= amberAt) return "amber";
+  return "red";
+}
+
+/** Niedrigere Median-Stunden = besser (schnellere Reaktion). */
+function hoursTraffic(h: number | null): AdvisorKpiTraffic {
+  if (h === null) return "neutral";
+  if (h <= 72) return "green";
+  if (h <= 168) return "amber";
+  return "red";
+}
+
+function trendNumeric(
+  current: number | null,
+  previous: number | null,
+  lowerIsBetter: boolean,
+): AdvisorKpiTrend {
+  if (current === null || previous === null) return "unknown";
+  const eps = 1e-6;
+  if (Math.abs(current - previous) < eps) return "flat";
+  const improved = lowerIsBetter ? current < previous : current > previous;
+  return improved ? "up" : "down";
+}
+
+function trendShare(current: number, previous: number): AdvisorKpiTrend {
+  const d = current - previous;
+  if (Math.abs(d) < 0.02) return "flat";
+  return d > 0 ? "up" : "down";
+}
+
+function formatPct(x: number): string {
+  return `${Math.round(x * 100)} %`;
+}
+
+function buildSegments(
+  rows: KanzleiPortfolioRow[],
+  segmentBy: "readiness" | "primary_segment",
+): AdvisorKpiSegmentBreakdown[] {
+  const buckets = new Map<string, KanzleiPortfolioRow[]>();
+  for (const row of rows) {
+    const key =
+      segmentBy === "readiness"
+        ? row.readiness_class
+        : row.primary_segment_label_de ?? "__none__";
+    const arr = buckets.get(key) ?? [];
+    arr.push(row);
+    buckets.set(key, arr);
+  }
+  const out: AdvisorKpiSegmentBreakdown[] = [];
+  for (const [key, list] of buckets) {
+    const n = list.length;
+    if (n === 0) continue;
+    const label_de =
+      segmentBy === "readiness"
+        ? GTM_READINESS_LABELS_DE[key as GtmReadinessClass] ?? key
+        : key === "__none__"
+          ? "Ohne Branchen-Label"
+          : key;
+    const reviewOk = list.filter((r) => !r.review_stale).length;
+    const exportOk = list.filter((r) => !r.any_export_stale).length;
+    const noRem = list.filter((r) => r.open_reminders_count === 0).length;
+    const noRed = list.filter((r) => !rowHasRedPillar(r)).length;
+    out.push({
+      segment_key: key,
+      label_de,
+      tenant_count: n,
+      review_current_share: reviewOk / n,
+      export_fresh_share: exportOk / n,
+      share_no_open_reminders: noRem / n,
+      share_no_red_pillar: noRed / n,
+    });
+  }
+  out.sort((a, b) => b.tenant_count - a.tenant_count);
+  return out;
+}
+
+export function buildAdvisorKpiPortfolioSnapshot(
+  input: BuildAdvisorKpiPortfolioInput,
+): AdvisorKpiPortfolioSnapshot {
+  const { payload, reminders, nowMs } = input;
+  const windowDays = Math.min(365, Math.max(7, Math.floor(input.windowDays)));
+  const windowMs = windowDays * 24 * 60 * 60 * 1000;
+  const segmentBy = input.segmentBy ?? "readiness";
+  const rows = payload.rows;
+  const n = rows.length || 1;
+
+  const curStart = nowMs - windowMs;
+  const prevStart = nowMs - 2 * windowMs;
+  const prevEnd = curStart;
+
+  let reviewOk = 0;
+  let ageSum = 0;
+  let ageN = 0;
+  let reviewsWin = 0;
+  let reviewsPrev = 0;
+  let exportOk = 0;
+  let exportTouchedWin = 0;
+  let exportTouchedPrev = 0;
+  let noOpenRem = 0;
+  let noRed = 0;
+
+  for (const row of rows) {
+    if (!row.review_stale) reviewOk += 1;
+    const d = daysSinceValidIso(row.last_review_marked_at, nowMs);
+    if (d !== null) {
+      ageSum += d;
+      ageN += 1;
+    }
+    if (row.last_review_marked_at && inMsRange(row.last_review_marked_at, curStart, nowMs)) {
+      reviewsWin += 1;
+    }
+    if (row.last_review_marked_at && inMsRange(row.last_review_marked_at, prevStart, prevEnd)) {
+      reviewsPrev += 1;
+    }
+    if (!row.any_export_stale) exportOk += 1;
+    const ex = lastExportIso(row);
+    if (ex && inMsRange(ex, curStart, nowMs)) exportTouchedWin += 1;
+    if (ex && inMsRange(ex, prevStart, prevEnd)) exportTouchedPrev += 1;
+    if (row.open_reminders_count === 0) noOpenRem += 1;
+    if (!rowHasRedPillar(row)) noRed += 1;
+  }
+
+  const reviewShare = n > 0 ? reviewOk / n : 0;
+  const exportShare = n > 0 ? exportOk / n : 0;
+  const exportTouchedShare = n > 0 ? exportTouchedWin / n : 0;
+  const exportTouchedPrevShare = n > 0 ? exportTouchedPrev / n : 0;
+  const meanAge = ageN > 0 ? ageSum / ageN : null;
+
+  const remHours = closedInWindow(reminders, curStart, nowMs);
+  const remHoursPrev = closedInWindow(reminders, prevStart, prevEnd);
+  const attHours = closedInWindow(reminders, curStart, nowMs, "portfolio_attention");
+  const attHoursPrev = closedInWindow(reminders, prevStart, prevEnd, "portfolio_attention");
+
+  const medRem = median(remHours);
+  const medRemPrev = median(remHoursPrev);
+  const medAtt = median(attHours);
+  const medAttPrev = median(attHoursPrev);
+
+  const shareNoRem = n > 0 ? noOpenRem / n : 0;
+  const shareNoRed = n > 0 ? noRed / n : 0;
+
+  const segments = buildSegments(rows, segmentBy);
+
+  const COCKPIT = "/admin/advisor-portfolio";
+
+  const reviewActivityShare = n > 0 ? reviewsWin / n : 0;
+  const reviewActivityPrevShare = n > 0 ? reviewsPrev / n : 0;
+
+  const strip: AdvisorKpiStripItem[] = [
+    {
+      id: "review_coverage",
+      label_de: "Review aktuell",
+      value_display_de: formatPct(reviewShare),
+      numeric_value: reviewShare,
+      unit: "ratio",
+      traffic_light: shareTraffic(reviewShare, 0.75, 0.5),
+      trend: trendShare(reviewActivityShare, reviewActivityPrevShare),
+      href: `${COCKPIT}#kanzlei-kpi-review`,
+      hint_de: `Anteil Mandanten ohne überfälliges Kanzlei-Review (Schwelle ${payload.constants.review_stale_days} Tage). Trend: Review-Zeitstempel im Fenster vs. Vorperiode.`,
+    },
+    {
+      id: "export_fresh",
+      label_de: "Export-Kadenz OK",
+      value_display_de: formatPct(exportShare),
+      numeric_value: exportShare,
+      unit: "ratio",
+      traffic_light: shareTraffic(exportShare, 0.7, 0.45),
+      trend: trendShare(exportTouchedShare, exportTouchedPrevShare),
+      href: `${COCKPIT}#kanzlei-kpi-export`,
+      hint_de: `Anteil mit gültigem letztem Readiness-/DATEV-Export (max. ${payload.constants.any_export_max_age_days} Tage).`,
+    },
+    {
+      id: "reminder_resolution",
+      label_de: "Reminder-Reaktionszeit (Median)",
+      value_display_de: medRem !== null ? `${medRem.toFixed(1)} h` : "—",
+      numeric_value: medRem,
+      unit: "hours",
+      traffic_light: hoursTraffic(medRem),
+      trend: trendNumeric(medRem, medRemPrev, true),
+      href: `${COCKPIT}#kanzlei-kpi-reminders`,
+      hint_de: `Median Stunden von Reminder-Anlage bis Erledigt/Zurückstellen (letzte ${windowDays} Tage, n=${remHours.length}).`,
+    },
+    {
+      id: "attention_proxy",
+      label_de: "Queue-Reminder (Median)",
+      value_display_de: medAtt !== null ? `${medAtt.toFixed(1)} h` : "—",
+      numeric_value: medAtt,
+      unit: "hours",
+      traffic_light: hoursTraffic(medAtt),
+      trend: trendNumeric(medAtt, medAttPrev, true),
+      href: `${COCKPIT}#kanzlei-kpi-queue`,
+      hint_de:
+        "Proxy für Attention-Bearbeitung: Auto-Reminder „Portfolio-Aufmerksamkeit“ von Anlage bis Abschluss (kein separates Queue-Event-Log).",
+    },
+    {
+      id: "hygiene_red_pillar",
+      label_de: "Ohne rote Säule",
+      value_display_de: formatPct(shareNoRed),
+      numeric_value: shareNoRed,
+      unit: "ratio",
+      traffic_light: shareTraffic(shareNoRed, 0.8, 0.6),
+      trend: "unknown",
+      href: `${COCKPIT}#kanzlei-kpi-table`,
+      hint_de: "Anteil Mandanten ohne rote Board-Readiness-Säule (EU AI Act, ISO 42001, NIS2, DSGVO).",
+    },
+  ];
+
+  const interpretation_notes_de = [
+    `Fenster: letzte ${windowDays} Tage; Vorperiode davor (gleiche Länge) für Median- und Export-Aktivitätsvergleiche.`,
+    "Echte „Anzahl Exporte“ pro Zeitraum ist ohne Event-Log nicht verfügbar – genutzt wird der Anteil Mandanten mit Exportzeitstempel im Fenster.",
+    "Attention-Queue selbst wird nicht zeitgestempelt; der Median für „Portfolio-Aufmerksamkeit“-Reminder dient als pragmatischer Proxy.",
+  ];
+
+  return {
+    version: ADVISOR_KPI_PORTFOLIO_VERSION,
+    generated_at: new Date(nowMs).toISOString(),
+    window_days: windowDays,
+    portfolio_version: payload.version,
+    portfolio_generated_at: payload.generated_at,
+    mapped_tenant_count: payload.mapped_tenant_count,
+    segment_by: segmentBy,
+    constants: {
+      review_stale_days: payload.constants.review_stale_days,
+      any_export_max_age_days: payload.constants.any_export_max_age_days,
+    },
+    review: {
+      current_share: reviewShare,
+      mean_age_days: meanAge,
+      reviews_touched_in_window: reviewsWin,
+      reviews_touched_prev_window: reviewsPrev,
+    },
+    export_kpis: {
+      fresh_share: exportShare,
+      export_touched_in_window_share: exportTouchedShare,
+      export_touched_prev_window_count: exportTouchedPrev,
+    },
+    responsiveness: {
+      reminder_median_resolution_hours: medRem,
+      reminder_median_prev_window_hours: medRemPrev,
+      attention_proxy_median_hours: medAtt,
+      attention_proxy_prev_median_hours: medAttPrev,
+      closed_reminders_in_window: remHours.length,
+    },
+    hygiene: {
+      share_no_open_reminders: shareNoRem,
+      share_no_red_pillar: shareNoRed,
+    },
+    segments,
+    strip,
+    interpretation_notes_de,
+  };
+}

--- a/frontend/src/lib/advisorKpiTypes.ts
+++ b/frontend/src/lib/advisorKpiTypes.ts
@@ -1,0 +1,87 @@
+/**
+ * Wave 45 – Advisor-/Kanzlei-KPIs (intern, operatives Steering).
+ */
+
+import type { MandantReminderRecord } from "@/lib/advisorMandantReminderTypes";
+import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+
+export const ADVISOR_KPI_PORTFOLIO_VERSION = "wave45-v1";
+
+export type AdvisorKpiTrend = "up" | "down" | "flat" | "unknown";
+
+export type AdvisorKpiTraffic = "green" | "amber" | "red" | "neutral";
+
+/** Kompakte Kachel für Cockpit-Strip und Querverweise. */
+export type AdvisorKpiStripItem = {
+  id: string;
+  label_de: string;
+  value_display_de: string;
+  numeric_value: number | null;
+  unit: "ratio" | "days" | "hours" | "count";
+  traffic_light: AdvisorKpiTraffic;
+  trend: AdvisorKpiTrend;
+  /** Relativer Hash auf derselben Seite oder Admin-Pfad mit Hash. */
+  href: string | null;
+  hint_de: string;
+};
+
+export type AdvisorKpiSegmentBreakdown = {
+  segment_key: string;
+  label_de: string;
+  tenant_count: number;
+  review_current_share: number;
+  export_fresh_share: number;
+  share_no_open_reminders: number;
+  share_no_red_pillar: number;
+};
+
+export type AdvisorKpiPortfolioSnapshot = {
+  version: typeof ADVISOR_KPI_PORTFOLIO_VERSION;
+  generated_at: string;
+  window_days: number;
+  portfolio_version: string;
+  portfolio_generated_at: string;
+  mapped_tenant_count: number;
+  segment_by: "readiness" | "primary_segment";
+  constants: {
+    review_stale_days: number;
+    any_export_max_age_days: number;
+  };
+  review: {
+    current_share: number;
+    mean_age_days: number | null;
+    /** Mandanten mit last_review im Fenster (Proxy für Review-Aktivität). */
+    reviews_touched_in_window: number;
+    reviews_touched_prev_window: number;
+  };
+  export_kpis: {
+    fresh_share: number;
+    /** Anteil Mandanten, deren letzter Export (Readiness/DATEV) im Fenster liegt. */
+    export_touched_in_window_share: number;
+    export_touched_prev_window_count: number;
+  };
+  responsiveness: {
+    /** Alle geschlossenen Reminder im Fenster (done/dismissed). */
+    reminder_median_resolution_hours: number | null;
+    reminder_median_prev_window_hours: number | null;
+    /** Nur Kategorie portfolio_attention (Proxy: Queue-Signal → Abschluss). */
+    attention_proxy_median_hours: number | null;
+    attention_proxy_prev_median_hours: number | null;
+    closed_reminders_in_window: number;
+  };
+  hygiene: {
+    share_no_open_reminders: number;
+    share_no_red_pillar: number;
+  };
+  segments: AdvisorKpiSegmentBreakdown[];
+  strip: AdvisorKpiStripItem[];
+  interpretation_notes_de: string[];
+};
+
+export type BuildAdvisorKpiPortfolioInput = {
+  payload: KanzleiPortfolioPayload;
+  reminders: MandantReminderRecord[];
+  nowMs: number;
+  windowDays: number;
+  segmentBy?: "readiness" | "primary_segment";
+};

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
@@ -114,5 +114,6 @@ describe("kanzleiMonthlyReportBuild", () => {
     );
     expect(r.compared_to_baseline).toBe(false);
     expect(r.section_3_changes.readiness_improved.length).toBe(0);
+    expect(r.section_5_advisor_kpis).toBeNull();
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.ts
@@ -5,6 +5,7 @@
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import { GTM_READINESS_LABELS_DE, type GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type {
   KanzleiAttentionBand,
   KanzleiMonthlyBaselineTenant,
@@ -302,6 +303,8 @@ export type BuildMonthlyReportOptions = {
   /** Wenn false, wird Abschnitt 3 ohne Vergleich ausgegeben (leer außer Metainfo). */
   compareToBaseline: boolean;
   attentionTopN: number;
+  /** Wave 45 – optionaler KPI-Block (Abschnitt 5). */
+  advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
 };
 
 export function buildKanzleiMonthlyReport(
@@ -348,5 +351,6 @@ export function buildKanzleiMonthlyReport(
     section_2_attention_top: top,
     section_3_changes: s3,
     section_4_focus_areas_de: buildKanzleiPortfolioFocusAreasDe(payload, s1),
+    section_5_advisor_kpis: opts.advisorKpiSnapshot ?? null,
   };
 }

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
 import { kanzleiMonthlyReportMarkdownDe } from "@/lib/kanzleiMonthlyReportMarkdown";
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
@@ -76,5 +77,25 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).toContain("# Kanzlei-Portfolio-Report");
     expect(md).toContain("## 1) Portfolio-Überblick");
     expect(md).toContain("## 4) Empfohlene Schwerpunkte");
+    expect(md).not.toContain("## 5) Kanzlei-KPIs");
+  });
+
+  it("includes KPI section when snapshot provided", () => {
+    const p = minimalPayload();
+    const nowMs = Date.parse("2026-04-04T12:00:00Z");
+    const kpi = buildAdvisorKpiPortfolioSnapshot({
+      payload: p,
+      reminders: [],
+      nowMs,
+      windowDays: 90,
+    });
+    const r = buildKanzleiMonthlyReport(p, null, {
+      periodLabel: "2026-04",
+      compareToBaseline: false,
+      attentionTopN: 5,
+      advisorKpiSnapshot: kpi,
+    });
+    const md = kanzleiMonthlyReportMarkdownDe(r);
+    expect(md).toContain("## 5) Kanzlei-KPIs");
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
@@ -83,6 +83,33 @@ export function kanzleiMonthlyReportMarkdownDe(r: KanzleiMonthlyReportDto): stri
     parts.push(`- ${f}`);
   }
 
+  const kpi = r.section_5_advisor_kpis;
+  if (kpi) {
+    parts.push(`## 5) Kanzlei-KPIs (Wave 45)`);
+    parts.push(
+      `_Fenster **${kpi.window_days}** Tage · Schema ${kpi.version} · Median-Reaktionszeiten vs. Vorperiode._`,
+    );
+    for (const tile of kpi.strip) {
+      const tr =
+        tile.trend === "up"
+          ? "↑"
+          : tile.trend === "down"
+            ? "↓"
+            : tile.trend === "flat"
+              ? "→"
+              : "○";
+      parts.push(
+        `- **${tile.label_de}:** ${tile.value_display_de} ${tr} (_Ampel: ${tile.traffic_light}_) — ${tile.hint_de}`,
+      );
+    }
+    parts.push(`### Segment-Überblick (${kpi.segment_by === "readiness" ? "Readiness" : "Branchenlabel"})`);
+    for (const s of kpi.segments.slice(0, 6)) {
+      parts.push(
+        `- **${s.label_de}** (${s.tenant_count}): Review aktuell ${Math.round(s.review_current_share * 100)} % · Export OK ${Math.round(s.export_fresh_share * 100)} % · ohne Reminder ${Math.round(s.share_no_open_reminders * 100)} % · ohne rote Säule ${Math.round(s.share_no_red_pillar * 100)} %`,
+      );
+    }
+  }
+
   parts.push(`---`);
   parts.push(
     `Hinweis: Portfolio-Report für interne Kanzlei-Arbeit; keine Board-Tischreife. Daten aus Live-API und lokaler Historie – Änderungslogik bewusst grob (siehe Doku Wave 42).`,

--- a/frontend/src/lib/kanzleiMonthlyReportTypes.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportTypes.ts
@@ -1,11 +1,12 @@
 /**
- * Wave 42 – Kanzlei-Monatsreport / Sammelreport (Portfolio-Ebene, kein Board-Pack).
+ * Wave 42–45 – Kanzlei-Monatsreport / Sammelreport (Portfolio-Ebene, kein Board-Pack).
  */
 
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 
-export const KANZLEI_MONTHLY_REPORT_VERSION = "wave42-v1";
+export const KANZLEI_MONTHLY_REPORT_VERSION = "wave45-v1";
 
 export type KanzleiAttentionBand = "low" | "medium" | "high";
 
@@ -82,4 +83,6 @@ export type KanzleiMonthlyReportDto = {
   section_2_attention_top: KanzleiMonthlyReportAttentionRow[];
   section_3_changes: KanzleiMonthlyReportSection3;
   section_4_focus_areas_de: string[];
+  /** Wave 45 – Kanzlei-KPI-Snapshot; null wenn nicht mitgeliefert. */
+  section_5_advisor_kpis: AdvisorKpiPortfolioSnapshot | null;
 };

--- a/frontend/src/lib/partnerReviewPackageBuild.test.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.test.ts
@@ -93,6 +93,7 @@ describe("partnerReviewPackageBuild", () => {
     p.reminders_due_today_or_overdue_count = 1;
     p.reminders_due_this_week_open_count = 1;
     const pkg = buildPartnerReviewPackage(p, null, { compareToBaseline: false, attentionTopN: 5 });
+    expect(pkg.part_e_advisor_kpis).toBeNull();
     expect(pkg.part_a_portfolio_overview.count_review_stale).toBe(1);
     expect(pkg.part_a_portfolio_overview.open_reminders_open_count).toBe(1);
     expect(pkg.part_b_top_attention.length).toBe(1);

--- a/frontend/src/lib/partnerReviewPackageBuild.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.ts
@@ -8,6 +8,7 @@ import {
   buildKanzleiPortfolioFocusAreasDe,
   summarizeKanzleiMonthlyReportSection1,
 } from "@/lib/kanzleiMonthlyReportBuild";
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
 import type {
   PartnerReviewAttentionEntry,
@@ -98,6 +99,8 @@ export type BuildPartnerReviewPackageOptions = {
   compareToBaseline: boolean;
   attentionTopN: number;
   generatedAt?: Date;
+  /** Wave 45 – Kanzlei-KPIs (optional). */
+  advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
 };
 
 export function buildPartnerReviewPackage(
@@ -147,5 +150,6 @@ export function buildPartnerReviewPackage(
     part_b_top_attention: buildPartB(payload, opts.attentionTopN),
     part_c_changes_since_baseline: mergePartC(s3),
     part_d_recommended_priorities_de: part_d.slice(0, 8),
+    part_e_advisor_kpis: opts.advisorKpiSnapshot ?? null,
   };
 }

--- a/frontend/src/lib/partnerReviewPackageMarkdown.ts
+++ b/frontend/src/lib/partnerReviewPackageMarkdown.ts
@@ -114,6 +114,28 @@ export function partnerReviewPackageMarkdownDe(pkg: PartnerReviewPackageDto): st
   }
   lines.push("");
 
+  const kpi = pkg.part_e_advisor_kpis;
+  if (kpi) {
+    lines.push("## E) Kanzlei-KPIs (Steuerung)");
+    lines.push("");
+    lines.push(
+      `Fenster **${kpi.window_days}** Tage · ${kpi.mapped_tenant_count} Mandanten · Schema ${kpi.version}.`,
+    );
+    lines.push("");
+    for (const tile of kpi.strip) {
+      const tr =
+        tile.trend === "up"
+          ? "↑"
+          : tile.trend === "down"
+            ? "↓"
+            : tile.trend === "flat"
+              ? "→"
+              : "○";
+      lines.push(`- **${tile.label_de}:** ${tile.value_display_de} ${tr} (${tile.traffic_light})`);
+    }
+    lines.push("");
+  }
+
   lines.push("---");
   lines.push("");
   lines.push("### Priorisierung (Kurz)");

--- a/frontend/src/lib/partnerReviewPackageTypes.ts
+++ b/frontend/src/lib/partnerReviewPackageTypes.ts
@@ -2,10 +2,11 @@
  * Wave 44 – Kanzlei Partner-Review-Paket (Portfolio-Steuerung, kein Board-Pack).
  */
 
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiMonthlyChangeLine } from "@/lib/kanzleiMonthlyReportTypes";
 
-export const PARTNER_REVIEW_PACKAGE_VERSION = "wave44-v1";
+export const PARTNER_REVIEW_PACKAGE_VERSION = "wave45-v1";
 
 export type PartnerReviewPackageMeta = {
   version: typeof PARTNER_REVIEW_PACKAGE_VERSION;
@@ -61,4 +62,6 @@ export type PartnerReviewPackageDto = {
   part_b_top_attention: PartnerReviewAttentionEntry[];
   part_c_changes_since_baseline: PartnerReviewPartC;
   part_d_recommended_priorities_de: string[];
+  /** Wave 45 – gleicher Snapshot wie Monatsreport-KPI-Block. */
+  part_e_advisor_kpis: AdvisorKpiPortfolioSnapshot | null;
 };


### PR DESCRIPTION
Add advisor KPI snapshot (review/export/hygiene, reminder medians, segments), internal kpi-portfolio API, cockpit strip with anchors, monthly report section 5 and partner package part E; document definitions and limits.

Made-with: Cursor