### PR TITLE
feat: add Wave 56 connector candidate scoring layer

### DIFF
--- a/app/enterprise_connector_candidate_models.py
+++ b/app/enterprise_connector_candidate_models.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from app.enterprise_integration_blueprint_models import SourceSystemType
+
+
+class ConnectorCandidatePriority(StrEnum):
+    high = "high"
+    medium = "medium"
+    low = "low"
+    not_now = "not_now"
+
+
+class ImplementationComplexityBand(StrEnum):
+    low = "low"
+    medium = "medium"
+    high = "high"
+
+
+class EnterpriseConnectorCandidateRow(BaseModel):
+    tenant_id: str
+    connector_type: SourceSystemType
+    readiness_score: int = Field(ge=0, le=100)
+    blocker_score: int = Field(ge=0, le=100)
+    strategic_value_score: int = Field(ge=0, le=100)
+    compliance_impact_score: int = Field(ge=0, le=100)
+    estimated_implementation_complexity: int = Field(ge=0, le=100)
+    complexity_band: ImplementationComplexityBand
+    recommended_priority: ConnectorCandidatePriority
+    rationale_summary_de: str
+    rationale_factors_de: list[str] = Field(default_factory=list)
+    score_total: int = Field(ge=0, le=100)
+
+
+class ConnectorScoringWeights(BaseModel):
+    readiness_weight: int = 35
+    blocker_weight: int = 20
+    strategic_value_weight: int = 25
+    compliance_impact_weight: int = 20
+
+
+class EnterpriseConnectorCandidatesResponse(BaseModel):
+    tenant_id: str
+    generated_at_utc: datetime
+    scoring_weights: ConnectorScoringWeights
+    candidate_rows: list[EnterpriseConnectorCandidateRow]
+    top_priorities: list[EnterpriseConnectorCandidateRow]
+    grouped_priorities_by_connector_type: dict[str, list[EnterpriseConnectorCandidateRow]]
+    markdown_de: str | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -180,6 +180,7 @@ from app.demo_tenant_guard import (
     tenant_mutation_blocked_meta,
     workspace_mode_for_telemetry,
 )
+from app.enterprise_connector_candidate_models import EnterpriseConnectorCandidatesResponse
 from app.enterprise_control_center_models import EnterpriseControlCenterResponse
 from app.enterprise_integration_blueprint_models import (
     EnterpriseIntegrationBlueprintResponse,
@@ -396,6 +397,9 @@ from app.services.cross_regulation_llm_gap_assistant import (
 from app.services.cross_regulation_seed import ensure_cross_regulation_catalog_seeded
 from app.services.demo_governance_maturity_seed import seed_demo_governance_maturity_layer
 from app.services.demo_tenant_seeder import seed_demo_tenant
+from app.services.enterprise_connector_candidate_scoring import (
+    build_connector_candidates_response,
+)
 from app.services.enterprise_control_center import build_enterprise_control_center
 from app.services.enterprise_integration_blueprint import (
     build_enterprise_integration_blueprint_response,
@@ -5427,6 +5431,52 @@ def get_enterprise_integration_blueprints(
         tenant_id=auth.tenant_id,
         blueprint_rows=blueprint_repo.list_for_tenant(auth.tenant_id),
         onboarding=onboarding,
+        include_markdown=include_markdown,
+    )
+
+
+@app.get(
+    "/api/internal/enterprise/connector-candidates",
+    response_model=EnterpriseConnectorCandidatesResponse,
+    tags=["internal", "enterprise"],
+)
+def get_enterprise_connector_candidates(
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    _: Annotated[EnterpriseRole, Depends(require_permission(Permission.VIEW_DASHBOARD))],
+    session: Annotated[Session, Depends(get_session)],
+    onboarding_repo: Annotated[
+        EnterpriseOnboardingRepository,
+        Depends(get_enterprise_onboarding_repository),
+    ],
+    blueprint_repo: Annotated[
+        EnterpriseIntegrationBlueprintRepository,
+        Depends(get_enterprise_integration_blueprint_repository),
+    ],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+    incident_repo: Annotated[NIS2IncidentRepository, Depends(get_nis2_incident_repository)],
+    deadline_repo: Annotated[
+        ComplianceDeadlineRepository,
+        Depends(get_compliance_deadline_repository),
+    ],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    include_markdown: bool = Query(False),
+) -> EnterpriseConnectorCandidatesResponse:
+    onboarding = onboarding_repo.get(auth.tenant_id)
+    blueprints = build_enterprise_integration_blueprint_response(
+        tenant_id=auth.tenant_id,
+        blueprint_rows=blueprint_repo.list_for_tenant(auth.tenant_id),
+        onboarding=onboarding,
+        include_markdown=False,
+    ).blueprint_rows
+    return build_connector_candidates_response(
+        tenant_id=auth.tenant_id,
+        session=session,
+        onboarding=onboarding,
+        blueprints=blueprints,
+        audit_repo=audit_repo,
+        incident_repo=incident_repo,
+        deadline_repo=deadline_repo,
+        ai_repo=ai_repo,
         include_markdown=include_markdown,
     )
 

--- a/app/services/enterprise_connector_candidate_scoring.py
+++ b/app/services/enterprise_connector_candidate_scoring.py
@@ -1,0 +1,294 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy.orm import Session
+
+from app.enterprise_connector_candidate_models import (
+    ConnectorCandidatePriority,
+    ConnectorScoringWeights,
+    EnterpriseConnectorCandidateRow,
+    EnterpriseConnectorCandidatesResponse,
+    ImplementationComplexityBand,
+)
+from app.enterprise_integration_blueprint_models import (
+    EnterpriseIntegrationBlueprintRow,
+    EvidenceDomain,
+    IntegrationBlueprintStatus,
+    SourceSystemType,
+)
+from app.enterprise_onboarding_models import (
+    EnterpriseOnboardingReadinessResponse,
+    IntegrationReadinessStatus,
+    ReadinessStatus,
+)
+from app.repositories.ai_systems import AISystemRepository
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.compliance_deadlines import ComplianceDeadlineRepository
+from app.repositories.nis2_incidents import NIS2IncidentRepository
+from app.services.enterprise_control_center import build_enterprise_control_center
+
+SCORING_WEIGHTS = ConnectorScoringWeights()
+
+_STRATEGIC_BASE: dict[SourceSystemType, int] = {
+    SourceSystemType.sap_s4hana: 85,
+    SourceSystemType.sap_btp: 80,
+    SourceSystemType.datev: 72,
+    SourceSystemType.ms_dynamics: 68,
+    SourceSystemType.generic_api: 55,
+}
+
+_COMPLEXITY_BASE: dict[SourceSystemType, int] = {
+    SourceSystemType.sap_s4hana: 76,
+    SourceSystemType.sap_btp: 71,
+    SourceSystemType.datev: 45,
+    SourceSystemType.ms_dynamics: 60,
+    SourceSystemType.generic_api: 42,
+}
+
+_COMPLIANCE_DOMAIN_SCORE: dict[EvidenceDomain, int] = {
+    EvidenceDomain.invoice: 14,
+    EvidenceDomain.approval: 14,
+    EvidenceDomain.access: 18,
+    EvidenceDomain.vendor: 10,
+    EvidenceDomain.ai_inventory: 14,
+    EvidenceDomain.policy_artifact: 10,
+    EvidenceDomain.workflow_evidence: 12,
+    EvidenceDomain.tax_export_context: 12,
+}
+
+
+def build_connector_candidates_response(
+    *,
+    tenant_id: str,
+    session: Session,
+    onboarding: EnterpriseOnboardingReadinessResponse | None,
+    blueprints: list[EnterpriseIntegrationBlueprintRow],
+    audit_repo: AuditLogRepository,
+    incident_repo: NIS2IncidentRepository,
+    deadline_repo: ComplianceDeadlineRepository,
+    ai_repo: AISystemRepository,
+    include_markdown: bool,
+) -> EnterpriseConnectorCandidatesResponse:
+    now = datetime.now(UTC)
+    cc = build_enterprise_control_center(
+        tenant_id=tenant_id,
+        session=session,
+        audit_repo=audit_repo,
+        incident_repo=incident_repo,
+        deadline_repo=deadline_repo,
+        ai_repo=ai_repo,
+        include_markdown=False,
+    )
+    rows = [
+        _score_row(
+            tenant_id=tenant_id,
+            blueprint=bp,
+            onboarding=onboarding,
+            cc_open=cc.summary_counts.total_open,
+        )
+        for bp in blueprints
+    ]
+    rows_sorted = sorted(rows, key=lambda r: r.score_total, reverse=True)
+    grouped = {row.connector_type.value: [row] for row in rows_sorted}
+    markdown = _build_markdown(tenant_id, rows_sorted) if include_markdown else None
+    return EnterpriseConnectorCandidatesResponse(
+        tenant_id=tenant_id,
+        generated_at_utc=now,
+        scoring_weights=SCORING_WEIGHTS,
+        candidate_rows=rows_sorted,
+        top_priorities=[r for r in rows_sorted if r.recommended_priority in {"high", "medium"}][:5],
+        grouped_priorities_by_connector_type=grouped,
+        markdown_de=markdown,
+    )
+
+
+def _score_row(
+    *,
+    tenant_id: str,
+    blueprint: EnterpriseIntegrationBlueprintRow,
+    onboarding: EnterpriseOnboardingReadinessResponse | None,
+    cc_open: int,
+) -> EnterpriseConnectorCandidateRow:
+    readiness = _readiness_score(blueprint, onboarding)
+    blocker = _blocker_score(blueprint, onboarding)
+    strategic = _strategic_value_score(blueprint, onboarding)
+    compliance = _compliance_impact_score(blueprint, cc_open)
+    complexity = _complexity_score(blueprint)
+
+    weighted = (
+        readiness * SCORING_WEIGHTS.readiness_weight
+        + (100 - blocker) * SCORING_WEIGHTS.blocker_weight
+        + strategic * SCORING_WEIGHTS.strategic_value_weight
+        + compliance * SCORING_WEIGHTS.compliance_impact_weight
+    ) / 100
+    score_total = int(max(0, min(100, round(weighted))))
+
+    if score_total >= 78 and blocker <= 35:
+        priority = ConnectorCandidatePriority.high
+    elif score_total >= 60 and blocker <= 55:
+        priority = ConnectorCandidatePriority.medium
+    elif score_total >= 45:
+        priority = ConnectorCandidatePriority.low
+    else:
+        priority = ConnectorCandidatePriority.not_now
+
+    if complexity >= 70:
+        complexity_band = ImplementationComplexityBand.high
+    elif complexity >= 45:
+        complexity_band = ImplementationComplexityBand.medium
+    else:
+        complexity_band = ImplementationComplexityBand.low
+
+    rationale_factors = [
+        f"Readiness {readiness}/100",
+        f"Blocker-Belastung {blocker}/100",
+        f"Strategischer Wert {strategic}/100 ({blueprint.source_system_type.value})",
+        f"Compliance-Impact {compliance}/100",
+        f"Komplexität {complexity}/100 ({complexity_band.value})",
+    ]
+    rationale_summary = (
+        f"{blueprint.source_system_type.value} ist als {priority.value} priorisiert "
+        f"(Gesamtscore {score_total}/100)."
+    )
+    return EnterpriseConnectorCandidateRow(
+        tenant_id=tenant_id,
+        connector_type=blueprint.source_system_type,
+        readiness_score=readiness,
+        blocker_score=blocker,
+        strategic_value_score=strategic,
+        compliance_impact_score=compliance,
+        estimated_implementation_complexity=complexity,
+        complexity_band=complexity_band,
+        recommended_priority=priority,
+        rationale_summary_de=rationale_summary,
+        rationale_factors_de=rationale_factors,
+        score_total=score_total,
+    )
+
+
+def _readiness_score(
+    blueprint: EnterpriseIntegrationBlueprintRow,
+    onboarding: EnterpriseOnboardingReadinessResponse | None,
+) -> int:
+    score = 35
+    if blueprint.integration_status == IntegrationBlueprintStatus.ready_for_build:
+        score += 35
+    elif blueprint.integration_status == IntegrationBlueprintStatus.designing:
+        score += 20
+    elif blueprint.integration_status == IntegrationBlueprintStatus.blocked:
+        score -= 15
+
+    if blueprint.data_owner:
+        score += 10
+    if blueprint.technical_owner:
+        score += 10
+    if blueprint.security_prerequisites:
+        score += 10
+
+    if onboarding is not None:
+        sso = onboarding.sso_readiness
+        if sso.onboarding_status == ReadinessStatus.validated:
+            score += 10
+        elif sso.onboarding_status in {ReadinessStatus.not_started, ReadinessStatus.planned}:
+            score -= 8
+        if sso.role_mapping_status == ReadinessStatus.validated:
+            score += 8
+        for item in onboarding.integration_readiness:
+            if item.target_type.value != blueprint.source_system_type.value:
+                continue
+            if item.readiness_status == IntegrationReadinessStatus.ready_for_implementation:
+                score += 10
+            elif item.readiness_status == IntegrationReadinessStatus.mapped:
+                score += 6
+            elif item.readiness_status == IntegrationReadinessStatus.discovery:
+                score += 2
+            if item.owner:
+                score += 4
+            if item.blocker:
+                score -= 8
+    return max(0, min(100, score))
+
+
+def _blocker_score(
+    blueprint: EnterpriseIntegrationBlueprintRow,
+    onboarding: EnterpriseOnboardingReadinessResponse | None,
+) -> int:
+    score = min(100, len(blueprint.blockers) * 20)
+    if not blueprint.data_owner or not blueprint.technical_owner:
+        score += 15
+    if not blueprint.security_prerequisites:
+        score += 15
+    if onboarding is not None:
+        score += min(35, len(onboarding.blockers) * 6)
+    return max(0, min(100, score))
+
+
+def _strategic_value_score(
+    blueprint: EnterpriseIntegrationBlueprintRow,
+    onboarding: EnterpriseOnboardingReadinessResponse | None,
+) -> int:
+    score = _STRATEGIC_BASE[blueprint.source_system_type]
+    score += min(10, len(blueprint.evidence_domains) * 2)
+    if blueprint.source_system_type in {SourceSystemType.sap_s4hana, SourceSystemType.sap_btp}:
+        score += 5
+    if onboarding is not None:
+        sap_targets = {
+            item.target_type.value
+            for item in onboarding.integration_readiness
+            if item.target_type.value
+            in {SourceSystemType.sap_s4hana.value, SourceSystemType.sap_btp.value}
+        }
+        if sap_targets and blueprint.source_system_type.value in sap_targets:
+            score += 8
+    return max(0, min(100, score))
+
+
+def _compliance_impact_score(
+    blueprint: EnterpriseIntegrationBlueprintRow,
+    cc_open: int,
+) -> int:
+    score = 20
+    score += sum(_COMPLIANCE_DOMAIN_SCORE.get(d, 0) for d in blueprint.evidence_domains[:6])
+    if cc_open >= 10:
+        score += 10
+    elif cc_open >= 5:
+        score += 6
+    return max(0, min(100, score))
+
+
+def _complexity_score(blueprint: EnterpriseIntegrationBlueprintRow) -> int:
+    score = _COMPLEXITY_BASE[blueprint.source_system_type]
+    score += min(12, len(blueprint.evidence_domains) * 2)
+    if blueprint.integration_status == IntegrationBlueprintStatus.ready_for_build:
+        score -= 8
+    if blueprint.integration_status == IntegrationBlueprintStatus.blocked:
+        score += 8
+    return max(0, min(100, score))
+
+
+def _build_markdown(tenant_id: str, rows: list[EnterpriseConnectorCandidateRow]) -> str:
+    lines = [
+        "# Connector Candidates (Wave 56)",
+        "",
+        f"- Mandant: {tenant_id}",
+        "- Hinweis: Explainable Rule-Based Scoring (kein ML-Lead-Scoring).",
+        "",
+        "## Top-Prioritäten",
+    ]
+    for row in rows[:5]:
+        lines.append(
+            f"- {row.connector_type.value}: {row.recommended_priority.value} "
+            f"({row.score_total}/100) - {row.rationale_summary_de}"
+        )
+    lines.extend(["", "## Empfohlener Erst-Connector"])
+    if rows:
+        top = rows[0]
+        lines.append(
+            f"- {top.connector_type.value} ({top.recommended_priority.value}) "
+            f"mit Score {top.score_total}/100."
+        )
+        lines.append(f"- Haupt-Blocker-Score: {top.blocker_score}/100.")
+    else:
+        lines.append("- Keine Connector-Kandidaten vorhanden.")
+    return "\n".join(lines).strip() + "\n"

--- a/app/services/enterprise_integration_blueprint.py
+++ b/app/services/enterprise_integration_blueprint.py
@@ -212,6 +212,7 @@ def _build_markdown(
             ),
             "- Evidence-Domain-Mapping mit Fachbereich und Revision validieren.",
             "- Build-Wave fuer priorisierten Connector planen (BTP/API, Testtenant, Audit-Trace).",
+            "- Wave-56 Connector-Candidate-Scoring fuer Prioritaetsabgleich heranziehen.",
         ]
     )
     return "\n".join(lines).strip() + "\n"

--- a/docs/enterprise/wave56-connector-candidate-scoring.md
+++ b/docs/enterprise/wave56-connector-candidate-scoring.md
@@ -1,0 +1,85 @@
+# Wave 56 - Connector Candidate Scoring
+
+## Ziel
+
+Wave 56 ergänzt den SAP/ERP-Blueprint um eine **erklärbare Priorisierungslogik** für
+Connector-Kandidaten je Mandant:
+
+- Welche Connector-Typen sind kurzfristig umsetzbar?
+- Wo ist strategischer und Compliance-seitiger Nutzen am höchsten?
+- Wo sind Blocker aktuell zu hoch (`not_now`)?
+
+Kein ML-Scoring, keine Blackbox: regelbasiert, nachvollziehbar, tunebare Gewichte.
+
+## Scoring-Modell
+
+Pro Kandidat (`tenant_id` + `connector_type`) werden folgende Felder geliefert:
+
+- `readiness_score`
+- `blocker_score`
+- `strategic_value_score`
+- `compliance_impact_score`
+- `estimated_implementation_complexity`
+- `complexity_band` (`low|medium|high`)
+- `recommended_priority` (`high|medium|low|not_now`)
+- `rationale_summary_de`
+- `rationale_factors_de`
+- `score_total`
+
+## Faktoren und Gewichte
+
+Gewichte sind explizit im Response enthalten (`scoring_weights`) und im Service zentral definiert:
+
+- Readiness: `35`
+- Blocker (inverse): `20`
+- Strategischer Wert: `25`
+- Compliance-Impact: `20`
+
+Formel:
+
+`score_total = readiness*0.35 + (100-blocker)*0.20 + strategic*0.25 + compliance*0.20`
+
+## Datenquellen (Reuse statt Duplikation)
+
+- Enterprise Onboarding Readiness
+  - SSO-Status, Role-Mapping-Status, Integrationsreadiness, Onboarding-Blocker
+- SAP Evidence Connector Blueprint (Wave 55)
+  - Connector-Typ, Domains, Security-Prerequisites, Status, Owner, Blocker
+- Enterprise Control Center
+  - offene Signale als Proxy für Compliance-/Operativitätsdruck
+- Evidence-Hook-Nähe
+  - über strukturierte `evidence_domains` und `evidence_ref`-nahe Mapping-Indikatoren
+
+## API
+
+- `GET /api/internal/enterprise/connector-candidates`
+  - liefert `candidate_rows`, `top_priorities`, `grouped_priorities_by_connector_type`
+  - optional Advisor-/Sales-Summary via `include_markdown=true`
+
+## Rationale-Regeln (Beispiele)
+
+- `high`: hoher Gesamtscore und niedrige Blocker-Belastung
+- `medium`: guter Score, aber noch moderate Voraussetzungen offen
+- `low`: begrenzter kurzfristiger ROI oder höhere Umsetzungslast
+- `not_now`: zu viele Blocker oder zu schwache Readiness
+
+## Nutzung durch GTM / Integration
+
+- Advisor & Solutioning:
+  - Erst-Connector für Workshop-/Discovery-Phase festlegen
+- Enterprise Sales:
+  - Upgrade- und Implementierungsreife pro Mandant transparent argumentieren
+- Delivery:
+  - Build-Reihenfolge nach erklärbarer Priorität planen
+
+## Limitierungen
+
+- Single-tenant Bewertung pro API-Call; kein Cross-Tenant-Ranking in dieser Welle
+- Kein Umsatz-/Vertragsdatenzugriff
+- Keine live-technische Konnektivitätsprüfung (nur Readiness-/Blueprint-Metadaten)
+
+## Security und Auditierbarkeit
+
+- Tenant-scharf und RBAC-geschützt (`view_dashboard`)
+- Keine Speicherung von Credentials/Secrets
+- Begründungen basieren auf strukturierten, prüfbaren Feldern

--- a/frontend/src/app/tenant/control-center/page.tsx
+++ b/frontend/src/app/tenant/control-center/page.tsx
@@ -4,6 +4,7 @@ import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import { PreparationPackPreview } from "@/components/tenant/PreparationPackPreview";
 import {
   fetchAuthorityAuditPreparationPack,
+  fetchEnterpriseConnectorCandidates,
   fetchEnterpriseControlCenter,
   fetchEnterpriseIntegrationBlueprints,
   type ControlCenterSeverityDto,
@@ -37,6 +38,7 @@ export default async function TenantControlCenterPage({ searchParams }: PageProp
       : "mixed";
   const data = await fetchEnterpriseControlCenter(tenantId, true);
   const blueprint = await fetchEnterpriseIntegrationBlueprints(tenantId, false);
+  const candidates = await fetchEnterpriseConnectorCandidates(tenantId, false);
   const prepPack = shouldGeneratePack
     ? await fetchAuthorityAuditPreparationPack(tenantId, focus)
     : null;
@@ -108,6 +110,51 @@ export default async function TenantControlCenterPage({ searchParams }: PageProp
             <li className="text-sm text-slate-500">Keine akuten Punkte.</li>
           ) : null}
         </ul>
+      </section>
+
+      <section className={CH_CARD}>
+        <div className="flex items-center justify-between gap-2">
+          <p className={CH_SECTION_LABEL}>Connector Candidates</p>
+          <span className="text-xs text-slate-500">
+            {new Date(candidates.generated_at_utc).toLocaleString("de-DE")}
+          </span>
+        </div>
+        <p className="mt-2 text-xs text-slate-600">
+          Explainable Scoring: Readiness, Blocker, strategischer Wert und Compliance-Impact.
+        </p>
+        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          <article className="rounded border border-slate-200 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Top Kandidaten
+            </p>
+            <ul className="mt-2 space-y-2 text-xs text-slate-700">
+              {candidates.top_priorities.slice(0, 4).map((row) => (
+                <li key={`${row.tenant_id}-${row.connector_type}`} className="rounded border border-slate-100 px-2 py-1">
+                  <p className="font-medium text-slate-900">
+                    {row.connector_type} · {row.recommended_priority} · {row.score_total}/100
+                  </p>
+                  <p>{row.rationale_summary_de}</p>
+                </li>
+              ))}
+            </ul>
+          </article>
+          <article className="rounded border border-slate-200 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Größte Blocker
+            </p>
+            <ul className="mt-2 space-y-1 text-xs text-slate-700">
+              {candidates.candidate_rows
+                .slice()
+                .sort((a, b) => b.blocker_score - a.blocker_score)
+                .slice(0, 4)
+                .map((row) => (
+                  <li key={`${row.connector_type}-blocker`} className="rounded border border-amber-200 bg-amber-50 px-2 py-1">
+                    {row.connector_type}: Blocker {row.blocker_score}/100 · {row.rationale_factors_de[1] ?? "—"}
+                  </li>
+                ))}
+            </ul>
+          </article>
+        </div>
       </section>
 
       <section className={CH_CARD}>

--- a/frontend/src/app/tenant/onboarding-readiness/page.tsx
+++ b/frontend/src/app/tenant/onboarding-readiness/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
 import {
+  fetchEnterpriseConnectorCandidates,
   fetchEnterpriseIntegrationBlueprints,
   fetchEnterpriseOnboardingReadiness,
 } from "@/lib/api";
@@ -17,6 +18,7 @@ export default async function TenantOnboardingReadinessPage() {
   const tenantId = await getWorkspaceTenantIdServer();
   const data = await fetchEnterpriseOnboardingReadiness(tenantId);
   const blueprint = await fetchEnterpriseIntegrationBlueprints(tenantId, false);
+  const candidates = await fetchEnterpriseConnectorCandidates(tenantId, false);
 
   return (
     <div className={CH_SHELL}>
@@ -108,6 +110,26 @@ export default async function TenantOnboardingReadinessPage() {
           {blueprint.top_enterprise_integration_candidates.length === 0 ? (
             <li className="text-xs text-slate-500">Noch keine priorisierten Integrationskandidaten.</li>
           ) : null}
+        </ul>
+      </section>
+
+      <section className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Connector Candidate Scoring</p>
+        <p className="mt-2 text-sm text-slate-700">
+          Empfohlener Erst-Connector:{" "}
+          <span className="font-semibold">
+            {candidates.candidate_rows[0]?.connector_type ?? "—"}
+          </span>
+          {" · "}
+          Priorität: {candidates.candidate_rows[0]?.recommended_priority ?? "—"}
+        </p>
+        <ul className="mt-3 space-y-2 text-xs text-slate-700">
+          {candidates.candidate_rows.slice(0, 3).map((row) => (
+            <li key={`cand-${row.connector_type}`} className="rounded border border-slate-200 px-3 py-2">
+              {row.connector_type}: Score {row.score_total}/100 · Readiness {row.readiness_score}
+              {" · "}Blocker {row.blocker_score} · {row.rationale_summary_de}
+            </li>
+          ))}
         </ul>
       </section>
     </div>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2754,6 +2754,50 @@ export async function fetchEnterpriseIntegrationBlueprints(
   ) as Promise<EnterpriseIntegrationBlueprintResponseDto>;
 }
 
+export type ConnectorCandidatePriorityDto = "high" | "medium" | "low" | "not_now";
+export type ConnectorComplexityBandDto = "low" | "medium" | "high";
+
+export interface EnterpriseConnectorCandidateRowDto {
+  tenant_id: string;
+  connector_type: IntegrationBlueprintSourceSystemTypeDto;
+  readiness_score: number;
+  blocker_score: number;
+  strategic_value_score: number;
+  compliance_impact_score: number;
+  estimated_implementation_complexity: number;
+  complexity_band: ConnectorComplexityBandDto;
+  recommended_priority: ConnectorCandidatePriorityDto;
+  rationale_summary_de: string;
+  rationale_factors_de: string[];
+  score_total: number;
+}
+
+export interface EnterpriseConnectorCandidatesResponseDto {
+  tenant_id: string;
+  generated_at_utc: string;
+  scoring_weights: {
+    readiness_weight: number;
+    blocker_weight: number;
+    strategic_value_weight: number;
+    compliance_impact_weight: number;
+  };
+  candidate_rows: EnterpriseConnectorCandidateRowDto[];
+  top_priorities: EnterpriseConnectorCandidateRowDto[];
+  grouped_priorities_by_connector_type: Record<string, EnterpriseConnectorCandidateRowDto[]>;
+  markdown_de?: string | null;
+}
+
+export async function fetchEnterpriseConnectorCandidates(
+  tenantId: string,
+  includeMarkdown = false,
+): Promise<EnterpriseConnectorCandidatesResponseDto> {
+  const qs = includeMarkdown ? "?include_markdown=true" : "";
+  return tenantApiFetch(
+    `/api/internal/enterprise/connector-candidates${qs}`,
+    tenantId,
+  ) as Promise<EnterpriseConnectorCandidatesResponseDto>;
+}
+
 export type IdentityProviderTypeDto =
   | "azure_ad"
   | "saml_generic"

--- a/tests/test_enterprise_connector_candidates.py
+++ b/tests/test_enterprise_connector_candidates.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _headers(tenant: str, role: str = "tenant_admin") -> dict[str, str]:
+    return {
+        "x-api-key": "test-key",
+        "x-tenant-id": tenant,
+        "x-opa-user-role": role,
+    }
+
+
+def test_connector_candidates_returns_explainable_rows() -> None:
+    tenant = "connector-candidates-tenant-a"
+    resp = client.get(
+        "/api/internal/enterprise/connector-candidates?include_markdown=true",
+        headers=_headers(tenant),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["tenant_id"] == tenant
+    assert body["candidate_rows"]
+    assert "scoring_weights" in body
+    assert "grouped_priorities_by_connector_type" in body
+    assert body["markdown_de"]


### PR DESCRIPTION
Introduce explainable connector candidate scoring across onboarding readiness, blueprint status, and control-center signals, with a new internal enterprise API, cockpit surfacing, and GTM-facing documentation.

Made-with: Cursor