### PR TITLE
feat(advisors): Wave 48 AI-Governance view and report integration

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -2,7 +2,7 @@
 
 Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine und wiederkehrende Status-Mails – **kein** Board-Pack, **kein** Mandanten-Einzelreport. Fokus: **Ist-Zustand**, **Top-Aufmerksamkeit**, **grobe Veränderungen** seit einem gespeicherten Stichtag, **Handlungsschwerpunkte**.
 
-## Report-Struktur (Kern 1–4; KPI, Trends und SLA optional)
+## Report-Struktur (Kern 1–4; KPI, Trends, SLA und AI-Governance optional)
 
 | Abschnitt | Inhalt |
 |-----------|--------|
@@ -12,6 +12,7 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | **4) Empfohlene Schwerpunkte** | Regelbasierte Bullet-Liste (EU AI Act, ISO 42001, NIS2, DSGVO, Export-/Review-Kadenz, API-Lesbarkeit, „viele Lücken ohne Export“) |
 | **5–6) KPIs & Trends** | Wave 45–46: siehe `wave45-advisor-kpis.md` / `wave46-kpi-trends.md` |
 | **7) SLA & Eskalation** | Wave 47: leichte Regeln, Befunde und Eskalationssignale aus KPI, Queue und Remindern – siehe `wave47-sla-and-escalations.md` |
+| **8) AI-Governance** | Wave 48: EU AI Act / ISO 42001 Portfolio-Posture – siehe `wave48-ai-governance-view.md` |
 
 ## API (intern, Lead-Admin)
 
@@ -69,6 +70,7 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave44-partner-review-package.md`

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -13,6 +13,7 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
 | **E – Kanzlei-KPIs** | Wave 45 – gleicher KPI-Snapshot wie Monatsreport. |
 | **F – KPI-Trends (Kurz)** | Wave 46 – Kurzsätze aus persistierter History (rolling 3 Monate); siehe `wave46-kpi-trends.md`. |
 | **G – SLA-Lagebild** | Wave 47 – SLA-Befunde, Eskalationssignale und kurze Nächste-Schritte; siehe `wave47-sla-and-escalations.md`. |
+| **H – AI-Governance** | Wave 48 – EU AI Act / ISO 42001 Steuerungsüberblick; siehe `wave48-ai-governance-view.md`. |
 
 ## API
 
@@ -55,6 +56,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave46-kpi-trends.md`
 - `docs/advisors/wave45-advisor-kpis.md`

--- a/docs/advisors/wave45-advisor-kpis.md
+++ b/docs/advisors/wave45-advisor-kpis.md
@@ -35,8 +35,8 @@ Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `stri
 
 ## Einbindung Monatsreport & Partner-Paket
 
-- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab. **Wave 46:** Abschnitt **6) KPI-Trends** (rolling 3 Monate), wenn KPIs an sind.
-- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional. **Wave 46:** Abschnitt **F) KPI-Trends**. **Wave 47:** Abschnitt **G) SLA-Lagebild** (Regeln & Eskalation aus KPI, Queue, Remindern) – siehe `wave47-sla-and-escalations.md`.
+- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab. **Wave 46:** Abschnitt **6) KPI-Trends** (rolling 3 Monate), wenn KPIs an sind. **Wave 47/48:** Abschnitte **7) SLA** und **8) AI-Governance** unabhängig von `kpi`.
+- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional. **Wave 46:** Abschnitt **F) KPI-Trends**. **Wave 47:** Abschnitt **G) SLA-Lagebild** (Regeln & Eskalation aus KPI, Queue, Remindern) – siehe `wave47-sla-and-escalations.md`. **Wave 48:** Monatsreport **8)**, Partner-Paket **H)** – AI-Governance; siehe `wave48-ai-governance-view.md`.
 
 ## Grenzen (bewusst)
 

--- a/docs/advisors/wave47-sla-and-escalations.md
+++ b/docs/advisors/wave47-sla-and-escalations.md
@@ -74,6 +74,7 @@ Bei `portfolio_red` **oder** `partner_attention_required`: bis zu **drei** Auto-
 
 ## Siehe auch
 
+- `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave46-kpi-trends.md`
 - `docs/advisors/wave43-reminders-and-followups.md`

--- a/docs/advisors/wave48-ai-governance-view.md
+++ b/docs/advisors/wave48-ai-governance-view.md
@@ -1,0 +1,83 @@
+# Wave 48 – AI-Governance Advisor View
+
+Interne **Advisor-Ansicht** für das Kanzlei-Portfolio mit Fokus auf **EU AI Act** und **ISO 42001**. Sie verdichtet dieselben Board-Readiness-Signale wie das Mandanten-Cockpit – **ohne** neue Rechtslogik und **ohne** automatische Risiko- oder Register-Qualifikation.
+
+## Modell (pro Mandant)
+
+Felder sind **erklärbar** und aus `TenantPillarSnapshot` / Roh-APIs abgeleitet (siehe `boardReadinessAggregate`, `tenantBoardReadinessGaps`).
+
+| Feld | Werte | Quelle (kurz) |
+|------|--------|----------------|
+| `ai_systems_declared` | ja / nein / unbekannt | `ai_systems.length`, `fetch_ok` |
+| `high_risk_indicator` | ja / nein / unbekannt | High-Risk-Einträge im Compliance-Dashboard |
+| `ai_act_artifact_completeness` | schwach / mittel / stark / unbekannt | EU-AI-Act-Säulen-Ampel (`eu.status`) |
+| `iso42001_governance_completeness` | schwach / mittel / stark / unbekannt | ISO-42001-Säule (`iso.status`) |
+| `post_market_monitoring_readiness` | ja / nein / teilweise | Board-Report-Aktualität bei HR-Systemen, Ampel |
+| `human_oversight_readiness` | ja / nein / teilweise | `owner_email` bei High-Risk-Systemen |
+| `registration_relevance` | ja / nein / unbekannt | Dashboard vorhanden + HR > 0 → Hinweis; sonst Heuristik |
+| `notes_de` | Kurztexte | Kombination aus obigen Signalen (Beratersprache) |
+| `links` | Export + Board Readiness | wie Kanzlei-Portfolio-Zeilen |
+
+## Portfolio-Aggregation
+
+Modul: `frontend/src/lib/advisorAiGovernanceBuild.ts` (pure Logik) und `frontend/src/lib/advisorAiGovernanceAggregate.ts` (Server: Mapping aus Snapshots).
+
+Zusammenfassung (`summary`):
+
+- Zähler für Mandanten mit **Hinweis auf mögliche AI-Act-/Register-Thematik** (Heuristik: Register-Relevanz „ja“ oder sehr schwache EU-Act-Säule).
+- **High-Risk-Exposition**: Mandanten mit mindestens einem High-Risk-System im Dashboard.
+- **ISO-42001-Nachholbedarf**: Säule schwach oder mittel.
+- **Post-Market/Reporting-Lücke**: HR-Kontext, Board-Report nicht frisch.
+- **Human-Oversight-Prüfbedarf**: fehlende Owner bei High-Risk-Systemen.
+- **Buckets** je Säule EU AI Act / ISO 42001 (schwach/mittel/stark/unbekannt).
+
+**Top-Aufmerksamkeit:** Priorisierung über ein einfaches Gewicht (Post-Market, Oversight, schwache Säulen, HR) – keine Ticket-Engine.
+
+## API
+
+- `GET /api/internal/advisor/ai-governance-overview`  
+  Antwort: `ai_governance_overview` (JSON), `markdown_de` (Kurz-Markdown für E-Mail/Wiki).
+
+Monatsreport und Partner-Paket laden Snapshots **einmal** und nutzen `computeAdvisorAiGovernanceFromBundle` neben `computeKanzleiPortfolioPayload({ preloadedBundle })`, um doppelte Mandanten-Runden zu vermeiden.
+
+## UI (Cockpit)
+
+Bereich **`#kanzlei-ai-governance-panel`** im Kanzlei-Portfolio: Kacheln mit Kennzahlen, Top-Mandanten mit Links zu **Mandanten-Export** und **Board Readiness**, Verweis auf die Mandantentabelle.
+
+## Wortlaut (DACH, advisor-safe)
+
+UI und Markdown verwenden Formulierungen wie:
+
+- „Hinweis auf mögliche AI-Act-Relevanz“
+- „Fehlende Governance-Artefakte“
+- „Prüfbedarf Human Oversight“
+- „Keine automatische Rechtsbewertung“
+
+Es wird **nicht** behauptet, dass ein Registerpflicht-Eintrag besteht oder ein System rechtsverbindlich „High-Risk“ ist – nur dass die **in der Plattform geführten** Daten solche **Beratungs- und Steuerungsfragen** nahelegen.
+
+## Report-Einbindung
+
+- **Kanzlei-Monatsreport:** Abschnitt **8) AI-Governance (Wave 48)**.
+- **Partner-Review-Paket:** Teil **H) AI-Governance-Steuerung**.
+
+## Grenzen / rechtliche Vorsicht
+
+- Keine Rechtsberatung; keine vollautomatische Klassifizierung nach EU AI Act.
+- Register- und Risikoentscheidungen liegen bei Mandant und qualifiziertem Berater.
+- NIS2/DSGVO sind in den Säulen sichtbar, aber **nicht** Gegenstand dieser Wave (keine eigenen Regeln).
+
+## Abgrenzung zu KPI, Queue und SLA
+
+| Artefakt | Zweck |
+|----------|--------|
+| **KPI / Trends (Wave 45–46)** | Kadenz, Reaktionszeiten, Segmentüberblick |
+| **Attention-Queue (Wave 41)** | Operative Priorität über Scores und harte Flags |
+| **SLA (Wave 47)** | Regelbasierte Eskalation aus KPI + Queue + Remindern |
+| **AI-Governance View (Wave 48)** | Fokus EU AI Act + ISO 42001 – **Posture** und Beraterkapazität |
+
+## Siehe auch
+
+- `docs/advisors/wave47-sla-and-escalations.md`
+- `docs/advisors/wave45-advisor-kpis.md`
+- `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`
+- `frontend/src/lib/boardReadinessAggregate.ts`

--- a/frontend/src/app/api/internal/advisor/ai-governance-overview/route.ts
+++ b/frontend/src/app/api/internal/advisor/ai-governance-overview/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { computeAdvisorAiGovernanceOverview } from "@/lib/advisorAiGovernanceAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const overview = await computeAdvisorAiGovernanceOverview(new Date());
+  return NextResponse.json({
+    ok: true,
+    ai_governance_overview: overview,
+    markdown_de: overview.markdown_de,
+  });
+}

--- a/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
+++ b/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
@@ -3,7 +3,9 @@ import { NextResponse } from "next/server";
 import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
+import { computeAdvisorAiGovernanceFromBundle } from "@/lib/advisorAiGovernanceAggregate";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
 import { readKanzleiMonthlyReportBaseline, writeKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
 import { kanzleiMonthlyReportMarkdownDe } from "@/lib/kanzleiMonthlyReportMarkdown";
@@ -37,7 +39,11 @@ export async function GET(req: Request) {
   const kpiOff = url.searchParams.get("kpi") === "0";
 
   const now = new Date();
-  const payload = await computeKanzleiPortfolioPayload(now);
+  const bundle = await loadMappedTenantPillarSnapshots(now);
+  const [payload, aiGovernance] = await Promise.all([
+    computeKanzleiPortfolioPayload(now, { preloadedBundle: bundle }),
+    Promise.resolve(computeAdvisorAiGovernanceFromBundle(bundle)),
+  ]);
   const baseline = await readKanzleiMonthlyReportBaseline();
 
   const advisorKpiSnapshot = kpiOff
@@ -61,6 +67,7 @@ export async function GET(req: Request) {
     attentionTopN,
     advisorKpiSnapshot,
     kpiTrendsNarrative,
+    aiGovernance,
   });
   const markdown_de = kanzleiMonthlyReportMarkdownDe(report);
 

--- a/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
+++ b/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
@@ -3,7 +3,9 @@ import { NextResponse } from "next/server";
 import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
+import { computeAdvisorAiGovernanceFromBundle } from "@/lib/advisorAiGovernanceAggregate";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
 import { readKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
 import { buildPartnerReviewPackage } from "@/lib/partnerReviewPackageBuild";
 import { partnerReviewPackageMarkdownDe } from "@/lib/partnerReviewPackageMarkdown";
@@ -29,7 +31,11 @@ export async function GET(req: Request) {
   const kpiOff = url.searchParams.get("kpi") === "0";
 
   const now = new Date();
-  const payload = await computeKanzleiPortfolioPayload(now);
+  const bundle = await loadMappedTenantPillarSnapshots(now);
+  const [payload, aiGovernance] = await Promise.all([
+    computeKanzleiPortfolioPayload(now, { preloadedBundle: bundle }),
+    Promise.resolve(computeAdvisorAiGovernanceFromBundle(bundle)),
+  ]);
   const baseline = await readKanzleiMonthlyReportBaseline();
 
   const advisorKpiSnapshot = kpiOff
@@ -52,6 +58,7 @@ export async function GET(req: Request) {
     attentionTopN,
     advisorKpiSnapshot,
     kpiTrendsNarrative,
+    aiGovernance,
   });
   const markdown_de = partnerReviewPackageMarkdownDe(partner_review_package);
 

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -18,6 +18,7 @@ import {
   type MandantReminderApiEntry,
 } from "@/lib/advisorMandantReminderTypes";
 import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { AdvisorSlaDeepLinkId } from "@/lib/advisorSlaTypes";
 import type {
   KanzleiAttentionQueueItem,
@@ -276,7 +277,9 @@ function ReminderRowItem({
 
 export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [payload, setPayload] = useState<KanzleiPortfolioPayload | null>(null);
+  const [aiGovernance, setAiGovernance] = useState<AdvisorAiGovernancePortfolioDto | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [aiGovernanceError, setAiGovernanceError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   const [readinessFilter, setReadinessFilter] = useState<KanzleiPortfolioReadinessFilter>("all");
@@ -323,21 +326,41 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const load = useCallback(async () => {
     setLoading(true);
     setLoadError(null);
+    setAiGovernanceError(null);
     try {
-      const r = await fetch("/api/internal/advisor/kanzlei-portfolio", { credentials: "include" });
-      if (r.status === 401) {
+      const [rPf, rAg] = await Promise.all([
+        fetch("/api/internal/advisor/kanzlei-portfolio", { credentials: "include" }),
+        fetch("/api/internal/advisor/ai-governance-overview", { credentials: "include" }),
+      ]);
+      if (rPf.status === 401) {
         setPayload(null);
+        setAiGovernance(null);
         setLoadError("unauthorized");
         return;
       }
-      if (!r.ok) {
-        setLoadError(`HTTP ${r.status}`);
+      if (!rPf.ok) {
+        setLoadError(`HTTP ${rPf.status}`);
+        setPayload(null);
+        setAiGovernance(null);
         return;
       }
-      const data = (await r.json()) as { ok?: boolean; kanzlei_portfolio?: KanzleiPortfolioPayload };
+      const data = (await rPf.json()) as { ok?: boolean; kanzlei_portfolio?: KanzleiPortfolioPayload };
       setPayload(data.kanzlei_portfolio ?? null);
+
+      if (rAg.ok) {
+        const agData = (await rAg.json()) as { ai_governance_overview?: AdvisorAiGovernancePortfolioDto };
+        setAiGovernance(agData.ai_governance_overview ?? null);
+      } else if (rAg.status === 401) {
+        setAiGovernance(null);
+        setAiGovernanceError("AI-Governance: nicht angemeldet.");
+      } else {
+        setAiGovernance(null);
+        setAiGovernanceError(`AI-Governance: HTTP ${rAg.status}`);
+      }
     } catch {
       setLoadError("Netzwerkfehler");
+      setPayload(null);
+      setAiGovernance(null);
     } finally {
       setLoading(false);
     }
@@ -674,14 +697,15 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             <span className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600">
               Intern · Mandanten-Steering
             </span>
-            <span className="text-[11px] text-slate-400">Waves 39–46</span>
+            <span className="text-[11px] text-slate-400">Waves 39–48</span>
           </div>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-[1.65rem]">
             Kanzlei-Portfolio
           </h1>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Operatives Cockpit für gemappte Mandanten: Readiness, Prüfpunkte, Export-Kadenz, Reviews,
-            Attention-Queue, Playbook, Reports, Reminders und Kanzlei-KPIs inkl. Trend-Verlauf.
+            Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA-Signale und AI-Governance-Fokus
+            (EU AI Act / ISO 42001, heuristisch).
           </p>
           {payload ? (
             <p className="mt-3 text-xs tabular-nums text-slate-500">
@@ -711,6 +735,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             ·{" "}
             <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
               /sla-status
+            </code>{" "}
+            ·{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /ai-governance-overview
             </code>
           </p>
         </div>
@@ -740,6 +768,9 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
 
       {loadError && loadError !== "unauthorized" ? (
         <p className="text-sm text-red-600">{loadError}</p>
+      ) : null}
+      {aiGovernanceError && payload && !aiGovernance ? (
+        <p className="text-xs text-amber-800">{aiGovernanceError}</p>
       ) : null}
 
       {payload?.advisor_sla ? (
@@ -830,6 +861,101 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
               ))}
             </ul>
           ) : null}
+        </section>
+      ) : null}
+
+      {aiGovernance ? (
+        <section
+          id="kanzlei-ai-governance-panel"
+          className="rounded-xl border border-cyan-200/80 bg-white p-4 shadow-sm ring-1 ring-cyan-950/[0.06]"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 max-w-2xl">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-cyan-800/90">AI Governance</p>
+              <h2 className="mt-0.5 text-sm font-semibold tracking-tight text-slate-900">
+                EU AI Act & ISO 42001 – Portfolio-Fokus
+              </h2>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600">
+                {aiGovernance.disclaimer_de}
+              </p>
+              <p className="mt-1.5 text-[10px] text-slate-500">
+                Stand {new Date(aiGovernance.generated_at).toLocaleString("de-DE")} · Schema{" "}
+                {aiGovernance.version}
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">AI-Act-/Register-Hinweis</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {aiGovernance.summary.count_likely_ai_act_relevance} Mandanten (Heuristik)
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">High-Risk im Dashboard</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {aiGovernance.summary.count_potential_high_risk_exposure} Mandanten
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">ISO-42001 Nachholbedarf</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {aiGovernance.summary.count_weak_iso42001} Mandanten (schwach/mittel)
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Post-Market / Reporting</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {aiGovernance.summary.count_weak_post_market} mit Lücke (HR-Kontext)
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Human Oversight</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {aiGovernance.summary.count_weak_human_oversight} Prüfbedarf
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">EU AI Act Ampel-Buckets</span>
+              <div className="mt-0.5 text-slate-700">
+                S {aiGovernance.summary.bucket_ai_act.strong} · M {aiGovernance.summary.bucket_ai_act.medium} · W{" "}
+                {aiGovernance.summary.bucket_ai_act.weak}
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 border-t border-slate-100 pt-3">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">
+              Top Mandanten für Beraterkapazität
+            </p>
+            <ul className="mt-2 space-y-2">
+              {aiGovernance.top_attention.slice(0, 6).map((t) => (
+                <li
+                  key={t.tenant_id}
+                  className="flex flex-wrap items-start justify-between gap-2 rounded-md border border-slate-100 bg-white px-2 py-1.5 text-[11px]"
+                >
+                  <div className="min-w-0">
+                    <span className="font-medium text-slate-900">{t.mandant_label ?? t.tenant_id}</span>
+                    <span className="ml-1 font-mono text-[10px] text-slate-400">{t.tenant_id}</span>
+                    <p className="mt-0.5 text-slate-600">{t.priority_hint_de}</p>
+                  </div>
+                  <div className="flex shrink-0 flex-col gap-1 text-[10px]">
+                    <a className="text-cyan-800 underline" href={t.links.mandant_export_page}>
+                      Export
+                    </a>
+                    <a className="text-cyan-800 underline" href={t.links.board_readiness_admin}>
+                      Board Readiness
+                    </a>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className="mt-3 text-[10px] text-slate-500">
+            <a className="font-medium text-slate-700 underline" href="#kanzlei-kpi-table">
+              Zur Mandantentabelle
+            </a>{" "}
+            (Säulenfilter EU AI Act / ISO 42001) · Keine automatische Rechtsbewertung.
+          </p>
         </section>
       ) : null}
 

--- a/frontend/src/lib/advisorAiGovernanceAggregate.ts
+++ b/frontend/src/lib/advisorAiGovernanceAggregate.ts
@@ -1,0 +1,43 @@
+import "server-only";
+
+import { buildAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
+import type { AdvisorAiGovernanceSnapshotInput } from "@/lib/advisorAiGovernanceTypes";
+import type { MappedTenantPillarSnapshotBundle, TenantPillarSnapshot } from "@/lib/boardReadinessAggregate";
+import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
+
+export function advisorAiGovernanceSnapshotInputFromTenant(s: TenantPillarSnapshot): AdvisorAiGovernanceSnapshotInput {
+  const hrIds =
+    s.raw.compliance_dashboard?.systems
+      .filter((x) => x.risk_level === "high_risk")
+      .map((x) => x.ai_system_id) ?? [];
+  let high_risk_without_owner_count = 0;
+  for (const id of hrIds) {
+    const sys = s.raw.ai_systems.find((x) => x.id === id);
+    if (!String(sys?.owner_email || "").trim()) high_risk_without_owner_count += 1;
+  }
+
+  return {
+    tenant_id: s.tenant_id,
+    mandant_label: s.tenant_label,
+    api_fetch_ok: s.raw.fetch_ok,
+    declared_ai_system_count: s.raw.ai_systems.length,
+    has_compliance_dashboard: s.raw.compliance_dashboard != null,
+    high_risk_system_count: s.eu.hr_total,
+    eu_ai_act_status: s.eu.status,
+    eu_ai_act_score: s.eu.score,
+    iso_42001_status: s.iso.status,
+    iso_42001_score: s.iso.score,
+    board_report_fresh_when_hr: s.eu.board_fresh,
+    high_risk_without_owner_count,
+  };
+}
+
+export function computeAdvisorAiGovernanceFromBundle(bundle: MappedTenantPillarSnapshotBundle) {
+  const inputs = bundle.snapshots.map(advisorAiGovernanceSnapshotInputFromTenant);
+  return buildAdvisorAiGovernancePortfolioDto(inputs, bundle.tenants_partial, bundle.generated_at);
+}
+
+export async function computeAdvisorAiGovernanceOverview(now: Date = new Date()) {
+  const bundle = await loadMappedTenantPillarSnapshots(now);
+  return computeAdvisorAiGovernanceFromBundle(bundle);
+}

--- a/frontend/src/lib/advisorAiGovernanceBuild.test.ts
+++ b/frontend/src/lib/advisorAiGovernanceBuild.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAdvisorAiGovernanceMandantRow,
+  buildAdvisorAiGovernancePortfolioDto,
+  stubAdvisorAiGovernancePortfolioDto,
+  trafficToCompletenessBucket,
+} from "@/lib/advisorAiGovernanceBuild";
+import type { AdvisorAiGovernanceSnapshotInput } from "@/lib/advisorAiGovernanceTypes";
+import { ADVISOR_AI_GOVERNANCE_VERSION } from "@/lib/advisorAiGovernanceTypes";
+
+function baseInput(partial: Partial<AdvisorAiGovernanceSnapshotInput> = {}): AdvisorAiGovernanceSnapshotInput {
+  return {
+    tenant_id: "t-1",
+    mandant_label: "Acme",
+    api_fetch_ok: true,
+    declared_ai_system_count: 2,
+    has_compliance_dashboard: true,
+    high_risk_system_count: 1,
+    eu_ai_act_status: "amber",
+    eu_ai_act_score: 55,
+    iso_42001_status: "red",
+    iso_42001_score: 33,
+    board_report_fresh_when_hr: true,
+    high_risk_without_owner_count: 1,
+    ...partial,
+  };
+}
+
+describe("advisorAiGovernanceBuild", () => {
+  it("trafficToCompletenessBucket maps traffic", () => {
+    expect(trafficToCompletenessBucket("red", true)).toBe("weak");
+    expect(trafficToCompletenessBucket("amber", true)).toBe("medium");
+    expect(trafficToCompletenessBucket("green", true)).toBe("strong");
+    expect(trafficToCompletenessBucket("green", false)).toBe("unknown");
+  });
+
+  it("buildAdvisorAiGovernanceMandantRow sets registration and oversight hints", () => {
+    const row = buildAdvisorAiGovernanceMandantRow(baseInput());
+    expect(row.high_risk_indicator).toBe("yes");
+    expect(row.registration_relevance).toBe("yes");
+    expect(row.human_oversight_readiness).toBe("no");
+    expect(row.notes_de.length).toBeGreaterThan(0);
+  });
+
+  it("stubAdvisorAiGovernancePortfolioDto matches version", () => {
+    const dto = stubAdvisorAiGovernancePortfolioDto("2026-04-01T12:00:00Z");
+    expect(dto.version).toBe(ADVISOR_AI_GOVERNANCE_VERSION);
+    expect(dto.summary.total_mandanten).toBe(0);
+  });
+
+  it("buildAdvisorAiGovernancePortfolioDto aggregates buckets", () => {
+    const dto = buildAdvisorAiGovernancePortfolioDto(
+      [baseInput({ tenant_id: "a" }), baseInput({ tenant_id: "b", high_risk_system_count: 0, high_risk_without_owner_count: 0 })],
+      0,
+      "2026-04-01T12:00:00Z",
+    );
+    expect(dto.mandanten).toHaveLength(2);
+    expect(dto.summary.count_potential_high_risk_exposure).toBe(1);
+    expect(dto.top_attention.length).toBeGreaterThan(0);
+    expect(dto.markdown_de).toContain("AI-Governance");
+  });
+});

--- a/frontend/src/lib/advisorAiGovernanceBuild.ts
+++ b/frontend/src/lib/advisorAiGovernanceBuild.ts
@@ -1,0 +1,270 @@
+/**
+ * Wave 48 – AI-Governance-Aggregation aus Snapshot-Signalen (pure, ohne server-only).
+ */
+
+import type { BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+import {
+  ADVISOR_AI_GOVERNANCE_VERSION,
+  type AdvisorAiGovernanceCompletenessBucket,
+  type AdvisorAiGovernanceMandantRow,
+  type AdvisorAiGovernancePartialTri,
+  type AdvisorAiGovernancePortfolioDto,
+  type AdvisorAiGovernancePortfolioSummary,
+  type AdvisorAiGovernanceSnapshotInput,
+  type AdvisorAiGovernanceTopAttention,
+  type AdvisorAiGovernanceTriState,
+} from "@/lib/advisorAiGovernanceTypes";
+
+export const ADVISOR_AI_GOVERNANCE_DISCLAIMER_DE =
+  "Hinweis: Aggregat aus Board-Readiness- und Compliance-Rohdaten. Keine Rechtsberatung und keine automatische Risiko- oder Register-Qualifikation – Bewertungen verbleiben bei Mandant und Berater.";
+
+export function trafficToCompletenessBucket(
+  status: BoardReadinessTraffic,
+  apiOk: boolean,
+): AdvisorAiGovernanceCompletenessBucket {
+  if (!apiOk) return "unknown";
+  if (status === "red") return "weak";
+  if (status === "amber") return "medium";
+  return "strong";
+}
+
+function triDeclared(input: AdvisorAiGovernanceSnapshotInput): AdvisorAiGovernanceTriState {
+  if (!input.api_fetch_ok) return "unknown";
+  return input.declared_ai_system_count > 0 ? "yes" : "no";
+}
+
+function triHighRisk(input: AdvisorAiGovernanceSnapshotInput): AdvisorAiGovernanceTriState {
+  if (!input.api_fetch_ok) return "unknown";
+  return input.high_risk_system_count > 0 ? "yes" : "no";
+}
+
+function triRegistration(input: AdvisorAiGovernanceSnapshotInput): AdvisorAiGovernanceTriState {
+  if (!input.api_fetch_ok) return "unknown";
+  if (!input.has_compliance_dashboard) return "unknown";
+  if (input.high_risk_system_count > 0) return "yes";
+  if (input.declared_ai_system_count > 0) return "unknown";
+  return "no";
+}
+
+function postMarket(input: AdvisorAiGovernanceSnapshotInput): AdvisorAiGovernancePartialTri {
+  if (!input.api_fetch_ok) return "partial";
+  if (input.high_risk_system_count === 0) return "partial";
+  if (!input.board_report_fresh_when_hr) return "no";
+  if (input.eu_ai_act_status === "green") return "yes";
+  return "partial";
+}
+
+function humanOversight(input: AdvisorAiGovernanceSnapshotInput): AdvisorAiGovernancePartialTri {
+  if (!input.api_fetch_ok) return "partial";
+  if (input.high_risk_system_count === 0) return "partial";
+  if (input.high_risk_without_owner_count === 0) return "yes";
+  if (input.high_risk_without_owner_count >= input.high_risk_system_count) return "no";
+  return "partial";
+}
+
+function buildNotes(row: AdvisorAiGovernanceMandantRow, input: AdvisorAiGovernanceSnapshotInput): string[] {
+  const notes: string[] = [];
+  if (!input.api_fetch_ok) {
+    notes.push("API-Daten unvollständig – AI-Governance-Posture nicht belastbar.");
+    return notes.slice(0, 3);
+  }
+  if (input.declared_ai_system_count === 0) {
+    notes.push("Keine KI-Systeme in der Übersicht erfasst – Erklärung im Mandantengespräch klären.");
+  }
+  if (input.high_risk_system_count > 0) {
+    notes.push(
+      "Hinweis auf mögliche AI-Act-Relevanz: High-Risk-Systeme im Dashboard – Register- und Dokumentationspfade mit Mandant abstimmen.",
+    );
+  }
+  if (row.ai_act_artifact_completeness === "weak" || row.ai_act_artifact_completeness === "medium") {
+    notes.push("Fehlende oder unvollständige Governance-Artefakte (EU AI Act-Säule) – Nachweise und Lücken im Workspace prüfen.");
+  }
+  if (row.iso42001_governance_completeness === "weak") {
+    notes.push("Fehlende ISO-42001-Governance-Artefakte (Scope, Rollen, Policies) – AIMs-Vorbereitung einplanen.");
+  }
+  if (row.post_market_monitoring_readiness === "no") {
+    notes.push("Prüfbedarf Post-Market/Reporting: Board- oder Statusbericht im HR-Kontext nicht im Zielkorridor.");
+  }
+  if (row.human_oversight_readiness === "no" || row.human_oversight_readiness === "partial") {
+    notes.push("Prüfbedarf Human Oversight: Verantwortliche bei High-Risk-Systemen nicht vollständig hinterlegt.");
+  }
+  return notes.slice(0, 4);
+}
+
+export function buildAdvisorAiGovernanceMandantRow(
+  input: AdvisorAiGovernanceSnapshotInput,
+): AdvisorAiGovernanceMandantRow {
+  const tidEnc = encodeURIComponent(input.tenant_id);
+  const ai_act_artifact_completeness = trafficToCompletenessBucket(
+    input.eu_ai_act_status,
+    input.api_fetch_ok,
+  );
+  const iso42001_governance_completeness = trafficToCompletenessBucket(
+    input.iso_42001_status,
+    input.api_fetch_ok,
+  );
+
+  const row: AdvisorAiGovernanceMandantRow = {
+    tenant_id: input.tenant_id,
+    mandant_label: input.mandant_label,
+    ai_systems_declared: triDeclared(input),
+    high_risk_indicator: triHighRisk(input),
+    ai_act_artifact_completeness,
+    iso42001_governance_completeness,
+    post_market_monitoring_readiness: postMarket(input),
+    human_oversight_readiness: humanOversight(input),
+    registration_relevance: triRegistration(input),
+    notes_de: [],
+    links: {
+      mandant_export_page: `/admin/advisor-mandant-export?client_id=${tidEnc}`,
+      board_readiness_admin: "/admin/board-readiness",
+    },
+  };
+  row.notes_de = buildNotes(row, input);
+  return row;
+}
+
+function emptyBuckets(): Record<AdvisorAiGovernanceCompletenessBucket, number> {
+  return { weak: 0, medium: 0, strong: 0, unknown: 0 };
+}
+
+function priorityScore(row: AdvisorAiGovernanceMandantRow): number {
+  let s = 0;
+  if (row.post_market_monitoring_readiness === "no") s += 5;
+  if (row.human_oversight_readiness === "no") s += 4;
+  if (row.ai_act_artifact_completeness === "weak") s += 4;
+  else if (row.ai_act_artifact_completeness === "medium") s += 2;
+  if (row.iso42001_governance_completeness === "weak") s += 3;
+  else if (row.iso42001_governance_completeness === "medium") s += 1;
+  if (row.high_risk_indicator === "yes") s += 2;
+  if (row.registration_relevance === "yes" && row.ai_act_artifact_completeness !== "strong") s += 1;
+  return s;
+}
+
+function topHint(row: AdvisorAiGovernanceMandantRow): string {
+  if (row.post_market_monitoring_readiness === "no") return "Post-Market/Reporting im HR-Kontext nachziehen.";
+  if (row.human_oversight_readiness === "no") return "Human Oversight: Verantwortliche bei High-Risk-Systemen ergänzen.";
+  if (row.ai_act_artifact_completeness === "weak") return "EU AI Act: Artefakte und Nachweise priorisieren.";
+  if (row.iso42001_governance_completeness === "weak") return "ISO 42001: Governance-Grundlagen (Scope/Rollen/Policies) schließen.";
+  if (row.high_risk_indicator === "yes") return "High-Risk-Systeme: Register- und Dokumentationspfad mit Mandant klären.";
+  return "AI-Governance-Steuerung im Einzelfall vertiefen.";
+}
+
+export function summarizeAdvisorAiGovernancePortfolio(
+  mandanten: AdvisorAiGovernanceMandantRow[],
+  tenantsPartial: number,
+): AdvisorAiGovernancePortfolioSummary {
+  const bucket_ai_act = emptyBuckets();
+  const bucket_iso42001 = emptyBuckets();
+  let count_likely_ai_act_relevance = 0;
+  let count_potential_high_risk_exposure = 0;
+  let count_weak_iso42001 = 0;
+  let count_weak_post_market = 0;
+  let count_weak_human_oversight = 0;
+
+  for (const m of mandanten) {
+    bucket_ai_act[m.ai_act_artifact_completeness] += 1;
+    bucket_iso42001[m.iso42001_governance_completeness] += 1;
+    if (m.registration_relevance === "yes" || m.ai_act_artifact_completeness === "weak") {
+      count_likely_ai_act_relevance += 1;
+    }
+    if (m.high_risk_indicator === "yes") count_potential_high_risk_exposure += 1;
+    if (m.iso42001_governance_completeness === "weak" || m.iso42001_governance_completeness === "medium") {
+      count_weak_iso42001 += 1;
+    }
+    if (m.post_market_monitoring_readiness === "no") count_weak_post_market += 1;
+    if (m.human_oversight_readiness === "no") count_weak_human_oversight += 1;
+  }
+
+  return {
+    total_mandanten: mandanten.length,
+    tenants_partial_api: tenantsPartial,
+    count_likely_ai_act_relevance,
+    count_potential_high_risk_exposure,
+    count_weak_iso42001,
+    count_weak_post_market,
+    count_weak_human_oversight,
+    bucket_ai_act,
+    bucket_iso42001,
+  };
+}
+
+export function buildAdvisorAiGovernanceTopAttention(
+  mandanten: AdvisorAiGovernanceMandantRow[],
+  maxN: number,
+): AdvisorAiGovernanceTopAttention[] {
+  const ranked = [...mandanten].sort((a, b) => {
+    const d = priorityScore(b) - priorityScore(a);
+    if (d !== 0) return d;
+    return (a.mandant_label ?? a.tenant_id).localeCompare(b.mandant_label ?? b.tenant_id, "de");
+  });
+  const n = Math.min(12, Math.max(3, maxN));
+  return ranked.slice(0, n).map((m) => ({
+    tenant_id: m.tenant_id,
+    mandant_label: m.mandant_label,
+    priority_hint_de: topHint(m),
+    links: m.links,
+  }));
+}
+
+export function advisorAiGovernanceMarkdownDe(dto: AdvisorAiGovernancePortfolioDto): string {
+  const s = dto.summary;
+  const lines: string[] = [];
+  lines.push(`# AI-Governance Portfolio (Advisor)`);
+  lines.push(
+    `_Erzeugt: ${new Date(dto.generated_at).toLocaleString("de-DE")} · Portfolio-Stand: ${new Date(dto.portfolio_generated_at).toLocaleString("de-DE")} · Schema ${dto.version}_`,
+  );
+  lines.push("");
+  lines.push(`_${dto.disclaimer_de}_`);
+  lines.push("");
+  lines.push(`## Überblick`);
+  lines.push(`- Mandanten: **${s.total_mandanten}** (API teilweise: **${s.tenants_partial_api}**)`);
+  lines.push(`- Hinweis AI-Act-/Register-Thematik (Heuristik): **${s.count_likely_ai_act_relevance}**`);
+  lines.push(`- High-Risk-Systeme im Dashboard: **${s.count_potential_high_risk_exposure}** Mandanten`);
+  lines.push(`- Schwache ISO-42001-Säule: **${s.count_weak_iso42001}**`);
+  lines.push(`- Post-Market/Reporting-Lücke (HR-Kontext): **${s.count_weak_post_market}**`);
+  lines.push(`- Prüfbedarf Human Oversight: **${s.count_weak_human_oversight}**`);
+  lines.push("");
+  lines.push(`## EU AI Act – Verteilung (Ampel → Bucket)`);
+  lines.push(
+    `- schwach: **${s.bucket_ai_act.weak}** · mittel: **${s.bucket_ai_act.medium}** · stark: **${s.bucket_ai_act.strong}** · unbekannt: **${s.bucket_ai_act.unknown}**`,
+  );
+  lines.push(`## ISO 42001 – Verteilung`);
+  lines.push(
+    `- schwach: **${s.bucket_iso42001.weak}** · mittel: **${s.bucket_iso42001.medium}** · stark: **${s.bucket_iso42001.strong}** · unbekannt: **${s.bucket_iso42001.unknown}**`,
+  );
+  lines.push("");
+  lines.push(`## Top Mandanten (Advisor-Fokus)`);
+  for (const t of dto.top_attention) {
+    const name = t.mandant_label ?? t.tenant_id;
+    lines.push(`- **${name}** (\`${t.tenant_id}\`): ${t.priority_hint_de}`);
+  }
+  return lines.join("\n");
+}
+
+/** Leerer Überblick für Tests oder Fallback, wenn keine Snapshots vorliegen. */
+export function stubAdvisorAiGovernancePortfolioDto(portfolioGeneratedAt: string): AdvisorAiGovernancePortfolioDto {
+  return buildAdvisorAiGovernancePortfolioDto([], 0, portfolioGeneratedAt);
+}
+
+export function buildAdvisorAiGovernancePortfolioDto(
+  inputs: AdvisorAiGovernanceSnapshotInput[],
+  tenantsPartial: number,
+  portfolioGeneratedAt: string,
+): AdvisorAiGovernancePortfolioDto {
+  const mandanten = inputs.map(buildAdvisorAiGovernanceMandantRow);
+  const summary = summarizeAdvisorAiGovernancePortfolio(mandanten, tenantsPartial);
+  const top_attention = buildAdvisorAiGovernanceTopAttention(mandanten, 8);
+  const generated_at = new Date().toISOString();
+  const base: Omit<AdvisorAiGovernancePortfolioDto, "markdown_de"> = {
+    version: ADVISOR_AI_GOVERNANCE_VERSION,
+    generated_at,
+    portfolio_generated_at: portfolioGeneratedAt,
+    disclaimer_de: ADVISOR_AI_GOVERNANCE_DISCLAIMER_DE,
+    summary,
+    mandanten,
+    top_attention,
+  };
+  const markdown_de = advisorAiGovernanceMarkdownDe({ ...base, markdown_de: "" });
+  return { ...base, markdown_de };
+}

--- a/frontend/src/lib/advisorAiGovernanceTypes.ts
+++ b/frontend/src/lib/advisorAiGovernanceTypes.ts
@@ -1,0 +1,83 @@
+/**
+ * Wave 48 – AI-Governance-Posture für Advisor-Ansicht (keine Rechtsqualifikation).
+ */
+
+import type { BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+
+export const ADVISOR_AI_GOVERNANCE_VERSION = "wave48-v1";
+
+/** Rohdaten-Hinweis ja / nein / nicht belastbar. */
+export type AdvisorAiGovernanceTriState = "yes" | "no" | "unknown";
+
+/** Posture mit Zwischenstufe (z. B. nur Teilmenge der Systeme abgedeckt). */
+export type AdvisorAiGovernancePartialTri = "yes" | "no" | "partial";
+
+export type AdvisorAiGovernanceCompletenessBucket = "weak" | "medium" | "strong" | "unknown";
+
+/** Eingangssignale aus Board-Readiness-Snapshot (rein technisch, testbar). */
+export type AdvisorAiGovernanceSnapshotInput = {
+  tenant_id: string;
+  mandant_label: string | null;
+  api_fetch_ok: boolean;
+  declared_ai_system_count: number;
+  has_compliance_dashboard: boolean;
+  high_risk_system_count: number;
+  eu_ai_act_status: BoardReadinessTraffic;
+  eu_ai_act_score: number | null;
+  iso_42001_status: BoardReadinessTraffic;
+  iso_42001_score: number | null;
+  board_report_fresh_when_hr: boolean;
+  high_risk_without_owner_count: number;
+};
+
+export type AdvisorAiGovernanceMandantRow = {
+  tenant_id: string;
+  mandant_label: string | null;
+  ai_systems_declared: AdvisorAiGovernanceTriState;
+  high_risk_indicator: AdvisorAiGovernanceTriState;
+  ai_act_artifact_completeness: AdvisorAiGovernanceCompletenessBucket;
+  iso42001_governance_completeness: AdvisorAiGovernanceCompletenessBucket;
+  post_market_monitoring_readiness: AdvisorAiGovernancePartialTri;
+  human_oversight_readiness: AdvisorAiGovernancePartialTri;
+  registration_relevance: AdvisorAiGovernanceTriState;
+  notes_de: string[];
+  links: {
+    mandant_export_page: string;
+    board_readiness_admin: string;
+  };
+};
+
+export type AdvisorAiGovernancePortfolioSummary = {
+  total_mandanten: number;
+  tenants_partial_api: number;
+  /** Mandanten mit Hinweis auf mögliche AI-Act-/Register-Thematik (High-Risk im Dashboard). */
+  count_likely_ai_act_relevance: number;
+  /** High-Risk-Systeme im Compliance-Dashboard erfasst. */
+  count_potential_high_risk_exposure: number;
+  /** ISO-42001-Säule schwach oder mittel mit rot. */
+  count_weak_iso42001: number;
+  /** Post-Market/Reporting-Lücke bei vorhandenen HR-Systemen. */
+  count_weak_post_market: number;
+  /** Prüfbedarf Human Oversight (fehlende Owner bei HR). */
+  count_weak_human_oversight: number;
+  bucket_ai_act: Record<AdvisorAiGovernanceCompletenessBucket, number>;
+  bucket_iso42001: Record<AdvisorAiGovernanceCompletenessBucket, number>;
+};
+
+export type AdvisorAiGovernanceTopAttention = {
+  tenant_id: string;
+  mandant_label: string | null;
+  priority_hint_de: string;
+  links: AdvisorAiGovernanceMandantRow["links"];
+};
+
+export type AdvisorAiGovernancePortfolioDto = {
+  version: typeof ADVISOR_AI_GOVERNANCE_VERSION;
+  generated_at: string;
+  portfolio_generated_at: string;
+  disclaimer_de: string;
+  summary: AdvisorAiGovernancePortfolioSummary;
+  mandanten: AdvisorAiGovernanceMandantRow[];
+  top_attention: AdvisorAiGovernanceTopAttention[];
+  markdown_de: string;
+};

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
 import {
   attentionBand,
   buildKanzleiMonthlyReport,
@@ -99,7 +100,12 @@ describe("kanzleiMonthlyReportBuild", () => {
     const r = buildKanzleiMonthlyReport(
       p,
       { saved_at: "2026-03-01T00:00:00Z", period_label: "2026-03", tenants: { x: base } },
-      { periodLabel: "2026-04", compareToBaseline: true, attentionTopN: 5 },
+      {
+        periodLabel: "2026-04",
+        compareToBaseline: true,
+        attentionTopN: 5,
+        aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      },
     );
     expect(r.compared_to_baseline).toBe(true);
     expect(r.section_3_changes.readiness_improved.length).toBe(1);
@@ -113,7 +119,12 @@ describe("kanzleiMonthlyReportBuild", () => {
     const r = buildKanzleiMonthlyReport(
       p,
       { saved_at: "2026-03-01T00:00:00Z", period_label: "2026-03", tenants: { x: base } },
-      { periodLabel: "2026-04", compareToBaseline: false, attentionTopN: 5 },
+      {
+        periodLabel: "2026-04",
+        compareToBaseline: false,
+        attentionTopN: 5,
+        aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      },
     );
     expect(r.compared_to_baseline).toBe(false);
     expect(r.section_3_changes.readiness_improved.length).toBe(0);

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.ts
@@ -7,6 +7,7 @@ import { GTM_READINESS_LABELS_DE, type GtmReadinessClass } from "@/lib/gtmAccoun
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type {
   KanzleiAttentionBand,
   KanzleiMonthlyBaselineTenant,
@@ -308,6 +309,8 @@ export type BuildMonthlyReportOptions = {
   advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
   /** Wave 46 – optionaler Trend-Kurzblock (Abschnitt 6). */
   kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
+  /** Wave 48 – AI-Governance-Überblick (Abschnitt 8). */
+  aiGovernance: AdvisorAiGovernancePortfolioDto;
 };
 
 export function buildKanzleiMonthlyReport(
@@ -357,5 +360,6 @@ export function buildKanzleiMonthlyReport(
     section_5_advisor_kpis: opts.advisorKpiSnapshot ?? null,
     section_6_kpi_trends: opts.kpiTrendsNarrative ?? null,
     section_7_advisor_sla: payload.advisor_sla,
+    section_8_ai_governance: opts.aiGovernance,
   };
 }

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
 import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
 import { ADVISOR_KPI_TRENDS_VERSION } from "@/lib/advisorKpiTrendsBuild";
 import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
@@ -75,6 +76,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
       periodLabel: "2026-04",
       compareToBaseline: true,
       attentionTopN: 5,
+      aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
     });
     const md = kanzleiMonthlyReportMarkdownDe(r);
     expect(md).toContain("# Kanzlei-Portfolio-Report");
@@ -82,6 +84,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).toContain("## 4) Empfohlene Schwerpunkte");
     expect(md).not.toContain("## 5) Kanzlei-KPIs");
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
+    expect(md).toContain("## 8) AI-Governance (Wave 48)");
   });
 
   it("includes KPI section when snapshot provided", () => {
@@ -104,11 +107,13 @@ describe("kanzleiMonthlyReportMarkdown", () => {
         period_label_de: "Letzte 3 Monate",
         narrative_lines_de: ["Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen."],
       },
+      aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
     });
     const md = kanzleiMonthlyReportMarkdownDe(r);
     expect(md).toContain("## 5) Kanzlei-KPIs");
     expect(md).toContain("## 6) KPI-Trends (Wave 46)");
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
+    expect(md).toContain("## 8) AI-Governance (Wave 48)");
     expect(md).toContain("Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen.");
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
@@ -142,6 +142,33 @@ export function kanzleiMonthlyReportMarkdownDe(r: KanzleiMonthlyReportDto): stri
     parts.push(`- Nächster Schritt: ${step}`);
   }
 
+  const ag = r.section_8_ai_governance;
+  const ags = ag.summary;
+  parts.push(`## 8) AI-Governance (Wave 48)`);
+  parts.push(`_${ag.disclaimer_de}_`);
+  parts.push(
+    `- Mandanten: **${ags.total_mandanten}** · API teilweise: **${ags.tenants_partial_api}** · Schema ${ag.version}.`,
+  );
+  parts.push(
+    `- Hinweis auf mögliche AI-Act-/Register-Thematik (Heuristik): **${ags.count_likely_ai_act_relevance}** · High-Risk im Dashboard: **${ags.count_potential_high_risk_exposure}**`,
+  );
+  parts.push(
+    `- Schwache ISO-42001-Säule (schwach/mittel): **${ags.count_weak_iso42001}** · Post-Market/Reporting-Lücke: **${ags.count_weak_post_market}** · Prüfbedarf Human Oversight: **${ags.count_weak_human_oversight}**`,
+  );
+  parts.push(`- EU AI Act (Bucket): schwach **${ags.bucket_ai_act.weak}**, mittel **${ags.bucket_ai_act.medium}**, stark **${ags.bucket_ai_act.strong}**, unbekannt **${ags.bucket_ai_act.unknown}**`);
+  parts.push(
+    `- ISO 42001 (Bucket): schwach **${ags.bucket_iso42001.weak}**, mittel **${ags.bucket_iso42001.medium}**, stark **${ags.bucket_iso42001.strong}**, unbekannt **${ags.bucket_iso42001.unknown}**`,
+  );
+  parts.push(`### Top-Fokus Mandanten`);
+  if (ag.top_attention.length === 0) {
+    parts.push(`- _Keine Mandanten im Überblick._`);
+  } else {
+    for (const t of ag.top_attention.slice(0, 8)) {
+      const name = t.mandant_label ?? t.tenant_id;
+      parts.push(`- **${name}** (\`${t.tenant_id}\`): ${t.priority_hint_de}`);
+    }
+  }
+
   parts.push(`---`);
   parts.push(
     `Hinweis: Portfolio-Report für interne Kanzlei-Arbeit; keine Board-Tischreife. Daten aus Live-API und lokaler Historie – Änderungslogik bewusst grob (siehe Doku Wave 42).`,

--- a/frontend/src/lib/kanzleiMonthlyReportTypes.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportTypes.ts
@@ -4,11 +4,12 @@
 
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 
-export const KANZLEI_MONTHLY_REPORT_VERSION = "wave46-v1";
+export const KANZLEI_MONTHLY_REPORT_VERSION = "wave48-v1";
 
 export type KanzleiAttentionBand = "low" | "medium" | "high";
 
@@ -91,4 +92,6 @@ export type KanzleiMonthlyReportDto = {
   section_6_kpi_trends: AdvisorKpiTrendsNarrativeBlock | null;
   /** Wave 47 – SLA-Befunde und Eskalationssignale (aus Portfolio-Compute). */
   section_7_advisor_sla: AdvisorSlaEvaluationDto;
+  /** Wave 48 – AI-Governance-Posture (EU AI Act / ISO 42001, heuristisch). */
+  section_8_ai_governance: AdvisorAiGovernancePortfolioDto;
 };

--- a/frontend/src/lib/kanzleiPortfolioAggregate.ts
+++ b/frontend/src/lib/kanzleiPortfolioAggregate.ts
@@ -21,7 +21,10 @@ import {
   isNonEmptyUnparsableIso,
   maxIsoTimestamps,
 } from "@/lib/mandantHistoryMerge";
-import type { TenantPillarSnapshot } from "@/lib/boardReadinessAggregate";
+import type {
+  MappedTenantPillarSnapshotBundle,
+  TenantPillarSnapshot,
+} from "@/lib/boardReadinessAggregate";
 import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
 import { worstTraffic } from "@/lib/boardReadinessThresholds";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
@@ -343,9 +346,17 @@ function assemblePortfolioPayloadWithoutSla(
   };
 }
 
-export async function computeKanzleiPortfolioPayload(now: Date = new Date()): Promise<KanzleiPortfolioPayload> {
+export type ComputeKanzleiPortfolioOptions = {
+  /** Vermeidet doppeltes Laden wenn Snapshots bereits für AI-Governance o. ä. geholt wurden. */
+  preloadedBundle?: MappedTenantPillarSnapshotBundle;
+};
+
+export async function computeKanzleiPortfolioPayload(
+  now: Date = new Date(),
+  opts?: ComputeKanzleiPortfolioOptions,
+): Promise<KanzleiPortfolioPayload> {
   const [bundle, historyByTenant] = await Promise.all([
-    loadMappedTenantPillarSnapshots(now),
+    opts?.preloadedBundle ?? loadMappedTenantPillarSnapshots(now),
     readAdvisorMandantHistoryMap(),
   ]);
   const nowMs = bundle.nowMs;

--- a/frontend/src/lib/kanzleiPortfolioTypes.ts
+++ b/frontend/src/lib/kanzleiPortfolioTypes.ts
@@ -7,7 +7,7 @@ import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { MandantReminderApiEntry } from "@/lib/advisorMandantReminderTypes";
 
-export const KANZLEI_PORTFOLIO_VERSION = "wave47-v1";
+export const KANZLEI_PORTFOLIO_VERSION = "wave48-v1";
 
 export type KanzleiPortfolioPillarFilter = BoardReadinessPillarKey | "all";
 

--- a/frontend/src/lib/partnerReviewPackageBuild.test.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 
+import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
 import { buildPartnerReviewPackage } from "@/lib/partnerReviewPackageBuild";
 import { partnerReviewPackageMarkdownDe } from "@/lib/partnerReviewPackageMarkdown";
 import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
@@ -95,7 +96,11 @@ describe("partnerReviewPackageBuild", () => {
     ];
     p.reminders_due_today_or_overdue_count = 1;
     p.reminders_due_this_week_open_count = 1;
-    const pkg = buildPartnerReviewPackage(p, null, { compareToBaseline: false, attentionTopN: 5 });
+    const pkg = buildPartnerReviewPackage(p, null, {
+      compareToBaseline: false,
+      attentionTopN: 5,
+      aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+    });
     expect(pkg.part_e_advisor_kpis).toBeNull();
     expect(pkg.part_f_kpi_trends).toBeNull();
     expect(pkg.part_g_sla_lagebild.version).toBe(ADVISOR_SLA_VERSION);
@@ -115,16 +120,22 @@ describe("partnerReviewPackageBuild", () => {
     const pkg = buildPartnerReviewPackage(
       p,
       { saved_at: "2026-03-01T00:00:00Z", period_label: "2026-03", tenants: { x: base } },
-      { compareToBaseline: true, attentionTopN: 3 },
+      {
+        compareToBaseline: true,
+        attentionTopN: 3,
+        aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      },
     );
     expect(pkg.meta.compared_to_baseline).toBe(true);
     expect(pkg.part_c_changes_since_baseline.improvements.length).toBeGreaterThanOrEqual(1);
   });
 
   it("markdown contains section headers", () => {
-    const pkg = buildPartnerReviewPackage(mkPayload([baseRow({})]), null, {
+    const p = mkPayload([baseRow({})]);
+    const pkg = buildPartnerReviewPackage(p, null, {
       compareToBaseline: false,
       attentionTopN: 3,
+      aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
     });
     const md = partnerReviewPackageMarkdownDe(pkg);
     expect(md).toContain("## A) Portfolio-Überblick");
@@ -133,5 +144,7 @@ describe("partnerReviewPackageBuild", () => {
     expect(md).toContain(`Schema ${ADVISOR_SLA_VERSION}`);
     expect(md).toContain("Portfolio kritisch (mehrere SLA-Critical)");
     expect(md).toContain("Keine SLA-Abweichungen – bestehende Kadenz beibehalten.");
+    expect(md).toContain("## H) AI-Governance-Steuerung (Wave 48)");
+    expect(md).toContain("wave48-v1");
   });
 });

--- a/frontend/src/lib/partnerReviewPackageBuild.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.ts
@@ -8,6 +8,7 @@ import {
   buildKanzleiPortfolioFocusAreasDe,
   summarizeKanzleiMonthlyReportSection1,
 } from "@/lib/kanzleiMonthlyReportBuild";
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
@@ -104,6 +105,8 @@ export type BuildPartnerReviewPackageOptions = {
   advisorKpiSnapshot?: AdvisorKpiPortfolioSnapshot | null;
   /** Wave 46 – KPI-Trends (optional). */
   kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
+  /** Wave 48 – AI-Governance-Überblick. */
+  aiGovernance: AdvisorAiGovernancePortfolioDto;
 };
 
 export function buildPartnerReviewPackage(
@@ -156,5 +159,6 @@ export function buildPartnerReviewPackage(
     part_e_advisor_kpis: opts.advisorKpiSnapshot ?? null,
     part_f_kpi_trends: opts.kpiTrendsNarrative ?? null,
     part_g_sla_lagebild: payload.advisor_sla,
+    part_h_ai_governance: opts.aiGovernance,
   };
 }

--- a/frontend/src/lib/partnerReviewPackageMarkdown.ts
+++ b/frontend/src/lib/partnerReviewPackageMarkdown.ts
@@ -173,6 +173,28 @@ export function partnerReviewPackageMarkdownDe(pkg: PartnerReviewPackageDto): st
   }
   lines.push("");
 
+  const ag = pkg.part_h_ai_governance;
+  const ags = ag.summary;
+  lines.push("## H) AI-Governance-Steuerung (Wave 48)");
+  lines.push("");
+  lines.push(`_${ag.disclaimer_de}_`);
+  lines.push("");
+  lines.push(
+    `- Mandanten: **${ags.total_mandanten}** · API teilweise: **${ags.tenants_partial_api}** · Schema ${ag.version}.`,
+  );
+  lines.push(
+    `- Hinweis AI-Act-/Register-Thematik: **${ags.count_likely_ai_act_relevance}** · High-Risk im Dashboard: **${ags.count_potential_high_risk_exposure}**`,
+  );
+  lines.push(
+    `- ISO-42001 Nachholbedarf (schwach/mittel): **${ags.count_weak_iso42001}** · Post-Market-Lücke: **${ags.count_weak_post_market}** · Human Oversight: **${ags.count_weak_human_oversight}**`,
+  );
+  lines.push("");
+  lines.push("### Top Mandanten für Beraterkapazität");
+  for (const t of ag.top_attention.slice(0, 8)) {
+    lines.push(`- **${lineLabel(t)}:** ${t.priority_hint_de}`);
+  }
+  lines.push("");
+
   lines.push("---");
   lines.push("");
   lines.push("### Priorisierung (Kurz)");

--- a/frontend/src/lib/partnerReviewPackageTypes.ts
+++ b/frontend/src/lib/partnerReviewPackageTypes.ts
@@ -4,11 +4,12 @@
 
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiMonthlyChangeLine } from "@/lib/kanzleiMonthlyReportTypes";
 
-export const PARTNER_REVIEW_PACKAGE_VERSION = "wave46-v1";
+export const PARTNER_REVIEW_PACKAGE_VERSION = "wave48-v1";
 
 export type PartnerReviewPackageMeta = {
   version: typeof PARTNER_REVIEW_PACKAGE_VERSION;
@@ -70,4 +71,6 @@ export type PartnerReviewPackageDto = {
   part_f_kpi_trends: AdvisorKpiTrendsNarrativeBlock | null;
   /** Wave 47 – SLA-Lagebild (Befunde + Eskalation). */
   part_g_sla_lagebild: AdvisorSlaEvaluationDto;
+  /** Wave 48 – AI-Governance-Steuerung (EU AI Act / ISO 42001). */
+  part_h_ai_governance: AdvisorAiGovernancePortfolioDto;
 };


### PR DESCRIPTION
- Add advisor AI-governance types, pure build/aggregate from board snapshots, GET /api/internal/advisor/ai-governance-overview with markdown_de.
- Cockpit panel with portfolio counts, top mandanten, export/board links.
- Monthly report section 8 and partner package part H; schema wave48-v1.
- Preloaded snapshot bundle for portfolio + governance to avoid double fetch.
- Docs wave48 and cross-links; tests for ai-governance build.

Made-with: Cursor