### PR TITLE
feat(frontend): EU AI Act Self-Assessment Workspace und SBS/KanzleiAI-UI

### DIFF
--- a/frontend/public/static/css/design-tokens.css
+++ b/frontend/public/static/css/design-tokens.css
@@ -1,6 +1,6 @@
 /**
- * Design-Tokens – angelehnt an SBS Deutschland / SBS Nexus (Enterprise KI, DACH).
- * Referenz: https://sbsdeutschland.com/sbshomepage/
+ * Design-Tokens – SBS Deutschland / Enterprise KI (DACH), konsistent mit KanzleiAI.
+ * Referenz: https://sbsdeutschland.com/sbshomepage/ · Produktlinie https://kanzlei-ai.com/
  */
 :root {
   --sbs-navy-deep: #003366;

--- a/frontend/src/app/app/ai-act/self-assessments/[sessionId]/page.tsx
+++ b/frontend/src/app/app/ai-act/self-assessments/[sessionId]/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from "next/navigation";
+
+import { tenantAiActSelfAssessmentDetailPath } from "@/lib/aiActSelfAssessmentRoutes";
+
+interface PageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+/** Legacy URL unter `/app/...` → mandantenfähiger Tenant-Workspace. */
+export default async function LegacySelfAssessmentSessionRedirectPage({ params }: PageProps) {
+  const { sessionId: rawId } = await params;
+  redirect(tenantAiActSelfAssessmentDetailPath(decodeURIComponent(rawId)));
+}

--- a/frontend/src/app/app/ai-act/self-assessments/page.tsx
+++ b/frontend/src/app/app/ai-act/self-assessments/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+import { TENANT_AI_ACT_SELF_ASSESSMENTS_PATH } from "@/lib/aiActSelfAssessmentRoutes";
+
+/** Legacy URL: Enterprise-Workspace nutzt den Tenant-Shell-Pfad. */
+export default function LegacySelfAssessmentsRedirectPage() {
+  redirect(TENANT_AI_ACT_SELF_ASSESSMENTS_PATH);
+}

--- a/frontend/src/app/tenant/ai-act/self-assessments/[sessionId]/page.tsx
+++ b/frontend/src/app/tenant/ai-act/self-assessments/[sessionId]/page.tsx
@@ -1,0 +1,72 @@
+import { notFound } from "next/navigation";
+
+import { SelfAssessmentWorkspaceClient } from "@/components/ai-act/SelfAssessmentWorkspaceClient";
+import {
+  getSelfAssessmentAnswers,
+  getSelfAssessmentAuditEvents,
+  getSelfAssessmentClassification,
+  getSelfAssessmentSession,
+} from "@/lib/aiActSelfAssessmentApi";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+interface PageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default async function TenantSelfAssessmentSessionPage({ params }: PageProps) {
+  const { sessionId: rawId } = await params;
+  const sessionId = decodeURIComponent(rawId);
+  const tenantId = await getWorkspaceTenantIdServer();
+
+  const sessionRes = await getSelfAssessmentSession(tenantId, sessionId);
+  if (!sessionRes.ok && sessionRes.status === 404) {
+    notFound();
+  }
+  if (!sessionRes.ok || !sessionRes.data) {
+    return (
+      <div className="mx-auto max-w-3xl rounded-2xl border border-rose-200 bg-rose-50/80 p-6 shadow-sm">
+        <h1 className="text-lg font-semibold text-slate-900">Self-Assessment</h1>
+        <p className="mt-2 text-sm text-rose-900" role="alert">
+          {!sessionRes.ok
+            ? `Sitzung konnte nicht geladen werden (${sessionRes.status}): ${sessionRes.message}`
+            : "Sitzung konnte nicht geladen werden: leere Antwort."}
+        </p>
+      </div>
+    );
+  }
+
+  const session = sessionRes.data;
+  const completed = session.status === "completed";
+
+  const [answersRes, auditRes, classRes] = await Promise.all([
+    getSelfAssessmentAnswers(tenantId, sessionId),
+    getSelfAssessmentAuditEvents(tenantId, sessionId),
+    completed
+      ? getSelfAssessmentClassification(tenantId, sessionId)
+      : Promise.resolve({ ok: true as const, data: null }),
+  ]);
+
+  const initialAnswers = answersRes.ok ? answersRes.data : {};
+  const initialAudit = auditRes.ok ? auditRes.data : [];
+  const initialClassification = classRes.ok ? classRes.data : null;
+
+  return (
+    <SelfAssessmentWorkspaceClient
+      tenantId={tenantId}
+      sessionId={sessionId}
+      initialSession={session}
+      initialAnswers={initialAnswers}
+      initialAudit={initialAudit}
+      initialClassification={initialClassification}
+      initialAnswersError={
+        answersRes.ok ? null : `${answersRes.status}: ${answersRes.message}`
+      }
+      initialAuditError={auditRes.ok ? null : `${auditRes.status}: ${auditRes.message}`}
+      initialClassificationError={
+        completed && classRes && !classRes.ok
+          ? `${classRes.status}: ${classRes.message}`
+          : null
+      }
+    />
+  );
+}

--- a/frontend/src/app/tenant/ai-act/self-assessments/page.tsx
+++ b/frontend/src/app/tenant/ai-act/self-assessments/page.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link";
+
+import { StartNewSelfAssessmentButton } from "@/components/ai-act/StartNewSelfAssessmentButton";
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { listSelfAssessments } from "@/lib/aiActSelfAssessmentApi";
+import { tenantAiActSelfAssessmentDetailPath } from "@/lib/aiActSelfAssessmentRoutes";
+import {
+  CH_CARD,
+  CH_PAGE_NAV_LINK,
+  CH_SECTION_LABEL,
+  CH_SHELL,
+} from "@/lib/boardLayout";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+function formatTs(iso: string | null | undefined): string {
+  if (!iso) {
+    return "—";
+  }
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  return d.toLocaleString("de-DE", { dateStyle: "short", timeStyle: "short" });
+}
+
+export default async function TenantSelfAssessmentsListPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  const res = await listSelfAssessments(tenantId);
+
+  const rows = res.ok ? res.data : [];
+  const loadError = !res.ok ? `${res.status}: ${res.message}` : null;
+
+  return (
+    <div className={CH_SHELL}>
+      <EnterprisePageHeader
+        eyebrow="Enterprise · EU AI Act"
+        title="Self-Assessment Workspace"
+        description={
+          <>
+            Mandantenbezogene Runs für die EU-AI-Act-Selbsteinschätzung — Status, gebundenes
+            KI-System und Schema-Version auf einen Blick. Daten kommen aus dem ComplianceHub-API.
+          </>
+        }
+        breadcrumbs={[
+          { label: "Tenant", href: "/tenant/compliance-overview" },
+          { label: "Self-Assessments" },
+        ]}
+        actions={
+          <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center">
+            <StartNewSelfAssessmentButton tenantId={tenantId} />
+            <Link href="/tenant/eu-ai-act" className={`${CH_PAGE_NAV_LINK} text-center sm:text-left`}>
+              Zur EU-AI-Act-Übersicht
+            </Link>
+          </div>
+        }
+      />
+
+      {loadError ? (
+        <div
+          className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900 shadow-sm"
+          role="alert"
+        >
+          <p className="font-semibold">Liste konnte nicht geladen werden</p>
+          <p className="mt-1 text-rose-800">{loadError}</p>
+        </div>
+      ) : null}
+
+      <section className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Alle Runs</p>
+        <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200/80">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+            <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">KI-System</th>
+                <th className="px-4 py-3">Schema</th>
+                <th className="px-4 py-3">Gestartet</th>
+                <th className="px-4 py-3">Abgeschlossen</th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {rows.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="px-4 py-12 text-center text-slate-500">
+                    Keine Self-Assessments vorhanden. Starten Sie einen neuen Run über die Aktion
+                    oben.
+                  </td>
+                </tr>
+              ) : (
+                rows.map((row) => {
+                  const nameOrId = row.ai_system_name ?? row.ai_system_id ?? "—";
+                  return (
+                    <tr key={row.session_id} className="transition hover:bg-slate-50/90">
+                      <td className="px-4 py-3 font-medium text-slate-900">{row.status}</td>
+                      <td className="px-4 py-3 text-slate-700">{nameOrId}</td>
+                      <td className="px-4 py-3 text-slate-600">{row.schema_version ?? "—"}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatTs(row.started_at)}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatTs(row.completed_at)}</td>
+                      <td className="px-4 py-3 text-right">
+                        <Link
+                          href={tenantAiActSelfAssessmentDetailPath(row.session_id)}
+                          className={CH_PAGE_NAV_LINK}
+                        >
+                          Öffnen
+                        </Link>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/app/tenant/eu-ai-act/page.tsx
+++ b/frontend/src/app/tenant/eu-ai-act/page.tsx
@@ -12,6 +12,7 @@ import {
   type Nis2KritisKpiListResponse,
   type Nis2KritisKpiType,
 } from "@/lib/api";
+import { TENANT_AI_ACT_SELF_ASSESSMENTS_PATH } from "@/lib/aiActSelfAssessmentRoutes";
 import { readWorkspaceTenantIdFromDocumentCookie } from "@/lib/workspaceTenantBrowser";
 import {
   CH_BTN_PRIMARY,
@@ -407,6 +408,9 @@ export default function EUAIActPage() {
               </Link>
               <Link href="/tenant/ai-systems" className={CH_PAGE_NAV_LINK}>
                 KI-System-Register
+              </Link>
+              <Link href={TENANT_AI_ACT_SELF_ASSESSMENTS_PATH} className={CH_PAGE_NAV_LINK}>
+                Self-Assessment Workspace
               </Link>
             </>
           }

--- a/frontend/src/components/ai-act/SelfAssessmentWorkspaceClient.tsx
+++ b/frontend/src/components/ai-act/SelfAssessmentWorkspaceClient.tsx
@@ -1,0 +1,666 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import {
+  completeSelfAssessment,
+  exportSelfAssessment,
+  getSelfAssessmentAuditEvents,
+  getSelfAssessmentClassification,
+  getSelfAssessmentSession,
+  patchSelfAssessmentSession,
+  putSelfAssessmentAnswer,
+  resolveExportDownloadUrl,
+  type ExportSelfAssessmentResult,
+  type SelfAssessmentAuditEvent,
+  type SelfAssessmentClassification,
+  type SelfAssessmentSessionDetail,
+} from "@/lib/aiActSelfAssessmentApi";
+import { TENANT_AI_ACT_SELF_ASSESSMENTS_PATH } from "@/lib/aiActSelfAssessmentRoutes";
+import {
+  CH_BADGE,
+  CH_BTN_GHOST,
+  CH_BTN_PRIMARY,
+  CH_BTN_SECONDARY,
+  CH_CARD,
+  CH_CARD_MUTED,
+  CH_SECTION_LABEL,
+  CH_SHELL,
+} from "@/lib/boardLayout";
+
+type TabKey = "questionnaire" | "classification" | "audit";
+
+const DOMAIN_OPTIONS = [
+  { value: "HR", label: "HR" },
+  { value: "Critical Infrastructure", label: "Kritische Infrastruktur" },
+  { value: "Healthcare", label: "Gesundheitswesen" },
+  { value: "Law Enforcement", label: "Strafverfolgung" },
+  { value: "Other", label: "Sonstiges" },
+] as const;
+
+function asBool(v: unknown): boolean {
+  if (typeof v === "boolean") {
+    return v;
+  }
+  if (v === 1 || v === "1" || v === "true") {
+    return true;
+  }
+  return false;
+}
+
+function asString(v: unknown, fallback: string): string {
+  if (v == null) {
+    return fallback;
+  }
+  return String(v);
+}
+
+function statusBadgeTone(status: string): string {
+  switch (status) {
+    case "completed":
+      return "bg-emerald-100 text-emerald-900 ring-emerald-200/80";
+    case "in_review":
+      return "bg-amber-100 text-amber-950 ring-amber-200/80";
+    default:
+      return "bg-slate-100 text-slate-800 ring-slate-200/80";
+  }
+}
+
+function formatTs(iso: string | null | undefined): string {
+  if (!iso) {
+    return "—";
+  }
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return iso;
+  }
+  return d.toLocaleString("de-DE", { dateStyle: "short", timeStyle: "short" });
+}
+
+function formatClock(iso: string | null | undefined): string {
+  if (!iso) {
+    return "";
+  }
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) {
+    return "";
+  }
+  return d.toLocaleTimeString("de-DE", { hour: "2-digit", minute: "2-digit" });
+}
+
+function auditEventType(e: SelfAssessmentAuditEvent): string {
+  return String(e.event_type ?? e.type ?? "—");
+}
+
+function auditActor(e: SelfAssessmentAuditEvent): string {
+  return String(e.user ?? e.actor ?? e.user_id ?? "—");
+}
+
+function auditWhen(e: SelfAssessmentAuditEvent): string {
+  return String(e.timestamp ?? e.created_at ?? "—");
+}
+
+function auditDetails(e: SelfAssessmentAuditEvent): string {
+  const raw = e.details ?? e.detail;
+  if (raw == null) {
+    return "—";
+  }
+  if (typeof raw === "string") {
+    return raw;
+  }
+  try {
+    return JSON.stringify(raw);
+  } catch {
+    return "—";
+  }
+}
+
+export interface SelfAssessmentWorkspaceClientProps {
+  tenantId: string;
+  sessionId: string;
+  initialSession: SelfAssessmentSessionDetail;
+  initialAnswers: Record<string, unknown>;
+  initialAudit: SelfAssessmentAuditEvent[];
+  initialClassification: SelfAssessmentClassification | null;
+  initialAnswersError?: string | null;
+  initialAuditError?: string | null;
+  initialClassificationError?: string | null;
+}
+
+export function SelfAssessmentWorkspaceClient({
+  tenantId,
+  sessionId,
+  initialSession,
+  initialAnswers,
+  initialAudit,
+  initialClassification,
+  initialAnswersError,
+  initialAuditError,
+  initialClassificationError,
+}: SelfAssessmentWorkspaceClientProps) {
+  const [tab, setTab] = useState<TabKey>("questionnaire");
+  const [session, setSession] = useState(initialSession);
+  const [answers, setAnswers] = useState<Record<string, unknown>>(initialAnswers);
+  const [audit, setAudit] = useState<SelfAssessmentAuditEvent[]>(initialAudit);
+  const [classification, setClassification] = useState<SelfAssessmentClassification | null>(
+    initialClassification,
+  );
+
+  const [toast, setToast] = useState<{ kind: "success" | "error"; text: string } | null>(null);
+  const [inlineError, setInlineError] = useState<string | null>(null);
+
+  const [saveState, setSaveState] = useState<"idle" | "saving" | "saved" | "error">("idle");
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const [actionBusy, setActionBusy] = useState<string | null>(null);
+
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const readOnly = session.status === "completed";
+
+  useEffect(() => {
+    setSession(initialSession);
+  }, [initialSession]);
+
+  useEffect(() => {
+    setAnswers(initialAnswers);
+  }, [initialAnswers]);
+
+  useEffect(() => {
+    setAudit(initialAudit);
+  }, [initialAudit]);
+
+  useEffect(() => {
+    setClassification(initialClassification);
+  }, [initialClassification]);
+
+  const ownerLabel = useMemo(() => {
+    return session.owner ?? session.created_by ?? "—";
+  }, [session]);
+
+  const showToast = useCallback((kind: "success" | "error", text: string) => {
+    setToast({ kind, text });
+    window.setTimeout(() => setToast(null), 6000);
+  }, []);
+
+  const scheduleSave = useCallback(
+    (questionKey: string, value: unknown) => {
+      if (readOnly) {
+        return;
+      }
+      const prev = timers.current[questionKey];
+      if (prev) {
+        clearTimeout(prev);
+      }
+      setSaveState("saving");
+      setInlineError(null);
+      timers.current[questionKey] = setTimeout(() => {
+        void (async () => {
+          const res = await putSelfAssessmentAnswer(tenantId, sessionId, questionKey, value);
+          if (!res.ok) {
+            setSaveState("error");
+            setInlineError(`${res.status}: ${res.message}`);
+            showToast("error", `Speichern fehlgeschlagen (${res.status})`);
+            return;
+          }
+          setSaveState("saved");
+          setSavedAt(new Date().toISOString());
+        })();
+      }, 450);
+    },
+    [readOnly, sessionId, showToast, tenantId],
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const t of Object.values(timers.current)) {
+        clearTimeout(t);
+      }
+    };
+  }, []);
+
+  async function refreshSessionAndClassification() {
+    const s = await getSelfAssessmentSession(tenantId, sessionId);
+    if (s.ok && s.data) {
+      setSession(s.data);
+    }
+    if (s.ok && s.data?.status === "completed") {
+      const c = await getSelfAssessmentClassification(tenantId, sessionId);
+      if (c.ok) {
+        setClassification(c.data);
+      } else {
+        showToast("error", `Klassifikation: ${c.status} ${c.message}`);
+      }
+    }
+  }
+
+  async function refreshAudit() {
+    const r = await getSelfAssessmentAuditEvents(tenantId, sessionId);
+    if (r.ok) {
+      setAudit(r.data);
+    }
+  }
+
+  async function onSetInReview() {
+    setInlineError(null);
+    setActionBusy("review");
+    const res = await patchSelfAssessmentSession(tenantId, sessionId, { status: "in_review" });
+    setActionBusy(null);
+    if (!res.ok) {
+      setInlineError(`${res.status}: ${res.message}`);
+      showToast("error", res.message);
+      return;
+    }
+    if (res.data) {
+      setSession(res.data);
+    }
+    showToast("success", "Status auf „In Review“ gesetzt.");
+    await refreshAudit();
+  }
+
+  async function onComplete() {
+    setInlineError(null);
+    setActionBusy("complete");
+    const res = await completeSelfAssessment(tenantId, sessionId);
+    setActionBusy(null);
+    if (!res.ok) {
+      setInlineError(`${res.status}: ${res.message}`);
+      showToast("error", res.message);
+      return;
+    }
+    showToast("success", "Run abgeschlossen.");
+    await refreshSessionAndClassification();
+    await refreshAudit();
+    setTab("classification");
+  }
+
+  async function onExport() {
+    setInlineError(null);
+    setActionBusy("export");
+    const res = await exportSelfAssessment(tenantId, sessionId);
+    setActionBusy(null);
+    if (!res.ok) {
+      setInlineError(`${res.status}: ${res.message}`);
+      showToast("error", res.message);
+      return;
+    }
+    const url = resolveExportDownloadUrl(res.data as ExportSelfAssessmentResult);
+    if (!url) {
+      showToast("error", "Export-Antwort enthält keinen Download-Link.");
+      return;
+    }
+    window.open(url, "_blank", "noopener,noreferrer");
+    showToast("success", "Export gestartet.");
+    await refreshAudit();
+  }
+
+  function setAnswerField(key: string, value: unknown) {
+    setAnswers((prev) => ({ ...prev, [key]: value }));
+    scheduleSave(key, value);
+  }
+
+  const domainValue = asString(
+    answers.intended_use_domain,
+    DOMAIN_OPTIONS[DOMAIN_OPTIONS.length - 1]!.value,
+  );
+
+  const sessionShort =
+    sessionId.length > 14 ? `${sessionId.slice(0, 8)}…${sessionId.slice(-4)}` : sessionId;
+
+  const fieldClass =
+    "mt-1 w-full rounded-xl border border-slate-200 bg-white px-3 py-2.5 text-sm text-slate-900 shadow-sm outline-none transition focus:border-[var(--sbs-navy-mid)] focus:ring-2 focus:ring-[var(--sbs-navy-mid)]/20 disabled:cursor-not-allowed disabled:bg-slate-50";
+
+  return (
+    <div className={CH_SHELL}>
+      {toast ? (
+        <div
+          role="status"
+          className={
+            toast.kind === "error"
+              ? "rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900 shadow-sm"
+              : "rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900 shadow-sm"
+          }
+        >
+          {toast.text}
+        </div>
+      ) : null}
+
+      <EnterprisePageHeader
+        eyebrow="Enterprise · EU AI Act"
+        title="Self-Assessment Run"
+        description={
+          <div className="space-y-2">
+            <p className="font-mono text-sm text-slate-600">
+              Session <span className="text-slate-900">{sessionShort}</span>
+            </p>
+            <p className="text-base text-slate-600">
+              <span className={`${CH_BADGE} ${statusBadgeTone(String(session.status))}`}>
+                {String(session.status)}
+              </span>
+              <span className="mx-2 text-slate-300" aria-hidden>
+                ·
+              </span>
+              KI-System:{" "}
+              <span className="font-medium text-slate-800">
+                {session.ai_system_name ?? session.ai_system_id ?? "—"}
+              </span>
+            </p>
+          </div>
+        }
+        breadcrumbs={[
+          { label: "Tenant", href: "/tenant/compliance-overview" },
+          { label: "Self-Assessments", href: TENANT_AI_ACT_SELF_ASSESSMENTS_PATH },
+          { label: sessionShort },
+        ]}
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <Link href={TENANT_AI_ACT_SELF_ASSESSMENTS_PATH} className={CH_BTN_SECONDARY}>
+              Zur Übersicht
+            </Link>
+          </div>
+        }
+      />
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Metadaten & Aktionen</p>
+        <dl className="mt-4 grid gap-4 text-sm text-slate-700 sm:grid-cols-2">
+          <div>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Owner</dt>
+            <dd className="mt-1 font-semibold text-slate-900">{ownerLabel}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              Schema-Version
+            </dt>
+            <dd className="mt-1 font-semibold text-slate-900">{session.schema_version ?? "—"}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Gestartet</dt>
+            <dd className="mt-1 font-semibold text-slate-900">{formatTs(session.started_at)}</dd>
+          </div>
+          <div>
+            <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">
+              Abgeschlossen
+            </dt>
+            <dd className="mt-1 font-semibold text-slate-900">{formatTs(session.completed_at)}</dd>
+          </div>
+        </dl>
+
+        {inlineError ? (
+          <p className="mt-4 text-sm text-rose-800" role="alert">
+            {inlineError}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-wrap gap-2 border-t border-slate-200/80 pt-6">
+          <button
+            type="button"
+            disabled={readOnly || actionBusy !== null || session.status === "in_review"}
+            onClick={() => void onSetInReview()}
+            className={`${CH_BTN_SECONDARY} disabled:pointer-events-none disabled:opacity-40`}
+          >
+            {actionBusy === "review" ? "Bitte warten…" : "Status auf „In Review“ setzen"}
+          </button>
+          <button
+            type="button"
+            disabled={readOnly || actionBusy !== null}
+            onClick={() => void onComplete()}
+            className={`${CH_BTN_PRIMARY} disabled:pointer-events-none disabled:opacity-40`}
+          >
+            {actionBusy === "complete" ? "Bitte warten…" : "Run abschließen"}
+          </button>
+          <button
+            type="button"
+            disabled={actionBusy !== null}
+            onClick={() => void onExport()}
+            className={`${CH_BTN_SECONDARY} disabled:pointer-events-none disabled:opacity-40`}
+          >
+            {actionBusy === "export" ? "Export…" : "Export (PDF)"}
+          </button>
+        </div>
+      </article>
+
+      <div
+        className="flex flex-wrap gap-2 border-b border-slate-200/80 pb-1"
+        role="tablist"
+        aria-label="Self-Assessment Bereiche"
+      >
+        {(
+          [
+            ["questionnaire", "Fragebogen"],
+            ["classification", "Klassifikation"],
+            ["audit", "Audit-Trail"],
+          ] as const
+        ).map(([k, label]) => (
+          <button
+            key={k}
+            type="button"
+            role="tab"
+            aria-selected={tab === k}
+            onClick={() => setTab(k)}
+            className={
+              tab === k
+                ? "rounded-xl bg-[var(--sbs-navy-mid)] px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--sbs-navy-deep)]"
+                : "rounded-xl px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100 hover:text-slate-900"
+            }
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === "questionnaire" ? (
+        <article className={CH_CARD}>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className={CH_SECTION_LABEL}>Fragebogen</p>
+              <h2 className="mt-1 text-lg font-semibold text-slate-900">Eingaben</h2>
+            </div>
+            <p className="text-xs text-slate-500" aria-live="polite">
+              {readOnly ? (
+                <span className="font-medium text-slate-700">Abgeschlossen — nur Lesen.</span>
+              ) : saveState === "saving" ? (
+                <span className="font-medium text-[var(--sbs-navy-deep)]">Speichern…</span>
+              ) : saveState === "saved" && savedAt ? (
+                <span className="font-medium text-emerald-800">
+                  Gespeichert um {formatClock(savedAt)}
+                </span>
+              ) : saveState === "error" ? (
+                <span className="font-medium text-rose-800">Letzter Speicherversuch fehlgeschlagen</span>
+              ) : (
+                <span>Änderungen werden automatisch gespeichert.</span>
+              )}
+            </p>
+          </div>
+
+          {initialAnswersError ? (
+            <p className="mt-4 text-sm text-amber-900" role="alert">
+              Antworten konnten beim ersten Laden nicht geladen werden: {initialAnswersError}
+            </p>
+          ) : null}
+
+          <div className="mt-6 grid gap-6 sm:grid-cols-2">
+            <label className="block text-sm">
+              <span className="font-medium text-slate-800">Einsatzbereich (intended_use_domain)</span>
+              <select
+                className={fieldClass}
+                disabled={readOnly}
+                value={DOMAIN_OPTIONS.some((o) => o.value === domainValue) ? domainValue : "Other"}
+                onChange={(e) => setAnswerField("intended_use_domain", e.target.value)}
+              >
+                {DOMAIN_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {(
+              [
+                ["interacts_with_humans", "Interagiert mit Menschen"],
+                ["uses_personal_data", "Verarbeitet personenbezogene Daten"],
+                ["uses_biometric_identification", "Biometrische Identifikation"],
+                ["is_gpai_model", "General Purpose AI (GPAI) / Foundation Model"],
+                ["performs_automated_decision_making", "Automatisierte Entscheidungsfindung"],
+                ["monitors_public_spaces", "Überwachung öffentlicher Räume"],
+                ["safety_component_of_product", "Sicherheitskomponente eines Produkts"],
+                ["uses_emotion_recognition", "Emotionserkennung"],
+              ] as const
+            ).map(([key, label]) => (
+              <label
+                key={key}
+                className="flex items-center justify-between gap-3 rounded-xl border border-slate-200/80 bg-slate-50/40 px-3 py-3 text-sm"
+              >
+                <span className="text-slate-800">{label}</span>
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-slate-300 text-[var(--sbs-navy-mid)] focus:ring-[var(--sbs-navy-mid)] disabled:cursor-not-allowed"
+                  disabled={readOnly}
+                  checked={asBool(answers[key])}
+                  onChange={(e) => setAnswerField(key, e.target.checked)}
+                />
+              </label>
+            ))}
+          </div>
+
+          <label className="mt-6 block text-sm">
+            <span className="font-medium text-slate-800">
+              Dokumentationsreife (documentation_maturity)
+            </span>
+            <select
+              className={`${fieldClass} max-w-md`}
+              disabled={readOnly}
+              value={asString(answers.documentation_maturity, "basic")}
+              onChange={(e) => setAnswerField("documentation_maturity", e.target.value)}
+            >
+              <option value="basic">Basis</option>
+              <option value="structured">Strukturiert</option>
+              <option value="full">Vollständig / auditierbar</option>
+            </select>
+          </label>
+        </article>
+      ) : null}
+
+      {tab === "classification" ? (
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Risiko & Begründung</p>
+          <h2 className="mt-1 text-lg font-semibold text-slate-900">Klassifikation</h2>
+          {session.status !== "completed" ? (
+            <p className="mt-4 text-sm leading-relaxed text-slate-600">
+              Die Klassifikation steht erst nach Abschluss des Runs zur Verfügung. Bitte zuerst
+              „Run abschließen“ ausführen.
+            </p>
+          ) : initialClassificationError ? (
+            <p className="mt-4 text-sm text-rose-800" role="alert">
+              {initialClassificationError}
+            </p>
+          ) : classification ? (
+            <div className={`mt-4 space-y-4 text-sm ${CH_CARD_MUTED}`}>
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  risk_level
+                </div>
+                <div className="mt-1 text-base font-semibold text-slate-900">
+                  {classification.risk_level ?? "—"}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  requires_manual_review
+                </div>
+                <div className="mt-1 font-medium text-slate-800">
+                  {classification.requires_manual_review == null
+                    ? "—"
+                    : classification.requires_manual_review
+                      ? "Ja"
+                      : "Nein"}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  rationale
+                </div>
+                <p className="mt-1 whitespace-pre-wrap text-slate-800">
+                  {classification.rationale ?? "—"}
+                </p>
+              </div>
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  eu_ai_act_refs
+                </div>
+                {classification.eu_ai_act_refs?.length ? (
+                  <ul className="mt-2 list-disc space-y-1 pl-5 text-slate-800">
+                    {classification.eu_ai_act_refs.map((ref) => (
+                      <li key={ref}>{ref}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <div className="mt-1">—</div>
+                )}
+              </div>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-slate-600">Keine Klassifikationsdaten geliefert.</p>
+          )}
+        </article>
+      ) : null}
+
+      {tab === "audit" ? (
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Nachvollziehbarkeit</p>
+          <h2 className="mt-1 text-lg font-semibold text-slate-900">Audit-Trail</h2>
+          {initialAuditError ? (
+            <p className="mt-4 text-sm text-amber-900" role="alert">
+              Audit-Events konnten beim ersten Laden nicht geladen werden: {initialAuditError}
+            </p>
+          ) : null}
+          <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200/80">
+            <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+              <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="px-4 py-3">Ereignis</th>
+                  <th className="px-4 py-3">Nutzer</th>
+                  <th className="px-4 py-3">Zeitpunkt</th>
+                  <th className="px-4 py-3">Details</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 bg-white">
+                {audit.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-4 py-8 text-center text-slate-500">
+                      Keine Events.
+                    </td>
+                  </tr>
+                ) : (
+                  audit.map((e, i) => (
+                    <tr key={`${auditWhen(e)}-${i}`} className="hover:bg-slate-50/80">
+                      <td className="px-4 py-3 font-medium text-slate-900">{auditEventType(e)}</td>
+                      <td className="px-4 py-3 text-slate-700">{auditActor(e)}</td>
+                      <td className="px-4 py-3 text-slate-600">{formatTs(auditWhen(e))}</td>
+                      <td
+                        className="max-w-md truncate px-4 py-3 text-slate-600"
+                        title={auditDetails(e)}
+                      >
+                        {auditDetails(e)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <button
+            type="button"
+            className={`${CH_BTN_GHOST} mt-4`}
+            onClick={() => void refreshAudit()}
+          >
+            Audit-Liste aktualisieren
+          </button>
+        </article>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ai-act/StartNewSelfAssessmentButton.tsx
+++ b/frontend/src/components/ai-act/StartNewSelfAssessmentButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+import { createSelfAssessment, normalizeSessionId } from "@/lib/aiActSelfAssessmentApi";
+import { tenantAiActSelfAssessmentDetailPath } from "@/lib/aiActSelfAssessmentRoutes";
+import { CH_BTN_PRIMARY } from "@/lib/boardLayout";
+
+interface Props {
+  tenantId: string;
+  className?: string;
+}
+
+export function StartNewSelfAssessmentButton({ tenantId, className }: Props) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onClick() {
+    setError(null);
+    setBusy(true);
+    try {
+      const res = await createSelfAssessment(tenantId, {});
+      if (!res.ok) {
+        setError(`${res.status}: ${res.message}`);
+        return;
+      }
+      const row = res.data as Record<string, unknown>;
+      const id = normalizeSessionId(row);
+      if (!id) {
+        setError("Antwort enthält keine session_id.");
+        return;
+      }
+      router.push(tenantAiActSelfAssessmentDetailPath(id));
+      router.refresh();
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      <button
+        type="button"
+        disabled={busy}
+        onClick={() => void onClick()}
+        className={
+          className ?? `${CH_BTN_PRIMARY} disabled:pointer-events-none disabled:opacity-50`
+        }
+      >
+        {busy ? "Wird erstellt…" : "Neues Self-Assessment starten"}
+      </button>
+      {error ? (
+        <p className="max-w-prose text-sm text-red-700" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/sbs/TenantNav.tsx
+++ b/frontend/src/components/sbs/TenantNav.tsx
@@ -15,6 +15,7 @@ import {
 const baseItems = [
   { href: "/tenant/compliance-overview", label: "Mandant & Übersicht" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },
+  { href: "/tenant/ai-act/self-assessments", label: "Self-Assessment (AI Act)" },
   { href: "/tenant/ai-systems", label: "KI-Systeme" },
   { href: "/tenant/policies", label: "Policies & Regeln" },
   { href: "/tenant/audit-log", label: "Audit & Evidence" },
@@ -63,13 +64,13 @@ export function TenantNav({ workspaceTenantId }: TenantNavProps) {
             href={item.href}
             className={`flex items-center gap-2 rounded-lg px-2 py-2 no-underline transition ${
               active
-                ? "bg-cyan-50 font-semibold text-cyan-900"
+                ? "bg-slate-100 font-semibold text-[var(--sbs-navy-deep)]"
                 : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
             }`}
           >
             <span
               className={`h-1.5 w-1.5 shrink-0 rounded-full ${
-                active ? "bg-cyan-500" : "bg-slate-300"
+                active ? "bg-[var(--sbs-navy-mid)]" : "bg-slate-300"
               }`}
               aria-hidden
             />
@@ -86,14 +87,14 @@ export function TenantNav({ workspaceTenantId }: TenantNavProps) {
             href={evidenceHref}
             className={`flex items-center gap-2 rounded-lg px-2 py-2 no-underline transition ${
               pathname === evidenceHref || pathname.startsWith(`${evidenceHref}/`)
-                ? "bg-cyan-50 font-semibold text-cyan-900"
+                ? "bg-slate-100 font-semibold text-[var(--sbs-navy-deep)]"
                 : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
             }`}
           >
             <span
               className={`h-1.5 w-1.5 shrink-0 rounded-full ${
                 pathname === evidenceHref || pathname.startsWith(`${evidenceHref}/`)
-                  ? "bg-cyan-500"
+                  ? "bg-[var(--sbs-navy-mid)]"
                   : "bg-slate-300"
               }`}
               aria-hidden

--- a/frontend/src/lib/aiActSelfAssessmentApi.ts
+++ b/frontend/src/lib/aiActSelfAssessmentApi.ts
@@ -1,0 +1,379 @@
+/**
+ * EU AI Act Self-Assessment API client (FastAPI).
+ *
+ * Wiring: set NEXT_PUBLIC_AI_ACT_SELF_ASSESSMENT_PREFIX (default "/ai-act")
+ * and NEXT_PUBLIC_AI_ACT_AUDIT_PREFIX (default "/audit") to match your mount,
+ * e.g. "/api/v1/ai-act" if the router is included under /api/v1.
+ */
+import { tenantRequestHeaders } from "@/lib/api";
+
+export function getComplianceHubApiBaseUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    process.env.COMPLIANCEHUB_API_BASE_URL ||
+    "http://localhost:8000"
+  );
+}
+
+const SA_PREFIX = (
+  process.env.NEXT_PUBLIC_AI_ACT_SELF_ASSESSMENT_PREFIX ?? "/ai-act"
+).replace(/\/$/, "");
+
+const AUDIT_PREFIX = (process.env.NEXT_PUBLIC_AI_ACT_AUDIT_PREFIX ?? "/audit").replace(
+  /\/$/,
+  "",
+);
+
+export type SelfAssessmentStatus = "draft" | "in_review" | "completed";
+
+export interface SelfAssessmentListItem {
+  session_id: string;
+  status: SelfAssessmentStatus | string;
+  ai_system_id?: string | null;
+  ai_system_name?: string | null;
+  schema_version?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  owner?: string | null;
+  created_by?: string | null;
+}
+
+export interface SelfAssessmentSessionDetail extends SelfAssessmentListItem {
+  updated_at?: string | null;
+}
+
+export interface SelfAssessmentClassification {
+  risk_level?: string | null;
+  rationale?: string | null;
+  eu_ai_act_refs?: string[] | null;
+  requires_manual_review?: boolean | null;
+}
+
+export interface SelfAssessmentAuditEvent {
+  event_type?: string | null;
+  type?: string | null;
+  user?: string | null;
+  actor?: string | null;
+  user_id?: string | null;
+  timestamp?: string | null;
+  created_at?: string | null;
+  details?: string | Record<string, unknown> | null;
+  detail?: string | Record<string, unknown> | null;
+}
+
+export type SaApiOk<T> = { ok: true; data: T };
+export type SaApiErr = { ok: false; status: number; message: string };
+export type SaApiResult<T> = SaApiOk<T> | SaApiErr;
+
+function saBase(path: string): string {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${SA_PREFIX}${p}`;
+}
+
+function auditBase(path: string): string {
+  const p = path.startsWith("/") ? path : `/${path}`;
+  return `${AUDIT_PREFIX}${p}`;
+}
+
+async function readErrorMessage(res: Response): Promise<string> {
+  const raw = await res.text();
+  try {
+    const j = JSON.parse(raw) as { detail?: unknown };
+    if (typeof j.detail === "string") {
+      return j.detail;
+    }
+    if (Array.isArray(j.detail)) {
+      return j.detail
+        .map((e) => {
+          if (e && typeof e === "object" && "msg" in e) {
+            return String((e as { msg: unknown }).msg);
+          }
+          return JSON.stringify(e);
+        })
+        .join("; ");
+    }
+  } catch {
+    // ignore
+  }
+  return raw.trim() || `HTTP ${res.status}`;
+}
+
+export async function tenantSaFetchJson<T>(
+  tenantId: string,
+  path: string,
+  init?: RequestInit,
+): Promise<SaApiResult<T>> {
+  const url = `${getComplianceHubApiBaseUrl()}${path}`;
+  const res = await fetch(url, {
+    ...init,
+    headers: tenantRequestHeaders(tenantId, init?.headers, {
+      json: init?.body != null || (init?.method ?? "GET").toUpperCase() !== "GET",
+    }),
+    cache: "no-store",
+  });
+  if (res.status === 204) {
+    return { ok: true, data: undefined as T };
+  }
+  if (!res.ok) {
+    return { ok: false, status: res.status, message: await readErrorMessage(res) };
+  }
+  const ct = res.headers.get("content-type") ?? "";
+  if (!ct.includes("application/json")) {
+    const text = await res.text();
+    return { ok: true, data: text as unknown as T };
+  }
+  return { ok: true, data: (await res.json()) as T };
+}
+
+export function normalizeSessionId(row: Record<string, unknown>): string {
+  const sid = row.session_id ?? row.id;
+  return String(sid ?? "");
+}
+
+export function normalizeListResponse(body: unknown): SelfAssessmentListItem[] {
+  if (Array.isArray(body)) {
+    return body.map((row) => normalizeListItem(row as Record<string, unknown>));
+  }
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    const arr =
+      (o.items as unknown) ??
+      (o.self_assessments as unknown) ??
+      (o.data as unknown) ??
+      (o.results as unknown);
+    if (Array.isArray(arr)) {
+      return arr.map((row) => normalizeListItem(row as Record<string, unknown>));
+    }
+  }
+  return [];
+}
+
+function normalizeListItem(row: Record<string, unknown>): SelfAssessmentListItem {
+  return {
+    session_id: normalizeSessionId(row),
+    status: String(row.status ?? "draft"),
+    ai_system_id: row.ai_system_id != null ? String(row.ai_system_id) : null,
+    ai_system_name: row.ai_system_name != null ? String(row.ai_system_name) : null,
+    schema_version: row.schema_version != null ? String(row.schema_version) : null,
+    started_at: row.started_at != null ? String(row.started_at) : null,
+    completed_at: row.completed_at != null ? String(row.completed_at) : null,
+    owner: row.owner != null ? String(row.owner) : null,
+    created_by: row.created_by != null ? String(row.created_by) : null,
+  };
+}
+
+export function normalizeSessionDetail(body: unknown): SelfAssessmentSessionDetail | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+  const row = body as Record<string, unknown>;
+  const id = normalizeSessionId(row);
+  if (!id) {
+    return null;
+  }
+  return { ...normalizeListItem(row), updated_at: row.updated_at != null ? String(row.updated_at) : null };
+}
+
+export function normalizeAnswersPayload(body: unknown): Record<string, unknown> {
+  if (!body || typeof body !== "object") {
+    return {};
+  }
+  const o = body as Record<string, unknown>;
+  const inner = o.answers;
+  if (inner && typeof inner === "object" && !Array.isArray(inner)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(inner as Record<string, unknown>)) {
+      if (v && typeof v === "object" && !Array.isArray(v) && "value" in v) {
+        out[k] = (v as { value: unknown }).value;
+      } else {
+        out[k] = v;
+      }
+    }
+    return out;
+  }
+  // flat map of question_key -> value
+  const skip = new Set(["session_id", "tenant_id", "status"]);
+  const flat: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(o)) {
+    if (!skip.has(k)) {
+      flat[k] = v;
+    }
+  }
+  return flat;
+}
+
+export function normalizeAuditEvents(body: unknown): SelfAssessmentAuditEvent[] {
+  if (Array.isArray(body)) {
+    return body as SelfAssessmentAuditEvent[];
+  }
+  if (body && typeof body === "object") {
+    const o = body as Record<string, unknown>;
+    const arr = (o.events as unknown) ?? (o.items as unknown);
+    if (Array.isArray(arr)) {
+      return arr as SelfAssessmentAuditEvent[];
+    }
+  }
+  return [];
+}
+
+export function normalizeClassification(body: unknown): SelfAssessmentClassification | null {
+  if (!body || typeof body !== "object") {
+    return null;
+  }
+  const o = body as Record<string, unknown>;
+  const refs = o.eu_ai_act_refs;
+  return {
+    risk_level: o.risk_level != null ? String(o.risk_level) : null,
+    rationale: o.rationale != null ? String(o.rationale) : null,
+    eu_ai_act_refs: Array.isArray(refs) ? refs.map(String) : null,
+    requires_manual_review:
+      typeof o.requires_manual_review === "boolean" ? o.requires_manual_review : null,
+  };
+}
+
+export async function listSelfAssessments(
+  tenantId: string,
+): Promise<SaApiResult<SelfAssessmentListItem[]>> {
+  const r = await tenantSaFetchJson<unknown>(tenantId, saBase("/self-assessments"));
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeListResponse(r.data) };
+}
+
+export async function createSelfAssessment(
+  tenantId: string,
+  body: Record<string, unknown> = {},
+): Promise<SaApiResult<{ session_id?: string; id?: string }>> {
+  return tenantSaFetchJson(tenantId, saBase("/self-assessments"), {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function getSelfAssessmentSession(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<SelfAssessmentSessionDetail | null>> {
+  const r = await tenantSaFetchJson<unknown>(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}`),
+  );
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeSessionDetail(r.data) };
+}
+
+export async function patchSelfAssessmentSession(
+  tenantId: string,
+  sessionId: string,
+  body: Record<string, unknown>,
+): Promise<SaApiResult<SelfAssessmentSessionDetail | null>> {
+  const r = await tenantSaFetchJson<unknown>(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}`),
+    { method: "PATCH", body: JSON.stringify(body) },
+  );
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeSessionDetail(r.data) };
+}
+
+export async function completeSelfAssessment(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<unknown>> {
+  return tenantSaFetchJson(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}/complete`),
+    { method: "POST", body: JSON.stringify({}) },
+  );
+}
+
+export async function getSelfAssessmentAnswers(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<Record<string, unknown>>> {
+  const r = await tenantSaFetchJson<unknown>(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}/answers`),
+  );
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeAnswersPayload(r.data) };
+}
+
+export async function putSelfAssessmentAnswer(
+  tenantId: string,
+  sessionId: string,
+  questionKey: string,
+  value: unknown,
+): Promise<SaApiResult<unknown>> {
+  return tenantSaFetchJson(
+    tenantId,
+    saBase(
+      `/self-assessments/${encodeURIComponent(sessionId)}/answers/${encodeURIComponent(questionKey)}`,
+    ),
+    { method: "PUT", body: JSON.stringify({ value }) },
+  );
+}
+
+export async function getSelfAssessmentClassification(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<SelfAssessmentClassification | null>> {
+  const r = await tenantSaFetchJson<unknown>(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}/classification`),
+  );
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeClassification(r.data) };
+}
+
+export interface ExportSelfAssessmentResult {
+  download_url?: string;
+  url?: string;
+  file_url?: string;
+}
+
+export async function exportSelfAssessment(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<ExportSelfAssessmentResult>> {
+  return tenantSaFetchJson(
+    tenantId,
+    saBase(`/self-assessments/${encodeURIComponent(sessionId)}/export`),
+    { method: "POST", body: JSON.stringify({}) },
+  );
+}
+
+export async function getSelfAssessmentAuditEvents(
+  tenantId: string,
+  sessionId: string,
+): Promise<SaApiResult<SelfAssessmentAuditEvent[]>> {
+  const r = await tenantSaFetchJson<unknown>(
+    tenantId,
+    auditBase(`/self-assessments/${encodeURIComponent(sessionId)}/events`),
+  );
+  if (!r.ok) {
+    return r;
+  }
+  return { ok: true, data: normalizeAuditEvents(r.data) };
+}
+
+export function resolveExportDownloadUrl(payload: ExportSelfAssessmentResult): string | null {
+  const u = payload.download_url ?? payload.url ?? payload.file_url;
+  if (!u) {
+    return null;
+  }
+  if (u.startsWith("http://") || u.startsWith("https://")) {
+    return u;
+  }
+  const base = getComplianceHubApiBaseUrl().replace(/\/$/, "");
+  return `${base}${u.startsWith("/") ? u : `/${u}`}`;
+}

--- a/frontend/src/lib/aiActSelfAssessmentRoutes.ts
+++ b/frontend/src/lib/aiActSelfAssessmentRoutes.ts
@@ -1,0 +1,6 @@
+/** Mandanten-Workspace: EU AI Act Self-Assessment (Enterprise Shell). */
+export const TENANT_AI_ACT_SELF_ASSESSMENTS_PATH = "/tenant/ai-act/self-assessments";
+
+export function tenantAiActSelfAssessmentDetailPath(sessionId: string): string {
+  return `${TENANT_AI_ACT_SELF_ASSESSMENTS_PATH}/${encodeURIComponent(sessionId)}`;
+}

--- a/frontend/src/lib/boardLayout.ts
+++ b/frontend/src/lib/boardLayout.ts
@@ -17,18 +17,19 @@ export const CH_PAGE_TITLE =
 export const CH_PAGE_SUB =
   "mt-2 max-w-2xl text-base leading-relaxed text-slate-600";
 
+/** Eyebrow / Akzent — SBS-Navy (KanzleiAI / Enterprise DACH, vgl. design-tokens.css). */
 export const CH_EYEBROW =
-  "text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700";
+  "text-xs font-semibold uppercase tracking-[0.14em] text-[var(--sbs-navy-mid)]";
 
 export const CH_SECTION_LABEL =
   "text-xs font-semibold uppercase tracking-[0.12em] text-slate-500";
 
 /** Inline-Navigation unter dem Seitentitel */
 export const CH_PAGE_NAV_LINK =
-  "text-sm font-medium text-cyan-700 underline decoration-cyan-600/25 underline-offset-4 transition hover:text-cyan-900";
+  "text-sm font-medium text-[var(--sbs-text-accent)] underline decoration-[var(--sbs-navy-mid)]/30 underline-offset-4 transition hover:text-[var(--sbs-navy-deep)]";
 
 export const CH_BTN_PRIMARY =
-  "inline-flex items-center justify-center rounded-xl bg-cyan-600 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-cyan-700";
+  "inline-flex items-center justify-center rounded-xl bg-[var(--sbs-navy-mid)] px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-[var(--sbs-navy-deep)]";
 
 export const CH_BTN_SECONDARY =
   "inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50";
@@ -61,7 +62,7 @@ export function chKpiStatusFromRatio(ratio: number): {
 
 /** Breadcrumb separator and link style. */
 export const CH_BREADCRUMB_LINK =
-  "text-xs font-medium text-slate-500 hover:text-cyan-700 transition";
+  "text-xs font-medium text-slate-500 hover:text-[var(--sbs-text-accent)] transition";
 
 export const CH_BREADCRUMB_CURRENT =
   "text-xs font-semibold text-slate-800";


### PR DESCRIPTION
- Mandanten-Routen unter /tenant/ai-act/self-assessments inkl. Detail-Run, API-Client, Legacy-Redirect von /app/ai-act/self-assessments
- TenantNav und EU-AI-Act-Seite verlinken den Workspace
- Enterprise-Farben an KanzleiAI/SBS ausgerichtet: Navy-Akzente aus design-tokens statt Cyan (boardLayout, TenantNav, Self-Assessment-UI)

Made-with: Cursor