### PR TITLE
feat(advisor): Wave 50 ERP evidence hooks, API, cockpit, reports

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -14,6 +14,7 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | **7) SLA & Eskalation** | Wave 47: leichte Regeln, Befunde und Eskalationssignale aus KPI, Queue und Remindern – siehe `wave47-sla-and-escalations.md` |
 | **8) AI-Governance** | Wave 48: EU AI Act / ISO 42001 Portfolio-Posture – siehe `wave48-ai-governance-view.md` |
 | **9) Cross-Regulation** | Wave 49: Vier-Säulen-Matrix – siehe `wave49-cross-regulation-matrix.md` |
+| **10) Enterprise Evidence Hooks** | Wave 50: SAP-/ERP-/DATEV-Evidenz-Metadaten und Portfolio-Lücken – siehe `wave50-enterprise-evidence-hooks.md` |
 
 ## API (intern, Lead-Admin)
 
@@ -32,7 +33,7 @@ Portfolio-weiter **Sammelbericht** für interne Kanzlei-Reviews, Partner-Termine
 | `kpi_window_days` | `90` | Wave 45–46: Fenster für KPI-Abschnitt 5 und History-Schreiben für Abschnitt 6 (7–365) |
 | `kpi` | `1` | `kpi=0` schaltet Abschnitt 5 und 6 ab |
 
-**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (`wave46-v1` inkl. optionalen Abschnitten 5–6), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
+**Antwort:** `{ ok, report, markdown_de, baseline_updated }` – `report` ist strukturiertes JSON (Schema aktuell `wave50-v1`, inkl. optionaler Abschnitte 5–6 und Evidence Hooks 10), `markdown_de` für Kopieren in E-Mails oder Arbeitsmappen.
 
 **Wave 46:** Abschnitt **6) KPI-Trends** – Kurzsätze aus persistierter KPI-History (rolling 3 Monate). Siehe `wave46-kpi-trends.md`.
 
@@ -71,6 +72,7 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -15,6 +15,7 @@ Kompaktes **Portfolio-Artefakt** für interne Partnerrunden, vierteljährliche M
 | **G – SLA-Lagebild** | Wave 47 – SLA-Befunde, Eskalationssignale und kurze Nächste-Schritte; siehe `wave47-sla-and-escalations.md`. |
 | **H – AI-Governance** | Wave 48 – EU AI Act / ISO 42001 Steuerungsüberblick; siehe `wave48-ai-governance-view.md`. |
 | **I – Cross-Regulation** | Wave 49 – Vier-Säulen-Matrix; siehe `wave49-cross-regulation-matrix.md`. |
+| **J – Enterprise Evidence Hooks** | Wave 50 – SAP-/ERP-/DATEV-Evidenz-Metadaten, Portfolio-Lücken; siehe `wave50-enterprise-evidence-hooks.md`. |
 
 ## API
 
@@ -57,6 +58,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave47-sla-and-escalations.md`

--- a/docs/advisors/wave49-cross-regulation-matrix.md
+++ b/docs/advisors/wave49-cross-regulation-matrix.md
@@ -48,8 +48,8 @@ Panel **`#kanzlei-cross-regulation-panel`**: kompakte Tabelle Mandant × Säule 
 
 ## Reports
 
-- **Kanzlei-Monatsreport:** Abschnitt **9) Cross-Regulation-Matrix**.
-- **Partner-Review-Paket:** Teil **I)**.
+- **Kanzlei-Monatsreport:** Abschnitt **9) Cross-Regulation-Matrix**; Abschnitt **10) Enterprise Evidence Hooks** (Wave 50, SAP/ERP-Metadaten) siehe `wave50-enterprise-evidence-hooks.md`.
+- **Partner-Review-Paket:** Teil **I)**; Teil **J)** Evidence Hooks (Wave 50).
 
 ## Wortlaut (advisor-safe)
 
@@ -59,11 +59,12 @@ Panel **`#kanzlei-cross-regulation-panel`**: kompakte Tabelle Mandant × Säule 
 ## Grenzen
 
 - Keine Rechtsmeinung, kein Ersatz für Mandanten-Audit oder externe Beratung.
-- Keine SAP/ERP-Anbindung in dieser Wave.
+- Keine SAP/ERP-Anbindung in dieser Wave; **Evidenz-Anknüpfungspunkte** (Metadaten, kein ETL) in Wave 50: `docs/advisors/wave50-enterprise-evidence-hooks.md`.
 - NIS2/KRITIS-Labeling ist **kommunikativ** (DACH-Kontext); fachliche Tiefe bleibt in Mandanten-Workspace und Board-Readiness.
 
 ## Siehe auch
 
+- `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`
 - `docs/advisors/wave41-kanzlei-review-playbook-and-queue.md`

--- a/docs/advisors/wave50-enterprise-evidence-hooks.md
+++ b/docs/advisors/wave50-enterprise-evidence-hooks.md
@@ -1,0 +1,85 @@
+# Wave 50 – Enterprise-/SAP-ERP-Evidence-Hooks
+
+Interne Advisor-Funktion: **Metadaten-Hooks** zur Darstellung möglicher Evidenz-Anknüpfungspunkte an Systemlandschaften (SAP, DATEV, Dynamics, generisches ERP). **Kein ETL, keine Live-Integration**, keine automatische Rechtsbewertung.
+
+## Datenmodell (gespeicherte Hooks)
+
+Pfad: `frontend/data/advisor-evidence-hooks.json` (Next.js-`process.cwd()` = `frontend`) bzw. `ADVISOR_EVIDENCE_HOOKS_PATH` oder unter Vercel `/tmp/compliancehub-advisor-evidence-hooks.json`.
+
+| Feld | Beschreibung |
+|------|----------------|
+| `hook_id` | Eindeutige ID (z. B. UUID oder sprechender Schlüssel) |
+| `tenant_id` | Mandanten-ID (`client_id`) |
+| `source_system_type` | Siehe unten |
+| `source_label` | Freitext-Anzeige (z. B. „S/4HANA Produktiv“) |
+| `evidence_domain` | Siehe unten |
+| `connection_status` | `not_connected` · `planned` · `connected` · `error` |
+| `last_sync_at` | Optional, ISO-8601 (letzte bekannte Synchronisation/Abgleich) |
+| `note` | Optional, Beraterhinweis |
+
+## Unterstützte `source_system_type`
+
+- `sap_s4hana` – SAP S/4HANA (Industrie-Mittelstand / Enterprise)
+- `sap_btp` – SAP BTP als Integrations-/Evidenzpfad
+- `datev` – DATEV-Kanal (Kanzlei)
+- `ms_dynamics` – Microsoft Dynamics / Business Central (breitere ERP-Fit)
+- `generic_erp` – Sonstiges ERP, bewusst unspezifisch
+
+## `evidence_domain`
+
+- `invoice` – Belege, Rechnungen, E-Rechnung/GoBD-Kontext
+- `access` – Zugriffe, Berechtigungen (NIS2, ISO 27001)
+- `approval` – Freigaben, Vier-Augen
+- `vendor` – Lieferanten, AV-Verträge
+- `ai_system_inventory` – KI-Inventar / Register
+- `policy_artifact` – Policies, Arbeitsanweisungen
+
+## Mapping Domäne → Compliance-Sicht (explizit)
+
+Die Zuordnung ist im Code als `evidenceDomainComplianceRelevanceDe` hinterlegt (kurz):
+
+| Domäne | Relevanz (Auszug) |
+|--------|-------------------|
+| `invoice` | DSGVO (Kontext), GoBD, EN 16931 |
+| `access` | NIS2/KRITIS-Dach, ISO 27001, DSGVO Art. 32 |
+| `approval` | GoBD/Interne Kontrolle, ISO 27001/42001, NIS2 |
+| `vendor` | DSGVO AV, NIS2 Lieferkette, ISO 27001 |
+| `ai_system_inventory` | EU AI Act, ISO 42001, NIS2 (Kontext) |
+| `policy_artifact` | ISO 42001/27001, EU AI Act (Doku), DSGVO |
+
+## Synthetische Hooks (ohne Store-Eintrag)
+
+Aus dem **Kanzlei-Portfolio** werden automatisch ergänzt:
+
+- **DATEV / `invoice`:** aus `last_datev_bundle_export_at` und Export-Kadenz (`any_export_max_age_days`).
+- **SAP S/4HANA-Platzhalter / `invoice`:** wenn kein gespeicherter SAP- oder BTP-Hook für den Mandanten existiert – sichtbar als Enterprise-Readiness-Lücke, nicht als Produktanspruch.
+
+## API
+
+`GET /api/internal/advisor/evidence-hooks` (Lead-Admin-Auth wie andere Advisor-Routen)
+
+- Antwort: `evidence_hooks` (Portfolio-DTO inkl. `summary`, `mandanten`, `top_gaps`, `markdown_de`)
+- Query `markdown=0`: `markdown_de` im Objekt leer, `markdown_de` top-level `null` (schlankeres JSON)
+
+## Berater-Wortlaut (Empfehlung)
+
+- Betonen: **Steuerung und Transparenz**, keine „Anbindung fertig“.
+- **DATEV** für Kanzlei und steuerliche Evidenz; **SAP/ERP** für Mittelstand/Enterprise-Belegflüsse.
+- Upsell: „Evidenz aus der echten Landschaft kann die Nachweisfähigkeit stärken – nächster Schritt wäre Klärung der technischen Roadmap (z. B. BTP), nicht sofort Vollintegration.“
+
+## Grenzen
+
+- Nur Metadaten und Heuristiken; **keine** direkte SAP-/DATEV-API-Anbindung in dieser Wave.
+- Keine Mandantenfähigkeit über RLS in diesem JSON-Store – Datei ist **Lead-Admin-/Installationsweit**; tenant_id pro Hook bleibt Pflicht für Zuordnung.
+
+## Ausblick (SAP BTP / S/4HANA)
+
+- Phase 1 (diese Wave): Darstellung, KPIs im Cockpit, Reports/Partnerpaket.
+- Später: OAuth/API über BTP, ausgewählte Entitäten (z. B. Freigaben, Schnittstellen-Logs), immer mit explizitem Mandanten- und Einwilligungskontext; Weiterführung siehe Produkt-Roadmap GRC/ERP.
+
+## Verwandte Doku
+
+- `docs/advisors/wave42-kanzlei-monatsreport.md` (Abschnitt 10)
+- `docs/advisors/wave44-partner-review-package.md` (Teil J)
+- `docs/advisors/wave49-cross-regulation-matrix.md`
+- `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`

--- a/frontend/data/advisor-evidence-hooks.json
+++ b/frontend/data/advisor-evidence-hooks.json
@@ -1,0 +1,4 @@
+{
+  "version": "wave50-v1",
+  "hooks": []
+}

--- a/frontend/src/app/api/internal/advisor/evidence-hooks/route.ts
+++ b/frontend/src/app/api/internal/advisor/evidence-hooks/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
+import { readAdvisorEvidenceHooks } from "@/lib/advisorEvidenceHookStore";
+import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const omitMarkdown = url.searchParams.get("markdown") === "0";
+
+  const now = new Date();
+  const [payload, stored] = await Promise.all([
+    computeKanzleiPortfolioPayload(now),
+    readAdvisorEvidenceHooks(),
+  ]);
+  const evidence_hooks = buildAdvisorEvidenceHooksPortfolioDto(payload, stored);
+
+  if (omitMarkdown) {
+    return NextResponse.json({
+      ok: true,
+      evidence_hooks: { ...evidence_hooks, markdown_de: "" },
+      markdown_de: null,
+    });
+  }
+
+  return NextResponse.json({
+    ok: true,
+    evidence_hooks,
+    markdown_de: evidence_hooks.markdown_de,
+  });
+}

--- a/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
+++ b/frontend/src/app/api/internal/advisor/kanzlei-monthly-report/route.ts
@@ -4,6 +4,8 @@ import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
 import { computeAdvisorAiGovernanceFromBundle } from "@/lib/advisorAiGovernanceAggregate";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
+import { readAdvisorEvidenceHooks } from "@/lib/advisorEvidenceHookStore";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
 import { readKanzleiMonthlyReportBaseline, writeKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
@@ -40,10 +42,12 @@ export async function GET(req: Request) {
 
   const now = new Date();
   const bundle = await loadMappedTenantPillarSnapshots(now);
-  const [payload, aiGovernance] = await Promise.all([
+  const [payload, aiGovernance, storedEvidenceHooks] = await Promise.all([
     computeKanzleiPortfolioPayload(now, { preloadedBundle: bundle }),
     Promise.resolve(computeAdvisorAiGovernanceFromBundle(bundle)),
+    readAdvisorEvidenceHooks(),
   ]);
+  const evidenceHooks = buildAdvisorEvidenceHooksPortfolioDto(payload, storedEvidenceHooks);
   const baseline = await readKanzleiMonthlyReportBaseline();
 
   const advisorKpiSnapshot = kpiOff
@@ -68,6 +72,7 @@ export async function GET(req: Request) {
     advisorKpiSnapshot,
     kpiTrendsNarrative,
     aiGovernance,
+    evidenceHooks,
   });
   const markdown_de = kanzleiMonthlyReportMarkdownDe(report);
 

--- a/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
+++ b/frontend/src/app/api/internal/advisor/partner-review-package/route.ts
@@ -4,6 +4,8 @@ import { upsertAdvisorKpiHistoryDaily } from "@/lib/advisorKpiHistoryStore";
 import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
 import { advisorKpiTrendsNarrativeBlock, buildAdvisorKpiTrendsDto } from "@/lib/advisorKpiTrendsBuild";
 import { computeAdvisorAiGovernanceFromBundle } from "@/lib/advisorAiGovernanceAggregate";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
+import { readAdvisorEvidenceHooks } from "@/lib/advisorEvidenceHookStore";
 import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
 import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
 import { readKanzleiMonthlyReportBaseline } from "@/lib/kanzleiMonthlyReportBaseline";
@@ -32,10 +34,12 @@ export async function GET(req: Request) {
 
   const now = new Date();
   const bundle = await loadMappedTenantPillarSnapshots(now);
-  const [payload, aiGovernance] = await Promise.all([
+  const [payload, aiGovernance, storedEvidenceHooks] = await Promise.all([
     computeKanzleiPortfolioPayload(now, { preloadedBundle: bundle }),
     Promise.resolve(computeAdvisorAiGovernanceFromBundle(bundle)),
+    readAdvisorEvidenceHooks(),
   ]);
+  const evidenceHooks = buildAdvisorEvidenceHooksPortfolioDto(payload, storedEvidenceHooks);
   const baseline = await readKanzleiMonthlyReportBaseline();
 
   const advisorKpiSnapshot = kpiOff
@@ -59,6 +63,7 @@ export async function GET(req: Request) {
     advisorKpiSnapshot,
     kpiTrendsNarrative,
     aiGovernance,
+    evidenceHooks,
   });
   const markdown_de = partnerReviewPackageMarkdownDe(partner_review_package);
 

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/advisorMandantReminderTypes";
 import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
 import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import {
   CROSS_REGULATION_PILLAR_LABEL_DE,
@@ -353,18 +354,24 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [manualRemBusy, setManualRemBusy] = useState(false);
   const [crossRegFilter, setCrossRegFilter] = useState<CrossRegMatrixFilter>("all");
 
+  const [evidenceHooks, setEvidenceHooks] = useState<AdvisorEvidenceHooksPortfolioDto | null>(null);
+  const [evidenceHooksErr, setEvidenceHooksErr] = useState<string | null>(null);
+
   const load = useCallback(async () => {
     setLoading(true);
     setLoadError(null);
     setAiGovernanceError(null);
     try {
-      const [rPf, rAg] = await Promise.all([
+      const [rPf, rAg, rEh] = await Promise.all([
         fetch("/api/internal/advisor/kanzlei-portfolio", { credentials: "include" }),
         fetch("/api/internal/advisor/ai-governance-overview", { credentials: "include" }),
+        fetch("/api/internal/advisor/evidence-hooks?markdown=0", { credentials: "include" }),
       ]);
       if (rPf.status === 401) {
         setPayload(null);
         setAiGovernance(null);
+        setEvidenceHooks(null);
+        setEvidenceHooksErr(null);
         setLoadError("unauthorized");
         return;
       }
@@ -372,6 +379,8 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
         setLoadError(`HTTP ${rPf.status}`);
         setPayload(null);
         setAiGovernance(null);
+        setEvidenceHooks(null);
+        setEvidenceHooksErr(null);
         return;
       }
       const data = (await rPf.json()) as { ok?: boolean; kanzlei_portfolio?: KanzleiPortfolioPayload };
@@ -387,10 +396,24 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
         setAiGovernance(null);
         setAiGovernanceError(`AI-Governance: HTTP ${rAg.status}`);
       }
+
+      if (rEh.ok) {
+        const ehData = (await rEh.json()) as { evidence_hooks?: AdvisorEvidenceHooksPortfolioDto };
+        setEvidenceHooks(ehData.evidence_hooks ?? null);
+        setEvidenceHooksErr(null);
+      } else if (rEh.status === 401) {
+        setEvidenceHooks(null);
+        setEvidenceHooksErr("Evidence Hooks: nicht angemeldet.");
+      } else {
+        setEvidenceHooks(null);
+        setEvidenceHooksErr(`Evidence Hooks: HTTP ${rEh.status}`);
+      }
     } catch {
       setLoadError("Netzwerkfehler");
       setPayload(null);
       setAiGovernance(null);
+      setEvidenceHooks(null);
+      setEvidenceHooksErr(null);
     } finally {
       setLoading(false);
     }
@@ -756,8 +779,8 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
           </h1>
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Operatives Cockpit für gemappte Mandanten: Readiness, Prüfpunkte, Export-Kadenz, Reviews,
-            Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA, AI-Governance und
-            Cross-Regulation-Matrix (vier Säulen – Steuerung, keine Rechtsautomatik).
+            Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA, AI-Governance,
+            Cross-Regulation-Matrix und Enterprise Evidence Hooks (SAP/ERP-Metadaten, keine Live-Integration).
           </p>
           {payload ? (
             <p className="mt-3 text-xs tabular-nums text-slate-500">
@@ -828,6 +851,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
       {aiGovernanceError && payload && !aiGovernance ? (
         <p className="text-xs text-amber-800">{aiGovernanceError}</p>
       ) : null}
+      {evidenceHooksErr && payload ? <p className="text-xs text-amber-800">{evidenceHooksErr}</p> : null}
 
       {payload?.advisor_sla ? (
         <section
@@ -1125,6 +1149,75 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
               ))}
             </ul>
           </div>
+        </section>
+      ) : null}
+
+      {evidenceHooks && payload ? (
+        <section
+          id="kanzlei-enterprise-evidence-hooks"
+          className="rounded-xl border border-amber-200/85 bg-white p-4 shadow-sm ring-1 ring-amber-950/[0.05]"
+        >
+          <div className="min-w-0 max-w-2xl">
+            <p className="text-[11px] font-medium uppercase tracking-wider text-amber-900/85">
+              Enterprise Evidence Hooks
+            </p>
+            <h2 className="mt-0.5 text-sm font-semibold tracking-tight text-slate-900">
+              Wave 50 – ERP-/SAP-Evidenz (Metadaten)
+            </h2>
+            <p className="mt-1 text-xs leading-relaxed text-slate-600">{evidenceHooks.disclaimer_de}</p>
+            <p className="mt-1.5 text-[10px] text-slate-500">
+              Stand {new Date(evidenceHooks.generated_at).toLocaleString("de-DE")} · {evidenceHooks.version}
+            </p>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Ohne SAP/BTP-Touchpoint</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {evidenceHooks.summary.mandanten_without_sap_touchpoint} Mandanten
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Ohne DATEV-Export (Historie)</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {evidenceHooks.summary.mandanten_without_datev_export} Mandanten
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Hooks verbunden / geplant</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {evidenceHooks.summary.by_status.connected} · {evidenceHooks.summary.by_status.planned}
+              </div>
+            </div>
+            <div className="rounded-lg border border-slate-100 bg-slate-50/80 px-3 py-2 text-[11px] text-slate-800">
+              <span className="font-semibold text-slate-900">Upsell-Kandidaten</span>
+              <div className="mt-0.5 tabular-nums text-slate-700">
+                {evidenceHooks.summary.mandanten_enterprise_upsell_candidates} (Governance + Druck)
+              </div>
+            </div>
+          </div>
+          <div className="mt-3 border-t border-slate-100 pt-3">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">Top Lücken</p>
+            <ul className="mt-1 space-y-1.5 text-[11px] text-slate-700">
+              {evidenceHooks.top_gaps.slice(0, 5).map((g) => (
+                <li key={g.tenant_id} className="flex flex-wrap items-start justify-between gap-2">
+                  <span>
+                    <span className="font-medium text-slate-900">{g.mandant_label ?? g.tenant_id}</span>
+                    <span className="ml-1 font-mono text-[10px] text-slate-400">{g.tenant_id}</span>
+                    <span className="block text-slate-600">{g.hint_de}</span>
+                  </span>
+                  <a
+                    className="shrink-0 text-[10px] font-medium text-amber-900 underline"
+                    href={g.links.mandant_export_page}
+                  >
+                    Export
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <p className="mt-2 text-[10px] text-slate-500">
+            DATEV deckt den Kanzlei-Kanal; SAP/ERP-Hooks markieren Enterprise-Readiness ohne Integrationsausbau.
+          </p>
         </section>
       ) : null}
 

--- a/frontend/src/lib/advisorEvidenceHookBuild.test.ts
+++ b/frontend/src/lib/advisorEvidenceHookBuild.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAdvisorEvidenceHooksPortfolioDto, evidenceDomainComplianceRelevanceDe } from "@/lib/advisorEvidenceHookBuild";
+import type { EvidenceHookStoredRecord } from "@/lib/advisorEvidenceHookTypes";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import { KANZLEI_PORTFOLIO_VERSION } from "@/lib/kanzleiPortfolioTypes";
+import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
+
+const NOW = Date.parse("2026-04-04T12:00:00.000Z");
+
+function baseRow(p: Partial<KanzleiPortfolioRow>): KanzleiPortfolioRow {
+  return {
+    tenant_id: "t-1",
+    mandant_label: "Acme",
+    readiness_class: "baseline_governance",
+    readiness_label_de: "Baseline",
+    primary_segment_label_de: null,
+    open_points_count: 1,
+    open_points_hoch: 0,
+    top_gap_pillar_code: "DSGVO",
+    top_gap_pillar_label_de: "DSGVO",
+    pillar_traffic: {
+      eu_ai_act: "green",
+      iso_42001: "green",
+      nis2: "green",
+      dsgvo: "green",
+    },
+    board_report_stale: false,
+    api_fetch_ok: true,
+    attention_score: 5,
+    attention_flags_de: [],
+    last_mandant_readiness_export_at: null,
+    last_datev_bundle_export_at: null,
+    last_any_export_at: null,
+    last_review_marked_at: null,
+    last_review_note_de: null,
+    review_stale: false,
+    any_export_stale: false,
+    never_any_export: false,
+    gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
+    links: {
+      mandant_export_page: "/x",
+      datev_bundle_api: "/y",
+      readiness_export_api: "/z",
+      board_readiness_admin: "/b",
+    },
+    ...p,
+  };
+}
+
+function mkPayload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
+  return {
+    version: KANZLEI_PORTFOLIO_VERSION,
+    generated_at: "2026-04-04T10:00:00.000Z",
+    backend_reachable: true,
+    mapped_tenant_count: rows.length,
+    tenants_partial: 0,
+    constants: {
+      review_stale_days: 90,
+      any_export_max_age_days: 90,
+      many_open_points_threshold: 4,
+      gap_heavy_min_open_for_export_rule: 5,
+    },
+    rows,
+    attention_queue: [],
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
+    advisor_sla: stubAdvisorSlaEvaluation("2026-04-04T10:00:00.000Z"),
+  };
+}
+
+describe("advisorEvidenceHookBuild", () => {
+  it("evidenceDomainComplianceRelevanceDe covers invoice and access", () => {
+    expect(evidenceDomainComplianceRelevanceDe("invoice").some((s) => s.includes("GoBD"))).toBe(true);
+    expect(evidenceDomainComplianceRelevanceDe("access").some((s) => s.includes("NIS2"))).toBe(true);
+  });
+
+  it("adds synthetic DATEV and SAP rows when store empty", () => {
+    const p = mkPayload([baseRow({ tenant_id: "a" })]);
+    const dto = buildAdvisorEvidenceHooksPortfolioDto(p, [], {
+      generatedAt: new Date(NOW),
+      nowMs: NOW,
+    });
+    const m = dto.mandanten[0];
+    expect(m.hooks.length).toBe(2);
+    expect(m.hooks.filter((h) => h.source_system_type === "datev").length).toBe(1);
+    expect(m.hooks.filter((h) => h.source_system_type === "sap_s4hana").length).toBe(1);
+    expect(dto.summary.mandanten_without_datev_export).toBe(1);
+    expect(dto.summary.mandanten_without_sap_touchpoint).toBe(1);
+    expect(dto.version).toBe("wave50-v1");
+    expect(dto.markdown_de).toContain("Enterprise Evidence Hooks");
+  });
+
+  it("DATEV synthetic connected when recent export", () => {
+    const p = mkPayload([
+      baseRow({
+        last_datev_bundle_export_at: "2026-04-01T10:00:00.000Z",
+      }),
+    ]);
+    const dto = buildAdvisorEvidenceHooksPortfolioDto(p, [], { nowMs: NOW });
+    const dv = dto.mandanten[0].hooks.find((h) => h.source_system_type === "datev");
+    expect(dv?.connection_status).toBe("connected");
+  });
+
+  it("skips synthetic SAP when stored SAP planned exists", () => {
+    const stored: EvidenceHookStoredRecord[] = [
+      {
+        hook_id: "h1",
+        tenant_id: "t-1",
+        source_system_type: "sap_btp",
+        source_label: "BTP",
+        evidence_domain: "access",
+        connection_status: "planned",
+        last_sync_at: null,
+        note: null,
+      },
+    ];
+    const p = mkPayload([baseRow({})]);
+    const dto = buildAdvisorEvidenceHooksPortfolioDto(p, stored, { nowMs: NOW });
+    const sapRows = dto.mandanten[0].hooks.filter(
+      (h) => h.source_system_type === "sap_s4hana" || h.source_system_type === "sap_btp",
+    );
+    expect(sapRows.length).toBe(1);
+    expect(sapRows[0].is_synthetic).toBe(false);
+    expect(dto.summary.mandanten_without_sap_touchpoint).toBe(0);
+  });
+
+  it("counts enterprise upsell when governance + pressure signals", () => {
+    const p = mkPayload([
+      baseRow({
+        readiness_class: "advanced_governance",
+        open_points_count: 5,
+      }),
+    ]);
+    const dto = buildAdvisorEvidenceHooksPortfolioDto(p, [], { nowMs: NOW });
+    expect(dto.summary.mandanten_enterprise_upsell_candidates).toBe(1);
+  });
+});

--- a/frontend/src/lib/advisorEvidenceHookBuild.ts
+++ b/frontend/src/lib/advisorEvidenceHookBuild.ts
@@ -1,0 +1,364 @@
+/**
+ * Wave 50 – ERP-/SAP-Evidence-Hooks aus Portfolio + optionalem JSON-Store (rein funktional).
+ */
+
+import { daysSinceValidIso, isNonEmptyUnparsableIso } from "@/lib/mandantHistoryMerge";
+import type {
+  AdvisorEvidenceHooksMandantBlockDto,
+  AdvisorEvidenceHooksPortfolioDto,
+  AdvisorEvidenceHooksSummaryDto,
+  AdvisorEvidenceHooksTopGapDto,
+  EvidenceConnectionStatus,
+  EvidenceDomain,
+  EvidenceHookRowDto,
+  EvidenceHookStoredRecord,
+  EvidenceSourceSystemType,
+} from "@/lib/advisorEvidenceHookTypes";
+import { ADVISOR_EVIDENCE_HOOKS_VERSION } from "@/lib/advisorEvidenceHookTypes";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+
+const DISCLAIMER_DE =
+  "Metadaten-Hooks zur Enterprise-Readiness: keine Live-Anbindung an SAP, DATEV oder Dynamics. " +
+  "Evidenz aus Mandanten-Historie (DATEV/Export) und manuell gepflegte Hooks – keine technische Vollintegration.";
+
+/** Explizite, erklärbare Zuordnung Domäne → regulatorischer Kontext (DACH). */
+export function evidenceDomainComplianceRelevanceDe(domain: EvidenceDomain): string[] {
+  switch (domain) {
+    case "invoice":
+      return [
+        "DSGVO: Verarbeitungskontext bei Beleg- und Rechnungsdaten",
+        "GoBD: Aufzeichnungs- und Nachvollziehbarkeit (Belege)",
+        "E-Rechnung EN 16931: Schnittstellen- und Exportevidenz",
+      ];
+    case "access":
+      return [
+        "NIS2 / KRITIS-Dach: Zugriffs- und Berechtigungsnachweise",
+        "ISO 27001: Zutritts- und Zugriffssteuerung",
+        "DSGVO Art. 32: TOM, Zugriffsschutz",
+      ];
+    case "approval":
+      return [
+        "GoBD / interne Kontrolle: Vier-Augen / Freigaben",
+        "ISO 27001 / 42001: Steuerung sensibler Änderungen",
+        "NIS2: Governance-Nachweise",
+      ];
+    case "vendor":
+      return [
+        "DSGVO: Auftragsverarbeitung, Lieferantenrisiko",
+        "NIS2: Lieferketten-/Drittanbieter-Nachweise",
+        "ISO 27001: Drittanbieter-Management",
+      ];
+    case "ai_system_inventory":
+      return [
+        "EU AI Act: Inventar und Risikoklassifikation",
+        "ISO 42001: AI-Managementsystem, Lebenszyklus",
+        "NIS2: Kritische Dienste und KI-Nutzung (Kontext)",
+      ];
+    case "policy_artifact":
+      return [
+        "ISO 42001 / 27001: Policies und Arbeitsanweisungen als Evidenz",
+        "EU AI Act: Dokumentationspflichten (High-Risk-Kontext)",
+        "DSGVO: Verzeichnis, TOM-Dokumentation",
+      ];
+    default: {
+      const _x: never = domain;
+      return [_x];
+    }
+  }
+}
+
+function datevSyntheticRow(
+  row: KanzleiPortfolioRow,
+  maxAgeDays: number,
+  nowMs: number,
+): EvidenceHookRowDto {
+  const raw = row.last_datev_bundle_export_at;
+  if (!raw?.trim()) {
+    return {
+      hook_id: `synthetic:datev:invoice:${row.tenant_id}`,
+      tenant_id: row.tenant_id,
+      source_system_type: "datev",
+      source_label: "DATEV Export-Bundle (Historie)",
+      evidence_domain: "invoice",
+      connection_status: "not_connected",
+      last_sync_at: null,
+      evidence_hint_de:
+        "Kein DATEV-Bundle-Export in der Mandanten-Historie erfasst. Kanzlei-Kanal: ZIP-Export als Evidenzanker neben Readiness-Export.",
+      compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+      is_synthetic: true,
+    };
+  }
+  if (isNonEmptyUnparsableIso(raw)) {
+    return {
+      hook_id: `synthetic:datev:invoice:${row.tenant_id}`,
+      tenant_id: row.tenant_id,
+      source_system_type: "datev",
+      source_label: "DATEV Export-Bundle (Historie)",
+      evidence_domain: "invoice",
+      connection_status: "error",
+      last_sync_at: raw,
+      evidence_hint_de: "Letzter DATEV-Export-Zeitstempel nicht auswertbar – Historie prüfen.",
+      compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+      is_synthetic: true,
+    };
+  }
+  const days = daysSinceValidIso(raw, nowMs);
+  if (days === null) {
+    return {
+      hook_id: `synthetic:datev:invoice:${row.tenant_id}`,
+      tenant_id: row.tenant_id,
+      source_system_type: "datev",
+      source_label: "DATEV Export-Bundle (Historie)",
+      evidence_domain: "invoice",
+      connection_status: "error",
+      last_sync_at: raw,
+      evidence_hint_de: "Letzter DATEV-Export-Zeitstempel ungültig.",
+      compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+      is_synthetic: true,
+    };
+  }
+  if (days > maxAgeDays) {
+    return {
+      hook_id: `synthetic:datev:invoice:${row.tenant_id}`,
+      tenant_id: row.tenant_id,
+      source_system_type: "datev",
+      source_label: "DATEV Export-Bundle (Historie)",
+      evidence_domain: "invoice",
+      connection_status: "planned",
+      last_sync_at: raw,
+      evidence_hint_de: `DATEV-Export älter als ${maxAgeDays} Tage – Kadenz mit Mandant abstimmen (GoBD/E-Rechnung-Kontext).`,
+      compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+      is_synthetic: true,
+    };
+  }
+  return {
+    hook_id: `synthetic:datev:invoice:${row.tenant_id}`,
+    tenant_id: row.tenant_id,
+    source_system_type: "datev",
+    source_label: "DATEV Export-Bundle (Historie)",
+    evidence_domain: "invoice",
+    connection_status: "connected",
+    last_sync_at: raw,
+    evidence_hint_de: "DATEV-Bundle-Export zuletzt innerhalb der Export-Kadenz erfasst.",
+    compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+    is_synthetic: true,
+  };
+}
+
+function hasStoredDatevInvoice(stored: EvidenceHookStoredRecord[], tenantId: string): boolean {
+  return stored.some(
+    (h) =>
+      h.tenant_id === tenantId &&
+      h.source_system_type === "datev" &&
+      h.evidence_domain === "invoice",
+  );
+}
+
+function hasSapFamilyStored(stored: EvidenceHookStoredRecord[], tenantId: string): boolean {
+  return stored.some(
+    (h) =>
+      h.tenant_id === tenantId &&
+      (h.source_system_type === "sap_s4hana" || h.source_system_type === "sap_btp"),
+  );
+}
+
+function sapFamilyActiveInHooks(hooks: EvidenceHookRowDto[]): boolean {
+  return hooks.some(
+    (h) =>
+      (h.source_system_type === "sap_s4hana" || h.source_system_type === "sap_btp") &&
+      (h.connection_status === "connected" || h.connection_status === "planned"),
+  );
+}
+
+function datevConnectedInHooks(hooks: EvidenceHookRowDto[]): boolean {
+  return hooks.some((h) => h.source_system_type === "datev" && h.connection_status === "connected");
+}
+
+function storedToRow(h: EvidenceHookStoredRecord): EvidenceHookRowDto {
+  const hint =
+    h.note?.trim() ||
+    `Manuell gepflegter Hook (${h.source_label}). Status: ${h.connection_status}.`;
+  return {
+    hook_id: h.hook_id,
+    tenant_id: h.tenant_id,
+    source_system_type: h.source_system_type,
+    source_label: h.source_label,
+    evidence_domain: h.evidence_domain,
+    connection_status: h.connection_status,
+    last_sync_at: h.last_sync_at,
+    evidence_hint_de: hint,
+    compliance_relevance_de: evidenceDomainComplianceRelevanceDe(h.evidence_domain),
+    is_synthetic: false,
+  };
+}
+
+function mandantHintDe(block: AdvisorEvidenceHooksMandantBlockDto): string {
+  const sapActive = sapFamilyActiveInHooks(block.hooks);
+  const datevOk = datevConnectedInHooks(block.hooks);
+  const parts: string[] = [];
+  if (sapActive) parts.push("SAP/BTP-Evidenz-Hook als verbunden oder geplant erfasst.");
+  else parts.push("Kein aktiver SAP-/BTP-Hook – typische Enterprise-Lücke für Industrie-Mittelstand.");
+  if (datevOk) parts.push("DATEV-Bundle-Evidenz innerhalb Kadenz.");
+  else parts.push("DATEV-Bundle fehlt oder Kadenz offen – Kanzlei-Fokus.");
+  return parts.join(" ");
+}
+
+function buildMarkdownDe(dto: AdvisorEvidenceHooksPortfolioDto): string {
+  const s = dto.summary;
+  const lines: string[] = [];
+  lines.push("# Enterprise Evidence Hooks (Portfolio)");
+  lines.push("");
+  lines.push(`_${dto.disclaimer_de}_`);
+  lines.push("");
+  lines.push(`Erzeugt: ${new Date(dto.generated_at).toLocaleString("de-DE")} · Schema ${dto.version}`);
+  lines.push("");
+  lines.push("## Kurzüberblick");
+  lines.push(`- Hook-Zeilen gesamt: **${s.total_hook_rows}**`);
+  lines.push(
+    `- Status: verbunden **${s.by_status.connected}**, geplant **${s.by_status.planned}**, nicht verbunden **${s.by_status.not_connected}**, Fehler **${s.by_status.error}**`,
+  );
+  lines.push(`- Mandanten ohne SAP/BTP-Touchpoint (verbunden/geplant): **${s.mandanten_without_sap_touchpoint}**`);
+  lines.push(`- Mandanten ohne DATEV-Export in Historie: **${s.mandanten_without_datev_export}**`);
+  lines.push(`- Upsell-Kandidaten (Enterprise-Lücke + Drucksignal): **${s.mandanten_enterprise_upsell_candidates}**`);
+  lines.push("");
+  lines.push("## Top Lücken");
+  for (const g of dto.top_gaps.slice(0, 8)) {
+    const name = g.mandant_label ?? g.tenant_id;
+    lines.push(`- **${name}** (\`${g.tenant_id}\`): ${g.hint_de}`);
+  }
+  lines.push("");
+  lines.push("## DATEV vs. ERP");
+  lines.push(
+    "- DATEV-Bundle deckt den Kanzlei-Kanal; SAP/ERP-Hooks adressieren Industrie-Mittelstand und Enterprise-Landschaften.",
+  );
+  lines.push(
+    "- Beides ergänzt sich: strukturierter Readiness-/DATEV-Export in ComplianceHub plus spätere Systemevidenz.",
+  );
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function buildAdvisorEvidenceHooksPortfolioDto(
+  payload: KanzleiPortfolioPayload,
+  stored: EvidenceHookStoredRecord[],
+  opts?: { generatedAt?: Date; nowMs?: number },
+): AdvisorEvidenceHooksPortfolioDto {
+  const generatedAt = opts?.generatedAt ?? new Date();
+  const nowMs = opts?.nowMs ?? generatedAt.getTime();
+  const maxAge = payload.constants.any_export_max_age_days;
+
+  const byTenantStored = new Map<string, EvidenceHookStoredRecord[]>();
+  for (const h of stored) {
+    const list = byTenantStored.get(h.tenant_id) ?? [];
+    list.push(h);
+    byTenantStored.set(h.tenant_id, list);
+  }
+
+  const mandanten: AdvisorEvidenceHooksMandantBlockDto[] = [];
+  let mandantenWithoutDatevExport = 0;
+  let mandantenWithoutSapTouchpoint = 0;
+  let upsellCandidates = 0;
+
+  for (const row of payload.rows) {
+    const tid = row.tenant_id;
+    const tenantStored = byTenantStored.get(tid) ?? [];
+    const hooks: EvidenceHookRowDto[] = tenantStored.map(storedToRow);
+
+    if (!hasStoredDatevInvoice(stored, tid)) {
+      hooks.push(datevSyntheticRow(row, maxAge, nowMs));
+    }
+
+    if (!hasSapFamilyStored(stored, tid)) {
+      hooks.push({
+        hook_id: `synthetic:sap_s4hana:invoice:${tid}`,
+        tenant_id: tid,
+        source_system_type: "sap_s4hana",
+        source_label: "SAP S/4HANA / ERP-Landschaft (Evidenz-Platzhalter)",
+        evidence_domain: "invoice",
+        connection_status: "not_connected",
+        last_sync_at: null,
+        evidence_hint_de:
+          "Kein SAP- oder BTP-Hook erfasst. Für viele Mittelständler zentrale Beleg-/Buchungsevidenz – später z. B. über SAP BTP anbindbar.",
+        compliance_relevance_de: evidenceDomainComplianceRelevanceDe("invoice"),
+        is_synthetic: true,
+      });
+    }
+
+    const block: AdvisorEvidenceHooksMandantBlockDto = {
+      tenant_id: tid,
+      mandant_label: row.mandant_label,
+      hooks,
+      enterprise_readiness_hint_de: "",
+      links: row.links,
+    };
+    block.enterprise_readiness_hint_de = mandantHintDe(block);
+    mandanten.push(block);
+
+    if (!row.last_datev_bundle_export_at?.trim()) mandantenWithoutDatevExport += 1;
+
+    if (!sapFamilyActiveInHooks(hooks)) mandantenWithoutSapTouchpoint += 1;
+
+    const upsell =
+      !sapFamilyActiveInHooks(hooks) &&
+      (row.readiness_class === "advanced_governance" || row.readiness_class === "baseline_governance") &&
+      (row.never_any_export ||
+        row.any_export_stale ||
+        row.open_points_count >= payload.constants.many_open_points_threshold);
+    if (upsell) upsellCandidates += 1;
+  }
+
+  const by_status: Record<EvidenceConnectionStatus, number> = {
+    not_connected: 0,
+    planned: 0,
+    connected: 0,
+    error: 0,
+  };
+  const by_source: Partial<Record<EvidenceSourceSystemType, number>> = {};
+  for (const m of mandanten) {
+    for (const h of m.hooks) {
+      by_status[h.connection_status] += 1;
+      by_source[h.source_system_type] = (by_source[h.source_system_type] ?? 0) + 1;
+    }
+  }
+
+  const totalRows = mandanten.reduce((acc, m) => acc + m.hooks.length, 0);
+
+  const summary: AdvisorEvidenceHooksSummaryDto = {
+    total_hook_rows: totalRows,
+    by_status,
+    by_source_type: by_source,
+    mandanten_without_sap_touchpoint: mandantenWithoutSapTouchpoint,
+    mandanten_without_datev_export: mandantenWithoutDatevExport,
+    mandanten_enterprise_upsell_candidates: upsellCandidates,
+  };
+
+  const gapScores = mandanten.map((m) => {
+    let score = 0;
+    if (!datevConnectedInHooks(m.hooks)) score += 2;
+    if (!sapFamilyActiveInHooks(m.hooks)) score += 2;
+    if (m.hooks.some((h) => h.connection_status === "error")) score += 3;
+    const row = payload.rows.find((r) => r.tenant_id === m.tenant_id);
+    if (row?.never_any_export) score += 1;
+    return { m, score };
+  });
+  gapScores.sort((a, b) => b.score - a.score);
+  const top_gaps: AdvisorEvidenceHooksTopGapDto[] = gapScores.slice(0, 8).map(({ m }) => ({
+    tenant_id: m.tenant_id,
+    mandant_label: m.mandant_label,
+    hint_de: m.enterprise_readiness_hint_de,
+    links: m.links,
+  }));
+
+  const dto: AdvisorEvidenceHooksPortfolioDto = {
+    version: ADVISOR_EVIDENCE_HOOKS_VERSION,
+    generated_at: generatedAt.toISOString(),
+    portfolio_generated_at: payload.generated_at,
+    disclaimer_de: DISCLAIMER_DE,
+    summary,
+    mandanten,
+    top_gaps,
+    markdown_de: "",
+  };
+  dto.markdown_de = buildMarkdownDe(dto);
+  return dto;
+}

--- a/frontend/src/lib/advisorEvidenceHookStore.ts
+++ b/frontend/src/lib/advisorEvidenceHookStore.ts
@@ -1,0 +1,87 @@
+import "server-only";
+
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+import type { EvidenceHookStoredRecord, EvidenceSourceSystemType } from "@/lib/advisorEvidenceHookTypes";
+
+function hooksPath(): string {
+  const fromEnv = process.env.ADVISOR_EVIDENCE_HOOKS_PATH?.trim();
+  if (fromEnv) return fromEnv;
+  if (process.env.VERCEL) return join("/tmp", "compliancehub-advisor-evidence-hooks.json");
+  return join(process.cwd(), "data", "advisor-evidence-hooks.json");
+}
+
+const SOURCE_TYPES: EvidenceSourceSystemType[] = [
+  "sap_s4hana",
+  "sap_btp",
+  "datev",
+  "ms_dynamics",
+  "generic_erp",
+];
+
+function isSourceType(s: string): s is EvidenceSourceSystemType {
+  return SOURCE_TYPES.includes(s as EvidenceSourceSystemType);
+}
+
+const DOMAINS = [
+  "invoice",
+  "access",
+  "approval",
+  "vendor",
+  "ai_system_inventory",
+  "policy_artifact",
+] as const;
+
+function isDomain(s: string): s is EvidenceHookStoredRecord["evidence_domain"] {
+  return (DOMAINS as readonly string[]).includes(s);
+}
+
+const STATUSES: EvidenceHookStoredRecord["connection_status"][] = [
+  "not_connected",
+  "planned",
+  "connected",
+  "error",
+];
+
+function isStatus(s: string): s is EvidenceHookStoredRecord["connection_status"] {
+  return STATUSES.includes(s as EvidenceHookStoredRecord["connection_status"]);
+}
+
+export type AdvisorEvidenceHooksFile = { version?: string; hooks?: unknown };
+
+export async function readAdvisorEvidenceHooks(): Promise<EvidenceHookStoredRecord[]> {
+  const path = hooksPath();
+  try {
+    const raw = await readFile(path, "utf8");
+    const o = JSON.parse(raw) as AdvisorEvidenceHooksFile;
+    if (!o || typeof o !== "object" || !Array.isArray(o.hooks)) return [];
+    const out: EvidenceHookStoredRecord[] = [];
+    for (const e of o.hooks) {
+      if (!e || typeof e !== "object") continue;
+      const r = e as Record<string, unknown>;
+      if (typeof r.hook_id !== "string" || !r.hook_id.trim()) continue;
+      if (typeof r.tenant_id !== "string" || !r.tenant_id.trim()) continue;
+      if (typeof r.source_system_type !== "string" || !isSourceType(r.source_system_type)) continue;
+      if (typeof r.source_label !== "string" || !r.source_label.trim()) continue;
+      if (typeof r.evidence_domain !== "string" || !isDomain(r.evidence_domain)) continue;
+      if (typeof r.connection_status !== "string" || !isStatus(r.connection_status)) continue;
+      const last_sync_at =
+        r.last_sync_at == null ? null : typeof r.last_sync_at === "string" ? r.last_sync_at : null;
+      const note = r.note == null ? null : typeof r.note === "string" ? r.note : null;
+      out.push({
+        hook_id: r.hook_id.trim(),
+        tenant_id: r.tenant_id.trim(),
+        source_system_type: r.source_system_type,
+        source_label: r.source_label.trim(),
+        evidence_domain: r.evidence_domain,
+        connection_status: r.connection_status,
+        last_sync_at,
+        note,
+      });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/frontend/src/lib/advisorEvidenceHookTypes.ts
+++ b/frontend/src/lib/advisorEvidenceHookTypes.ts
@@ -1,0 +1,83 @@
+/** Wave 50 – ERP-Evidence-Hooks (metadata). */
+export const ADVISOR_EVIDENCE_HOOKS_VERSION = "wave50-v1";
+
+export type EvidenceSourceSystemType =
+  | "sap_s4hana"
+  | "sap_btp"
+  | "datev"
+  | "ms_dynamics"
+  | "generic_erp";
+
+export type EvidenceDomain =
+  | "invoice"
+  | "access"
+  | "approval"
+  | "vendor"
+  | "ai_system_inventory"
+  | "policy_artifact";
+
+export type EvidenceConnectionStatus = "not_connected" | "planned" | "connected" | "error";
+
+export type EvidenceHookStoredRecord = {
+  hook_id: string;
+  tenant_id: string;
+  source_system_type: EvidenceSourceSystemType;
+  source_label: string;
+  evidence_domain: EvidenceDomain;
+  connection_status: EvidenceConnectionStatus;
+  last_sync_at: string | null;
+  note: string | null;
+};
+
+export type EvidenceHookRowDto = {
+  hook_id: string;
+  tenant_id: string;
+  source_system_type: EvidenceSourceSystemType;
+  source_label: string;
+  evidence_domain: EvidenceDomain;
+  connection_status: EvidenceConnectionStatus;
+  last_sync_at: string | null;
+  evidence_hint_de: string;
+  compliance_relevance_de: string[];
+  is_synthetic: boolean;
+};
+
+export type AdvisorEvidenceHooksSummaryDto = {
+  total_hook_rows: number;
+  by_status: Record<EvidenceConnectionStatus, number>;
+  by_source_type: Partial<Record<EvidenceSourceSystemType, number>>;
+  mandanten_without_sap_touchpoint: number;
+  mandanten_without_datev_export: number;
+  mandanten_enterprise_upsell_candidates: number;
+};
+
+export type AdvisorEvidenceHooksMandantBlockDto = {
+  tenant_id: string;
+  mandant_label: string | null;
+  hooks: EvidenceHookRowDto[];
+  enterprise_readiness_hint_de: string;
+  links: {
+    mandant_export_page: string;
+    datev_bundle_api: string;
+    readiness_export_api: string;
+    board_readiness_admin: string;
+  };
+};
+
+export type AdvisorEvidenceHooksTopGapDto = {
+  tenant_id: string;
+  mandant_label: string | null;
+  hint_de: string;
+  links: AdvisorEvidenceHooksMandantBlockDto["links"];
+};
+
+export type AdvisorEvidenceHooksPortfolioDto = {
+  version: typeof ADVISOR_EVIDENCE_HOOKS_VERSION;
+  generated_at: string;
+  portfolio_generated_at: string;
+  disclaimer_de: string;
+  summary: AdvisorEvidenceHooksSummaryDto;
+  mandanten: AdvisorEvidenceHooksMandantBlockDto[];
+  top_gaps: AdvisorEvidenceHooksTopGapDto[];
+  markdown_de: string;
+};

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
 import {
   attentionBand,
   buildKanzleiMonthlyReport,
@@ -82,6 +83,10 @@ function payload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
   };
 }
 
+function evidenceHooksFor(p: KanzleiPortfolioPayload) {
+  return buildAdvisorEvidenceHooksPortfolioDto(p, [], { generatedAt: new Date(p.generated_at) });
+}
+
 describe("kanzleiMonthlyReportBuild", () => {
   it("attentionBand buckets scores", () => {
     expect(attentionBand(10)).toBe("low");
@@ -105,6 +110,7 @@ describe("kanzleiMonthlyReportBuild", () => {
         compareToBaseline: true,
         attentionTopN: 5,
         aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+        evidenceHooks: evidenceHooksFor(p),
       },
     );
     expect(r.compared_to_baseline).toBe(true);
@@ -124,6 +130,7 @@ describe("kanzleiMonthlyReportBuild", () => {
         compareToBaseline: false,
         attentionTopN: 5,
         aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+        evidenceHooks: evidenceHooksFor(p),
       },
     );
     expect(r.compared_to_baseline).toBe(false);

--- a/frontend/src/lib/kanzleiMonthlyReportBuild.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBuild.ts
@@ -8,6 +8,7 @@ import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzlei
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
 import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import type {
   KanzleiAttentionBand,
@@ -312,6 +313,8 @@ export type BuildMonthlyReportOptions = {
   kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
   /** Wave 48 – AI-Governance-Überblick (Abschnitt 8). */
   aiGovernance: AdvisorAiGovernancePortfolioDto;
+  /** Wave 50 – Enterprise-/ERP-Evidence-Hooks (Abschnitt 10). */
+  evidenceHooks: AdvisorEvidenceHooksPortfolioDto;
 };
 
 export function buildKanzleiMonthlyReport(
@@ -363,5 +366,6 @@ export function buildKanzleiMonthlyReport(
     section_7_advisor_sla: payload.advisor_sla,
     section_8_ai_governance: opts.aiGovernance,
     section_9_cross_regulation_matrix: buildCrossRegulationMatrixFromPayload(payload),
+    section_10_enterprise_evidence_hooks: opts.evidenceHooks,
   };
 }

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.test.ts
@@ -4,6 +4,7 @@ import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBu
 import { buildAdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiPortfolioBuild";
 import { ADVISOR_KPI_TRENDS_VERSION } from "@/lib/advisorKpiTrendsBuild";
 import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
 import { buildKanzleiMonthlyReport } from "@/lib/kanzleiMonthlyReportBuild";
 import { kanzleiMonthlyReportMarkdownDe } from "@/lib/kanzleiMonthlyReportMarkdown";
 import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
@@ -69,6 +70,10 @@ function minimalPayload(): KanzleiPortfolioPayload {
   };
 }
 
+function evidenceHooksFor(p: KanzleiPortfolioPayload) {
+  return buildAdvisorEvidenceHooksPortfolioDto(p, [], { generatedAt: new Date(p.generated_at) });
+}
+
 describe("kanzleiMonthlyReportMarkdown", () => {
   it("includes section headings", () => {
     const p = minimalPayload();
@@ -77,6 +82,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
       compareToBaseline: true,
       attentionTopN: 5,
       aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      evidenceHooks: evidenceHooksFor(p),
     });
     const md = kanzleiMonthlyReportMarkdownDe(r);
     expect(md).toContain("# Kanzlei-Portfolio-Report");
@@ -86,6 +92,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
     expect(md).toContain("## 8) AI-Governance (Wave 48)");
     expect(md).toContain("## 9) Cross-Regulation-Matrix (Wave 49)");
+    expect(md).toContain("## 10) Enterprise Evidence Hooks (Wave 50)");
   });
 
   it("includes KPI section when snapshot provided", () => {
@@ -109,6 +116,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
         narrative_lines_de: ["Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen."],
       },
       aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      evidenceHooks: evidenceHooksFor(p),
     });
     const md = kanzleiMonthlyReportMarkdownDe(r);
     expect(md).toContain("## 5) Kanzlei-KPIs");
@@ -116,6 +124,7 @@ describe("kanzleiMonthlyReportMarkdown", () => {
     expect(md).toContain("## 7) SLA & Eskalation (Wave 47)");
     expect(md).toContain("## 8) AI-Governance (Wave 48)");
     expect(md).toContain("## 9) Cross-Regulation-Matrix (Wave 49)");
+    expect(md).toContain("## 10) Enterprise Evidence Hooks (Wave 50)");
     expect(md).toContain("Review-Deckung im Vergleich zum vorherigen History-Punkt gestiegen.");
   });
 });

--- a/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportMarkdown.ts
@@ -193,6 +193,29 @@ export function kanzleiMonthlyReportMarkdownDe(r: KanzleiMonthlyReportDto): stri
     parts.push(`- **${name}** (\`${t.tenant_id}\`): ${t.hint_de}`);
   }
 
+  const eh = r.section_10_enterprise_evidence_hooks;
+  const ehs = eh.summary;
+  parts.push(`## 10) Enterprise Evidence Hooks (Wave 50)`);
+  parts.push(`_${eh.disclaimer_de}_`);
+  parts.push(
+    `- Hook-Zeilen gesamt: **${ehs.total_hook_rows}** · SAP/BTP ohne Touchpoint (verbunden/geplant): **${ehs.mandanten_without_sap_touchpoint}** · ohne DATEV-Export in Historie: **${ehs.mandanten_without_datev_export}** · Upsell-Kandidaten: **${ehs.mandanten_enterprise_upsell_candidates}** · Schema ${eh.version}.`,
+  );
+  parts.push(
+    `- Status: verbunden **${ehs.by_status.connected}**, geplant **${ehs.by_status.planned}**, nicht verbunden **${ehs.by_status.not_connected}**, Fehler **${ehs.by_status.error}**`,
+  );
+  parts.push(`### Wo Systemevidenz die Postur stärken kann`);
+  parts.push(
+    `- **DATEV (Kanzlei):** Bundle-Export und Kadenz – Ergänzung zu Readiness-Export, Fokus GoBD/E-Rechnung im Steuerumfeld.`,
+  );
+  parts.push(
+    `- **SAP/ERP (Mittelstand/Enterprise):** Beleg- und Buchungskontext – spätere Anbindung (z. B. BTP) als Evidenzpfad, aktuell nur Metadaten-Hooks.`,
+  );
+  parts.push(`### Top Lücken (Kurz)`);
+  for (const g of eh.top_gaps.slice(0, 6)) {
+    const name = g.mandant_label ?? g.tenant_id;
+    parts.push(`- **${name}** (\`${g.tenant_id}\`): ${g.hint_de}`);
+  }
+
   parts.push(`---`);
   parts.push(
     `Hinweis: Portfolio-Report für interne Kanzlei-Arbeit; keine Board-Tischreife. Daten aus Live-API und lokaler Historie – Änderungslogik bewusst grob (siehe Doku Wave 42).`,

--- a/frontend/src/lib/kanzleiMonthlyReportTypes.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportTypes.ts
@@ -6,11 +6,12 @@ import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { CrossRegulationMatrixDto } from "@/lib/advisorCrossRegulationTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 
-export const KANZLEI_MONTHLY_REPORT_VERSION = "wave49-v1";
+export const KANZLEI_MONTHLY_REPORT_VERSION = "wave50-v1";
 
 export type KanzleiAttentionBand = "low" | "medium" | "high";
 
@@ -97,4 +98,6 @@ export type KanzleiMonthlyReportDto = {
   section_8_ai_governance: AdvisorAiGovernancePortfolioDto;
   /** Wave 49 – Cross-Regulation-Matrix (vier Säulen). */
   section_9_cross_regulation_matrix: CrossRegulationMatrixDto;
+  /** Wave 50 – SAP-/ERP-Evidence-Hooks (Metadaten, Portfolio). */
+  section_10_enterprise_evidence_hooks: AdvisorEvidenceHooksPortfolioDto;
 };

--- a/frontend/src/lib/partnerReviewPackageBuild.test.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
 import { buildPartnerReviewPackage } from "@/lib/partnerReviewPackageBuild";
 import { partnerReviewPackageMarkdownDe } from "@/lib/partnerReviewPackageMarkdown";
 import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
@@ -80,6 +81,10 @@ function mkPayload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
   };
 }
 
+function evidenceHooksFor(p: KanzleiPortfolioPayload) {
+  return buildAdvisorEvidenceHooksPortfolioDto(p, [], { generatedAt: new Date(p.generated_at) });
+}
+
 describe("partnerReviewPackageBuild", () => {
   it("builds Part A with reminder counts from payload", () => {
     const p = mkPayload([baseRow({ tenant_id: "a", review_stale: true })]);
@@ -100,6 +105,7 @@ describe("partnerReviewPackageBuild", () => {
       compareToBaseline: false,
       attentionTopN: 5,
       aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      evidenceHooks: evidenceHooksFor(p),
     });
     expect(pkg.part_e_advisor_kpis).toBeNull();
     expect(pkg.part_f_kpi_trends).toBeNull();
@@ -124,6 +130,7 @@ describe("partnerReviewPackageBuild", () => {
         compareToBaseline: true,
         attentionTopN: 3,
         aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+        evidenceHooks: evidenceHooksFor(p),
       },
     );
     expect(pkg.meta.compared_to_baseline).toBe(true);
@@ -136,6 +143,7 @@ describe("partnerReviewPackageBuild", () => {
       compareToBaseline: false,
       attentionTopN: 3,
       aiGovernance: stubAdvisorAiGovernancePortfolioDto(p.generated_at),
+      evidenceHooks: evidenceHooksFor(p),
     });
     const md = partnerReviewPackageMarkdownDe(pkg);
     expect(md).toContain("## A) Portfolio-Überblick");
@@ -146,6 +154,8 @@ describe("partnerReviewPackageBuild", () => {
     expect(md).toContain("Keine SLA-Abweichungen – bestehende Kadenz beibehalten.");
     expect(md).toContain("## H) AI-Governance-Steuerung (Wave 48)");
     expect(md).toContain("## I) Cross-Regulation-Matrix (Wave 49)");
+    expect(md).toContain("## J) Enterprise Evidence Hooks (Wave 50)");
     expect(md).toContain("wave49-v1");
+    expect(md).toContain("wave50-v1");
   });
 });

--- a/frontend/src/lib/partnerReviewPackageBuild.ts
+++ b/frontend/src/lib/partnerReviewPackageBuild.ts
@@ -9,6 +9,7 @@ import {
   summarizeKanzleiMonthlyReportSection1,
 } from "@/lib/kanzleiMonthlyReportBuild";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
 import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild";
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
@@ -108,6 +109,8 @@ export type BuildPartnerReviewPackageOptions = {
   kpiTrendsNarrative?: AdvisorKpiTrendsNarrativeBlock | null;
   /** Wave 48 – AI-Governance-Überblick. */
   aiGovernance: AdvisorAiGovernancePortfolioDto;
+  /** Wave 50 – Evidence-Hooks-Lagebild. */
+  evidenceHooks: AdvisorEvidenceHooksPortfolioDto;
 };
 
 export function buildPartnerReviewPackage(
@@ -162,5 +165,6 @@ export function buildPartnerReviewPackage(
     part_g_sla_lagebild: payload.advisor_sla,
     part_h_ai_governance: opts.aiGovernance,
     part_i_cross_regulation_matrix: buildCrossRegulationMatrixFromPayload(payload),
+    part_j_enterprise_evidence_hooks: opts.evidenceHooks,
   };
 }

--- a/frontend/src/lib/partnerReviewPackageMarkdown.ts
+++ b/frontend/src/lib/partnerReviewPackageMarkdown.ts
@@ -222,6 +222,30 @@ export function partnerReviewPackageMarkdownDe(pkg: PartnerReviewPackageDto): st
   }
   lines.push("");
 
+  const eh = pkg.part_j_enterprise_evidence_hooks;
+  const ehs = eh.summary;
+  lines.push("## J) Enterprise Evidence Hooks (Wave 50)");
+  lines.push("");
+  lines.push(`_${eh.disclaimer_de}_`);
+  lines.push("");
+  lines.push(
+    `- Portfolio: **${ehs.total_hook_rows}** Hook-Zeilen · SAP/BTP ohne aktiven Touchpoint: **${ehs.mandanten_without_sap_touchpoint}** · ohne DATEV-Export-Historie: **${ehs.mandanten_without_datev_export}** · Upsell-Kandidaten (Governance + Druck): **${ehs.mandanten_enterprise_upsell_candidates}** · ${eh.version}`,
+  );
+  lines.push(
+    `- Status: verbunden ${ehs.by_status.connected}, geplant ${ehs.by_status.planned}, nicht verbunden ${ehs.by_status.not_connected}, Fehler ${ehs.by_status.error}`,
+  );
+  lines.push("");
+  lines.push("### Beratungsnutzen");
+  lines.push(
+    "- DATEV und Readiness-Export liefern den Kanzlei-Kanal; ERP-/SAP-Hooks zeigen, wo echte Systemlandschaft die Nachweise ergänzen könnte – ohne Integrationsversprechen.",
+  );
+  lines.push("");
+  lines.push("### Beispiel-Mandanten (Lücken)");
+  for (const g of eh.top_gaps.slice(0, 5)) {
+    lines.push(`- **${lineLabel(g)}:** ${g.hint_de}`);
+  }
+  lines.push("");
+
   lines.push("---");
   lines.push("");
   lines.push("### Priorisierung (Kurz)");

--- a/frontend/src/lib/partnerReviewPackageTypes.ts
+++ b/frontend/src/lib/partnerReviewPackageTypes.ts
@@ -6,11 +6,12 @@ import type { AdvisorKpiTrendsNarrativeBlock } from "@/lib/advisorKpiTrendsBuild
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { CrossRegulationMatrixDto } from "@/lib/advisorCrossRegulationTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
 import type { AdvisorSlaEvaluationDto } from "@/lib/advisorSlaTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import type { KanzleiMonthlyChangeLine } from "@/lib/kanzleiMonthlyReportTypes";
 
-export const PARTNER_REVIEW_PACKAGE_VERSION = "wave49-v1";
+export const PARTNER_REVIEW_PACKAGE_VERSION = "wave50-v1";
 
 export type PartnerReviewPackageMeta = {
   version: typeof PARTNER_REVIEW_PACKAGE_VERSION;
@@ -76,4 +77,6 @@ export type PartnerReviewPackageDto = {
   part_h_ai_governance: AdvisorAiGovernancePortfolioDto;
   /** Wave 49 – Cross-Regulation-Matrix. */
   part_i_cross_regulation_matrix: CrossRegulationMatrixDto;
+  /** Wave 50 – Enterprise-/ERP-Evidence-Hooks (Kurzlage für Partner). */
+  part_j_enterprise_evidence_hooks: AdvisorEvidenceHooksPortfolioDto;
 };


### PR DESCRIPTION
- Add metadata-first evidence hooks (store, DTO build, synthetic DATEV/SAP rows)
- GET /api/internal/advisor/evidence-hooks (optional markdown=0)
- Cockpit panel Enterprise Evidence Hooks; monthly report §10 and partner part J
- Docs: wave50 guide; cross-links in wave42, wave44, wave49; default JSON store

Made-with: Cursor