### PR TITLE
feat(advisor): Wave 46 KPI trends, history, enterprise cockpit UI

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -2,7 +2,7 @@
 
 Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine und wiederkehrende Status-Mails – **kein** Board-Pack, **kein** Mandanten-Einzelreport. Fokus: **Ist-Zustand**, **Top-Aufmerksamkeit**, **grobe Veränderungen** seit einem gespeicherten Stichtag, **Handlungsschwerpunkte**.
 
-## Report-Struktur (vier Abschnitte)
+## Report-Struktur (Kern: vier Abschnitte; KPI/Trends optional)
 
 | Abschnitt | Inhalt |
 |-----------|--------|
@@ -25,10 +25,12 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | `compare` | `1` (an) | `compare=0` schaltet Abschnitt 3 ab (Snapshot trotzdem nutzbar) |
 | `update_baseline` | `0` | `update_baseline=1` **überschreibt** die Baseline-Datei mit dem **aktuellen** Portfolio-Snapshot |
 | `top_n` | `10` | Anzahl Zeilen in Abschnitt 2 (3–25) |
-| `kpi_window_days` | `90` | Wave 45: Fenster für KPI-Abschnitt 5 (7–365) |
-| `kpi` | `1` | `kpi=0` schaltet Abschnitt 5 ab |
+| `kpi_window_days` | `90` | Wave 45–46: Fenster für KPI-Abschnitt 5 und History-Schreiben für Abschnitt 6 (7–365) |
+| `kpi` | `1` | `kpi=0` schaltet Abschnitt 5 und 6 ab |
 
-**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (`wave45-v1` inkl. optionalem Abschnitt 5), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
+**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (`wave46-v1` inkl. optionalen Abschnitten 5–6), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
+
+**Wave 46:** Abschnitt **6) KPI-Trends** – Kurzsätze aus persistierter KPI-History (rolling 3 Monate). Siehe `wave46-kpi-trends.md`.
 
 ## Baseline & Change-Logik
 

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -10,6 +10,8 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
 | **B – Top Attention-Mandanten** | Die ersten *N* Einträge der bestehenden Attention-Queue (typisch 5–10) mit **Warum jetzt?** und **Nächster Schritt** – identisch zur Cockpit-Logik (Wave 41). |
 | **C – Veränderungen seit letzter Periode** | Nutzt dieselbe **Monats-Baseline** wie der Kanzlei-Monatsreport (`data/kanzlei-monthly-report-baseline.json` bzw. `KANZLEI_MONTHLY_REPORT_BASELINE_PATH`): Verbesserungen, Verschlechterungen/Mehrlast, neu dringlicher (Attention-Eskalation + Kadenz-Hinweise). Ohne Baseline ist dieser Block erklärend leer. |
 | **D – Empfohlene Prioritäten** | Kurze, aggregierte Handlungsempfehlungen für den nächsten Monat/Quartal (gleiche Fokus-Heuristik wie Monatsreport Abschnitt 4). |
+| **E – Kanzlei-KPIs** | Wave 45 – gleicher KPI-Snapshot wie Monatsreport. |
+| **F – KPI-Trends (Kurz)** | Wave 46 – Kurzsätze aus persistierter History (rolling 3 Monate); siehe `wave46-kpi-trends.md`. |
 
 ## API
 
@@ -19,8 +21,8 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
     - `compare=0` – kein Vergleich mit Baseline (Teil C ohne Inhalt außer Hinweis).
     - `top_n` – Anzahl Top-Mandanten in Teil B (3–15, Standard 8).
     - `format=markdown` – Antwort als **Markdown-Datei** (`Content-Disposition: attachment`) statt JSON.
-    - `kpi_window_days` / `kpi=0` – Wave 45: KPI-Teil E wie beim Monatsreport.
-  - JSON-Antwort: `partner_review_package` (strukturiert, Schema `wave45-v1`), `markdown_de`, kompaktes `meta`.
+    - `kpi_window_days` / `kpi=0` – Wave 45–46: KPI-Teil E und Trend-Teil F wie beim Monatsreport.
+  - JSON-Antwort: `partner_review_package` (strukturiert, Schema `wave46-v1`), `markdown_de`, kompaktes `meta`.
 
 ## Priorisierung (transparent)
 
@@ -52,6 +54,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave46-kpi-trends.md`
 - `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave43-reminders-and-followups.md`
 - `docs/advisors/wave42-kanzlei-monatsreport.md`

--- a/docs/advisors/wave45-advisor-kpis.md
+++ b/docs/advisors/wave45-advisor-kpis.md
@@ -19,7 +19,7 @@ Zusätzlich im JSON (nicht immer im Strip): **Mittleres Review-Alter** (Tage sei
 - **Review:** Vergleich der *Aktivität*: Anteil Mandanten mit Review-Zeitstempel im aktuellen Fenster vs. der Vorperiode (gleiche Länge).
 - **Export-Aktivität:** Anteil Mandanten mit Export-Zeitstempel im Fenster vs. Vorperiode.
 - **Median-Stunden (Reminder / Queue-Proxy):** niedrigere Mediane in der aktuellen Periode = Verbesserung (↑).
-- **Ohne rote Säule:** Trend `unknown` (kein historischer Querschnitt ohne zusätzliche Persistenz).
+- **Ohne rote Säule:** Im Strip weiterhin oft `unknown`; **Wave 46** ergänzt dafür persistierte **History-Trends** (siehe `wave46-kpi-trends.md`).
 
 ## API
 
@@ -29,13 +29,14 @@ Zusätzlich im JSON (nicht immer im Strip): **Mittleres Review-Alter** (Tage sei
 |-----------|----------|-----------|
 | `window_days` | `90` | Auswertungsfenster und Länge der Vorperiode (7–365) |
 | `segment_by` | `readiness` | `readiness` oder `primary_segment` (Branchencluster aus GTM-Segment) |
+| `persist_history` | — | `1` = nach Snapshot einen **Tagespunkt** in die KPI-History schreiben (Wave 46) |
 
 Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `strip`, `segments`, `interpretation_notes_de`.
 
 ## Einbindung Monatsreport & Partner-Paket
 
-- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab.
-- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional.
+- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab. **Wave 46:** Abschnitt **6) KPI-Trends** (rolling 3 Monate), wenn KPIs an sind.
+- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional. **Wave 46:** Abschnitt **F) KPI-Trends**.
 
 ## Grenzen (bewusst)
 
@@ -51,6 +52,7 @@ Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `stri
 
 ## Siehe auch
 
+- `docs/advisors/wave46-kpi-trends.md`
 - `docs/advisors/wave44-partner-review-package.md`
 - `docs/advisors/wave42-kanzlei-monatsreport.md`
 - `docs/advisors/wave43-reminders-and-followups.md`

--- a/docs/advisors/wave46-kpi-trends.md
+++ b/docs/advisors/wave46-kpi-trends.md
@@ -1,0 +1,71 @@
+# Wave 46 – KPI-Trends / einfache Zeitreihen (Advisor)
+
+Leichtgewichtige **Trend-Sicht** für Kanzlei-Steering: wenige Metriken, **persistierte Tages-Snapshots** (erklärbar, kein Event-Rebuild), kompakte API und Cockpit-Visuals. **Kein** BI-Warehouse und kein Charting-Framework.
+
+## Unterstützte Metriken (History)
+
+Alle Werte stammen aus dem gleichen Tagespunkt wie der Wave-45-KPI-Snapshot (ein Eintrag pro UTC-Tag, letzter Stand des Tages gewinnt):
+
+| ID | Bedeutung | Einheit |
+|----|-----------|---------|
+| `review_coverage` | Review aktuell (Anteil) | 0–1 |
+| `export_fresh` | Export-Kadenz OK (Anteil) | 0–1 |
+| `open_reminders` | Offene Reminder (Anzahl) | Zahl |
+| `no_open_reminders_share` | Anteil Mandanten ohne offenen Reminder | 0–1 |
+| `no_red_pillar` | Anteil Mandanten ohne rote Board-Säule | 0–1 |
+| `reminder_median_hours` | Median Auflösungszeit Reminder im KPI-Fenster | Stunden oder `null` |
+
+## Snapshot- / History-Logik
+
+- **Speicherort:** `data/advisor-kpi-history.json` (lokal) bzw. `ADVISOR_KPI_HISTORY_PATH` oder unter Vercel `/tmp/...`.
+- **Version:** `ADVISOR_KPI_HISTORY_FILE_VERSION` (`wave46-v1`).
+- **Granularität:** höchstens **ein Punkt pro UTC-Kalendertag**; erneuter Auftag am selben Tag **ersetzt** den Punkt.
+- **Retention:** maximal **120** Punkte (älteste werden verworfen).
+- **Schreiben:** erfolgt u. a. bei `GET /api/internal/advisor/kpi-portfolio?persist_history=1`, bei `GET /api/internal/advisor/kpi-trends` mit `append` ungleich `0`, sowie beim Erzeugen von Monatsreport / Partner-Paket mit aktivem KPI-Block (`kpi` nicht `0`).
+
+## API `GET /api/internal/advisor/kpi-trends`
+
+Lead-Admin-Auth wie andere Advisor-Interna (`LEAD_ADMIN_SECRET`).
+
+| Parameter | Standard | Bedeutung |
+|-----------|----------|-----------|
+| `period` | `4w` | `4w` (28 Tage), `3m` (92 Tage), `qtd` (Quartal bis heute, UTC) |
+| `append` | `1` | `0` = keine neue History schreiben, nur lesen/rechnen |
+| `kpi_window_days` | `90` | muss zum Snapshot passen (7–365); gleiches Fenster wie KPI-Portfolio |
+| `segment` | — | optional; wenn gesetzt und nicht `all`, liefert die API nur einen **Hinweistext** (`segment_note_de`) – Zeitreihen bleiben portfolio-weit (v1) |
+| `segment_by` | `readiness` | nur bei `append=1`: `readiness` oder `primary_segment` für den Snapshot beim Append |
+
+**Antwort (Auszug):** `advisor_kpi_trends` mit `version`, `period`, `period_label_de`, `history_points_in_period`, `segment_note_de`, `metrics[]` (je `current_value`, `previous_value`, `direction` `up|down|flat|unknown`, `delta_display_de`, `series[]` mit `t`/`v`), `narrative_lines_de` (Kurzsätze DE).
+
+**Richtung / Delta:** `up` bedeutet „verbessert“ im KPI-Sinn (`lower_is_better` für Counts und Median-Stunden). Vergleich = **letzter gültiger History-Punkt vs. vorheriger gültiger Punkt** innerhalb des gewählten `period`-Fensters (nicht automatisch „Vormonat“).
+
+## Cockpit (UI)
+
+- Nach dem KPI-Strip: **Verlauf (History)** mit Periodenwahl (4 Wochen / 3 Monate / QTD), dezente **Sparklines**, Delta-Text und Scope-Label.
+- KPI-Laden nutzt `kpi-portfolio` mit `persist_history=1`; Trends werden mit `kpi-trends?append=0` geholt (ein Portfolio-Compute pro Refresh).
+- Readiness-Filter ≠ `all` setzt `segment` für den Hinweis (`segment_note_de`).
+
+## Monatsreport & Partner-Paket
+
+- **Monatsreport:** Abschnitt **6) KPI-Trends** – rolling **3 Monate** (`period` `3m`), Kurzsätze aus `narrative_lines_de`. Nur wenn KPIs nicht mit `kpi=0` abgeschaltet sind.
+- **Partner-Review-Paket:** Abschnitt **F) KPI-Trends (Kurz)** – gleiche Logik.
+
+## Interpretation (Kurz)
+
+- Wenige Punkte im Zeitraum → Richtung oft `unknown` oder `flat`; Narrativ weist auf fehlende History hin.
+- Sätze beziehen sich auf **aufeinanderfolgende Snapshots**, nicht auf Steuerungs-Baseline des Monatsreports (Abschnitt 3).
+- **Segment-Filter** im Cockpit filtert die Tabelle, nicht die persistierte History (v1).
+
+## Grenzen (bewusst)
+
+- Keine mandantenweise Zeitreihen, keine Segment-Zeitreihen in v1.
+- Median-Stunden hängen vom gewählten `kpi_window_days` ab; ändernde Fenster erschweren Vergleich über lange Zeiträume.
+- Datei-basierte History: bei serverlosem Betrieb (z. B. Vercel) ist Persistenz instanzgebunden (`/tmp`).
+
+## Siehe auch
+
+- `docs/advisors/wave45-advisor-kpis.md`
+- `docs/advisors/wave42-kanzlei-monatsreport.md`
+- `docs/advisors/wave44-partner-review-package.md`
+- `frontend/src/lib/advisorKpiTrendsBuild.ts`
+- `frontend/src/lib/advisorKpiHistoryStore.ts`

--- a/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
+++ b/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 
+import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
+import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { readKanzleiMonthlyReportBaseline, writeKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
@@ -42,11 +44,23 @@ export async function GET(req: Request) {
     ? null
     : await attachAdvisorKpiToPayload(payload, now.getTime(), kpiWindowDays);
 
+  let kpiTrendsNarrative = null;
+  if (!kpiOff && advisorKpiSnapshot) {
+    const hist = await upsertAdvisorKpiHistoryDaily(payload, advisorKpiSnapshot);
+    const trends = buildAdvisorKpiTrendsDto({
+      history: hist.snapshots,
+      period: "3m",
+      nowMs: now.getTime(),
+    });
+    kpiTrendsNarrative = advisorKpiTrendsNarrativeBlock(trends);
+  }
+
   const report = buildKanzleiMonthlyReport(payload, baseline, {
     periodLabel: period,
     compareToBaseline: compare,
     attentionTopN,
     advisorKpiSnapshot,
+    kpiTrendsNarrative,
   });
   const markdown_de = kanzleiMonthlyReportMarkdownDe(report);
 

--- a/frontend/src/app/api/internal/advisor/kpi-portfolio/route.ts
+++ b/frontend/src/app/api/internal/advisor/kpi-portfolio/route.ts
@@ -19,8 +19,11 @@ export async function GET(req: Request) {
   const seg = url.searchParams.get("segment_by")?.trim().toLowerCase();
   const segmentBy: "readiness" | "primary_segment" =
     seg === "primary_segment" || seg === "segment" ? "primary_segment" : "readiness";
+  const persistHistory = url.searchParams.get("persist_history") === "1";
 
-  const snapshot = await computeAdvisorKpiPortfolioSnapshot(new Date(), windowDays, segmentBy);
+  const snapshot = await computeAdvisorKpiPortfolioSnapshot(new Date(), windowDays, segmentBy, {
+    persistHistory,
+  });
 
   return NextResponse.json({
     ok: true,

--- a/frontend/src/app/api/internal/advisor/kpi-trends/route.ts
+++ b/frontend/src/app/api/internal/advisor/kpi-trends/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+
+import { computeAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioAggregate";
+import { readAdvisorKpiHistoryState } from "@/lib/advisorKpiHistoryStore";
+import type { AdvisorKpiTrendPeriod } from "@/lib/advisorKpiTrendsBuild";
+import { buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+function parsePeriod(raw: string | null): AdvisorKpiTrendPeriod {
+  const p = raw?.trim().toLowerCase();
+  if (p === "3m" || p === "quarter" || p === "3mo") return "3m";
+  if (p === "qtd" || p === "quarter_to_date") return "qtd";
+  return "4w";
+}
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const period = parsePeriod(url.searchParams.get("period"));
+  const append = url.searchParams.get("append") !== "0";
+  const kpiWindowRaw = url.searchParams.get("kpi_window_days");
+  const kpiWindowDays = Math.min(365, Math.max(7, Number.parseInt(kpiWindowRaw ?? "90", 10) || 90));
+  const segment = url.searchParams.get("segment")?.trim() ?? null;
+  const seg = url.searchParams.get("segment_by")?.trim().toLowerCase();
+  const segmentBy: "readiness" | "primary_segment" =
+    seg === "primary_segment" || seg === "segment" ? "primary_segment" : "readiness";
+
+  const now = new Date();
+  const nowMs = now.getTime();
+
+  let history = await readAdvisorKpiHistoryState();
+  if (append) {
+    await computeAdvisorKpiPortfolioSnapshot(now, kpiWindowDays, segmentBy, { persistHistory: true });
+    history = await readAdvisorKpiHistoryState();
+  }
+
+  const trends = buildAdvisorKpiTrendsDto({
+    history: history.snapshots,
+    period,
+    nowMs,
+    segment_filter: segment,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    advisor_kpi_trends: trends,
+    history_snapshot_count: history.snapshots.length,
+  });
+}

--- a/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
+++ b/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 
+import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
+import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { readKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildPartnerReviewPackage } from "@/lib/partnerReviewPackageBuild";
@@ -34,10 +36,22 @@ export async function GET(req: Request) {
     ? null
     : await attachAdvisorKpiToPayload(payload, now.getTime(), kpiWindowDays);
 
+  let kpiTrendsNarrative = null;
+  if (!kpiOff && advisorKpiSnapshot) {
+    const hist = await upsertAdvisorKpiHistoryDaily(payload, advisorKpiSnapshot);
+    const trends = buildAdvisorKpiTrendsDto({
+      history: hist.snapshots,
+      period: "3m",
+      nowMs: now.getTime(),
+    });
+    kpiTrendsNarrative = advisorKpiTrendsNarrativeBlock(trends);
+  }
+
   const partner_review_package = buildPartnerReviewPackage(payload, baseline, {
     compareToBaseline: compare,
     attentionTopN,
     advisorKpiSnapshot,
+    kpiTrendsNarrative,
   });
   const markdown_de = partnerReviewPackageMarkdownDe(partner_review_package);
 

--- a/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.test.tsx
+++ b/frontend/src/app/board/ai-compliance-report/AiComplianceBoardReportClient.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TenantWorkspaceMetaDto } from "@/lib/api";
@@ -177,11 +177,10 @@ describe("AiComplianceBoardReportClient", () => {
 
     render(<AiComplianceBoardReportClient tenantId="t1" />);
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("heading", { name: "AI Performance & Risk KPIs" }),
-      ).toBeTruthy();
-    });
+    const viewer = await screen.findByTestId("board-report-viewer", {}, { timeout: 5000 });
+    expect(
+      within(viewer).getByRole("heading", { name: "AI Performance & Risk KPIs" }),
+    ).toBeTruthy();
   });
 
   it("zeigt Demo-read-only-Hinweis und deaktiviert den Report-CTA bei mutationsBlocked", async () => {

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -5,6 +5,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import { GTM_READINESS_CLASSES, GTM_READINESS_SHORT_DE } from "@/lib/gtmAccountReadiness";
 import { KanzleiReviewPlaybookHelper } from "@/components/admin/KanzleiReviewPlaybookHelper";
+import type {
+  AdvisorKpiTrendPeriod,
+  AdvisorKpiTrendsDto,
+  AdvisorKpiTrendSeriesPoint,
+} from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot, AdvisorKpiTrend, AdvisorKpiTraffic } from "@/lib/advisorKpiTypes";
 import type { KanzleiMonthlyReportDto } from "@/lib/kanzleiMonthlyReportTypes";
 import type { PartnerReviewPackageDto } from "@/lib/partnerReviewPackageTypes";
@@ -31,11 +36,62 @@ function kpiTrendSymbol(t: AdvisorKpiTrend): string {
   return "○";
 }
 
-function kpiTileBorder(t: AdvisorKpiTraffic): string {
-  if (t === "green") return "border-emerald-300 bg-emerald-50/70";
-  if (t === "amber") return "border-amber-300 bg-amber-50/70";
-  if (t === "red") return "border-rose-300 bg-rose-50/70";
-  return "border-slate-200 bg-slate-50/80";
+function kpiHistoryTrendArrow(d: "up" | "down" | "flat" | "unknown"): string {
+  if (d === "up") return "↑";
+  if (d === "down") return "↓";
+  if (d === "flat") return "→";
+  return "○";
+}
+
+function KpiTrendSparkline({ series }: { series: AdvisorKpiTrendSeriesPoint[] }) {
+  const vals = series.map((s) => s.v).filter((v): v is number => v !== null && Number.isFinite(v));
+  if (vals.length < 2) {
+    return <span className="tabular-nums text-slate-400">—</span>;
+  }
+  const min = Math.min(...vals);
+  const max = Math.max(...vals);
+  const span = max === min ? 1 : max - min;
+  const w = 96;
+  const h = 22;
+  const n = series.length;
+  const pts = series
+    .map((s, i) => {
+      if (s.v === null || !Number.isFinite(s.v)) return null;
+      const x = n <= 1 ? w / 2 : (i / (n - 1)) * w;
+      const y = h - ((s.v - min) / span) * (h - 4) - 2;
+      return `${x},${y}`;
+    })
+    .filter(Boolean) as string[];
+  if (pts.length < 2) {
+    return <span className="tabular-nums text-slate-400">—</span>;
+  }
+  return (
+    <svg width={w} height={h} className="shrink-0 text-slate-500" aria-hidden>
+      <polyline
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        points={pts.join(" ")}
+      />
+    </svg>
+  );
+}
+
+/** Ruhige Enterprise-Karten: weiß, linker Status-Akzent (keine Vollflächen-Pastelle). */
+function kpiTileClasses(t: AdvisorKpiTraffic): string {
+  const base =
+    "border border-slate-200/95 bg-white shadow-sm transition-[border-color,box-shadow] hover:border-slate-300 hover:shadow-md";
+  const left =
+    t === "green"
+      ? "border-l-[3px] border-l-emerald-500"
+      : t === "amber"
+        ? "border-l-[3px] border-l-amber-500"
+        : t === "red"
+          ? "border-l-[3px] border-l-rose-500"
+          : "border-l-[3px] border-l-slate-300";
+  return `${base} ${left}`;
 }
 
 function trafficPill(s: BoardReadinessTraffic): string {
@@ -233,6 +289,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [kpiLoading, setKpiLoading] = useState(false);
   const [kpiErr, setKpiErr] = useState<string | null>(null);
   const [kpiWindowDays, setKpiWindowDays] = useState(90);
+  const [kpiTrendPeriod, setKpiTrendPeriod] = useState<AdvisorKpiTrendPeriod>("4w");
+  const [kpiTrends, setKpiTrends] = useState<AdvisorKpiTrendsDto | null>(null);
+  const [kpiTrendsLoading, setKpiTrendsLoading] = useState(false);
+  const [kpiTrendsErr, setKpiTrendsErr] = useState<string | null>(null);
 
   const [reminderPatchBusyId, setReminderPatchBusyId] = useState<string | null>(null);
   const [manualRemTenantId, setManualRemTenantId] = useState("");
@@ -274,7 +334,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     setKpiErr(null);
     try {
       const w = Math.min(365, Math.max(7, kpiWindowDays));
-      const r = await fetch(`/api/internal/advisor/kpi-portfolio?window_days=${w}`, {
+      const r = await fetch(`/api/internal/advisor/kpi-portfolio?window_days=${w}&persist_history=1`, {
         credentials: "include",
       });
       if (r.status === 401) {
@@ -297,10 +357,46 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     }
   }, [kpiWindowDays]);
 
+  const fetchKpiTrends = useCallback(async () => {
+    setKpiTrendsLoading(true);
+    setKpiTrendsErr(null);
+    try {
+      const w = Math.min(365, Math.max(7, kpiWindowDays));
+      const q = new URLSearchParams();
+      q.set("period", kpiTrendPeriod);
+      q.set("append", "0");
+      q.set("kpi_window_days", String(w));
+      if (readinessFilter !== "all") q.set("segment", readinessFilter);
+      const r = await fetch(`/api/internal/advisor/kpi-trends?${q}`, { credentials: "include" });
+      if (r.status === 401) {
+        setKpiTrendsErr("Trends: nicht angemeldet.");
+        setKpiTrends(null);
+        return;
+      }
+      if (!r.ok) {
+        setKpiTrendsErr(`Trends: HTTP ${r.status}`);
+        setKpiTrends(null);
+        return;
+      }
+      const data = (await r.json()) as { advisor_kpi_trends?: AdvisorKpiTrendsDto };
+      setKpiTrends(data.advisor_kpi_trends ?? null);
+    } catch {
+      setKpiTrendsErr("Trends: Netzwerkfehler");
+      setKpiTrends(null);
+    } finally {
+      setKpiTrendsLoading(false);
+    }
+  }, [kpiTrendPeriod, kpiWindowDays, readinessFilter]);
+
   useEffect(() => {
     if (!adminConfigured || !payload?.generated_at) return;
     void fetchKpi();
   }, [adminConfigured, payload?.generated_at, fetchKpi]);
+
+  useEffect(() => {
+    if (!adminConfigured || !kpiSnapshot || kpiErr) return;
+    void fetchKpiTrends();
+  }, [adminConfigured, kpiSnapshot, kpiErr, fetchKpiTrends]);
 
   const filteredRows = useMemo(() => {
     if (!payload) return [];
@@ -526,19 +622,23 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
 
   if (!adminConfigured) {
     return (
-      <div className="rounded-xl border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
-        Kanzlei-Cockpit nicht konfiguriert (<code className="font-mono">LEAD_ADMIN_SECRET</code>).
+      <div className="mx-auto max-w-lg rounded-xl border border-amber-200/90 bg-amber-50/80 p-6 text-sm text-amber-950 shadow-sm ring-1 ring-amber-950/[0.06]">
+        <p className="font-medium">Kanzlei-Cockpit nicht konfiguriert</p>
+        <p className="mt-1 text-amber-900/90">
+          Setze <code className="rounded bg-white/80 px-1.5 py-0.5 font-mono text-xs">LEAD_ADMIN_SECRET</code> in
+          der Umgebung.
+        </p>
       </div>
     );
   }
 
   if (loadError === "unauthorized") {
     return (
-      <div className="mx-auto max-w-lg rounded-xl border border-slate-200 bg-white p-8 shadow-sm">
-        <h1 className="text-lg font-semibold text-slate-900">Kanzlei-Portfolio</h1>
-        <p className="mt-2 text-sm text-slate-600">
+      <div className="mx-auto max-w-lg rounded-xl border border-slate-200/90 bg-white p-8 shadow-sm ring-1 ring-slate-950/[0.04]">
+        <h1 className="text-lg font-semibold tracking-tight text-slate-900">Kanzlei-Portfolio</h1>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600">
           Bitte zuerst unter{" "}
-          <a className="text-cyan-700 underline" href="/admin/leads">
+          <a className="font-medium text-slate-900 underline decoration-slate-300 underline-offset-2 hover:decoration-slate-500" href="/admin/leads">
             Lead-Inbox
           </a>{" "}
           mit dem Admin-Secret anmelden, dann diese Seite neu laden.
@@ -548,49 +648,59 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-wrap items-end justify-between gap-4">
-        <div>
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Wave 39–45 · Kanzlei / Berater</p>
-          <h1 className="text-2xl font-semibold text-slate-900">Mehrmandanten-Kanzlei-Cockpit</h1>
-          <p className="mt-1 max-w-3xl text-sm text-slate-600">
-            Welcher Mandant braucht jetzt Aufmerksamkeit? Portfolio über gemappte Mandanten mit Readiness,
-            offenen Prüfpunkten, Export-Historie (Readiness / DATEV-ZIP), Review-Kadenz (Wave 40),
-            Attention-Queue, Review-Playbook (Wave 41), Monatsreport (Wave 42), Reminders / Follow-ups
-            (Wave 43), Partner-Review-Paket (Wave 44) und Kanzlei-KPIs (Wave 45) für internes Steering.
+    <div className="mx-auto max-w-[min(100%,88rem)] space-y-8">
+      <div className="flex flex-wrap items-end justify-between gap-6 border-b border-slate-200/90 pb-6">
+        <div className="min-w-0 max-w-3xl">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600">
+              Intern · Mandanten-Steering
+            </span>
+            <span className="text-[11px] text-slate-400">Waves 39–46</span>
+          </div>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-[1.65rem]">
+            Kanzlei-Portfolio
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Operatives Cockpit für gemappte Mandanten: Readiness, Prüfpunkte, Export-Kadenz, Reviews,
+            Attention-Queue, Playbook, Reports, Reminders und Kanzlei-KPIs inkl. Trend-Verlauf.
           </p>
           {payload ? (
-            <p className="mt-1 font-mono text-xs text-slate-400">
-              Stand: {new Date(payload.generated_at).toLocaleString("de-DE")} · Mandanten:{" "}
-              {payload.mapped_tenant_count}
+            <p className="mt-3 text-xs tabular-nums text-slate-500">
+              <span className="font-medium text-slate-700">Stand</span>{" "}
+              {new Date(payload.generated_at).toLocaleString("de-DE")} ·{" "}
+              <span className="font-medium text-slate-700">{payload.mapped_tenant_count}</span> Mandanten
               {payload.tenants_partial ? ` · API teilweise: ${payload.tenants_partial}` : ""}
             </p>
           ) : null}
-          <p className="mt-2 text-xs text-slate-500">
-            API:{" "}
-            <code className="rounded bg-slate-100 px-1 text-[11px]">
-              GET /api/internal/advisor/kanzlei-portfolio
+          <p className="mt-3 text-[11px] leading-relaxed text-slate-500">
+            <span className="font-medium text-slate-600">Interne APIs</span>{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /kanzlei-portfolio
             </code>{" "}
             ·{" "}
-            <code className="rounded bg-slate-100 px-1 text-[11px]">
-              GET /api/internal/advisor/partner-review-package
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /partner-review-package
             </code>{" "}
             ·{" "}
-            <code className="rounded bg-slate-100 px-1 text-[11px]">
-              GET /api/internal/advisor/kpi-portfolio
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /kpi-portfolio
+            </code>{" "}
+            ·{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /kpi-trends
             </code>
           </p>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div className="flex shrink-0 flex-wrap gap-2">
           <a
             href="/admin/advisor-mandant-export"
-            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+            className="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
           >
             Mandanten-Export
           </a>
           <a
             href="/admin/board-readiness"
-            className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50"
+            className="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50"
           >
             Board Readiness
           </a>
@@ -598,7 +708,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             type="button"
             onClick={() => void load()}
             disabled={loading}
-            className="rounded-lg bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+            className="inline-flex items-center justify-center rounded-md bg-slate-900 px-3 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:pointer-events-none disabled:opacity-50"
           >
             {loading ? "Laden…" : "Aktualisieren"}
           </button>
@@ -612,21 +722,23 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       {payload ? (
         <section
           id="kanzlei-kpi-strip"
-          className="rounded-xl border border-teal-200 bg-teal-50/40 p-4 shadow-sm"
+          className="rounded-xl border border-slate-200/90 bg-white p-5 shadow-sm ring-1 ring-slate-950/[0.04]"
         >
-          <div className="flex flex-wrap items-end justify-between gap-3">
-            <div>
-              <h2 className="text-sm font-semibold text-teal-950">Kanzlei-KPIs (Wave 45)</h2>
-              <p className="mt-1 text-[11px] text-slate-600">
-                Operative Kennzahlen für Regelmäßigkeit (Review, Export, Reminder-Reaktion). Kein BI-System –{" "}
-                <code className="rounded bg-white px-1">GET /api/internal/advisor/kpi-portfolio</code>.
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div className="min-w-0 max-w-2xl">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-slate-500">Portfolio-KPIs</p>
+              <h2 className="mt-0.5 text-base font-semibold tracking-tight text-slate-900">
+                Regelmäßigkeit, Exporte & Reaktion
+              </h2>
+              <p className="mt-1.5 text-xs leading-relaxed text-slate-600">
+                Kompakte Kennzahlen ohne BI-Stack. Trendkurven nutzen tägliche Snapshots (lokal, max. 120 Tage).
               </p>
             </div>
-            <div className="flex flex-wrap items-end gap-2">
-              <label className="text-[11px] font-medium text-slate-700">
+            <div className="flex flex-wrap items-end gap-3">
+              <label className="text-xs font-medium text-slate-700">
                 Fenster (Tage)
                 <select
-                  className="mt-0.5 block rounded border border-slate-300 bg-white px-2 py-1 text-[11px]"
+                  className="mt-1 block min-w-[5.5rem] rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/20"
                   value={kpiWindowDays}
                   onChange={(e) => setKpiWindowDays(Number.parseInt(e.target.value, 10) || 90)}
                 >
@@ -635,38 +747,102 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
                   <option value={90}>90</option>
                 </select>
               </label>
+              <label className="text-xs font-medium text-slate-700">
+                Trend-Zeitraum
+                <select
+                  className="mt-1 block min-w-[7.5rem] rounded-md border border-slate-200 bg-white px-2.5 py-1.5 text-xs text-slate-900 shadow-sm focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-400/20"
+                  value={kpiTrendPeriod}
+                  onChange={(e) => setKpiTrendPeriod(e.target.value as AdvisorKpiTrendPeriod)}
+                >
+                  <option value="4w">4 Wochen</option>
+                  <option value="3m">3 Monate</option>
+                  <option value="qtd">Quartal (QTD)</option>
+                </select>
+              </label>
               <button
                 type="button"
                 disabled={kpiLoading}
                 onClick={() => void fetchKpi()}
-                className="rounded-lg border border-teal-700 bg-teal-800 px-2 py-1 text-[11px] text-white hover:bg-teal-900 disabled:opacity-50"
+                className="rounded-md bg-slate-900 px-3 py-1.5 text-xs font-medium text-white shadow-sm transition hover:bg-slate-800 disabled:pointer-events-none disabled:opacity-50"
               >
                 {kpiLoading ? "…" : "KPI aktualisieren"}
               </button>
             </div>
           </div>
           {kpiErr ? <p className="mt-2 text-[11px] text-red-600">{kpiErr}</p> : null}
+          {kpiTrendsErr ? <p className="mt-1 text-[11px] text-amber-800">{kpiTrendsErr}</p> : null}
           {kpiSnapshot ? (
-            <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+            <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
               {kpiSnapshot.strip.map((tile) => (
                 <a
                   key={tile.id}
                   href={tile.href ?? "#"}
-                  className={`block rounded-lg border p-2.5 text-[11px] shadow-sm transition hover:opacity-95 ${kpiTileBorder(tile.traffic_light)}`}
+                  className={`block rounded-lg p-3 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/35 focus-visible:ring-offset-2 ${kpiTileClasses(tile.traffic_light)}`}
                 >
-                  <div className="font-semibold text-slate-900">{tile.label_de}</div>
-                  <div className="mt-1 flex items-baseline gap-1.5 tabular-nums">
-                    <span className="text-base font-bold text-slate-900">{tile.value_display_de}</span>
-                    <span className="text-slate-600" title="Trend vs. Vorperiode (wo verfügbar)">
+                  <div className="font-medium text-slate-800">{tile.label_de}</div>
+                  <div className="mt-2 flex items-baseline gap-2 tabular-nums">
+                    <span className="text-lg font-semibold tracking-tight text-slate-900">
+                      {tile.value_display_de}
+                    </span>
+                    <span className="text-sm text-slate-500" title="Trend vs. Vorperiode (wo verfügbar)">
                       {kpiTrendSymbol(tile.trend)}
                     </span>
                   </div>
-                  <p className="mt-1 leading-snug text-slate-600">{tile.hint_de}</p>
+                  <p className="mt-2 leading-snug text-slate-600">{tile.hint_de}</p>
                 </a>
               ))}
             </div>
           ) : !kpiLoading ? (
             <p className="mt-2 text-[11px] text-slate-500">KPI werden nach Portfolio-Laden geladen …</p>
+          ) : null}
+          {kpiSnapshot && (kpiTrends || kpiTrendsLoading) ? (
+            <div className="mt-5 border-t border-slate-100 pt-5">
+              <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                  Trend-Verlauf
+                </h3>
+                <p className="text-xs text-slate-500">
+                  {kpiTrends ? (
+                    <>
+                      <span className="font-medium text-slate-700">{kpiTrends.period_label_de}</span>
+                      {kpiTrendsLoading ? " · aktualisieren…" : null}
+                      <span className="text-slate-400">
+                        {" "}
+                        · {kpiTrends.history_points_in_period} Datenpunkt(e)
+                      </span>
+                    </>
+                  ) : (
+                    "Lade Trends…"
+                  )}
+                </p>
+              </div>
+              {kpiTrends?.segment_note_de ? (
+                <p className="mt-2 rounded-md border border-slate-100 bg-slate-50/80 px-2.5 py-1.5 text-xs text-slate-600">
+                  {kpiTrends.segment_note_de}
+                </p>
+              ) : null}
+              {kpiTrends ? (
+                <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                  {kpiTrends.metrics.map((m) => (
+                    <div
+                      key={m.id}
+                      className="flex items-center gap-3 rounded-lg border border-slate-200/90 bg-slate-50/40 px-3 py-2.5 text-xs text-slate-700 shadow-sm"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium text-slate-800">{m.label_de}</div>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-2 tabular-nums text-slate-600">
+                          <span title="Letzter History-Punkt vs. vorheriger">
+                            <span className="text-slate-800">{kpiHistoryTrendArrow(m.direction)}</span>
+                            {m.delta_display_de ? <span className="ml-1.5">{m.delta_display_de}</span> : null}
+                          </span>
+                        </div>
+                      </div>
+                      <KpiTrendSparkline series={m.series} />
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </div>
           ) : null}
         </section>
       ) : null}
@@ -818,7 +994,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             <code className="rounded bg-white px-1">GET /api/internal/advisor/kanzlei-monthly-report</code>.
             Vergleich nutzt optional{" "}
             <code className="rounded bg-white px-1">data/kanzlei-monthly-report-baseline.json</code> (siehe
-            Doku). Abschnitt 5 (KPIs):{" "}
+            Doku). Abschnitt 5–6 (KPIs + Trends):{" "}
             <code className="rounded bg-white px-1">kpi_window_days</code>, abschalten mit{" "}
             <code className="rounded bg-white px-1">kpi=0</code>.
           </p>
@@ -885,7 +1061,8 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
           <h2 className="text-sm font-semibold text-slate-900">Partner-Review-Paket (Wave 44–45)</h2>
           <p className="mt-1 text-[11px] text-slate-600">
             Kompaktes Sammelpaket für Partnerrunden und Portfolio-Steuerung (nicht Mandanten-Einzel, nicht
-            Board-Pack). Teil C nutzt dieselbe Baseline wie der Monatsreport; Teil E enthält Kanzlei-KPIs
+            Board-Pack). Teil C nutzt dieselbe Baseline wie der Monatsreport; Teil E/F enthalten Kanzlei-KPIs und
+            Trend-Kurzsätze
             (Wave 45).{" "}
             <code className="rounded bg-white px-1">GET /api/internal/advisor/partner-review-package</code> ·{" "}
             <code className="rounded bg-white px-1">?format=markdown</code> · optional{" "}

--- a/frontend/src/lib/advisorKpiHistoryStore.ts
+++ b/frontend/src/lib/advisorKpiHistoryStore.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { mkdir, readFile, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
+import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+import {
+  ADVISOR_KPI_HISTORY_FILE_VERSION,
+  type AdvisorKpiHistoryPoint,
+  type AdvisorKpiHistoryState,
+} from "@/lib/advisorKpiHistoryTypes";
+
+const MAX_SNAPSHOTS = 120;
+
+function historyPath(): string {
+  const fromEnv = process.env.ADVISOR_KPI_HISTORY_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) {
+    return join("/tmp", "compliancehub-advisor-kpi-history.json");
+  }
+  return join(process.cwd(), "data", "advisor-kpi-history.json");
+}
+
+function emptyState(): AdvisorKpiHistoryState {
+  return { version: ADVISOR_KPI_HISTORY_FILE_VERSION, snapshots: [] };
+}
+
+export async function readAdvisorKpiHistoryState(): Promise<AdvisorKpiHistoryState> {
+  const path = historyPath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const o = JSON.parse(raw) as Record<string, unknown>;
+    if (!o || typeof o !== "object") return emptyState();
+    const snaps: AdvisorKpiHistoryPoint[] = [];
+    if (Array.isArray(o.snapshots)) {
+      for (const e of o.snapshots) {
+        if (!e || typeof e !== "object") continue;
+        const r = e as Record<string, unknown>;
+        if (typeof r.captured_at !== "string") continue;
+        snaps.push({
+          captured_at: r.captured_at,
+          mapped_tenant_count: typeof r.mapped_tenant_count === "number" ? r.mapped_tenant_count : 0,
+          kpi_window_days: typeof r.kpi_window_days === "number" ? r.kpi_window_days : 90,
+          review_current_share: typeof r.review_current_share === "number" ? r.review_current_share : 0,
+          export_fresh_share: typeof r.export_fresh_share === "number" ? r.export_fresh_share : 0,
+          open_reminders_open_count:
+            typeof r.open_reminders_open_count === "number" ? r.open_reminders_open_count : 0,
+          share_no_open_reminders:
+            typeof r.share_no_open_reminders === "number" ? r.share_no_open_reminders : 0,
+          share_no_red_pillar: typeof r.share_no_red_pillar === "number" ? r.share_no_red_pillar : 0,
+          reminder_median_resolution_hours:
+            typeof r.reminder_median_resolution_hours === "number"
+              ? r.reminder_median_resolution_hours
+              : null,
+        });
+      }
+    }
+    snaps.sort((a, b) => Date.parse(a.captured_at) - Date.parse(b.captured_at));
+    return { version: ADVISOR_KPI_HISTORY_FILE_VERSION, snapshots: snaps };
+  } catch {
+    return emptyState();
+  }
+}
+
+async function writeAdvisorKpiHistoryState(state: AdvisorKpiHistoryState): Promise<void> {
+  const path = historyPath();
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+}
+
+function utcDayKey(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().slice(0, 10);
+}
+
+export function historyPointFromSnapshot(
+  payload: KanzleiPortfolioPayload,
+  snapshot: AdvisorKpiPortfolioSnapshot,
+): AdvisorKpiHistoryPoint {
+  return {
+    captured_at: snapshot.generated_at,
+    mapped_tenant_count: payload.mapped_tenant_count,
+    kpi_window_days: snapshot.window_days,
+    review_current_share: snapshot.review.current_share,
+    export_fresh_share: snapshot.export_kpis.fresh_share,
+    open_reminders_open_count: payload.open_reminders.length,
+    share_no_open_reminders: snapshot.hygiene.share_no_open_reminders,
+    share_no_red_pillar: snapshot.hygiene.share_no_red_pillar,
+    reminder_median_resolution_hours: snapshot.responsiveness.reminder_median_resolution_hours,
+  };
+}
+
+/**
+ * Schreibt höchstens einen Eintrag pro UTC-Kalendertag (letzter Stand des Tages gewinnt).
+ */
+export async function upsertAdvisorKpiHistoryDaily(
+  payload: KanzleiPortfolioPayload,
+  snapshot: AdvisorKpiPortfolioSnapshot,
+): Promise<AdvisorKpiHistoryState> {
+  const state = await readAdvisorKpiHistoryState();
+  const point = historyPointFromSnapshot(payload, snapshot);
+  const day = utcDayKey(point.captured_at);
+  if (!day) return state;
+
+  const next = state.snapshots.filter((s) => utcDayKey(s.captured_at) !== day);
+  next.push(point);
+  next.sort((a, b) => Date.parse(a.captured_at) - Date.parse(b.captured_at));
+  while (next.length > MAX_SNAPSHOTS) next.shift();
+
+  const out: AdvisorKpiHistoryState = {
+    version: ADVISOR_KPI_HISTORY_FILE_VERSION,
+    snapshots: next,
+  };
+  await writeAdvisorKpiHistoryState(out);
+  return out;
+}

--- a/frontend/src/lib/advisorKpiHistoryTypes.ts
+++ b/frontend/src/lib/advisorKpiHistoryTypes.ts
@@ -1,0 +1,24 @@
+/**
+ * Wave 46 – Persistierte KPI-Zeitpunkte (kein BI-Warehouse).
+ */
+
+export const ADVISOR_KPI_HISTORY_FILE_VERSION = "wave46-v1";
+
+/** Ein gespeicherter Querschnitt (typisch einmal pro Kalendertag). */
+export type AdvisorKpiHistoryPoint = {
+  captured_at: string;
+  mapped_tenant_count: number;
+  /** Fenster für Median-Reaktionszeit beim Speichern (z. B. 90). */
+  kpi_window_days: number;
+  review_current_share: number;
+  export_fresh_share: number;
+  open_reminders_open_count: number;
+  share_no_open_reminders: number;
+  share_no_red_pillar: number;
+  reminder_median_resolution_hours: number | null;
+};
+
+export type AdvisorKpiHistoryState = {
+  version: typeof ADVISOR_KPI_HISTORY_FILE_VERSION;
+  snapshots: AdvisorKpiHistoryPoint[];
+};

--- a/frontend/src/lib/advisorKpiPortfolioAggregate.ts
+++ b/frontend/src/lib/advisorKpiPortfolioAggregate.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
+import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { readAdvisorMandantRemindersState } from "@/lib/advisorMandantReminderStore";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
@@ -26,7 +27,12 @@ export async function computeAdvisorKpiPortfolioSnapshot(
   now: Date = new Date(),
   windowDays: number = 90,
   segmentBy: "readiness" | "primary_segment" = "readiness",
+  options?: { persistHistory?: boolean },
 ) {
   const payload = await computeKanzleiPortfolioPayload(now);
-  return attachAdvisorKpiToPayload(payload, now.getTime(), windowDays, segmentBy);
+  const snapshot = await attachAdvisorKpiToPayload(payload, now.getTime(), windowDays, segmentBy);
+  if (options?.persistHistory) {
+    await upsertAdvisorKpiHistoryDaily(payload, snapshot);
+  }
+  return snapshot;
 }

--- a/frontend/src/lib/advisorKpiTrendsBuild.test.ts
+++ b/frontend/src/lib/advisorKpiTrendsBuild.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ADVISOR_KPI_TRENDS_VERSION,
+  buildAdvisorKpiTrendsDto,
+  buildKpiTrendNarrativeLinesDe,
+} from "@/lib/advisorKpiTrendsBuild";
+import type { AdvisorKpiHistoryPoint } from "@/lib/advisorKpiHistoryTypes";
+
+function point(
+  day: string,
+  review: number,
+  exportFresh: number,
+  openRem: number,
+  noRed: number,
+  med: number | null,
+): AdvisorKpiHistoryPoint {
+  return {
+    captured_at: `${day}T12:00:00.000Z`,
+    mapped_tenant_count: 10,
+    kpi_window_days: 90,
+    review_current_share: review,
+    export_fresh_share: exportFresh,
+    open_reminders_open_count: openRem,
+    share_no_open_reminders: 0.5,
+    share_no_red_pillar: noRed,
+    reminder_median_resolution_hours: med,
+  };
+}
+
+describe("advisorKpiTrendsBuild", () => {
+  it("builds series and direction for review coverage", () => {
+    const nowMs = Date.parse("2026-04-10T12:00:00Z");
+    const dto = buildAdvisorKpiTrendsDto({
+      history: [
+        point("2026-04-01", 0.5, 0.5, 3, 0.8, 10),
+        point("2026-04-08", 0.7, 0.5, 3, 0.8, 10),
+      ],
+      period: "4w",
+      nowMs,
+    });
+    expect(dto.version).toBe(ADVISOR_KPI_TRENDS_VERSION);
+    const m = dto.metrics.find((x) => x.id === "review_coverage");
+    expect(m?.current_value).toBe(0.7);
+    expect(m?.previous_value).toBe(0.5);
+    expect(m?.direction).toBe("up");
+  });
+
+  it("segment filter adds note", () => {
+    const dto = buildAdvisorKpiTrendsDto({
+      history: [],
+      period: "3m",
+      nowMs: Date.now(),
+      segment_filter: "early_pilot",
+    });
+    expect(dto.segment_note_de).toContain("portfolio-weit");
+  });
+
+  it("narrative mentions open reminders increase", () => {
+    const metrics = buildAdvisorKpiTrendsDto({
+      history: [
+        point("2026-04-01", 0.8, 0.8, 2, 0.9, 5),
+        point("2026-04-09", 0.8, 0.8, 6, 0.9, 5),
+      ],
+      period: "4w",
+      nowMs: Date.parse("2026-04-10T12:00:00Z"),
+    }).metrics;
+    const lines = buildKpiTrendNarrativeLinesDe(metrics);
+    expect(lines.some((l) => l.includes("Reminder zugenommen"))).toBe(true);
+  });
+});

--- a/frontend/src/lib/advisorKpiTrendsBuild.ts
+++ b/frontend/src/lib/advisorKpiTrendsBuild.ts
@@ -1,0 +1,267 @@
+/**
+ * Wave 46 – KPI-Trends aus History-Punkten (ohne server-only).
+ */
+
+import type { AdvisorKpiHistoryPoint } from "@/lib/advisorKpiHistoryTypes";
+
+export const ADVISOR_KPI_TRENDS_VERSION = "wave46-v1";
+
+export type AdvisorKpiTrendPeriod = "4w" | "3m" | "qtd";
+
+export type AdvisorKpiTrendDirection = "up" | "down" | "flat" | "unknown";
+
+export type AdvisorKpiTrendSeriesPoint = {
+  /** ISO-Datum (Tag) für Achse */
+  t: string;
+  v: number | null;
+};
+
+export type AdvisorKpiTrendMetric = {
+  id: string;
+  label_de: string;
+  unit: "ratio" | "hours" | "count";
+  lower_is_better: boolean;
+  current_value: number | null;
+  previous_value: number | null;
+  direction: AdvisorKpiTrendDirection;
+  delta_display_de: string | null;
+  series: AdvisorKpiTrendSeriesPoint[];
+};
+
+export type AdvisorKpiTrendsDto = {
+  version: typeof ADVISOR_KPI_TRENDS_VERSION;
+  period: AdvisorKpiTrendPeriod;
+  period_label_de: string;
+  history_points_in_period: number;
+  /** Wave 46: Zeitreihe nur portfolio-weit; Segment-Filter dokumentieren. */
+  segment_note_de: string | null;
+  metrics: AdvisorKpiTrendMetric[];
+  narrative_lines_de: string[];
+};
+
+/** Kompakter Block für Monatsreport / Partner-Paket (ohne Serien). */
+export type AdvisorKpiTrendsNarrativeBlock = Pick<
+  AdvisorKpiTrendsDto,
+  "version" | "period" | "period_label_de" | "narrative_lines_de"
+>;
+
+export function advisorKpiTrendsNarrativeBlock(dto: AdvisorKpiTrendsDto): AdvisorKpiTrendsNarrativeBlock {
+  return {
+    version: dto.version,
+    period: dto.period,
+    period_label_de: dto.period_label_de,
+    narrative_lines_de: dto.narrative_lines_de,
+  };
+}
+
+export type BuildAdvisorKpiTrendsInput = {
+  history: AdvisorKpiHistoryPoint[];
+  period: AdvisorKpiTrendPeriod;
+  nowMs: number;
+  /** Wenn gesetzt und nicht "all", Hinweis ausgeben (keine separaten Serien). */
+  segment_filter?: string | null;
+};
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function periodStartMs(period: AdvisorKpiTrendPeriod, nowMs: number): number {
+  const d = new Date(nowMs);
+  if (period === "4w") return nowMs - 28 * DAY;
+  if (period === "3m") return nowMs - 92 * DAY;
+  const y = d.getUTCFullYear();
+  const m = d.getUTCMonth();
+  const q0 = Math.floor(m / 3) * 3;
+  return Date.UTC(y, q0, 1, 12, 0, 0, 0);
+}
+
+function periodLabelDe(period: AdvisorKpiTrendPeriod): string {
+  if (period === "4w") return "Letzte 4 Wochen";
+  if (period === "3m") return "Letzte 3 Monate";
+  return "Quartal bis heute (QTD)";
+}
+
+function filterHistory(points: AdvisorKpiHistoryPoint[], startMs: number, nowMs: number): AdvisorKpiHistoryPoint[] {
+  return points.filter((p) => {
+    const t = Date.parse(p.captured_at);
+    if (Number.isNaN(t)) return false;
+    return t >= startMs && t <= nowMs;
+  });
+}
+
+function pickSeries(
+  points: AdvisorKpiHistoryPoint[],
+  getter: (p: AdvisorKpiHistoryPoint) => number | null,
+): AdvisorKpiTrendSeriesPoint[] {
+  return points.map((p) => ({
+    t: p.captured_at.slice(0, 10),
+    v: getter(p),
+  }));
+}
+
+function directionForMetric(
+  cur: number | null,
+  prev: number | null,
+  lowerIsBetter: boolean,
+): AdvisorKpiTrendDirection {
+  if (cur === null || prev === null) return "unknown";
+  const eps = 1e-9;
+  if (Math.abs(cur - prev) < eps) return "flat";
+  const improved = lowerIsBetter ? cur < prev : cur > prev;
+  return improved ? "up" : "down";
+}
+
+function deltaDe(
+  cur: number | null,
+  prev: number | null,
+  unit: "ratio" | "hours" | "count",
+): string | null {
+  if (cur === null || prev === null) return null;
+  const d = cur - prev;
+  if (unit === "ratio") {
+    const pp = Math.round(d * 100);
+    return pp === 0 ? "±0 PP" : pp > 0 ? `+${pp} PP` : `${pp} PP`;
+  }
+  if (unit === "hours") {
+    return d === 0 ? "±0 h" : d > 0 ? `+${d.toFixed(1)} h` : `${d.toFixed(1)} h`;
+  }
+  const n = Math.round(d);
+  return n === 0 ? "±0" : n > 0 ? `+${n}` : `${n}`;
+}
+
+function buildMetric(
+  id: string,
+  label_de: string,
+  unit: "ratio" | "hours" | "count",
+  lower_is_better: boolean,
+  series: AdvisorKpiTrendSeriesPoint[],
+): AdvisorKpiTrendMetric {
+  const valid = series.filter((s) => s.v !== null) as { t: string; v: number }[];
+  const last = valid.length >= 1 ? valid[valid.length - 1]!.v : null;
+  const prev = valid.length >= 2 ? valid[valid.length - 2]!.v : null;
+  return {
+    id,
+    label_de,
+    unit,
+    lower_is_better,
+    current_value: last,
+    previous_value: prev,
+    direction: directionForMetric(last, prev, lower_is_better),
+    delta_display_de: deltaDe(last, prev, unit),
+    series,
+  };
+}
+
+export function buildKpiTrendNarrativeLinesDe(metrics: AdvisorKpiTrendMetric[]): string[] {
+  const out: string[] = [];
+  const byId = new Map(metrics.map((m) => [m.id, m]));
+
+  const review = byId.get("review_coverage");
+  if (review && review.direction === "up" && review.unit === "ratio") {
+    out.push("Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen.");
+  } else if (review && review.direction === "down" && review.unit === "ratio") {
+    out.push("Review-Deckung gesunken – Kadenz und Historie prüfen.");
+  }
+
+  const exp = byId.get("export_fresh");
+  if (exp && exp.direction === "up") {
+    out.push("Export-Kadenz (Anteil „frisch“) verbessert.");
+  } else if (exp && exp.direction === "down") {
+    out.push("Export-Kadenz verschlechtert – Readiness-/DATEV-Exporte einplanen.");
+  }
+
+  const rem = byId.get("open_reminders");
+  if (rem && rem.direction === "up") {
+    out.push("Offene Reminder reduziert.");
+  } else if (rem && rem.direction === "down") {
+    out.push("Offene Reminder zugenommen – Follow-up und Queue prüfen.");
+  }
+
+  const hy = byId.get("no_red_pillar");
+  if (hy && hy.direction === "up") {
+    out.push("Anteil Mandanten ohne rote Säule gestiegen (Hygiene).");
+  } else if (hy && hy.direction === "down") {
+    out.push("Anteil ohne rote Säule gesunken – Fokus-Säulen in der Tabelle ansehen.");
+  }
+
+  const med = byId.get("reminder_median_hours");
+  if (med && med.direction === "up" && med.current_value !== null) {
+    out.push("Median-Reaktionszeit auf Reminder kürzer geworden (positiv).");
+  } else if (med && med.direction === "down" && med.current_value !== null) {
+    out.push("Median-Reaktionszeit auf Reminder länger – Engpässe im Team klären.");
+  }
+
+  if (out.length === 0) {
+    out.push("Noch zu wenige History-Punkte im gewählten Zeitraum für belastbare Trend-Sätze (täglich ein Punkt empfohlen).");
+  }
+
+  return out.slice(0, 6);
+}
+
+export function buildAdvisorKpiTrendsDto(input: BuildAdvisorKpiTrendsInput): AdvisorKpiTrendsDto {
+  const { history, period, nowMs } = input;
+  const start = periodStartMs(period, nowMs);
+  const filtered = filterHistory([...history].sort((a, b) => Date.parse(a.captured_at) - Date.parse(b.captured_at)), start, nowMs);
+
+  const seg = input.segment_filter?.trim();
+  const segment_note_de =
+    seg && seg !== "" && seg.toLowerCase() !== "all"
+      ? "Hinweis: Die Zeitreihe ist portfolio-weit. Segment-spezifische History ist in Wave 46 nicht persistiert."
+      : null;
+
+  const metrics: AdvisorKpiTrendMetric[] = [
+    buildMetric(
+      "review_coverage",
+      "Review aktuell (Anteil)",
+      "ratio",
+      false,
+      pickSeries(filtered, (p) => p.review_current_share),
+    ),
+    buildMetric(
+      "export_fresh",
+      "Export-Kadenz OK (Anteil)",
+      "ratio",
+      false,
+      pickSeries(filtered, (p) => p.export_fresh_share),
+    ),
+    buildMetric(
+      "open_reminders",
+      "Offene Reminder (Anzahl)",
+      "count",
+      true,
+      pickSeries(filtered, (p) => p.open_reminders_open_count),
+    ),
+    buildMetric(
+      "no_open_reminders_share",
+      "Ohne offene Reminder (Anteil)",
+      "ratio",
+      false,
+      pickSeries(filtered, (p) => p.share_no_open_reminders),
+    ),
+    buildMetric(
+      "no_red_pillar",
+      "Ohne rote Säule (Anteil)",
+      "ratio",
+      false,
+      pickSeries(filtered, (p) => p.share_no_red_pillar),
+    ),
+    buildMetric(
+      "reminder_median_hours",
+      "Reminder-Median (h, Fenster wie beim Snapshot)",
+      "hours",
+      true,
+      pickSeries(filtered, (p) => p.reminder_median_resolution_hours),
+    ),
+  ];
+
+  const narrative_lines_de = buildKpiTrendNarrativeLinesDe(metrics);
+
+  return {
+    version: ADVISOR_KPI_TRENDS_VERSION,
+    period,
+    period_label_de: periodLabelDe(period),
+    history_points_in_period: filtered.length,
+    segment_note_de,
+    metrics,
+    narrative_lines_de,
+  };
+}

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
@@ -101,6 +101,7 @@ describe("kanzleiMonthlyReportBuild", () => {
     );
     expect(r.compared_to_baseline).toBe(true);
     expect(r.section_3_changes.readiness_improved.length).toBe(1);
+    expect(r.section_6_kpi_trends).toBeNull();
   });
 
   it("buildKanzleiMonthlyReport skips compare when compareToBaseline false", () => {

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.ts
@@ -5,6 +5,7 @@
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import { GTM_READINESS_LABELS_DE, type GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type {
   KanzleiAttentionBand,
@@ -305,6 +306,8 @@ export type BuildMonthlyReportOptions = {
   attentionTopN: number;
   /** Wave 45 – optionaler KPI-Block (Abschnitt 5). */
   advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
+  /** Wave 46 – optionaler Trend-Kurzblock (Abschnitt 6). */
+  kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
 };
 
 export function buildKanzleiMonthlyReport(
@@ -352,5 +355,6 @@ export function buildKanzleiMonthlyReport(
     section_3_changes: s3,
     section_4_focus_areas_de: buildKanzleiPortfolioFocusAreasDe(payload, s1),
     section_5_advisor_kpis: opts.advisorKpiSnapshot ?? null,
+    section_6_kpi_trends: opts.kpiTrendsNarrative ?? null,
   };
 }

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
+import { ADVISOR_KPI_TRENDS_VERSION } from "@/lib/advisorKpiTrendsBuild";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
 import { kanzleiMonthlyReportMarkdownDe } from "@/lib/kanzleiMonthlyReportMarkdown";
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
@@ -94,8 +95,16 @@ describe("kanzleiMonthlyReportMarkdown", () => {
       compareToBaseline: false,
       attentionTopN: 5,
       advisorKpiSnapshot: kpi,
+      kpiTrendsNarrative: {
+        version: ADVISOR_KPI_TRENDS_VERSION,
+        period: "3m",
+        period_label_de: "Letzte 3 Monate",
+        narrative_lines_de: ["Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen."],
+      },
     });
     const md = kanzleiMonthlyReportMarkdownDe(r);
     expect(md).toContain("## 5) Kanzlei-KPIs");
+    expect(md).toContain("## 6) KPI-Trends (Wave 46)");
+    expect(md).toContain("Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen.");
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
@@ -110,6 +110,17 @@ export function kanzleiMonthlyReportMarkdownDe(r: KanzleiMonthlyReportDto): stri
     }
   }
 
+  const trd = r.section_6_kpi_trends;
+  if (trd) {
+    parts.push(`## 6) KPI-Trends (Wave 46)`);
+    parts.push(
+      `_Rolling **${trd.period_label_de}** · Schema ${trd.version} · Vergleich letzter History-Punkt vs. vorheriger Punkt im Zeitraum._`,
+    );
+    for (const line of trd.narrative_lines_de) {
+      parts.push(`- ${line}`);
+    }
+  }
+
   parts.push(`---`);
   parts.push(
     `Hinweis: Portfolio-Report für interne Kanzlei-Arbeit; keine Board-Tischreife. Daten aus Live-API und lokaler Historie – Änderungslogik bewusst grob (siehe Doku Wave 42).`,

--- a/frontend/src/lib/kanzleiMonthlyReportTypes.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportTypes.ts
@@ -2,11 +2,12 @@
  * Wave 42–45 – Kanzlei-Monatsreport / Sammelreport (Portfolio-Ebene, kein Board-Pack).
  */
 
+import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 
-export const KANZLEI_MONTHLY_REPORT_VERSION = "wave45-v1";
+export const KANZLEI_MONTHLY_REPORT_VERSION = "wave46-v1";
 
 export type KanzleiAttentionBand = "low" | "medium" | "high";
 
@@ -85,4 +86,6 @@ export type KanzleiMonthlyReportDto = {
   section_4_focus_areas_de: string[];
   /** Wave 45 – Kanzlei-KPI-Snapshot; null wenn nicht mitgeliefert. */
   section_5_advisor_kpis: AdvisorKpiPortfolioSnapshot | null;
+  /** Wave 46 – Kurz-Trends aus persistierter KPI-History (rolling, kein BI). */
+  section_6_kpi_trends: AdvisorKpiTrendsNarrativeBlock | null;
 };

--- a/frontend/src/lib/partnerReviewPackageBuild.test.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.test.ts
@@ -94,6 +94,7 @@ describe("partnerReviewPackageBuild", () => {
     p.reminders_due_this_week_open_count = 1;
     const pkg = buildPartnerReviewPackage(p, null, { compareToBaseline: false, attentionTopN: 5 });
     expect(pkg.part_e_advisor_kpis).toBeNull();
+    expect(pkg.part_f_kpi_trends).toBeNull();
     expect(pkg.part_a_portfolio_overview.count_review_stale).toBe(1);
     expect(pkg.part_a_portfolio_overview.open_reminders_open_count).toBe(1);
     expect(pkg.part_b_top_attention.length).toBe(1);

--- a/frontend/src/lib/partnerReviewPackageBuild.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.ts
@@ -8,6 +8,7 @@ import {
   buildKanzleiPortfolioFocusAreasDe,
   summarizeKanzleiMonthlyReportSection1,
 } from "@/lib/kanzleiMonthlyReportBuild";
+import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
 import type {
@@ -101,6 +102,8 @@ export type BuildPartnerReviewPackageOptions = {
   generatedAt?: Date;
   /** Wave 45 – Kanzlei-KPIs (optional). */
   advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
+  /** Wave 46 – KPI-Trends (optional). */
+  kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
 };
 
 export function buildPartnerReviewPackage(
@@ -151,5 +154,6 @@ export function buildPartnerReviewPackage(
     part_c_changes_since_baseline: mergePartC(s3),
     part_d_recommended_priorities_de: part_d.slice(0, 8),
     part_e_advisor_kpis: opts.advisorKpiSnapshot ?? null,
+    part_f_kpi_trends: opts.kpiTrendsNarrative ?? null,
   };
 }

--- a/frontend/src/lib/partnerReviewPackageMarkdown.ts
+++ b/frontend/src/lib/partnerReviewPackageMarkdown.ts
@@ -136,6 +136,20 @@ export function partnerReviewPackageMarkdownDe(pkg: PartnerReviewPackageDto): st
     lines.push("");
   }
 
+  const trd = pkg.part_f_kpi_trends;
+  if (trd) {
+    lines.push("## F) KPI-Trends (Kurz)");
+    lines.push("");
+    lines.push(
+      `Rolling **${trd.period_label_de}** · Schema ${trd.version} – letzter History-Punkt vs. vorheriger Punkt im Zeitraum.`,
+    );
+    lines.push("");
+    for (const line of trd.narrative_lines_de) {
+      lines.push(`- ${line}`);
+    }
+    lines.push("");
+  }
+
   lines.push("---");
   lines.push("");
   lines.push("### Priorisierung (Kurz)");

--- a/frontend/src/lib/partnerReviewPackageTypes.ts
+++ b/frontend/src/lib/partnerReviewPackageTypes.ts
@@ -2,11 +2,12 @@
  * Wave 44 – Kanzlei Partner-Review-Paket (Portfolio-Steuerung, kein Board-Pack).
  */
 
+import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiMonthlyChangeLine } from "@/lib/kanzleiMonthlyReportTypes";
 
-export const PARTNER_REVIEW_PACKAGE_VERSION = "wave45-v1";
+export const PARTNER_REVIEW_PACKAGE_VERSION = "wave46-v1";
 
 export type PartnerReviewPackageMeta = {
   version: typeof PARTNER_REVIEW_PACKAGE_VERSION;
@@ -64,4 +65,6 @@ export type PartnerReviewPackageDto = {
   part_d_recommended_priorities_de: string[];
   /** Wave 45 – gleicher Snapshot wie Monatsreport-KPI-Block. */
   part_e_advisor_kpis: AdvisorKpiPortfolioSnapshot | null;
+  /** Wave 46 – KPI-Trend-Kurzsätze (rolling History). */
+  part_f_kpi_trends: AdvisorKpiTrendsNarrativeBlock | null;
 };


### PR DESCRIPTION
Add persisted daily KPI history (JSON), GET /api/internal/advisor/kpi-trends with periods 4w/3m/qtd, and optional persist_history on kpi-portfolio.

Wire monthly report and partner package section 6/F with rolling 3m narrative lines. Extend cockpit with trend sparklines and calmer enterprise styling.

Document wave46-kpi-trends and cross-links. Harden Board Report client test by awaiting board-report-viewer before asserting markdown h2.

Made-with: Cursor