### PR TITLE
feat(advisors): Wave 49 cross-regulation matrix

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -13,6 +13,7 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | **5–6) KPIs & Trends** | Wave 45–46: siehe `wave45-advisor-kpis.md` / `wave46-kpi-trends.md` |
 | **7) SLA & Eskalation** | Wave 47: leichte Regeln, Befunde und Eskalationssignale aus KPI, Queue und Remindern – siehe `wave47-sla-and-escalations.md` |
 | **8) AI-Governance** | Wave 48: EU AI Act / ISO 42001 Portfolio-Posture – siehe `wave48-ai-governance-view.md` |
+| **9) Cross-Regulation** | Wave 49: Vier-Säulen-Matrix – siehe `wave49-cross-regulation-matrix.md` |
 
 ## API (intern, Lead-Admin)
 
@@ -70,6 +71,7 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave45-advisor-kpis.md`

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -14,6 +14,7 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
 | **F – KPI-Trends (Kurz)** | Wave 46 – Kurzsätze aus persistierter History (rolling 3 Monate); siehe `wave46-kpi-trends.md`. |
 | **G – SLA-Lagebild** | Wave 47 – SLA-Befunde, Eskalationssignale und kurze Nächste-Schritte; siehe `wave47-sla-and-escalations.md`. |
 | **H – AI-Governance** | Wave 48 – EU AI Act / ISO 42001 Steuerungsüberblick; siehe `wave48-ai-governance-view.md`. |
+| **I – Cross-Regulation** | Wave 49 – Vier-Säulen-Matrix; siehe `wave49-cross-regulation-matrix.md`. |
 
 ## API
 
@@ -56,6 +57,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave46-kpi-trends.md`

--- a/docs/advisors/wave45-advisor-kpis.md
+++ b/docs/advisors/wave45-advisor-kpis.md
@@ -35,8 +35,8 @@ Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `stri
 
 ## Einbindung Monatsreport & Partner-Paket
 
-- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab. **Wave 46:** Abschnitt **6) KPI-Trends** (rolling 3 Monate), wenn KPIs an sind. **Wave 47/48:** Abschnitte **7) SLA** und **8) AI-Governance** unabhängig von `kpi`.
-- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional. **Wave 46:** Abschnitt **F) KPI-Trends**. **Wave 47:** Abschnitt **G) SLA-Lagebild** (Regeln & Eskalation aus KPI, Queue, Remindern) – siehe `wave47-sla-and-escalations.md`. **Wave 48:** Monatsreport **8)**, Partner-Paket **H)** – AI-Governance; siehe `wave48-ai-governance-view.md`.
+- **Monatsreport:** Abschnitt **5) Kanzlei-KPIs** im Markdown/JSON, sofern KPIs nicht abgeschaltet werden. Query: `kpi_window_days`, `kpi=0` schaltet den Block ab. **Wave 46:** Abschnitt **6) KPI-Trends** (rolling 3 Monate), wenn KPIs an sind. **Wave 47–49:** Abschnitte **7) SLA**, **8) AI-Governance**, **9) Cross-Regulation** unabhängig von `kpi`.
+- **Partner-Review-Paket:** Abschnitt **E) Kanzlei-KPIs**; `kpi=0` optional. **Wave 46:** Abschnitt **F) KPI-Trends**. **Wave 47:** Abschnitt **G) SLA-Lagebild** (Regeln & Eskalation aus KPI, Queue, Remindern) – siehe `wave47-sla-and-escalations.md`. **Wave 48:** Partner-Paket **H)** – AI-Governance; siehe `wave48-ai-governance-view.md`. **Wave 49:** Partner-Paket **I)** – Cross-Regulation; siehe `wave49-cross-regulation-matrix.md`.
 
 ## Grenzen (bewusst)
 
@@ -52,6 +52,7 @@ Antwort: `{ ok, advisor_kpi_portfolio }` – vollständiger Snapshot inkl. `stri
 
 ## Siehe auch
 
+- `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave46-kpi-trends.md`
 - `docs/advisors/wave44-partner-review-package.md`

--- a/docs/advisors/wave48-ai-governance-view.md
+++ b/docs/advisors/wave48-ai-governance-view.md
@@ -77,6 +77,7 @@ Es wird **nicht** behauptet, dass ein Registerpflicht-Eintrag besteht oder ein S
 
 ## Siehe auch
 
+- `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave47-sla-and-escalations.md`
 - `docs/advisors/wave45-advisor-kpis.md`
 - `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`

--- a/docs/advisors/wave49-cross-regulation-matrix.md
+++ b/docs/advisors/wave49-cross-regulation-matrix.md
@@ -1,0 +1,70 @@
+# Wave 49 – Cross-Regulation Advisor Matrix
+
+Portfolio-weite **Steuerungsmatrix** über die vier Kern-Säulen des Board-Readiness-Modells: **EU AI Act**, **ISO 42001**, **NIS2 / KRITIS** und **DSGVO / BDSG**. Ziel: **„Map once, comply many“** – Berater sehen, wo ein Vorhaben mehrere Rahmen zugleich entlastet, ohne Rechtsautomatik.
+
+## Modell (pro Mandant)
+
+| Feld | Bedeutung |
+|------|-----------|
+| `pillars` | Pro Säule ein Bucket: `ok` \| `needs_attention` \| `priority` \| `unknown` |
+| `active_pillar_pressure_count` | Anzahl Säulen mit `priority` oder `needs_attention` |
+| `priority_pillar_count` | Anzahl Säulen mit `priority` |
+| `notes_de` | Kurzimpulse (Mehrfachbelastung, NIS2/DSGVO-Hinweise, Export) |
+| `links` | Wie Kanzlei-Portfolio (Export, Readiness-API, …) |
+
+Säulen-Reihenfolge im Code: `eu_ai_act`, `iso_42001`, `nis2`, `dsgvo`.
+
+## Bucket-Logik (transparent)
+
+1. **Basis:** Board-Readiness-Ampel je Säule (`pillar_traffic`): grün → `ok`, gelb → `needs_attention`, rot → `priority`.
+2. **`unknown`:** Wenn `api_fetch_ok` für den Mandanten false ist – keine belastbare Säulenlage.
+3. **Lücken-Heuristik:** Ist die **Top-Gap-Säule** (`top_gap_pillar_code`) gleich der Säule und gibt es **offene Prüfpunkte** (`open_points_count > 0`) und entweder **hohe Dringlichkeit** oder **viele offene Punkte** (≥ `many_open_points_threshold`), wird das Bucket für diese Säule mindestens auf `needs_attention` angehoben (ohne `priority` zu überschreiben).
+
+Es werden **keine** separaten juristischen Subsumtionen gebildet; die Matrix spiegelt **vorhandene** Board- und Gap-Signale.
+
+## Portfolio-Aggregation
+
+- **`totals.per_pillar`:** Zähler je Säule und Bucket.
+- **`mandanten_multi_pillar_priority`:** Mandanten mit **≥2** Säulen `priority`.
+- **`mandanten_multi_pillar_stress`:** Mandanten mit **≥2** Säulen unter Druck (`priority` oder `needs_attention`).
+- **`top_cases`:** Sortierung nach gewichteter Stress-Score (Priorität stärker als Nacharbeit), dann Prioritätszahl – für Querschnittsgespräche.
+
+## Interaktion der Säulen (für Berater)
+
+- **EU AI Act / ISO 42001** – KI-Governance und Managementsystem; oft **gemeinsame** Rollen, Policies, Evidence.
+- **NIS2 / KRITIS** – kann **unabhängig** von hoher KI-Nutzung relevant sein (Lieferkette, Meldewege, IKT-Risiko).
+- **DSGVO / BDSG** – Verarbeitungsübersicht, Verträge, TOMs; Schnittmenge zu KI-Verarbeitung und Lieferanten.
+
+Die Matrix macht sichtbar, wo **NIS2 oder DSGVO** Handlungsdruck erzeugen, **ohne** dass die EU-AI-Act-Säule rot ist – wichtig für **Mittelstand** und **WP-Kanzleien**.
+
+## API
+
+- `GET /api/internal/advisor/cross-regulation-matrix`  
+  Antwort: `cross_regulation_matrix`, `markdown_de`.
+
+## Cockpit
+
+Panel **`#kanzlei-cross-regulation-panel`**: kompakte Tabelle Mandant × Säule (Kürzel O / ! / P / ?), Filter, Top-Querschnitt. Daten werden **aus dem geladenen Portfolio** abgeleitet (identisch zur API-Logik über `buildCrossRegulationMatrixFromPayload`).
+
+## Reports
+
+- **Kanzlei-Monatsreport:** Abschnitt **9) Cross-Regulation-Matrix**.
+- **Partner-Review-Paket:** Teil **I)**.
+
+## Wortlaut (advisor-safe)
+
+- „Steuerungsmatrix“, „Nacharbeit“, „Priorität“, „Datenlage unbekannt“.
+- Keine Formulierungen wie „rechtskonform“ oder „Pflicht besteht“ ohne Mandantenentscheid.
+
+## Grenzen
+
+- Keine Rechtsmeinung, kein Ersatz für Mandanten-Audit oder externe Beratung.
+- Keine SAP/ERP-Anbindung in dieser Wave.
+- NIS2/KRITIS-Labeling ist **kommunikativ** (DACH-Kontext); fachliche Tiefe bleibt in Mandanten-Workspace und Board-Readiness.
+
+## Siehe auch
+
+- `docs/advisors/wave48-ai-governance-view.md`
+- `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`
+- `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`
+- `frontend/src/lib/advisorCrossRegulationBuild.ts`

--- a/frontend/src/app/api/internal/advisor/cross-regulation-matrix/route.ts
+++ b/frontend/src/app/api/internal/advisor/cross-regulation-matrix/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
+import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const payload = await computeKanzleiPortfolioPayload(new Date());
+  const cross_regulation_matrix = buildCrossRegulationMatrixFromPayload(payload);
+  return NextResponse.json({
+    ok: true,
+    cross_regulation_matrix,
+    markdown_de: cross_regulation_matrix.markdown_de,
+  });
+}

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -19,6 +19,12 @@ import {
 } from "@/lib/advisorMandantReminderTypes";
 import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
+import {
+  CROSS_REGULATION_PILLAR_LABEL_DE,
+  CROSS_REGULATION_PILLAR_ORDER,
+  type CrossRegulationBucket,
+} from "@/lib/advisorCrossRegulationTypes";
 import type { AdvisorSlaDeepLinkId } from "@/lib/advisorSlaTypes";
 import type {
   KanzleiAttentionQueueItem,
@@ -30,6 +36,29 @@ import type {
 import { isNonEmptyUnparsableIso } from "@/lib/mandantHistoryMerge";
 
 type Props = { adminConfigured: boolean };
+
+type CrossRegMatrixFilter = "all" | "multi_stress" | CrossRegulationBucket;
+
+function crossRegBucketAbbrev(b: CrossRegulationBucket): string {
+  if (b === "ok") return "O";
+  if (b === "needs_attention") return "!";
+  if (b === "priority") return "P";
+  return "?";
+}
+
+function crossRegBucketTitle(b: CrossRegulationBucket): string {
+  if (b === "ok") return "OK";
+  if (b === "needs_attention") return "Nacharbeit";
+  if (b === "priority") return "Priorität";
+  return "Unbekannt";
+}
+
+function crossRegBucketCellClass(b: CrossRegulationBucket): string {
+  if (b === "priority") return "border-rose-200 bg-rose-50 text-rose-950";
+  if (b === "needs_attention") return "border-amber-200 bg-amber-50 text-amber-950";
+  if (b === "ok") return "border-emerald-200 bg-emerald-50 text-emerald-950";
+  return "border-slate-200 bg-slate-50 text-slate-600";
+}
 
 function kpiTrendSymbol(t: AdvisorKpiTrend): string {
   if (t === "up") return "↑";
@@ -322,6 +351,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [manualRemCat, setManualRemCat] = useState<"manual" | "follow_up_note">("follow_up_note");
   const [manualRemNote, setManualRemNote] = useState("");
   const [manualRemBusy, setManualRemBusy] = useState(false);
+  const [crossRegFilter, setCrossRegFilter] = useState<CrossRegMatrixFilter>("all");
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -456,6 +486,28 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       return true;
     });
   }, [payload, readinessFilter, pillarFilter, staleOnly, manyOpenOnly, reviewStaleOnly]);
+
+  const crossRegMatrix = useMemo(
+    () => (payload ? buildCrossRegulationMatrixFromPayload(payload) : null),
+    [payload],
+  );
+
+  const crossRegFilteredMandanten = useMemo(() => {
+    if (!crossRegMatrix) return [];
+    let m = crossRegMatrix.mandanten;
+    if (crossRegFilter === "multi_stress") {
+      m = m.filter((x) => x.active_pillar_pressure_count >= 2);
+    } else if (crossRegFilter === "priority") {
+      m = m.filter((x) => CROSS_REGULATION_PILLAR_ORDER.some((pk) => x.pillars[pk] === "priority"));
+    } else if (crossRegFilter === "needs_attention") {
+      m = m.filter((x) => CROSS_REGULATION_PILLAR_ORDER.some((pk) => x.pillars[pk] === "needs_attention"));
+    } else if (crossRegFilter === "unknown") {
+      m = m.filter((x) => CROSS_REGULATION_PILLAR_ORDER.some((pk) => x.pillars[pk] === "unknown"));
+    } else if (crossRegFilter === "ok") {
+      m = m.filter((x) => CROSS_REGULATION_PILLAR_ORDER.every((pk) => x.pillars[pk] === "ok"));
+    }
+    return m;
+  }, [crossRegMatrix, crossRegFilter]);
 
   const markReviewDone = useCallback(
     async (tenantId: string) => {
@@ -697,15 +749,15 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             <span className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600">
               Intern · Mandanten-Steering
             </span>
-            <span className="text-[11px] text-slate-400">Waves 39–48</span>
+            <span className="text-[11px] text-slate-400">Waves 39–49</span>
           </div>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-[1.65rem]">
             Kanzlei-Portfolio
           </h1>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Operatives Cockpit für gemappte Mandanten: Readiness, Prüfpunkte, Export-Kadenz, Reviews,
-            Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA-Signale und AI-Governance-Fokus
-            (EU AI Act / ISO 42001, heuristisch).
+            Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA, AI-Governance und
+            Cross-Regulation-Matrix (vier Säulen – Steuerung, keine Rechtsautomatik).
           </p>
           {payload ? (
             <p className="mt-3 text-xs tabular-nums text-slate-500">
@@ -739,6 +791,10 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             ·{" "}
             <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
               /ai-governance-overview
+            </code>{" "}
+            ·{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /cross-regulation-matrix
             </code>
           </p>
         </div>
@@ -956,6 +1012,119 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             </a>{" "}
             (Säulenfilter EU AI Act / ISO 42001) · Keine automatische Rechtsbewertung.
           </p>
+        </section>
+      ) : null}
+
+      {crossRegMatrix && payload ? (
+        <section
+          id="kanzlei-cross-regulation-panel"
+          className="rounded-xl border border-violet-200/80 bg-white p-4 shadow-sm ring-1 ring-violet-950/[0.05]"
+        >
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="min-w-0 max-w-2xl">
+              <p className="text-[11px] font-medium uppercase tracking-wider text-violet-800/90">Cross-Regulation</p>
+              <h2 className="mt-0.5 text-sm font-semibold tracking-tight text-slate-900">
+                Vier Säulen – Portfolio-Matrix
+              </h2>
+              <p className="mt-1 text-xs leading-relaxed text-slate-600">{crossRegMatrix.disclaimer_de}</p>
+              <p className="mt-1.5 text-[10px] text-slate-500">
+                ≥2 Säulen prioritär:{" "}
+                <span className="font-semibold text-slate-800">
+                  {crossRegMatrix.totals.mandanten_multi_pillar_priority}
+                </span>{" "}
+                · ≥2 Säulen unter Druck:{" "}
+                <span className="font-semibold text-slate-800">
+                  {crossRegMatrix.totals.mandanten_multi_pillar_stress}
+                </span>{" "}
+                · {crossRegMatrix.version}
+              </p>
+            </div>
+            <label className="text-[11px] font-medium text-slate-700">
+              Filter
+              <select
+                className="mt-1 block min-w-[11rem] rounded-md border border-slate-200 bg-white px-2 py-1.5 text-xs text-slate-900 shadow-sm"
+                value={crossRegFilter}
+                onChange={(e) => setCrossRegFilter(e.target.value as CrossRegMatrixFilter)}
+              >
+                <option value="all">Alle Mandanten</option>
+                <option value="multi_stress">Mehrfach-Druck (≥2 Säulen)</option>
+                <option value="priority">Mindestens eine Priorität</option>
+                <option value="needs_attention">Mindestens Nacharbeit</option>
+                <option value="unknown">Unbekannt enthalten</option>
+                <option value="ok">Nur durchgehend OK (alle Säulen)</option>
+              </select>
+            </label>
+          </div>
+          <p className="mt-2 text-[10px] text-slate-500">
+            Legende: <span className="font-mono">O</span> OK · <span className="font-mono">!</span> Nacharbeit ·{" "}
+            <span className="font-mono">P</span> Priorität · <span className="font-mono">?</span> unbekannt (Datenlage).
+          </p>
+          <div className="mt-2 max-h-[min(55vh,420px)] overflow-auto rounded-lg border border-slate-100">
+            <table className="min-w-[640px] w-full border-collapse text-left text-[11px]">
+              <thead className="sticky top-0 z-10 bg-slate-50 text-[10px] font-semibold uppercase tracking-wide text-slate-600">
+                <tr>
+                  <th className="border-b border-slate-200 px-2 py-2">Mandant</th>
+                  {CROSS_REGULATION_PILLAR_ORDER.map((pk) => (
+                    <th key={pk} className="border-b border-slate-200 px-1.5 py-2 text-center">
+                      {CROSS_REGULATION_PILLAR_LABEL_DE[pk]}
+                    </th>
+                  ))}
+                  <th className="border-b border-slate-200 px-2 py-2 text-center">Links</th>
+                </tr>
+              </thead>
+              <tbody>
+                {crossRegFilteredMandanten.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="px-3 py-4 text-center text-slate-500">
+                      Keine Zeilen für diesen Filter.
+                    </td>
+                  </tr>
+                ) : (
+                  crossRegFilteredMandanten.map((m) => (
+                    <tr key={m.tenant_id} className="border-b border-slate-100 odd:bg-white even:bg-slate-50/50">
+                      <td className="max-w-[200px] px-2 py-1.5 align-top">
+                        <div className="truncate font-medium text-slate-900">{m.mandant_label ?? m.tenant_id}</div>
+                        <div className="font-mono text-[10px] text-slate-400">{m.tenant_id}</div>
+                      </td>
+                      {CROSS_REGULATION_PILLAR_ORDER.map((pk) => {
+                        const b = m.pillars[pk];
+                        return (
+                          <td key={pk} className="px-1 py-1 align-middle text-center">
+                            <span
+                              className={`inline-flex min-w-[1.75rem] justify-center rounded border px-1 py-0.5 font-mono text-[10px] font-semibold ${crossRegBucketCellClass(b)}`}
+                              title={crossRegBucketTitle(b)}
+                            >
+                              {crossRegBucketAbbrev(b)}
+                            </span>
+                          </td>
+                        );
+                      })}
+                      <td className="px-2 py-1 align-top">
+                        <div className="flex flex-col gap-0.5 text-[10px]">
+                          <a className="text-cyan-800 underline" href={m.links.mandant_export_page}>
+                            Export
+                          </a>
+                          <a className="text-cyan-800 underline" href={m.links.readiness_export_api}>
+                            Readiness-API
+                          </a>
+                        </div>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 border-t border-slate-100 pt-2">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Top Querschnitt</p>
+            <ul className="mt-1 space-y-1 text-[11px] text-slate-700">
+              {crossRegMatrix.top_cases.slice(0, 5).map((t) => (
+                <li key={t.tenant_id}>
+                  <span className="font-medium">{t.mandant_label ?? t.tenant_id}</span>: {t.hint_de}
+                </li>
+              ))}
+            </ul>
+          </div>
         </section>
       ) : null}
 

--- a/frontend/src/lib/advisorCrossRegulationBuild.test.ts
+++ b/frontend/src/lib/advisorCrossRegulationBuild.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCrossRegulationMatrixFromPayload,
+  stubCrossRegulationMatrixDto,
+  trafficToCrossRegulationBucket,
+} from "@/lib/advisorCrossRegulationBuild";
+import { ADVISOR_CROSS_REGULATION_VERSION } from "@/lib/advisorCrossRegulationTypes";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import { KANZLEI_PORTFOLIO_VERSION } from "@/lib/kanzleiPortfolioTypes";
+import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
+
+function row(partial: Partial<KanzleiPortfolioRow>): KanzleiPortfolioRow {
+  return {
+    tenant_id: "t-1",
+    mandant_label: "Acme",
+    readiness_class: "baseline_governance",
+    readiness_label_de: "Baseline",
+    primary_segment_label_de: null,
+    open_points_count: 0,
+    open_points_hoch: 0,
+    top_gap_pillar_code: "DSGVO",
+    top_gap_pillar_label_de: "DSGVO",
+    pillar_traffic: {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    },
+    board_report_stale: false,
+    api_fetch_ok: true,
+    attention_score: 5,
+    attention_flags_de: [],
+    last_mandant_readiness_export_at: null,
+    last_datev_bundle_export_at: null,
+    last_any_export_at: null,
+    last_review_marked_at: null,
+    last_review_note_de: null,
+    review_stale: false,
+    any_export_stale: false,
+    never_any_export: false,
+    gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
+    links: {
+      mandant_export_page: "/x",
+      datev_bundle_api: "/y",
+      readiness_export_api: "/z",
+      board_readiness_admin: "/b",
+    },
+    ...partial,
+  };
+}
+
+function mkPayload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
+  return {
+    version: KANZLEI_PORTFOLIO_VERSION,
+    generated_at: "2026-05-01T12:00:00Z",
+    backend_reachable: true,
+    mapped_tenant_count: rows.length,
+    tenants_partial: 0,
+    constants: {
+      review_stale_days: 90,
+      any_export_max_age_days: 90,
+      many_open_points_threshold: 4,
+      gap_heavy_min_open_for_export_rule: 5,
+    },
+    rows,
+    attention_queue: [],
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
+    advisor_sla: stubAdvisorSlaEvaluation("2026-05-01T12:00:00Z"),
+  };
+}
+
+describe("advisorCrossRegulationBuild", () => {
+  it("trafficToCrossRegulationBucket respects api and traffic", () => {
+    expect(trafficToCrossRegulationBucket("green", true)).toBe("ok");
+    expect(trafficToCrossRegulationBucket("amber", true)).toBe("needs_attention");
+    expect(trafficToCrossRegulationBucket("red", true)).toBe("priority");
+    expect(trafficToCrossRegulationBucket("green", false)).toBe("unknown");
+  });
+
+  it("stubCrossRegulationMatrixDto has version", () => {
+    const dto = stubCrossRegulationMatrixDto("2026-05-01T12:00:00Z");
+    expect(dto.version).toBe(ADVISOR_CROSS_REGULATION_VERSION);
+  });
+
+  it("buildCrossRegulationMatrixFromPayload counts multi-pillar stress", () => {
+    const dto = buildCrossRegulationMatrixFromPayload(
+      mkPayload([
+        row({
+          tenant_id: "a",
+          pillar_traffic: {
+            eu_ai_act: "red",
+            iso_42001: "red",
+            nis2: "green",
+            dsgvo: "green",
+          },
+        }),
+        row({
+          tenant_id: "b",
+          pillar_traffic: {
+            eu_ai_act: "green",
+            iso_42001: "green",
+            nis2: "green",
+            dsgvo: "green",
+          },
+        }),
+      ]),
+    );
+    expect(dto.totals.mandanten_multi_pillar_priority).toBe(1);
+    expect(dto.mandanten.find((m) => m.tenant_id === "a")?.priority_pillar_count).toBe(2);
+  });
+
+  it("gap pressure bumps pillar when top_gap matches and open points", () => {
+    const dto = buildCrossRegulationMatrixFromPayload(
+      mkPayload([
+        row({
+          pillar_traffic: {
+            eu_ai_act: "green",
+            iso_42001: "green",
+            nis2: "green",
+            dsgvo: "green",
+          },
+          top_gap_pillar_code: "DSGVO",
+          open_points_count: 5,
+          open_points_hoch: 1,
+        }),
+      ]),
+    );
+    const m = dto.mandanten[0]!;
+    expect(m.pillars.dsgvo).toBe("needs_attention");
+    expect(m.pillars.eu_ai_act).toBe("ok");
+  });
+});

--- a/frontend/src/lib/advisorCrossRegulationBuild.ts
+++ b/frontend/src/lib/advisorCrossRegulationBuild.ts
@@ -1,0 +1,247 @@
+/**
+ * Wave 49 – Matrix aus Kanzlei-Portfolio-Zeilen (Board-Säulen + erklärbare Lücken-Heuristik).
+ */
+
+import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
+import {
+  CROSS_REGULATION_PILLAR_LABEL_DE,
+  CROSS_REGULATION_PILLAR_ORDER,
+  ADVISOR_CROSS_REGULATION_VERSION,
+  type CrossRegulationBucket,
+  type CrossRegulationMandantRow,
+  type CrossRegulationMatrixDto,
+  type CrossRegulationPillarBucketCounts,
+  type CrossRegulationPortfolioTotals,
+  type CrossRegulationTopCase,
+} from "@/lib/advisorCrossRegulationTypes";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+
+export const ADVISOR_CROSS_REGULATION_DISCLAIMER_DE =
+  "Hinweis: Matrix aus Board-Readiness-Ampeln und offenen Prüfpunkten (Kanzlei-Semantik). Keine Rechtsbewertung und keine vollständige Normenabdeckung – Steuerungshilfe für Berater, besonders Mittelstand und WP-Kanzleien. NIS2- und DSGVO-Signale können auch ohne hohe EU-AI-Act-Relevanz relevant sein.";
+
+const TOP_GAP_CODE_TO_PILLAR: Record<string, BoardReadinessPillarKey> = {
+  EU_AI_Act: "eu_ai_act",
+  ISO_42001: "iso_42001",
+  NIS2: "nis2",
+  DSGVO: "dsgvo",
+};
+
+const BUCKET_RANK: Record<CrossRegulationBucket, number> = {
+  unknown: 0,
+  ok: 1,
+  needs_attention: 2,
+  priority: 3,
+};
+
+function maxBucket(a: CrossRegulationBucket, b: CrossRegulationBucket): CrossRegulationBucket {
+  return BUCKET_RANK[a] >= BUCKET_RANK[b] ? a : b;
+}
+
+export function trafficToCrossRegulationBucket(
+  traffic: BoardReadinessTraffic,
+  apiOk: boolean,
+): CrossRegulationBucket {
+  if (!apiOk) return "unknown";
+  if (traffic === "red") return "priority";
+  if (traffic === "amber") return "needs_attention";
+  return "ok";
+}
+
+function gapPressureOnPillar(row: KanzleiPortfolioRow, pillar: BoardReadinessPillarKey, manyOpenThr: number): boolean {
+  const mapped = TOP_GAP_CODE_TO_PILLAR[row.top_gap_pillar_code];
+  if (mapped !== pillar) return false;
+  if (row.open_points_count <= 0) return false;
+  if (row.open_points_hoch > 0) return true;
+  return row.open_points_count >= manyOpenThr;
+}
+
+function buildMandantRow(row: KanzleiPortfolioRow, manyOpenThr: number): CrossRegulationMandantRow {
+  const pillars = {} as Record<BoardReadinessPillarKey, CrossRegulationBucket>;
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    let b = trafficToCrossRegulationBucket(row.pillar_traffic[pk], row.api_fetch_ok);
+    if (row.api_fetch_ok && gapPressureOnPillar(row, pk, manyOpenThr)) {
+      b = maxBucket(b, "needs_attention");
+    }
+    pillars[pk] = b;
+  }
+
+  let priority_pillar_count = 0;
+  let active_pillar_pressure_count = 0;
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    const x = pillars[pk];
+    if (x === "priority") {
+      priority_pillar_count += 1;
+      active_pillar_pressure_count += 1;
+    } else if (x === "needs_attention") {
+      active_pillar_pressure_count += 1;
+    }
+  }
+
+  const notes_de: string[] = [];
+  if (!row.api_fetch_ok) {
+    notes_de.push("API teilweise nicht lesbar – Säulen nicht belastbar.");
+  } else {
+    if (priority_pillar_count >= 2) {
+      notes_de.push("Mehrere Säulen mit hohem Nachholbedarf – gemeinsame Vorhaben (Evidence, Rollen, Lieferkette) können Synergien nutzen (Map once, comply many).");
+    }
+    if (pillars.nis2 === "priority" || pillars.nis2 === "needs_attention") {
+      notes_de.push("NIS2 / KRITIS-Relevanz prüfen – auch bei geringer KI-Nutzung.");
+    }
+    if (pillars.dsgvo === "priority" || pillars.dsgvo === "needs_attention") {
+      notes_de.push("DSGVO / BDSG- und Verarbeitungsstammdaten im Blick behalten.");
+    }
+    if (row.gaps_heavy_without_recent_export) {
+      notes_de.push("Viele offene Punkte ohne frischen Export – Aktenstand für Querschnittsreview ziehen.");
+    }
+  }
+
+  return {
+    tenant_id: row.tenant_id,
+    mandant_label: row.mandant_label,
+    pillars,
+    active_pillar_pressure_count,
+    priority_pillar_count,
+    notes_de: notes_de.slice(0, 4),
+    links: { ...row.links },
+  };
+}
+
+function emptyPillarCounts(): CrossRegulationPillarBucketCounts {
+  return { ok: 0, needs_attention: 0, priority: 0, unknown: 0 };
+}
+
+function stressScore(m: CrossRegulationMandantRow): number {
+  let s = 0;
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    const x = m.pillars[pk];
+    if (x === "priority") s += 4;
+    else if (x === "needs_attention") s += 2;
+    else if (x === "unknown") s += 1;
+  }
+  return s;
+}
+
+function topHint(m: CrossRegulationMandantRow): string {
+  if (m.priority_pillar_count >= 2) {
+    return "Mehrere Säulen prioritär – gemeinsame Governance-Arbeit einplanen.";
+  }
+  if (m.pillars.eu_ai_act === "priority") return "EU AI Act: Dokumentation und Register-Pfade priorisieren.";
+  if (m.pillars.iso_42001 === "priority") return "ISO 42001: AIMs-Grundlagen und Rollen schließen.";
+  if (m.pillars.nis2 === "priority") return "NIS2 / KRITIS: Melde- und Lieferkettenpfade schärfen.";
+  if (m.pillars.dsgvo === "priority") return "DSGVO / BDSG: Verarbeitung und Nachweise klären.";
+  if (m.active_pillar_pressure_count >= 2) return "Mehrere Säulen beobachten – Querschnittsgespräch.";
+  return "Säulenlage im Einzelfall vertiefen.";
+}
+
+export function summarizeCrossRegulationTotals(mandanten: CrossRegulationMandantRow[]): CrossRegulationPortfolioTotals {
+  const per_pillar = {
+    eu_ai_act: emptyPillarCounts(),
+    iso_42001: emptyPillarCounts(),
+    nis2: emptyPillarCounts(),
+    dsgvo: emptyPillarCounts(),
+  } as Record<BoardReadinessPillarKey, CrossRegulationPillarBucketCounts>;
+
+  for (const m of mandanten) {
+    for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+      per_pillar[pk][m.pillars[pk]] += 1;
+    }
+  }
+
+  let mandanten_multi_pillar_priority = 0;
+  let mandanten_multi_pillar_stress = 0;
+  for (const m of mandanten) {
+    if (m.priority_pillar_count >= 2) mandanten_multi_pillar_priority += 1;
+    if (m.active_pillar_pressure_count >= 2) mandanten_multi_pillar_stress += 1;
+  }
+
+  return { per_pillar, mandanten_multi_pillar_priority, mandanten_multi_pillar_stress };
+}
+
+export function buildCrossRegulationTopCases(
+  mandanten: CrossRegulationMandantRow[],
+  maxN: number,
+): CrossRegulationTopCase[] {
+  const n = Math.min(15, Math.max(3, maxN));
+  const sorted = [...mandanten].sort((a, b) => {
+    const ds = stressScore(b) - stressScore(a);
+    if (ds !== 0) return ds;
+    if (b.priority_pillar_count !== a.priority_pillar_count) {
+      return b.priority_pillar_count - a.priority_pillar_count;
+    }
+    return (a.mandant_label ?? a.tenant_id).localeCompare(b.mandant_label ?? b.tenant_id, "de");
+  });
+  return sorted.slice(0, n).map((m) => ({
+    tenant_id: m.tenant_id,
+    mandant_label: m.mandant_label,
+    hint_de: topHint(m),
+    links: m.links,
+  }));
+}
+
+export function crossRegulationMatrixMarkdownDe(dto: CrossRegulationMatrixDto): string {
+  const lines: string[] = [];
+  lines.push("# Cross-Regulation Matrix (Advisor)");
+  lines.push(
+    `_Erzeugt: ${new Date(dto.generated_at).toLocaleString("de-DE")} · Portfolio: ${new Date(dto.portfolio_generated_at).toLocaleString("de-DE")} · ${dto.version}_`,
+  );
+  lines.push("");
+  lines.push(`_${dto.disclaimer_de}_`);
+  lines.push("");
+  lines.push("## Portfolio-Kennzahlen");
+  lines.push(
+    `- Mandanten mit **≥2** prioritären Säulen: **${dto.totals.mandanten_multi_pillar_priority}**`,
+  );
+  lines.push(
+    `- Mandanten mit **≥2** Säulen unter Druck (priority oder Nacharbeit): **${dto.totals.mandanten_multi_pillar_stress}**`,
+  );
+  lines.push("");
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    const c = dto.totals.per_pillar[pk];
+    const lab = CROSS_REGULATION_PILLAR_LABEL_DE[pk];
+    lines.push(
+      `- **${lab}:** OK ${c.ok} · Nacharbeit ${c.needs_attention} · Priorität ${c.priority} · unbekannt ${c.unknown}`,
+    );
+  }
+  lines.push("");
+  lines.push("## Top Fälle (Querschnitt)");
+  for (const t of dto.top_cases) {
+    const name = t.mandant_label ?? t.tenant_id;
+    lines.push(`- **${name}** (\`${t.tenant_id}\`): ${t.hint_de}`);
+  }
+  return lines.join("\n");
+}
+
+export function buildCrossRegulationMatrixFromPayload(payload: KanzleiPortfolioPayload): CrossRegulationMatrixDto {
+  const thr = payload.constants.many_open_points_threshold;
+  const mandanten = payload.rows.map((r) => buildMandantRow(r, thr));
+  const totals = summarizeCrossRegulationTotals(mandanten);
+  const top_cases = buildCrossRegulationTopCases(mandanten, 8);
+  const generated_at = new Date().toISOString();
+  const base: Omit<CrossRegulationMatrixDto, "markdown_de"> = {
+    version: ADVISOR_CROSS_REGULATION_VERSION,
+    generated_at,
+    portfolio_generated_at: payload.generated_at,
+    disclaimer_de: ADVISOR_CROSS_REGULATION_DISCLAIMER_DE,
+    totals,
+    mandanten,
+    top_cases,
+  };
+  const markdown_de = crossRegulationMatrixMarkdownDe({ ...base, markdown_de: "" });
+  return { ...base, markdown_de };
+}
+
+export function stubCrossRegulationMatrixDto(portfolioGeneratedAt: string): CrossRegulationMatrixDto {
+  const emptyMandanten: CrossRegulationMandantRow[] = [];
+  const totals = summarizeCrossRegulationTotals(emptyMandanten);
+  const generated_at = new Date().toISOString();
+  const base: Omit<CrossRegulationMatrixDto, "markdown_de"> = {
+    version: ADVISOR_CROSS_REGULATION_VERSION,
+    generated_at,
+    portfolio_generated_at: portfolioGeneratedAt,
+    disclaimer_de: ADVISOR_CROSS_REGULATION_DISCLAIMER_DE,
+    totals,
+    mandanten: [],
+    top_cases: [],
+  };
+  return { ...base, markdown_de: crossRegulationMatrixMarkdownDe({ ...base, markdown_de: "" }) };
+}

--- a/frontend/src/lib/advisorCrossRegulationTypes.ts
+++ b/frontend/src/lib/advisorCrossRegulationTypes.ts
@@ -1,0 +1,72 @@
+/**
+ * Wave 49 – Cross-Regulation Advisor Matrix („Map once, comply many“).
+ */
+
+import type { BoardReadinessPillarKey } from "@/lib/boardReadinessTypes";
+
+export const ADVISOR_CROSS_REGULATION_VERSION = "wave49-v1";
+
+export const CROSS_REGULATION_PILLAR_ORDER: BoardReadinessPillarKey[] = [
+  "eu_ai_act",
+  "iso_42001",
+  "nis2",
+  "dsgvo",
+];
+
+/** Kurzbezeichnung im UI (DACH). */
+export const CROSS_REGULATION_PILLAR_LABEL_DE: Record<BoardReadinessPillarKey, string> = {
+  eu_ai_act: "EU AI Act",
+  iso_42001: "ISO 42001",
+  nis2: "NIS2 / KRITIS",
+  dsgvo: "DSGVO / BDSG",
+};
+
+/**
+ * Posture-Bucket je Säule (aus Board-Ampel + Lücken-Heuristik).
+ * `unknown` = API/Mandant nicht belastbar lesbar.
+ */
+export type CrossRegulationBucket = "ok" | "needs_attention" | "priority" | "unknown";
+
+export type CrossRegulationMandantRow = {
+  tenant_id: string;
+  mandant_label: string | null;
+  pillars: Record<BoardReadinessPillarKey, CrossRegulationBucket>;
+  /** Säulen mit Druck (priority oder needs_attention). */
+  active_pillar_pressure_count: number;
+  priority_pillar_count: number;
+  notes_de: string[];
+  links: {
+    mandant_export_page: string;
+    datev_bundle_api: string;
+    readiness_export_api: string;
+    board_readiness_admin: string;
+  };
+};
+
+export type CrossRegulationPillarBucketCounts = Record<CrossRegulationBucket, number>;
+
+export type CrossRegulationPortfolioTotals = {
+  per_pillar: Record<BoardReadinessPillarKey, CrossRegulationPillarBucketCounts>;
+  /** ≥2 Säulen „priority“. */
+  mandanten_multi_pillar_priority: number;
+  /** ≥2 Säulen mit priority oder needs_attention. */
+  mandanten_multi_pillar_stress: number;
+};
+
+export type CrossRegulationTopCase = {
+  tenant_id: string;
+  mandant_label: string | null;
+  hint_de: string;
+  links: CrossRegulationMandantRow["links"];
+};
+
+export type CrossRegulationMatrixDto = {
+  version: typeof ADVISOR_CROSS_REGULATION_VERSION;
+  generated_at: string;
+  portfolio_generated_at: string;
+  disclaimer_de: string;
+  totals: CrossRegulationPortfolioTotals;
+  mandanten: CrossRegulationMandantRow[];
+  top_cases: CrossRegulationTopCase[];
+  markdown_de: string;
+};

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.ts
@@ -8,6 +8,7 @@ import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzlei
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import type {
   KanzleiAttentionBand,
   KanzleiMonthlyBaselineTenant,
@@ -361,5 +362,6 @@ export function buildKanzleiMonthlyReport(
     section_6_kpi_trends: opts.kpiTrendsNarrative ?? null,
     section_7_advisor_sla: payload.advisor_sla,
     section_8_ai_governance: opts.aiGovernance,
+    section_9_cross_regulation_matrix: buildCrossRegulationMatrixFromPayload(payload),
   };
 }

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -85,6 +85,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).not.toContain("## 5) Kanzlei-KPIs");
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
     expect(md).toContain("## 8) AI-Governance (Wave 48)");
+    expect(md).toContain("## 9) Cross-Regulation-Matrix (Wave 49)");
   });
 
   it("includes KPI section when snapshot provided", () => {
@@ -114,6 +115,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).toContain("## 6) KPI-Trends (Wave 46)");
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
     expect(md).toContain("## 8) AI-Governance (Wave 48)");
+    expect(md).toContain("## 9) Cross-Regulation-Matrix (Wave 49)");
     expect(md).toContain("Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen.");
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
@@ -3,6 +3,10 @@
  */
 
 import { GTM_READINESS_LABELS_DE } from "@/lib/gtmAccountReadiness";
+import {
+  CROSS_REGULATION_PILLAR_LABEL_DE,
+  CROSS_REGULATION_PILLAR_ORDER,
+} from "@/lib/advisorCrossRegulationTypes";
 import type { KanzleiMonthlyReportDto } from "@/lib/kanzleiMonthlyReportTypes";
 
 function readinessDe(code: string): string {
@@ -167,6 +171,26 @@ export function kanzleiMonthlyReportMarkdownDe(r: KanzleiMonthlyReportDto): stri
       const name = t.mandant_label ?? t.tenant_id;
       parts.push(`- **${name}** (\`${t.tenant_id}\`): ${t.priority_hint_de}`);
     }
+  }
+
+  const cr = r.section_9_cross_regulation_matrix;
+  const crt = cr.totals;
+  parts.push(`## 9) Cross-Regulation-Matrix (Wave 49)`);
+  parts.push(`_${cr.disclaimer_de}_`);
+  parts.push(
+    `- Mandanten mit **≥2** prioritären Säulen: **${crt.mandanten_multi_pillar_priority}** · mit **≥2** Säulen unter Druck (Priorität/Nacharbeit): **${crt.mandanten_multi_pillar_stress}** · Schema ${cr.version}.`,
+  );
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    const c = crt.per_pillar[pk];
+    const lab = CROSS_REGULATION_PILLAR_LABEL_DE[pk];
+    parts.push(
+      `- **${lab}:** OK **${c.ok}** · Nacharbeit **${c.needs_attention}** · Priorität **${c.priority}** · unbekannt **${c.unknown}**`,
+    );
+  }
+  parts.push(`### Top Querschnittsfälle (Map once, comply many)`);
+  for (const t of cr.top_cases.slice(0, 8)) {
+    const name = t.mandant_label ?? t.tenant_id;
+    parts.push(`- **${name}** (\`${t.tenant_id}\`): ${t.hint_de}`);
   }
 
   parts.push(`---`);

--- a/frontend/src/lib/kanzleiMonthlyReportTypes.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportTypes.ts
@@ -5,11 +5,12 @@
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { CrossRegulationMatrixDto } from "@/lib/advisorCrossRegulationTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 
-export const KANZLEI_MONTHLY_REPORT_VERSION = "wave48-v1";
+export const KANZLEI_MONTHLY_REPORT_VERSION = "wave49-v1";
 
 export type KanzleiAttentionBand = "low" | "medium" | "high";
 
@@ -94,4 +95,6 @@ export type KanzleiMonthlyReportDto = {
   section_7_advisor_sla: AdvisorSlaEvaluationDto;
   /** Wave 48 – AI-Governance-Posture (EU AI Act / ISO 42001, heuristisch). */
   section_8_ai_governance: AdvisorAiGovernancePortfolioDto;
+  /** Wave 49 – Cross-Regulation-Matrix (vier Säulen). */
+  section_9_cross_regulation_matrix: CrossRegulationMatrixDto;
 };

--- a/frontend/src/lib/kanzleiPortfolioTypes.ts
+++ b/frontend/src/lib/kanzleiPortfolioTypes.ts
@@ -7,7 +7,7 @@ import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { MandantReminderApiEntry } from "@/lib/advisorMandantReminderTypes";
 
-export const KANZLEI_PORTFOLIO_VERSION = "wave48-v1";
+export const KANZLEI_PORTFOLIO_VERSION = "wave49-v1";
 
 export type KanzleiPortfolioPillarFilter = BoardReadinessPillarKey | "all";
 

--- a/frontend/src/lib/partnerReviewPackageBuild.test.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.test.ts
@@ -145,6 +145,7 @@ describe("partnerReviewPackageBuild", () => {
     expect(md).toContain("Portfolio kritisch (mehrere SLA-Critical)");
     expect(md).toContain("Keine SLA-Abweichungen – bestehende Kadenz beibehalten.");
     expect(md).toContain("## H) AI-Governance-Steuerung (Wave 48)");
-    expect(md).toContain("wave48-v1");
+    expect(md).toContain("## I) Cross-Regulation-Matrix (Wave 49)");
+    expect(md).toContain("wave49-v1");
   });
 });

--- a/frontend/src/lib/partnerReviewPackageBuild.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.ts
@@ -9,6 +9,7 @@ import {
   summarizeKanzleiMonthlyReportSection1,
 } from "@/lib/kanzleiMonthlyReportBuild";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
@@ -160,5 +161,6 @@ export function buildPartnerReviewPackage(
     part_f_kpi_trends: opts.kpiTrendsNarrative ?? null,
     part_g_sla_lagebild: payload.advisor_sla,
     part_h_ai_governance: opts.aiGovernance,
+    part_i_cross_regulation_matrix: buildCrossRegulationMatrixFromPayload(payload),
   };
 }

--- a/frontend/src/lib/partnerReviewPackageMarkdown.ts
+++ b/frontend/src/lib/partnerReviewPackageMarkdown.ts
@@ -3,6 +3,10 @@
  */
 
 import { GTM_READINESS_LABELS_DE } from "@/lib/gtmAccountReadiness";
+import {
+  CROSS_REGULATION_PILLAR_LABEL_DE,
+  CROSS_REGULATION_PILLAR_ORDER,
+} from "@/lib/advisorCrossRegulationTypes";
 import type { PartnerReviewPackageDto } from "@/lib/partnerReviewPackageTypes";
 
 function lineLabel(row: { mandant_label: string | null; tenant_id: string }): string {
@@ -192,6 +196,29 @@ export function partnerReviewPackageMarkdownDe(pkg: PartnerReviewPackageDto): st
   lines.push("### Top Mandanten für Beraterkapazität");
   for (const t of ag.top_attention.slice(0, 8)) {
     lines.push(`- **${lineLabel(t)}:** ${t.priority_hint_de}`);
+  }
+  lines.push("");
+
+  const cr = pkg.part_i_cross_regulation_matrix;
+  const crt = cr.totals;
+  lines.push("## I) Cross-Regulation-Matrix (Wave 49)");
+  lines.push("");
+  lines.push(`_${cr.disclaimer_de}_`);
+  lines.push("");
+  lines.push(
+    `- **≥2** Säulen prioritär: **${crt.mandanten_multi_pillar_priority}** · **≥2** Säulen unter Druck: **${crt.mandanten_multi_pillar_stress}** · ${cr.version}.`,
+  );
+  for (const pk of CROSS_REGULATION_PILLAR_ORDER) {
+    const c = crt.per_pillar[pk];
+    const lab = CROSS_REGULATION_PILLAR_LABEL_DE[pk];
+    lines.push(
+      `- **${lab}:** OK ${c.ok} · Nacharbeit ${c.needs_attention} · Priorität ${c.priority} · unbek. ${c.unknown}`,
+    );
+  }
+  lines.push("");
+  lines.push("### Beratungs-Fokus (Mehrfachnutzen)");
+  for (const t of cr.top_cases.slice(0, 8)) {
+    lines.push(`- **${lineLabel(t)}:** ${t.hint_de}`);
   }
   lines.push("");
 

--- a/frontend/src/lib/partnerReviewPackageTypes.ts
+++ b/frontend/src/lib/partnerReviewPackageTypes.ts
@@ -5,11 +5,12 @@
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { CrossRegulationMatrixDto } from "@/lib/advisorCrossRegulationTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiMonthlyChangeLine } from "@/lib/kanzleiMonthlyReportTypes";
 
-export const PARTNER_REVIEW_PACKAGE_VERSION = "wave48-v1";
+export const PARTNER_REVIEW_PACKAGE_VERSION = "wave49-v1";
 
 export type PartnerReviewPackageMeta = {
   version: typeof PARTNER_REVIEW_PACKAGE_VERSION;
@@ -73,4 +74,6 @@ export type PartnerReviewPackageDto = {
   part_g_sla_lagebild: AdvisorSlaEvaluationDto;
   /** Wave 48 – AI-Governance-Steuerung (EU AI Act / ISO 42001). */
   part_h_ai_governance: AdvisorAiGovernancePortfolioDto;
+  /** Wave 49 – Cross-Regulation-Matrix. */
+  part_i_cross_regulation_matrix: CrossRegulationMatrixDto;
 };


### PR DESCRIPTION
- Add pillar buckets (ok/needs_attention/priority/unknown) from board traffic plus gap heuristics; portfolio totals, top cases, markdown export.
- GET /api/internal/advisor/cross-regulation-matrix; cockpit panel with filterable Mandant x pillar table derived from portfolio payload.
- Monthly report section 9 and partner package part I; schema wave49-v1.
- Docs wave49 and cross-links; unit tests for cross-regulation build.

Made-with: Cursor