### PR TITLE
feat(advisor): Wave 51 board-ready evidence pack

### DIFF
--- a/docs/advisors/wave42-kanzlei-monatsreport.md
+++ b/docs/advisors/wave42-kanzlei-monatsreport.md
@@ -72,6 +72,7 @@ Listen sind auf **12 Einträge** pro Kategorie begrenzt (Lesbarkeit).
 
 ## Siehe auch
 
+- `docs/advisors/wave51-board-ready-evidence-pack.md`
 - `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`

--- a/docs/advisors/wave44-partner-review-package.md
+++ b/docs/advisors/wave44-partner-review-package.md
@@ -58,6 +58,7 @@ Die API liefert zusätzlich `meta.prioritization_rationale_de` als Kurzliste fü
 
 ## Siehe auch
 
+- `docs/advisors/wave51-board-ready-evidence-pack.md`
 - `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave49-cross-regulation-matrix.md`
 - `docs/advisors/wave48-ai-governance-view.md`

--- a/docs/advisors/wave49-cross-regulation-matrix.md
+++ b/docs/advisors/wave49-cross-regulation-matrix.md
@@ -64,6 +64,7 @@ Panel **`#kanzlei-cross-regulation-panel`**: kompakte Tabelle Mandant × Säule 
 
 ## Siehe auch
 
+- `docs/advisors/wave51-board-ready-evidence-pack.md`
 - `docs/advisors/wave50-enterprise-evidence-hooks.md`
 - `docs/advisors/wave48-ai-governance-view.md`
 - `docs/advisors/wave39-kanzlei-portfolio-cockpit.md`

--- a/docs/advisors/wave50-enterprise-evidence-hooks.md
+++ b/docs/advisors/wave50-enterprise-evidence-hooks.md
@@ -79,6 +79,7 @@ Aus dem **Kanzlei-Portfolio** werden automatisch ergänzt:
 
 ## Verwandte Doku
 
+- `docs/advisors/wave51-board-ready-evidence-pack.md` (Abschnitt D – Evidence Touchpoints)
 - `docs/advisors/wave42-kanzlei-monatsreport.md` (Abschnitt 10)
 - `docs/advisors/wave44-partner-review-package.md` (Teil J)
 - `docs/advisors/wave49-cross-regulation-matrix.md`

--- a/docs/advisors/wave51-board-ready-evidence-pack.md
+++ b/docs/advisors/wave51-board-ready-evidence-pack.md
@@ -1,0 +1,74 @@
+# Wave 51 – Board-Ready Evidence Pack
+
+## Zweck und Zielgruppe
+
+Kompaktes **Markdown-Artefakt** für **Geschäftsführung**, **Bereichsleitung** und **board-nahe** Gespräche in KMU und oberem Mittelstand (DACH). Es bündelt bestehende Advisor-Signale in einer **kurzen, sachlichen** Fassung – ohne PDF-Layout, ohne Folien-Engine, ohne Mandanten-Einzeltiefe.
+
+**Nicht** gedacht als: Rechtsgutachten, Abschlussprüfung, vollständige Normenabdeckung oder Ersatz für Mandanten-Audit.
+
+## Struktur (A–E)
+
+| Abschnitt | Inhalt |
+|-----------|--------|
+| **A – Executive Readiness Snapshot** | Gesamtlage (Mandantenzahl, dominante Readiness-Klasse, Queue, offene Prüfpunkte); operative Top-Risiken aus SLA-Befunden/Eskalationssignalen; wesentliche offene Punkte (Kadenz, Queue-Kurzimpulse) |
+| **B – Cross-Regulation (Kurz)** | Je Säule (EU AI Act, ISO 42001, NIS2, DSGVO) Zähler OK / Nacharbeit / Priorität / unbekannt; optional Hinweis Mehrfach-Druck |
+| **C – AI-Governance (Kurz)** | Heuristische AI-Act-/Register-Relevanz; aggregierte Governance-Lücken (ISO 42001, Post-Market, Human Oversight); Hinweis zu Oversight/Monitoring |
+| **D – Evidence Touchpoints** | Kurzfassung Evidence Hooks (DATEV, SAP/ERP-Metadaten); Statusüberblick verbunden/geplant/nicht verbunden/Fehler |
+| **E – Empfohlene Management-Schritte** | 3–5 Punkte aus SLA-„Nächste Schritte“ und Portfolio-Schwerpunkt-Heuristik (wie Monatsreport Fokusliste), ohne Ticket-System |
+
+Am Ende des Markdown: Liste **eingeschlossener Signalquellen** (`meta.included_signals_de`) für Transparenz.
+
+## Eingeschlossene Signale (Build)
+
+Deterministisch aus:
+
+- `KanzleiPortfolioPayload` (Zeilen, Queue, SLA-Auswertung)
+- `buildCrossRegulationMatrixFromPayload` (Wave 49)
+- `AdvisorAiGovernancePortfolioDto` (Wave 48, aus Board-Bundle)
+- `buildAdvisorEvidenceHooksPortfolioDto` (Wave 50, inkl. Store + synthetische Zeilen)
+- optional `AdvisorKpiPortfolioSnapshot` (`attachAdvisorKpiToPayload`) für eine **zweizeilige KPI-Stichprobe** in Abschnitt A
+
+## API
+
+`GET /api/internal/advisor/board-ready-evidence-pack` (Lead-Admin-Auth wie andere Advisor-Routen)
+
+| Query | Standard | Bedeutung |
+|-------|----------|-----------|
+| `kpi_window_days` | `90` | Fenster für KPI-Snapshot (7–365) |
+| `kpi` | an | `kpi=0` schaltet KPI ab (kein Eintrag in Signalquellen-Liste für KPI, keine Stichprobe in A) |
+
+**Antwort:** `board_ready_evidence_pack` (strukturiert, `wave51-v1`), `markdown_de` (identisch zu `board_ready_evidence_pack.markdown_de`).
+
+## Wortwahl (management-tauglich)
+
+- **Postur**, **Steuerung**, **Hinweis**, **Prüfbedarf**, **Kadenz**, **Evidenz-Reife** – statt „compliant“ oder „rechtssicher“.
+- KI: **mögliche** Relevanz, **Dashboard-Indikator**, keine automatische Risikoklassifikation nach EU AI Act.
+- ERP/SAP/DATEV: **Metadaten-Hooks**, **keine Live-Integration** in dieser Wave.
+- Immer klarstellen: Angaben sind **Aggregat** aus ComplianceHub-Datenlage.
+
+## Abgrenzung
+
+| Artefakt | Fokus |
+|----------|--------|
+| **Partner-Review-Paket (Wave 44)** | Interne Kanzlei-/Partner-Steuerung, Top-Mandanten, Baseline-Delta, mehr operative Detailtiefe |
+| **Monatsreport (Wave 42)** | Periodischer Sammelreport inkl. optionaler Baseline, KPI-Abschnitte, längere Struktur |
+| **Board-Ready Evidence Pack (Wave 51)** | **Executive Kurzfassung** A–E, eine Seite Lesedauer, gleiche Datenbasis wie oben, andere Zuspitzung |
+
+## UI
+
+Kanzlei-Cockpit (`/admin/advisor-portfolio`): Block **„Board-Ready Pack erstellen“**, Vorschau, **Markdown kopieren**, Download als `.md`.
+
+## Grenzen und rechtlicher Hinweis
+
+- Keine Rechtsberatung; keine Gewähr für Vollständigkeit oder Aktualität außerhalb des erzeugten Portfolio-Zeitpunkts.
+- Keine substanzielle Prüfung einzelner Verarbeitungen oder Systeme.
+- Für verbindliche Board-Beschlüsse sind Mandanten-Fakten und externe Beratung erforderlich.
+
+## Siehe auch
+
+- `docs/advisors/wave50-enterprise-evidence-hooks.md`
+- `docs/advisors/wave49-cross-regulation-matrix.md`
+- `docs/advisors/wave48-ai-governance-view.md`
+- `docs/advisors/wave42-kanzlei-monatsreport.md`
+- `docs/advisors/wave44-partner-review-package.md`
+- `frontend/src/lib/boardReadyEvidencePackBuild.ts`

--- a/frontend/src/app/api/internal/advisor/board-ready-evidence-pack/route.ts
+++ b/frontend/src/app/api/internal/advisor/board-ready-evidence-pack/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { attachAdvisorKpiToPayload } from "@/lib/advisorKpiPortfolioAggregate";
+import { computeAdvisorAiGovernanceFromBundle } from "@/lib/advisorAiGovernanceAggregate";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
+import { readAdvisorEvidenceHooks } from "@/lib/advisorEvidenceHookStore";
+import { buildBoardReadyEvidencePack } from "@/lib/boardReadyEvidencePackBuild";
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
+import { computeKanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioAggregate";
+import { loadMappedTenantPillarSnapshots } from "@/lib/boardReadinessAggregate";
+import { isLeadAdminAuthorized } from "@/lib/leadAdminAuth";
+
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  if (!process.env.LEAD_ADMIN_SECRET?.trim()) {
+    return NextResponse.json({ error: "not_configured" }, { status: 404 });
+  }
+  if (!isLeadAdminAuthorized(req)) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const url = new URL(req.url);
+  const kpiWindowRaw = url.searchParams.get("kpi_window_days");
+  const kpiWindowDays = Math.min(365, Math.max(7, Number.parseInt(kpiWindowRaw ?? "90", 10) || 90));
+  const kpiOff = url.searchParams.get("kpi") === "0";
+
+  const now = new Date();
+  const bundle = await loadMappedTenantPillarSnapshots(now);
+  const [payload, aiGovernance, storedEvidenceHooks] = await Promise.all([
+    computeKanzleiPortfolioPayload(now, { preloadedBundle: bundle }),
+    Promise.resolve(computeAdvisorAiGovernanceFromBundle(bundle)),
+    readAdvisorEvidenceHooks(),
+  ]);
+  const crossRegulation = buildCrossRegulationMatrixFromPayload(payload);
+  const evidenceHooks = buildAdvisorEvidenceHooksPortfolioDto(payload, storedEvidenceHooks);
+
+  const kpiSnapshot = kpiOff ? null : await attachAdvisorKpiToPayload(payload, now.getTime(), kpiWindowDays);
+
+  const board_ready_evidence_pack = buildBoardReadyEvidencePack({
+    payload,
+    crossRegulation,
+    aiGovernance,
+    evidenceHooks,
+    kpiSnapshot,
+    generatedAt: now,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    board_ready_evidence_pack,
+    markdown_de: board_ready_evidence_pack.markdown_de,
+  });
+}

--- a/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
+++ b/frontend/src/components/admin/KanzleiPortfolioCockpitClient.tsx
@@ -20,6 +20,7 @@ import {
 import { isDueThisCalendarWeek, isDueTodayOrOverdue } from "@/lib/advisorMandantReminderRules";
 import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
 import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
+import type { BoardReadyEvidencePackDto } from "@/lib/boardReadyEvidencePackTypes";
 import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
 import {
   CROSS_REGULATION_PILLAR_LABEL_DE,
@@ -336,6 +337,12 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
   const [partnerDto, setPartnerDto] = useState<PartnerReviewPackageDto | null>(null);
   const [partnerCompare, setPartnerCompare] = useState(true);
   const [partnerTopN, setPartnerTopN] = useState(8);
+
+  const [boardPackLoading, setBoardPackLoading] = useState(false);
+  const [boardPackErr, setBoardPackErr] = useState<string | null>(null);
+  const [boardPackMd, setBoardPackMd] = useState<string | null>(null);
+  const [boardPackDto, setBoardPackDto] = useState<BoardReadyEvidencePackDto | null>(null);
+  const [boardPackKpiOff, setBoardPackKpiOff] = useState(false);
 
   const [kpiSnapshot, setKpiSnapshot] = useState<AdvisorKpiPortfolioSnapshot | null>(null);
   const [kpiLoading, setKpiLoading] = useState(false);
@@ -671,6 +678,63 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
     URL.revokeObjectURL(url);
   }, [partnerMd]);
 
+  const fetchBoardReadyEvidencePack = useCallback(async () => {
+    setBoardPackLoading(true);
+    setBoardPackErr(null);
+    try {
+      const q = new URLSearchParams();
+      const w = Math.min(365, Math.max(7, kpiWindowDays));
+      q.set("kpi_window_days", String(w));
+      if (boardPackKpiOff) q.set("kpi", "0");
+      const r = await fetch(`/api/internal/advisor/board-ready-evidence-pack?${q}`, { credentials: "include" });
+      if (r.status === 401) {
+        setBoardPackErr("Nicht angemeldet (Admin-Secret).");
+        setBoardPackMd(null);
+        setBoardPackDto(null);
+        return;
+      }
+      if (!r.ok) {
+        setBoardPackErr(`HTTP ${r.status}`);
+        setBoardPackMd(null);
+        setBoardPackDto(null);
+        return;
+      }
+      const data = (await r.json()) as {
+        ok?: boolean;
+        board_ready_evidence_pack?: BoardReadyEvidencePackDto;
+        markdown_de?: string;
+      };
+      setBoardPackDto(data.board_ready_evidence_pack ?? null);
+      setBoardPackMd(data.markdown_de ?? null);
+    } catch {
+      setBoardPackErr("Netzwerkfehler");
+      setBoardPackMd(null);
+      setBoardPackDto(null);
+    } finally {
+      setBoardPackLoading(false);
+    }
+  }, [boardPackKpiOff, kpiWindowDays]);
+
+  const copyBoardPackMd = useCallback(async () => {
+    if (!boardPackMd) return;
+    try {
+      await navigator.clipboard.writeText(boardPackMd);
+    } catch {
+      /* ignore */
+    }
+  }, [boardPackMd]);
+
+  const downloadBoardPackMd = useCallback(() => {
+    if (!boardPackMd) return;
+    const blob = new Blob([boardPackMd], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `board-ready-evidence-pack-${new Date().toISOString().slice(0, 10)}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [boardPackMd]);
+
   const patchReminderStatus = useCallback(
     async (reminderId: string, status: "done" | "dismissed") => {
       setReminderPatchBusyId(reminderId);
@@ -772,7 +836,7 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             <span className="inline-flex items-center rounded-md border border-slate-200 bg-slate-50 px-2 py-0.5 text-[11px] font-medium text-slate-600">
               Intern · Mandanten-Steering
             </span>
-            <span className="text-[11px] text-slate-400">Waves 39–49</span>
+            <span className="text-[11px] text-slate-400">Waves 39–51</span>
           </div>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-slate-900 sm:text-[1.65rem]">
             Kanzlei-Portfolio
@@ -780,7 +844,8 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
           <p className="mt-2 text-sm leading-relaxed text-slate-600">
             Operatives Cockpit für gemappte Mandanten: Readiness, Prüfpunkte, Export-Kadenz, Reviews,
             Attention-Queue, Playbook, Reports, Reminders, Kanzlei-KPIs, SLA, AI-Governance,
-            Cross-Regulation-Matrix und Enterprise Evidence Hooks (SAP/ERP-Metadaten, keine Live-Integration).
+            Cross-Regulation-Matrix, Enterprise Evidence Hooks und optional das Board-Ready Evidence Pack für
+            GF-/Board-nahe Kurzgespräche (Markdown, keine Rechtsberatung).
           </p>
           {payload ? (
             <p className="mt-3 text-xs tabular-nums text-slate-500">
@@ -818,6 +883,14 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
             ·{" "}
             <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
               /cross-regulation-matrix
+            </code>{" "}
+            ·{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /evidence-hooks
+            </code>{" "}
+            ·{" "}
+            <code className="rounded border border-slate-200 bg-slate-50 px-1.5 py-0.5 font-mono text-[10px] text-slate-700">
+              /board-ready-evidence-pack
             </code>
           </p>
         </div>
@@ -1628,6 +1701,65 @@ export function KanzleiPortfolioCockpitClient({ adminConfigured }: Props) {
           {partnerMd ? (
             <pre className="mt-3 max-h-[min(50vh,420px)] overflow-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-white p-3 font-mono text-[11px] leading-relaxed text-slate-800">
               {partnerMd}
+            </pre>
+          ) : null}
+        </section>
+      ) : null}
+
+      {payload ? (
+        <section className="rounded-xl border border-slate-300 bg-slate-50/80 p-4 shadow-sm ring-1 ring-slate-950/[0.04]">
+          <h2 className="text-sm font-semibold text-slate-900">Board-Ready Evidence Pack (Wave 51)</h2>
+          <p className="mt-1 text-[11px] text-slate-600">
+            Kompakte Markdown-Fassung für Geschäftsführung, Bereichsleitung oder board-nahe Gespräche – keine
+            Rechtsberatung, keine PDF-Engine. Bündelt Portfolio, Querschnittsmatrix, KI-Governance, SLA, Evidence
+            Hooks und optional Kanzlei-KPIs.{" "}
+            <code className="rounded bg-white px-1">GET /api/internal/advisor/board-ready-evidence-pack</code> ·{" "}
+            <code className="rounded bg-white px-1">kpi_window_days</code> ·{" "}
+            <code className="rounded bg-white px-1">kpi=0</code> ohne KPI-Stichprobe in Abschnitt A.
+          </p>
+          <div className="mt-3 flex flex-wrap items-end gap-3">
+            <label className="flex cursor-pointer items-center gap-2 text-xs text-slate-700">
+              <input
+                type="checkbox"
+                checked={boardPackKpiOff}
+                onChange={(e) => setBoardPackKpiOff(e.target.checked)}
+              />
+              KPI-Stichprobe in Pack ausblenden
+            </label>
+            <button
+              type="button"
+              disabled={boardPackLoading}
+              onClick={() => void fetchBoardReadyEvidencePack()}
+              className="rounded-lg bg-slate-800 px-3 py-1.5 text-sm text-white hover:bg-slate-900 disabled:opacity-50"
+            >
+              {boardPackLoading ? "Erzeuge…" : "Board-Ready Pack erstellen"}
+            </button>
+            <button
+              type="button"
+              disabled={!boardPackMd}
+              onClick={() => void copyBoardPackMd()}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Markdown kopieren
+            </button>
+            <button
+              type="button"
+              disabled={!boardPackMd}
+              onClick={() => downloadBoardPackMd()}
+              className="rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+            >
+              Als Markdown speichern
+            </button>
+          </div>
+          {boardPackErr ? <p className="mt-2 text-xs text-red-600">{boardPackErr}</p> : null}
+          {boardPackDto ? (
+            <p className="mt-2 font-mono text-[10px] text-slate-500">
+              Schema {boardPackDto.meta.version} · Signalquellen: {boardPackDto.meta.included_signals_de.length}
+            </p>
+          ) : null}
+          {boardPackMd ? (
+            <pre className="mt-3 max-h-[min(50vh,420px)] overflow-auto whitespace-pre-wrap rounded-lg border border-slate-200 bg-white p-3 font-mono text-[11px] leading-relaxed text-slate-800">
+              {boardPackMd}
             </pre>
           ) : null}
         </section>

--- a/frontend/src/lib/boardReadyEvidencePackBuild.test.ts
+++ b/frontend/src/lib/boardReadyEvidencePackBuild.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { stubAdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceBuild";
+import { buildAdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookBuild";
+import { buildCrossRegulationMatrixFromPayload } from "@/lib/advisorCrossRegulationBuild";
+import { buildBoardReadyEvidencePack } from "@/lib/boardReadyEvidencePackBuild";
+import { stubAdvisorSlaEvaluation } from "@/lib/advisorSlaEvaluate";
+import type { KanzleiPortfolioPayload, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
+import { KANZLEI_PORTFOLIO_VERSION } from "@/lib/kanzleiPortfolioTypes";
+
+function row(partial: Partial<KanzleiPortfolioRow>): KanzleiPortfolioRow {
+  return {
+    tenant_id: "t-1",
+    mandant_label: "Acme",
+    readiness_class: "baseline_governance",
+    readiness_label_de: "Baseline",
+    primary_segment_label_de: null,
+    open_points_count: 2,
+    open_points_hoch: 0,
+    top_gap_pillar_code: "DSGVO",
+    top_gap_pillar_label_de: "DSGVO",
+    pillar_traffic: {
+      eu_ai_act: "green",
+      iso_42001: "amber",
+      nis2: "green",
+      dsgvo: "green",
+    },
+    board_report_stale: false,
+    api_fetch_ok: true,
+    attention_score: 40,
+    attention_flags_de: [],
+    last_mandant_readiness_export_at: null,
+    last_datev_bundle_export_at: null,
+    last_any_export_at: null,
+    last_review_marked_at: null,
+    last_review_note_de: null,
+    review_stale: true,
+    any_export_stale: false,
+    never_any_export: false,
+    gaps_heavy_without_recent_export: false,
+    open_reminders_count: 0,
+    next_reminder_due_at: null,
+    links: {
+      mandant_export_page: "/x",
+      datev_bundle_api: "/y",
+      readiness_export_api: "/z",
+      board_readiness_admin: "/b",
+    },
+    ...partial,
+  };
+}
+
+function mkPayload(rows: KanzleiPortfolioRow[]): KanzleiPortfolioPayload {
+  return {
+    version: KANZLEI_PORTFOLIO_VERSION,
+    generated_at: "2026-04-10T10:00:00.000Z",
+    backend_reachable: true,
+    mapped_tenant_count: rows.length,
+    tenants_partial: 0,
+    constants: {
+      review_stale_days: 90,
+      any_export_max_age_days: 90,
+      many_open_points_threshold: 4,
+      gap_heavy_min_open_for_export_rule: 5,
+    },
+    rows,
+    attention_queue: rows.map((r) => ({
+      tenant_id: r.tenant_id,
+      mandant_label: r.mandant_label,
+      attention_score: r.attention_score,
+      warum_jetzt_de: ["Review offen"],
+      naechster_schritt_de: "Kanzlei-Review terminieren",
+      links: r.links,
+    })),
+    open_reminders: [],
+    reminders_due_today_or_overdue_count: 0,
+    reminders_due_this_week_open_count: 0,
+    advisor_sla: stubAdvisorSlaEvaluation("2026-04-10T10:00:00.000Z"),
+  };
+}
+
+describe("boardReadyEvidencePackBuild", () => {
+  it("builds pack with sections A–E and markdown", () => {
+    const p = mkPayload([row({ tenant_id: "a" })]);
+    const cr = buildCrossRegulationMatrixFromPayload(p);
+    const ag = stubAdvisorAiGovernancePortfolioDto(p.generated_at);
+    const eh = buildAdvisorEvidenceHooksPortfolioDto(p, [], {
+      generatedAt: new Date("2026-04-10T12:00:00.000Z"),
+    });
+    const dto = buildBoardReadyEvidencePack({
+      payload: p,
+      crossRegulation: cr,
+      aiGovernance: ag,
+      evidenceHooks: eh,
+      kpiSnapshot: null,
+      generatedAt: new Date("2026-04-10T12:00:00.000Z"),
+    });
+    expect(dto.meta.version).toBe("wave51-v1");
+    expect(dto.meta.included_signals_de.length).toBeGreaterThanOrEqual(5);
+    expect(dto.section_a_executive_snapshot.overall_posture_de).toContain("Mandanten");
+    expect(dto.section_b_cross_regulation.highlights).toHaveLength(4);
+    expect(dto.section_e_next_actions.actions_de.length).toBeGreaterThanOrEqual(3);
+    expect(dto.markdown_de).toContain("# Board-Ready Evidence Pack");
+    expect(dto.markdown_de).toContain("## A) Executive Readiness Snapshot");
+    expect(dto.markdown_de).toContain("## E) Empfohlene Management-Schritte");
+    expect(dto.markdown_de).toContain("Eingeschlossene Signalquellen");
+  });
+});

--- a/frontend/src/lib/boardReadyEvidencePackBuild.ts
+++ b/frontend/src/lib/boardReadyEvidencePackBuild.ts
@@ -1,0 +1,320 @@
+/**
+ * Wave 51 – Board-Ready Evidence Pack aus bestehenden Advisor-DTOs (deterministisch, erklärbar).
+ */
+
+import type { AdvisorAiGovernancePortfolioDto } from "@/lib/advisorAiGovernanceTypes";
+import type { AdvisorEvidenceHooksPortfolioDto } from "@/lib/advisorEvidenceHookTypes";
+import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
+import type { AdvisorSlaFindingDto, AdvisorSlaSeverity } from "@/lib/advisorSlaTypes";
+import {
+  CROSS_REGULATION_PILLAR_LABEL_DE,
+  CROSS_REGULATION_PILLAR_ORDER,
+  type CrossRegulationMatrixDto,
+} from "@/lib/advisorCrossRegulationTypes";
+import {
+  BOARD_READY_EVIDENCE_PACK_VERSION,
+  type BoardReadyEvidencePackDto,
+  type BoardReadyEvidencePackMeta,
+} from "@/lib/boardReadyEvidencePackTypes";
+import { GTM_READINESS_CLASSES, GTM_READINESS_LABELS_DE, type GtmReadinessClass } from "@/lib/gtmAccountReadiness";
+import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+import {
+  buildKanzleiPortfolioFocusAreasDe,
+  summarizeKanzleiMonthlyReportSection1,
+} from "@/lib/kanzleiMonthlyReportBuild";
+
+const DISCLAIMER_DE =
+  "Internes Arbeitspapier für Geschäftsführung, Bereichsleitung oder board-nahe Gespräche. " +
+  "Keine Rechtsberatung, keine Garantie der Vollständigkeit; Faktenlage pro Mandant kann abweichen. " +
+  "Signale stammen aus ComplianceHub-Steuerungsdaten (Ampeln, KPIs, Heuristiken) – keine substanzielle Prüfung einzelner Systeme.";
+
+function severityOrder(s: AdvisorSlaSeverity): number {
+  if (s === "critical") return 0;
+  if (s === "warning") return 1;
+  return 2;
+}
+
+function sortedFindings(findings: AdvisorSlaFindingDto[]): AdvisorSlaFindingDto[] {
+  return [...findings].sort((a, b) => {
+    const d = severityOrder(a.severity) - severityOrder(b.severity);
+    if (d !== 0) return d;
+    return a.title_de.localeCompare(b.title_de, "de");
+  });
+}
+
+function dominantReadinessClass(dist: Record<GtmReadinessClass, number>): GtmReadinessClass | null {
+  let best: GtmReadinessClass | null = null;
+  let max = 0;
+  for (const c of GTM_READINESS_CLASSES) {
+    const n = dist[c];
+    if (n > max) {
+      max = n;
+      best = c;
+    }
+  }
+  return max > 0 ? best : null;
+}
+
+function buildSectionA(
+  payload: KanzleiPortfolioPayload,
+  kpiSnapshot: AdvisorKpiPortfolioSnapshot | null,
+): BoardReadyEvidencePackDto["section_a_executive_snapshot"] {
+  const s1 = summarizeKanzleiMonthlyReportSection1(payload);
+  const dom = dominantReadinessClass(s1.readiness_distribution);
+  const domLabel = dom ? GTM_READINESS_LABELS_DE[dom] : "heterogen";
+  const backend = s1.backend_reachable ? "vollständig erreichbar" : "teilweise eingeschränkt";
+  let overall_posture_de = `Portfolio: **${s1.total_mandanten}** gemappte Mandanten; dominante Readiness-Einordnung: **${domLabel}**. ` +
+    `Backend/API: ${backend}. Attention-Queue: **${s1.count_queue}** Mandant(en) mit erhöhter Steuerungspriorität. ` +
+    `Offene Prüfpunkte gesamt: **${s1.total_open_points}** (davon hoch: **${s1.total_open_points_hoch}**).`;
+  if (kpiSnapshot?.strip?.length) {
+    const bits = kpiSnapshot.strip
+      .slice(0, 2)
+      .map((t) => `${t.label_de} ${t.value_display_de}`)
+      .join("; ");
+    overall_posture_de += ` Kanzlei-KPI-Stichprobe (${kpiSnapshot.window_days} Tage): ${bits}.`;
+  }
+
+  const top_risks_de: string[] = [];
+  const sf = sortedFindings(payload.advisor_sla.findings);
+  for (const f of sf.slice(0, 5)) {
+    top_risks_de.push(`${f.title_de}: ${f.detail_de}`);
+  }
+  if (top_risks_de.length === 0) {
+    for (const sig of payload.advisor_sla.signals) {
+      if (sig.active) top_risks_de.push(`${sig.label_de}: ${sig.detail_de}`);
+    }
+  }
+  if (top_risks_de.length === 0) {
+    top_risks_de.push(
+      "Keine aktiven SLA-Befunde im aktuellen Lauf – Kadenz und Queue dennoch im Blick behalten.",
+    );
+  }
+
+  const major_open_items_de: string[] = [];
+  if (s1.count_review_stale > 0) {
+    major_open_items_de.push(`${s1.count_review_stale} Mandant(en): Kanzlei-Review überfällig oder offen.`);
+  }
+  if (s1.count_export_stale > 0 || s1.count_never_export > 0) {
+    major_open_items_de.push(
+      `Exportlage: ${s1.count_export_stale} mit überschrittener Kadenz, ${s1.count_never_export} ohne erfassten Export.`,
+    );
+  }
+  if (s1.count_board_report_stale > 0) {
+    major_open_items_de.push(`${s1.count_board_report_stale} Mandant(en): Board-/Statusbericht überfällig.`);
+  }
+  for (const q of payload.attention_queue.slice(0, 3)) {
+    const name = q.mandant_label ?? q.tenant_id;
+    major_open_items_de.push(`${name}: ${q.naechster_schritt_de}`);
+  }
+  if (major_open_items_de.length === 0) {
+    major_open_items_de.push("Keine aggregierten Kadenz- oder Queue-Hervorhebungen über die Basisschwellen hinaus.");
+  }
+
+  return {
+    overall_posture_de,
+    top_risks_de: top_risks_de.slice(0, 6),
+    major_open_items_de: major_open_items_de.slice(0, 6),
+  };
+}
+
+function buildSectionB(cr: CrossRegulationMatrixDto): BoardReadyEvidencePackDto["section_b_cross_regulation"] {
+  const highlights = CROSS_REGULATION_PILLAR_ORDER.map((pk) => {
+    const c = cr.totals.per_pillar[pk];
+    const lab = CROSS_REGULATION_PILLAR_LABEL_DE[pk];
+    const summary_de = `Priorität: **${c.priority}**, Nacharbeit: **${c.needs_attention}**, OK: **${c.ok}**, Datenlage unklar: **${c.unknown}**.`;
+    return { pillar_label_de: lab, summary_de };
+  });
+  const multi =
+    cr.totals.mandanten_multi_pillar_stress > 0
+      ? `${cr.totals.mandanten_multi_pillar_stress} Mandant(en) mit Druck auf mindestens zwei Säulen gleichzeitig – geeignet für Querschnittsgespräche („map once, comply many“).`
+      : null;
+  return { highlights, multi_stress_note_de: multi };
+}
+
+function buildSectionC(ag: AdvisorAiGovernancePortfolioDto): BoardReadyEvidencePackDto["section_c_ai_governance"] {
+  const s = ag.summary;
+  const ai_act_relevance_note_de = `Heuristisch **${s.count_likely_ai_act_relevance}** Mandant(en) mit Hinweis auf mögliche AI-Act-/Register-Relevanz; **${s.count_potential_high_risk_exposure}** mit High-Risk-Indikator im Dashboard (keine Rechtsklassifikation).`;
+
+  const governance_gaps_de: string[] = [];
+  if (s.count_weak_iso42001 > 0) {
+    governance_gaps_de.push(
+      `ISO 42001: Bei **${s.count_weak_iso42001}** Mandant(en) Ampel schwach oder mittel – AIMs-Artefakte und Rollen klären.`,
+    );
+  }
+  if (s.count_weak_post_market > 0) {
+    governance_gaps_de.push(
+      `Überwachung/Reporting (Post-Market-Kontext): **${s.count_weak_post_market}** Mandant(en) mit Lückenhinweis bei High-Risk-Kontext.`,
+    );
+  }
+  if (s.count_weak_human_oversight > 0) {
+    governance_gaps_de.push(
+      `Human Oversight: **${s.count_weak_human_oversight}** Mandant(en) mit Prüfbedarf (Owner/Verantwortung).`,
+    );
+  }
+  if (governance_gaps_de.length === 0) {
+    governance_gaps_de.push("Keine aggregierten KI-Governance-Lücken über die Standard-Schwellen hinaus gemeldet.");
+  }
+
+  const oversight_monitoring_de =
+    "Monitoring und Nachweise bleiben mandantenindividuell zu belegen; dieses Pack spiegelt nur Dashboard- und Ampelstände wider.";
+
+  return {
+    ai_act_relevance_note_de,
+    governance_gaps_de: governance_gaps_de.slice(0, 5),
+    oversight_monitoring_de,
+  };
+}
+
+function buildSectionD(eh: AdvisorEvidenceHooksPortfolioDto): BoardReadyEvidencePackDto["section_d_evidence_touchpoints"] {
+  const s = eh.summary;
+  const executive_summary_de = `Evidenz-Reife (Metadaten): **${s.total_hook_rows}** Hook-Zeilen im Überblick. ` +
+    `**${s.mandanten_without_sap_touchpoint}** Mandant(en) ohne SAP/BTP-Touchpoint (verbunden oder geplant); **${s.mandanten_without_datev_export}** ohne DATEV-Export in der Historie.`;
+
+  const datev_erp_note_de =
+    "DATEV stützt den Kanzlei-Kanal (Belege/Steuerkontext); SAP/ERP-Hooks markieren typische Enterprise-Lücken – keine Live-Integration, keine technische Tiefe in diesem Dokument.";
+
+  const status_overview_de = `Status der Hooks: verbunden **${s.by_status.connected}**, geplant **${s.by_status.planned}**, nicht verbunden **${s.by_status.not_connected}**, Fehler **${s.by_status.error}**. Upsell-Kandidaten (Governance + Drucksignale): **${s.mandanten_enterprise_upsell_candidates}**.`;
+
+  return {
+    executive_summary_de,
+    datev_erp_note_de,
+    status_overview_de,
+  };
+}
+
+function buildSectionE(payload: KanzleiPortfolioPayload): BoardReadyEvidencePackDto["section_e_next_actions"] {
+  const s1 = summarizeKanzleiMonthlyReportSection1(payload);
+  const fromSla = payload.advisor_sla.next_steps_de;
+  const fromFocus = buildKanzleiPortfolioFocusAreasDe(payload, s1);
+  const pool = [...fromSla, ...fromFocus];
+  const seen = new Set<string>();
+  const actions_de: string[] = [];
+  for (const line of pool) {
+    const k = line.trim();
+    if (!k || seen.has(k)) continue;
+    seen.add(k);
+    actions_de.push(k);
+    if (actions_de.length >= 5) break;
+  }
+  if (actions_de.length < 3) {
+    actions_de.push("Termin mit Geschäftsführung/Bereichsleitung: Top-3-Mandanten aus Attention-Queue gemeinsam priorisieren.");
+  }
+  return { actions_de: actions_de.slice(0, 5) };
+}
+
+function buildMeta(
+  payload: KanzleiPortfolioPayload,
+  kpiSnapshot: AdvisorKpiPortfolioSnapshot | null,
+  generatedAt: Date,
+): BoardReadyEvidencePackMeta {
+  const included_signals_de = [
+    "Kanzlei-Portfolio & Board-Readiness-Zeilen",
+    "Cross-Regulation-Matrix (EU AI Act, ISO 42001, NIS2, DSGVO)",
+    "AI-Governance-Überblick (Heuristik)",
+    "SLA- und Eskalationssignale",
+    "Enterprise Evidence Hooks (Metadaten)",
+  ];
+  if (kpiSnapshot) {
+    included_signals_de.push(`Kanzlei-KPI-Snapshot (${kpiSnapshot.window_days} Tage)`);
+  }
+  return {
+    version: BOARD_READY_EVIDENCE_PACK_VERSION,
+    generated_at: generatedAt.toISOString(),
+    portfolio_version: payload.version,
+    portfolio_generated_at: payload.generated_at,
+    included_signals_de,
+    disclaimer_de: DISCLAIMER_DE,
+  };
+}
+
+function buildMarkdown(dto: BoardReadyEvidencePackDto): string {
+  const m = dto.meta;
+  const a = dto.section_a_executive_snapshot;
+  const b = dto.section_b_cross_regulation;
+  const c = dto.section_c_ai_governance;
+  const d = dto.section_d_evidence_touchpoints;
+  const e = dto.section_e_next_actions;
+  const lines: string[] = [];
+
+  lines.push("# Board-Ready Evidence Pack");
+  lines.push("");
+  lines.push(`_Erzeugt: ${new Date(m.generated_at).toLocaleString("de-DE")} · Portfolio ${m.portfolio_version} · Schema ${m.version}_`);
+  lines.push("");
+  lines.push(`_${m.disclaimer_de}_`);
+  lines.push("");
+  lines.push("## A) Executive Readiness Snapshot");
+  lines.push("");
+  lines.push("### Gesamtlage");
+  lines.push(a.overall_posture_de);
+  lines.push("");
+  lines.push("### Top-Risiken (operativ)");
+  for (const x of a.top_risks_de) lines.push(`- ${x}`);
+  lines.push("");
+  lines.push("### Wesentliche offene Punkte");
+  for (const x of a.major_open_items_de) lines.push(`- ${x}`);
+  lines.push("");
+  lines.push("## B) Cross-Regulation (Kurz)");
+  lines.push("");
+  for (const h of b.highlights) {
+    lines.push(`- **${h.pillar_label_de}:** ${h.summary_de}`);
+  }
+  if (b.multi_stress_note_de) {
+    lines.push("");
+    lines.push(b.multi_stress_note_de);
+  }
+  lines.push("");
+  lines.push("## C) AI-Governance (Kurz)");
+  lines.push("");
+  lines.push(c.ai_act_relevance_note_de);
+  lines.push("");
+  lines.push("### Governance-Lücken (aggregiert)");
+  for (const x of c.governance_gaps_de) lines.push(`- ${x}`);
+  lines.push("");
+  lines.push("### Oversight / Monitoring");
+  lines.push(c.oversight_monitoring_de);
+  lines.push("");
+  lines.push("## D) Evidence Touchpoints");
+  lines.push("");
+  lines.push(d.executive_summary_de);
+  lines.push("");
+  lines.push(d.datev_erp_note_de);
+  lines.push("");
+  lines.push(d.status_overview_de);
+  lines.push("");
+  lines.push("## E) Empfohlene Management-Schritte");
+  lines.push("");
+  e.actions_de.forEach((x, i) => lines.push(`${i + 1}. ${x}`));
+  lines.push("");
+  lines.push("---");
+  lines.push("");
+  lines.push("### Eingeschlossene Signalquellen");
+  for (const s of m.included_signals_de) lines.push(`- ${s}`);
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+export type BuildBoardReadyEvidencePackInput = {
+  payload: KanzleiPortfolioPayload;
+  crossRegulation: CrossRegulationMatrixDto;
+  aiGovernance: AdvisorAiGovernancePortfolioDto;
+  evidenceHooks: AdvisorEvidenceHooksPortfolioDto;
+  kpiSnapshot: AdvisorKpiPortfolioSnapshot | null;
+  generatedAt?: Date;
+};
+
+export function buildBoardReadyEvidencePack(input: BuildBoardReadyEvidencePackInput): BoardReadyEvidencePackDto {
+  const generatedAt = input.generatedAt ?? new Date();
+  const meta = buildMeta(input.payload, input.kpiSnapshot, generatedAt);
+  const dto: BoardReadyEvidencePackDto = {
+    meta,
+    section_a_executive_snapshot: buildSectionA(input.payload, input.kpiSnapshot),
+    section_b_cross_regulation: buildSectionB(input.crossRegulation),
+    section_c_ai_governance: buildSectionC(input.aiGovernance),
+    section_d_evidence_touchpoints: buildSectionD(input.evidenceHooks),
+    section_e_next_actions: buildSectionE(input.payload),
+    markdown_de: "",
+  };
+  dto.markdown_de = buildMarkdown(dto);
+  return dto;
+}

--- a/frontend/src/lib/boardReadyEvidencePackTypes.ts
+++ b/frontend/src/lib/boardReadyEvidencePackTypes.ts
@@ -1,0 +1,57 @@
+/**
+ * Wave 51 – Board-Ready Evidence Pack (Geschäftsführungs-/Board-nahe Kurzfassung, Markdown-first).
+ */
+
+export const BOARD_READY_EVIDENCE_PACK_VERSION = "wave51-v1";
+
+export type BoardReadyEvidencePackMeta = {
+  version: typeof BOARD_READY_EVIDENCE_PACK_VERSION;
+  generated_at: string;
+  portfolio_version: string;
+  portfolio_generated_at: string;
+  /** Welche Signalquellen eingeflossen sind (Nachvollziehbarkeit). */
+  included_signals_de: string[];
+  disclaimer_de: string;
+};
+
+export type BoardReadyEvidencePackSectionA = {
+  overall_posture_de: string;
+  top_risks_de: string[];
+  major_open_items_de: string[];
+};
+
+export type BoardReadyCrossRegHighlight = {
+  pillar_label_de: string;
+  summary_de: string;
+};
+
+export type BoardReadyEvidencePackSectionB = {
+  highlights: BoardReadyCrossRegHighlight[];
+  multi_stress_note_de: string | null;
+};
+
+export type BoardReadyEvidencePackSectionC = {
+  ai_act_relevance_note_de: string;
+  governance_gaps_de: string[];
+  oversight_monitoring_de: string;
+};
+
+export type BoardReadyEvidencePackSectionD = {
+  executive_summary_de: string;
+  datev_erp_note_de: string;
+  status_overview_de: string;
+};
+
+export type BoardReadyEvidencePackSectionE = {
+  actions_de: string[];
+};
+
+export type BoardReadyEvidencePackDto = {
+  meta: BoardReadyEvidencePackMeta;
+  section_a_executive_snapshot: BoardReadyEvidencePackSectionA;
+  section_b_cross_regulation: BoardReadyEvidencePackSectionB;
+  section_c_ai_governance: BoardReadyEvidencePackSectionC;
+  section_d_evidence_touchpoints: BoardReadyEvidencePackSectionD;
+  section_e_next_actions: BoardReadyEvidencePackSectionE;
+  markdown_de: string;
+};


### PR DESCRIPTION
- Add buildBoardReadyEvidencePack from portfolio, cross-regulation, AI governance, evidence hooks, optional KPI
- GET /api/internal/advisor/board-ready-evidence-pack with markdown_de
- Cockpit: create pack, preview, copy/download markdown; doc cross-links

Made-with: Cursor