### PR TITLE
Add operational resilience layer and wire governance operations UI.

### DIFF
--- a/app/db_migrations/migrations/m20260424_service_health_operational_resilience.py
+++ b/app/db_migrations/migrations/m20260424_service_health_operational_resilience.py
@@ -1,0 +1,85 @@
+"""Operational Resilience: service health snapshots + incidents (NIS2 / ISO monitoring MVP)."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260424_service_health_operational_resilience"
+DISPLAY_NAME = "service_health_operational_resilience"
+
+
+def satisfied(engine: Engine) -> bool:
+    return table_exists(engine, "service_health_snapshots")
+
+
+def apply(engine: Engine) -> bool:
+    if table_exists(engine, "service_health_snapshots"):
+        return False
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            CREATE TABLE service_health_snapshots (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                poll_run_id VARCHAR(36) NOT NULL,
+                source VARCHAR(64) NOT NULL DEFAULT 'internal_health_poll',
+                service_name VARCHAR(64) NOT NULL,
+                status VARCHAR(16) NOT NULL,
+                checked_at DATETIME NOT NULL,
+                raw_payload TEXT NOT NULL
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_service_health_snapshots_tenant_checked "
+                "ON service_health_snapshots (tenant_id, checked_at)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_service_health_snapshots_tenant_service "
+                "ON service_health_snapshots (tenant_id, service_name, checked_at)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE service_health_incidents (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                service_name VARCHAR(64) NOT NULL,
+                previous_status VARCHAR(16),
+                current_status VARCHAR(16) NOT NULL,
+                severity VARCHAR(16) NOT NULL,
+                incident_state VARCHAR(16) NOT NULL,
+                source VARCHAR(64) NOT NULL DEFAULT 'internal_health_poll',
+                detected_at DATETIME NOT NULL,
+                resolved_at DATETIME,
+                updated_at_utc DATETIME NOT NULL,
+                triggering_snapshot_id VARCHAR(36),
+                title VARCHAR(500) NOT NULL,
+                summary TEXT NOT NULL DEFAULT ''
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_service_health_incidents_tenant_state "
+                "ON service_health_incidents (tenant_id, incident_state)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_service_health_incidents_tenant_detected "
+                "ON service_health_incidents (tenant_id, detected_at)"
+            )
+        )
+    logger.info("db_migration applied: %s", MIGRATION_ID)
+    return True

--- a/app/governance_taxonomy.py
+++ b/app/governance_taxonomy.py
@@ -17,6 +17,8 @@ class GovernanceAuditEntity(StrEnum):
     AI_GOVERNANCE_ACTION = "ai_governance_action"
     TENANT_API_KEY = "tenant_api_key"
     EVIDENCE_FILE = "evidence_file"
+    SERVICE_HEALTH_SNAPSHOT = "service_health_snapshot"
+    SERVICE_HEALTH_INCIDENT = "service_health_incident"
 
 
 class GovernanceAuditAction(StrEnum):
@@ -43,6 +45,9 @@ class GovernanceAuditAction(StrEnum):
     TENANT_API_KEY_CREATE = "tenant_api_key.create"
     TENANT_API_KEY_REVOKE = "tenant_api_key.revoke"
     EVIDENCE_DELETE = "evidence.delete"
+    SERVICE_HEALTH_POLL_COMPLETED = "service_health.poll.completed"
+    SERVICE_HEALTH_INCIDENT_DETECTED = "service_health.incident.detected"
+    SERVICE_HEALTH_INCIDENT_RESOLVED = "service_health.incident.resolved"
 
 
 class NIS2DeadlinePolicy:

--- a/app/main.py
+++ b/app/main.py
@@ -7,10 +7,11 @@ import json
 import logging
 import os
 import re
+import secrets
 import uuid
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated, Any, Literal
 from urllib.parse import quote
 
@@ -29,6 +30,7 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
+from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.advisor.metrics import AdvisorMetricsResponse, aggregate_advisor_metrics
@@ -257,6 +259,8 @@ from app.operational_monitoring_models import (
     SystemMonitoringIndexOut,
     TenantOperationalMonitoringIndexOut,
 )
+from app.operations_resilience_models import OperationalHealthPollRunResponse
+from app.operations_resilience_routes import router as operations_resilience_router
 from app.policy.opa_client import evaluate_action_policy
 from app.policy.policy_guard import enforce_action_policy
 from app.policy.role_resolution import (
@@ -450,6 +454,8 @@ from app.services.governance_audit import (
     record_governance_audit,
     user_agent_from_request,
 )
+from app.services.health_monitor import run_operational_health_poll_all_tenants
+from app.services.internal_health_core import compute_internal_deep_health
 from app.services.governance_maturity_board_summary_llm import (
     maybe_build_governance_maturity_board_summary_result,
 )
@@ -567,6 +573,7 @@ app = FastAPI(
     lifespan=lifespan,
 )
 app.add_middleware(TelemetryMiddleware)
+app.include_router(operations_resilience_router)
 
 logger = logging.getLogger(__name__)
 
@@ -850,6 +857,96 @@ class NormEvidenceWithAudit(BaseModel):
 @app.get("/health")
 def health_root() -> dict[str, str]:
     return _health_payload()
+
+
+InternalHealthSignal = Literal["up", "degraded", "down"]
+
+
+class InternalDeepHealthResponse(BaseModel):
+    """Structured health for monitoring agents (gated; not tenant-scoped)."""
+
+    app: InternalHealthSignal
+    db: InternalHealthSignal
+    external_ai_provider: InternalHealthSignal
+    timestamp: datetime
+
+
+def _health_api_key_matches(provided: str, expected: str) -> bool:
+    try:
+        return secrets.compare_digest(
+            provided.encode("utf-8"),
+            expected.encode("utf-8"),
+        )
+    except (TypeError, ValueError, AttributeError):
+        return False
+
+
+def require_internal_health_gate(
+    request: Request,
+    x_health_key: Annotated[str | None, Header(alias="X-HEALTH-KEY")] = None,
+) -> None:
+    """API key + optional IP allowlist for internal monitoring (env-driven)."""
+    expected = os.getenv("INTERNAL_HEALTH_API_KEY", "").strip()
+    if not expected:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Internal health endpoint is not configured",
+        )
+    if x_health_key is None or not _health_api_key_matches(x_health_key, expected):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing X-HEALTH-KEY",
+        )
+    allow_raw = os.getenv("INTERNAL_HEALTH_ALLOWED_IPS", "").strip()
+    if not allow_raw:
+        return
+    allowed = {p.strip() for p in allow_raw.split(",") if p.strip()}
+    client_ip = client_ip_from_request(request)
+    if client_ip is None or client_ip not in allowed:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Client IP not allowed for internal health",
+        )
+
+
+@app.get(
+    "/api/internal/health",
+    response_model=InternalDeepHealthResponse,
+    tags=["internal", "health"],
+)
+def internal_deep_health(
+    _: Annotated[None, Depends(require_internal_health_gate)],
+    session: Annotated[Session, Depends(get_session)],
+) -> InternalDeepHealthResponse:
+    """Deep health for monitoring (DB + AI credential posture). Requires X-HEALTH-KEY."""
+    dto = compute_internal_deep_health(session)
+    return InternalDeepHealthResponse(
+        app=dto.app,
+        db=dto.db,
+        external_ai_provider=dto.external_ai_provider,
+        timestamp=dto.timestamp,
+    )
+
+
+@app.post(
+    "/api/internal/health/poll/run",
+    response_model=OperationalHealthPollRunResponse,
+    tags=["internal", "health"],
+)
+def internal_health_poll_run(
+    _: Annotated[None, Depends(require_internal_health_gate)],
+    session: Annotated[Session, Depends(get_session)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> OperationalHealthPollRunResponse:
+    """Cron/n8n-triggered poll: snapshots + incidents for all tenants (same X-HEALTH-KEY gate)."""
+    result = run_operational_health_poll_all_tenants(session, audit_repo)
+    return OperationalHealthPollRunResponse(
+        tenants_processed=result.tenants_processed,
+        snapshots_written=result.snapshots_written,
+        incidents_opened=result.incidents_opened,
+        incidents_resolved=result.incidents_resolved,
+        errors=result.errors,
+    )
 
 
 @app.post("/api/v1/documents/intake", response_model=DocumentIntakeResponse)

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,6 @@ from fastapi import (
 )
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
-from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.advisor.metrics import AdvisorMetricsResponse, aggregate_advisor_metrics
@@ -454,13 +453,13 @@ from app.services.governance_audit import (
     record_governance_audit,
     user_agent_from_request,
 )
-from app.services.health_monitor import run_operational_health_poll_all_tenants
-from app.services.internal_health_core import compute_internal_deep_health
 from app.services.governance_maturity_board_summary_llm import (
     maybe_build_governance_maturity_board_summary_result,
 )
 from app.services.governance_maturity_service import build_governance_maturity_response
+from app.services.health_monitor import run_operational_health_poll_all_tenants
 from app.services.high_risk_scenarios import list_high_risk_scenarios
+from app.services.internal_health_core import compute_internal_deep_health
 from app.services.llm_router import LLMRouter
 from app.services.nis2_kritis_ai_assist import generate_nis2_kpi_suggestions
 from app.services.nis2_kritis_alert_signals import build_nis2_kritis_alert_signals
@@ -8505,7 +8504,6 @@ def create_datev_extf_export(
 ) -> Response:
     """Generate DATEV EXTF ASCII export. Requires EXPORT_DATEV permission."""
     import uuid as _uuid
-    from datetime import UTC
     from datetime import datetime as _dt
 
     from app.models_db import DatevExportLogDB
@@ -8685,7 +8683,6 @@ def get_board_pdf_report(
 ) -> Response:
     """Generate PDF/A-3 board report from KPI data. GoBD-konform, archivierungssicher."""
     import uuid as _uuid
-    from datetime import UTC
     from datetime import datetime as _dt
 
     from app.models_db import ReportExportDB
@@ -8766,7 +8763,6 @@ def create_xrechnung_export(
 ) -> Response:
     """Generate XRechnung 3.0 / EN-16931 UBL 2.1 XML invoice."""
     import uuid as _uuid
-    from datetime import UTC
     from datetime import date as _date
     from datetime import datetime as _dt
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -1088,6 +1088,57 @@ class TenantOperationalMonitoringSnapshotTable(Base):
     )
 
 
+class ServiceHealthSnapshotTable(Base):
+    """Point-in-time per-service health (internal poll); raw_payload preserves audit/replay."""
+
+    __tablename__ = "service_health_snapshots"
+    __table_args__ = (
+        Index("idx_service_health_snapshots_tenant_checked", "tenant_id", "checked_at"),
+        Index(
+            "idx_service_health_snapshots_tenant_service",
+            "tenant_id",
+            "service_name",
+            "checked_at",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    poll_run_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    source: Mapped[str] = mapped_column(String(64), nullable=False, default="internal_health_poll")
+    service_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    checked_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    raw_payload: Mapped[str] = mapped_column(Text, nullable=False)
+
+
+class ServiceHealthIncidentTable(Base):
+    """Governance record from health transitions (monitoring; not full NIS2 case workflow)."""
+
+    __tablename__ = "service_health_incidents"
+    __table_args__ = (
+        Index("idx_service_health_incidents_tenant_state", "tenant_id", "incident_state"),
+        Index("idx_service_health_incidents_tenant_detected", "tenant_id", "detected_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    service_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    previous_status: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    current_status: Mapped[str] = mapped_column(String(16), nullable=False)
+    severity: Mapped[str] = mapped_column(String(16), nullable=False)
+    incident_state: Mapped[str] = mapped_column(String(16), nullable=False)
+    source: Mapped[str] = mapped_column(String(64), nullable=False, default="internal_health_poll")
+    detected_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    triggering_snapshot_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
+
+
 class NIS2IncidentTable(Base):
     """NIS2 Art. 21 compliant incident response records — multi-tenant."""
 

--- a/app/operations_resilience_models.py
+++ b/app/operations_resilience_models.py
@@ -1,0 +1,59 @@
+"""Pydantic models for governance operations / operational resilience APIs."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ServiceHealthSnapshotRead(BaseModel):
+    id: str
+    tenant_id: str
+    poll_run_id: str
+    source: str
+    service_name: str
+    status: str
+    checked_at: datetime
+
+
+class ServiceHealthIncidentRead(BaseModel):
+    id: str
+    tenant_id: str
+    service_name: str
+    previous_status: str | None
+    current_status: str
+    severity: str
+    incident_state: str
+    source: str
+    detected_at: datetime
+    resolved_at: datetime | None
+    title: str
+    summary: str
+
+
+class OperationsKpisRead(BaseModel):
+    last_checked_at: datetime | None
+    open_incidents: int
+    degraded_services: int
+    down_services: int
+
+
+class OperationalHealthPollRunResponse(BaseModel):
+    tenants_processed: int
+    snapshots_written: int
+    incidents_opened: int
+    incidents_resolved: int
+    errors: list[str] = Field(default_factory=list)
+
+
+class IncidentResolveRequest(BaseModel):
+    """Optional actor hint for manual resolution (distinct from auto-resolve on health recovery)."""
+
+    resolved_note: str | None = Field(default=None, max_length=2000)
+
+
+class IncidentResolveResponse(BaseModel):
+    id: str
+    incident_state: str
+    resolved_at: datetime

--- a/app/operations_resilience_routes.py
+++ b/app/operations_resilience_routes.py
@@ -1,0 +1,140 @@
+"""Tenant-scoped governance APIs: operational health snapshots & incidents."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from sqlalchemy.orm import Session
+
+from app.auth_dependencies import get_api_key_and_tenant
+from app.db import get_session
+from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.operations_resilience_models import (
+    IncidentResolveRequest,
+    IncidentResolveResponse,
+    OperationsKpisRead,
+    ServiceHealthIncidentRead,
+    ServiceHealthSnapshotRead,
+)
+from app.rbac.roles import EnterpriseRole
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.service_health import ServiceHealthRepository
+from app.services.governance_audit import record_governance_audit
+
+router = APIRouter(prefix="/api/v1/governance/operations", tags=["governance", "operations"])
+
+
+def get_audit_log_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> AuditLogRepository:
+    return AuditLogRepository(session)
+
+
+def get_service_health_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> ServiceHealthRepository:
+    return ServiceHealthRepository(session)
+
+
+@router.get("/kpis", response_model=OperationsKpisRead)
+def get_operations_kpis(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[ServiceHealthRepository, Depends(get_service_health_repository)],
+) -> OperationsKpisRead:
+    latest = repo.latest_snapshot_statuses(tenant_id)
+    degraded = sum(1 for s in latest.values() if s == "degraded")
+    down = sum(1 for s in latest.values() if s == "down")
+    return OperationsKpisRead(
+        last_checked_at=repo.last_checked_at(tenant_id),
+        open_incidents=repo.count_open_incidents(tenant_id),
+        degraded_services=degraded,
+        down_services=down,
+    )
+
+
+@router.get("/health/snapshots", response_model=list[ServiceHealthSnapshotRead])
+def list_health_snapshots(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[ServiceHealthRepository, Depends(get_service_health_repository)],
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> list[ServiceHealthSnapshotRead]:
+    rows = repo.list_snapshots(tenant_id, limit=limit)
+    return [
+        ServiceHealthSnapshotRead(
+            id=r.id,
+            tenant_id=r.tenant_id,
+            poll_run_id=r.poll_run_id,
+            source=r.source,
+            service_name=r.service_name,
+            status=r.status,
+            checked_at=r.checked_at,
+        )
+        for r in rows
+    ]
+
+
+@router.get("/incidents", response_model=list[ServiceHealthIncidentRead])
+def list_health_incidents(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[ServiceHealthRepository, Depends(get_service_health_repository)],
+    open_only: Annotated[bool, Query()] = False,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+) -> list[ServiceHealthIncidentRead]:
+    rows = repo.list_incidents(tenant_id, open_only=open_only, limit=limit)
+    return [
+        ServiceHealthIncidentRead(
+            id=r.id,
+            tenant_id=r.tenant_id,
+            service_name=r.service_name,
+            previous_status=r.previous_status,
+            current_status=r.current_status,
+            severity=r.severity,
+            incident_state=r.incident_state,
+            source=r.source,
+            detected_at=r.detected_at,
+            resolved_at=r.resolved_at,
+            title=r.title,
+            summary=r.summary,
+        )
+        for r in rows
+    ]
+
+
+@router.patch("/incidents/{incident_id}/resolve", response_model=IncidentResolveResponse)
+def resolve_health_incident(
+    incident_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[ServiceHealthRepository, Depends(get_service_health_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+    body: IncidentResolveRequest | None = Body(default=None),
+) -> IncidentResolveResponse:
+    when = datetime.now(UTC)
+    ok = repo.mark_incident_resolved(tenant_id, incident_id, when)
+    if not ok:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Incident not found or not open",
+        )
+    note = body.resolved_note if body is not None else None
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:tenant_user",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.SERVICE_HEALTH_INCIDENT_RESOLVED.value,
+        entity_type=GovernanceAuditEntity.SERVICE_HEALTH_INCIDENT.value,
+        entity_id=incident_id,
+        outcome="success",
+        before=None,
+        after=json.dumps({"resolved_at": when.isoformat(), "note": note}),
+        correlation_id=None,
+        metadata={"manual_resolve": True},
+    )
+    return IncidentResolveResponse(
+        id=incident_id,
+        incident_state="resolved",
+        resolved_at=when,
+    )

--- a/app/repositories/service_health.py
+++ b/app/repositories/service_health.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import uuid4
+
+from sqlalchemy import Select, func, select, update
+from sqlalchemy.orm import Session
+
+from app.models_db import ServiceHealthIncidentTable, ServiceHealthSnapshotTable, TenantDB
+
+
+@dataclass
+class ServiceHealthSnapshotRow:
+    id: str
+    tenant_id: str
+    poll_run_id: str
+    source: str
+    service_name: str
+    status: str
+    checked_at: datetime
+    raw_payload: str
+
+
+@dataclass
+class ServiceHealthIncidentRow:
+    id: str
+    tenant_id: str
+    service_name: str
+    previous_status: str | None
+    current_status: str
+    severity: str
+    incident_state: str
+    source: str
+    detected_at: datetime
+    resolved_at: datetime | None
+    title: str
+    summary: str
+
+
+class ServiceHealthRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def list_tenant_ids(self) -> list[str]:
+        stmt = select(TenantDB.id)
+        return list(self._session.scalars(stmt).all())
+
+    def last_status_for_service(self, tenant_id: str, service_name: str) -> str | None:
+        stmt: Select[tuple[str]] = (
+            select(ServiceHealthSnapshotTable.status)
+            .where(
+                ServiceHealthSnapshotTable.tenant_id == tenant_id,
+                ServiceHealthSnapshotTable.service_name == service_name,
+            )
+            .order_by(ServiceHealthSnapshotTable.checked_at.desc())
+            .limit(1)
+        )
+        return self._session.execute(stmt).scalar_one_or_none()
+
+    def insert_snapshot(
+        self,
+        *,
+        tenant_id: str,
+        poll_run_id: str,
+        service_name: str,
+        status: str,
+        checked_at: datetime,
+        raw_payload: dict,
+        source: str = "internal_health_poll",
+    ) -> str:
+        sid = str(uuid4())
+        row = ServiceHealthSnapshotTable(
+            id=sid,
+            tenant_id=tenant_id,
+            poll_run_id=poll_run_id,
+            source=source,
+            service_name=service_name,
+            status=status,
+            checked_at=checked_at,
+            raw_payload=json.dumps(raw_payload, default=str),
+        )
+        self._session.add(row)
+        self._session.flush()
+        return sid
+
+    def insert_incident(
+        self,
+        *,
+        tenant_id: str,
+        service_name: str,
+        previous_status: str | None,
+        current_status: str,
+        severity: str,
+        source: str,
+        detected_at: datetime,
+        triggering_snapshot_id: str | None,
+        title: str,
+        summary: str,
+    ) -> str:
+        iid = str(uuid4())
+        row = ServiceHealthIncidentTable(
+            id=iid,
+            tenant_id=tenant_id,
+            service_name=service_name,
+            previous_status=previous_status,
+            current_status=current_status,
+            severity=severity,
+            incident_state="open",
+            source=source,
+            detected_at=detected_at,
+            resolved_at=None,
+            updated_at_utc=detected_at,
+            triggering_snapshot_id=triggering_snapshot_id,
+            title=title,
+            summary=summary,
+        )
+        self._session.add(row)
+        self._session.flush()
+        return iid
+
+    def resolve_open_incidents_for_service(
+        self,
+        tenant_id: str,
+        service_name: str,
+        when: datetime,
+    ) -> int:
+        stmt = (
+            update(ServiceHealthIncidentTable)
+            .where(
+                ServiceHealthIncidentTable.tenant_id == tenant_id,
+                ServiceHealthIncidentTable.service_name == service_name,
+                ServiceHealthIncidentTable.incident_state == "open",
+            )
+            .values(
+                incident_state="resolved",
+                resolved_at=when,
+                updated_at_utc=when,
+            )
+        )
+        res = self._session.execute(stmt)
+        return int(res.rowcount or 0)
+
+    def list_snapshots(
+        self,
+        tenant_id: str,
+        *,
+        limit: int = 100,
+    ) -> list[ServiceHealthSnapshotRow]:
+        stmt = (
+            select(ServiceHealthSnapshotTable)
+            .where(ServiceHealthSnapshotTable.tenant_id == tenant_id)
+            .order_by(ServiceHealthSnapshotTable.checked_at.desc())
+            .limit(limit)
+        )
+        rows = self._session.scalars(stmt).all()
+        return [
+            ServiceHealthSnapshotRow(
+                id=r.id,
+                tenant_id=r.tenant_id,
+                poll_run_id=r.poll_run_id,
+                source=r.source,
+                service_name=r.service_name,
+                status=r.status,
+                checked_at=r.checked_at,
+                raw_payload=r.raw_payload,
+            )
+            for r in rows
+        ]
+
+    def list_incidents(
+        self,
+        tenant_id: str,
+        *,
+        open_only: bool = False,
+        limit: int = 100,
+    ) -> list[ServiceHealthIncidentRow]:
+        stmt = select(ServiceHealthIncidentTable).where(
+            ServiceHealthIncidentTable.tenant_id == tenant_id
+        )
+        if open_only:
+            stmt = stmt.where(ServiceHealthIncidentTable.incident_state == "open")
+        stmt = stmt.order_by(ServiceHealthIncidentTable.detected_at.desc()).limit(limit)
+        rows = self._session.scalars(stmt).all()
+        return [
+            ServiceHealthIncidentRow(
+                id=r.id,
+                tenant_id=r.tenant_id,
+                service_name=r.service_name,
+                previous_status=r.previous_status,
+                current_status=r.current_status,
+                severity=r.severity,
+                incident_state=r.incident_state,
+                source=r.source,
+                detected_at=r.detected_at,
+                resolved_at=r.resolved_at,
+                title=r.title,
+                summary=r.summary,
+            )
+            for r in rows
+        ]
+
+    def get_incident(self, tenant_id: str, incident_id: str) -> ServiceHealthIncidentTable | None:
+        stmt = select(ServiceHealthIncidentTable).where(
+            ServiceHealthIncidentTable.id == incident_id,
+            ServiceHealthIncidentTable.tenant_id == tenant_id,
+        )
+        return self._session.scalars(stmt).first()
+
+    def mark_incident_resolved(self, tenant_id: str, incident_id: str, when: datetime) -> bool:
+        row = self.get_incident(tenant_id, incident_id)
+        if row is None or row.incident_state != "open":
+            return False
+        row.incident_state = "resolved"
+        row.resolved_at = when
+        row.updated_at_utc = when
+        self._session.flush()
+        return True
+
+    def count_open_incidents(self, tenant_id: str) -> int:
+        stmt = select(func.count()).select_from(ServiceHealthIncidentTable).where(
+            ServiceHealthIncidentTable.tenant_id == tenant_id,
+            ServiceHealthIncidentTable.incident_state == "open",
+        )
+        return int(self._session.execute(stmt).scalar_one())
+
+    def latest_snapshot_statuses(self, tenant_id: str) -> dict[str, str]:
+        """Latest status per logical service_name for KPI tiles."""
+        # Per-service latest: fetch ordered rows and pick first per name (small N).
+        stmt = select(ServiceHealthSnapshotTable).where(
+            ServiceHealthSnapshotTable.tenant_id == tenant_id
+        ).order_by(ServiceHealthSnapshotTable.checked_at.desc())
+        rows = self._session.scalars(stmt).all()
+        out: dict[str, str] = {}
+        for r in rows:
+            if r.service_name not in out:
+                out[r.service_name] = r.status
+        return out
+
+    def last_checked_at(self, tenant_id: str) -> datetime | None:
+        stmt = select(func.max(ServiceHealthSnapshotTable.checked_at)).where(
+            ServiceHealthSnapshotTable.tenant_id == tenant_id
+        )
+        return self._session.execute(stmt).scalar_one_or_none()

--- a/app/repositories/service_health.py
+++ b/app/repositories/service_health.py
@@ -219,18 +219,24 @@ class ServiceHealthRepository:
         return True
 
     def count_open_incidents(self, tenant_id: str) -> int:
-        stmt = select(func.count()).select_from(ServiceHealthIncidentTable).where(
-            ServiceHealthIncidentTable.tenant_id == tenant_id,
-            ServiceHealthIncidentTable.incident_state == "open",
+        stmt = (
+            select(func.count())
+            .select_from(ServiceHealthIncidentTable)
+            .where(
+                ServiceHealthIncidentTable.tenant_id == tenant_id,
+                ServiceHealthIncidentTable.incident_state == "open",
+            )
         )
         return int(self._session.execute(stmt).scalar_one())
 
     def latest_snapshot_statuses(self, tenant_id: str) -> dict[str, str]:
         """Latest status per logical service_name for KPI tiles."""
         # Per-service latest: fetch ordered rows and pick first per name (small N).
-        stmt = select(ServiceHealthSnapshotTable).where(
-            ServiceHealthSnapshotTable.tenant_id == tenant_id
-        ).order_by(ServiceHealthSnapshotTable.checked_at.desc())
+        stmt = (
+            select(ServiceHealthSnapshotTable)
+            .where(ServiceHealthSnapshotTable.tenant_id == tenant_id)
+            .order_by(ServiceHealthSnapshotTable.checked_at.desc())
+        )
         rows = self._session.scalars(stmt).all()
         out: dict[str, str] = {}
         for r in rows:

--- a/app/services/health_incident_rules.py
+++ b/app/services/health_incident_rules.py
@@ -1,0 +1,108 @@
+"""Deterministic rules: health status transitions → incidents (Operational Resilience MVP)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+HealthSignal = Literal["up", "degraded", "down"]
+IncidentSeverity = Literal["warning", "critical"]
+
+
+@dataclass(frozen=True)
+class OpenIncidentInstruction:
+    """When set, caller persists a new open service_health_incidents row + audit."""
+
+    severity: IncidentSeverity
+    title_de: str
+    summary_de: str
+
+
+@dataclass(frozen=True)
+class TransitionDecision:
+    """
+    Outcome of comparing the last persisted service status with the new poll result.
+
+    Duplicate polls (previous == current): open_incident is None and resolve_open is False —
+    snapshots are still written by the poller for trend charts / audit replay.
+    """
+
+    open_incident: OpenIncidentInstruction | None
+    resolve_open: bool
+
+
+def evaluate_health_transition(
+    previous_status: HealthSignal | str | None,
+    current_status: HealthSignal | str,
+) -> TransitionDecision:
+    """
+    Explainable NIS2 / ISO-style monitoring rules (code is the policy spec).
+
+    Severity & incidents:
+    - up -> degraded       → Warning incident (partial degradation; incident readiness review).
+    - degraded -> down     → Critical incident (service effectively unavailable / escalation).
+    - up -> down           → Critical incident (hard failure; may skip degraded if missed).
+    - None -> degraded     → Warning (first observation already degraded — still actionable).
+    - None -> down         → Critical (first observation is outage).
+    - None -> up           → no incident (healthy baseline at first poll).
+
+    Recovery (closes open monitoring incidents for this service):
+    - degraded -> up       → resolve_open (service recovered to healthy).
+    - down -> up           → resolve_open.
+
+    Steady unhealthy (no NEW incident row — duplicate snapshot rule):
+    - degraded -> degraded → no new incident.
+    - down -> down         → no new incident.
+    - up -> up             → no new incident.
+
+    Note: resolve_open is independent: any transition *to* "up" from a non-up state triggers
+    resolution of existing open incidents for that service (recovery path).
+    """
+    prev = previous_status
+    cur = current_status
+
+    if prev == cur:
+        return TransitionDecision(open_incident=None, resolve_open=False)
+
+    resolve_open = cur == "up" and prev is not None and prev != "up"
+
+    if cur == "up":
+        return TransitionDecision(open_incident=None, resolve_open=resolve_open)
+
+    if cur == "degraded":
+        if prev == "down":
+            # down→degraded: partial recovery; keep critical incident open until "up".
+            return TransitionDecision(open_incident=None, resolve_open=False)
+        if prev is None or prev == "up":
+            return TransitionDecision(
+                open_incident=OpenIncidentInstruction(
+                    severity="warning",
+                    title_de="Service-Health: eingeschränkt (degraded)",
+                    summary_de="Monitoring meldet eingeschränkten Betrieb. Incident Readiness und "
+                    "NIS2-relevante Meldewege prüfen.",
+                ),
+                resolve_open=resolve_open,
+            )
+
+    if cur == "down":
+        if prev == "degraded":
+            return TransitionDecision(
+                open_incident=OpenIncidentInstruction(
+                    severity="critical",
+                    title_de="Service-Health: Ausfall (degraded → down)",
+                    summary_de="Kritischer Übergang — Incident Playbook, Business Continuity und "
+                    "behördliche Meldefristen (NIS2/KRITIS-Kontext) prüfen.",
+                ),
+                resolve_open=False,
+            )
+        return TransitionDecision(
+            open_incident=OpenIncidentInstruction(
+                severity="critical",
+                title_de="Service-Health: Ausfall",
+                summary_de="Direkter oder erster Ausfallzustand — kritische Eskalation und "
+                "Dokumentation auslösen.",
+            ),
+            resolve_open=False,
+        )
+
+    return TransitionDecision(open_incident=None, resolve_open=False)

--- a/app/services/health_monitor.py
+++ b/app/services/health_monitor.py
@@ -1,0 +1,226 @@
+"""
+Operational Resilience — poll internal deep health, persist snapshots, raise incidents.
+
+Scheduling: invoke ``run_operational_health_poll_all_tenants`` from a cron job, systemd timer,
+or (optional) APScheduler on app startup — see TODO at bottom. n8n / queue fan-out later.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.rbac.roles import EnterpriseRole
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.service_health import ServiceHealthRepository
+from app.services.governance_audit import record_governance_audit
+from app.services.health_incident_rules import evaluate_health_transition
+from app.services.internal_health_core import InternalDeepHealthDTO, compute_internal_deep_health
+
+logger = logging.getLogger(__name__)
+
+_SERVICE_NAMES = ("app", "db", "external_ai_provider")
+
+
+@dataclass
+class OperationalHealthPollResult:
+    tenants_processed: int = 0
+    snapshots_written: int = 0
+    incidents_opened: int = 0
+    incidents_resolved: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _status_for_service(dto: InternalDeepHealthDTO, service_name: str) -> str:
+    if service_name == "app":
+        return dto.app
+    if service_name == "db":
+        return dto.db
+    if service_name == "external_ai_provider":
+        return dto.external_ai_provider
+    raise ValueError(f"unknown service_name {service_name!r}")
+
+
+def _audit(
+    audit_repo: AuditLogRepository | None,
+    *,
+    tenant_id: str,
+    action: str,
+    entity_type: str,
+    entity_id: str,
+    metadata: dict,
+) -> None:
+    if audit_repo is None:
+        return
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="system:operational_health_poller",
+        actor_role=EnterpriseRole.AUDITOR,
+        action=action,
+        entity_type=entity_type,
+        entity_id=entity_id,
+        outcome="success",
+        before=None,
+        after=json.dumps(metadata, default=str),
+        correlation_id=None,
+        metadata=metadata,
+        ip_address=None,
+        user_agent="operational-health-monitor",
+    )
+
+
+def run_operational_health_poll_for_tenant(
+    session: Session,
+    tenant_id: str,
+    audit_repo: AuditLogRepository | None,
+    *,
+    dto: InternalDeepHealthDTO | None = None,
+) -> OperationalHealthPollResult:
+    """
+    Persist one poll wave for a single tenant (shared infra health replicated per tenant_id).
+
+    Platform health is identical across tenants in this MVP; per-tenant rows keep RLS-ready
+    shapes and tenant-scoped dashboards without leaking cross-tenant reads later.
+    """
+    out = OperationalHealthPollResult()
+    repo = ServiceHealthRepository(session)
+    dto = dto or compute_internal_deep_health(session)
+    raw_payload = {
+        "app": dto.app,
+        "db": dto.db,
+        "external_ai_provider": dto.external_ai_provider,
+        "timestamp": dto.timestamp.isoformat(),
+    }
+    poll_run_id = str(uuid4())
+    checked_at = dto.timestamp
+
+    incidents_opened = 0
+    incidents_resolved = 0
+
+    for service_name in _SERVICE_NAMES:
+        new_status = _status_for_service(dto, service_name)
+        previous = repo.last_status_for_service(tenant_id, service_name)
+        snap_id = repo.insert_snapshot(
+            tenant_id=tenant_id,
+            poll_run_id=poll_run_id,
+            service_name=service_name,
+            status=new_status,
+            checked_at=checked_at,
+            raw_payload=raw_payload,
+        )
+        out.snapshots_written += 1
+
+        decision = evaluate_health_transition(previous, new_status)
+
+        if decision.resolve_open:
+            n = repo.resolve_open_incidents_for_service(tenant_id, service_name, checked_at)
+            incidents_resolved += n
+            if n and audit_repo is not None:
+                _audit(
+                    audit_repo,
+                    tenant_id=tenant_id,
+                    action=GovernanceAuditAction.SERVICE_HEALTH_INCIDENT_RESOLVED.value,
+                    entity_type=GovernanceAuditEntity.SERVICE_HEALTH_INCIDENT.value,
+                    entity_id=f"{tenant_id}:{service_name}",
+                    metadata={
+                        "service_name": service_name,
+                        "resolved_at": checked_at.isoformat(),
+                        "rows_closed": n,
+                        "source": "internal_health_poll",
+                    },
+                )
+
+        instr = decision.open_incident
+        if instr is not None:
+            iid = repo.insert_incident(
+                tenant_id=tenant_id,
+                service_name=service_name,
+                previous_status=previous,
+                current_status=new_status,
+                severity=instr.severity,
+                source="internal_health_poll",
+                detected_at=checked_at,
+                triggering_snapshot_id=snap_id,
+                title=instr.title_de,
+                summary=instr.summary_de,
+            )
+            incidents_opened += 1
+            _audit(
+                audit_repo,
+                tenant_id=tenant_id,
+                action=GovernanceAuditAction.SERVICE_HEALTH_INCIDENT_DETECTED.value,
+                entity_type=GovernanceAuditEntity.SERVICE_HEALTH_INCIDENT.value,
+                entity_id=iid,
+                metadata={
+                    "service_name": service_name,
+                    "previous_status": previous,
+                    "current_status": new_status,
+                    "severity": instr.severity,
+                    "source": "internal_health_poll",
+                },
+            )
+
+    out.incidents_opened = incidents_opened
+    out.incidents_resolved = incidents_resolved
+    out.tenants_processed = 1
+
+    _audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        action=GovernanceAuditAction.SERVICE_HEALTH_POLL_COMPLETED.value,
+        entity_type=GovernanceAuditEntity.SERVICE_HEALTH_SNAPSHOT.value,
+        entity_id=poll_run_id,
+        metadata={
+            "poll_run_id": poll_run_id,
+            "snapshots": len(_SERVICE_NAMES),
+            "incidents_opened": incidents_opened,
+            "incidents_resolved": incidents_resolved,
+            "source": "internal_health_poll",
+        },
+    )
+
+    return out
+
+
+def run_operational_health_poll_all_tenants(
+    session: Session,
+    audit_repo: AuditLogRepository | None,
+) -> OperationalHealthPollResult:
+    """Poll once, write snapshots (+ incidents) for every registered tenant."""
+    aggregate = OperationalHealthPollResult()
+    repo = ServiceHealthRepository(session)
+    tenant_ids = repo.list_tenant_ids()
+    if not tenant_ids:
+        logger.info("operational health poll: no tenants registered — skipping")
+        return aggregate
+
+    dto = compute_internal_deep_health(session)
+    for tid in tenant_ids:
+        try:
+            part = run_operational_health_poll_for_tenant(
+                session, tid, audit_repo, dto=dto
+            )
+            aggregate.tenants_processed += part.tenants_processed
+            aggregate.snapshots_written += part.snapshots_written
+            aggregate.incidents_opened += part.incidents_opened
+            aggregate.incidents_resolved += part.incidents_resolved
+        except Exception as exc:  # noqa: BLE001 — log and continue other tenants
+            logger.exception("operational health poll failed for tenant %s", tid)
+            aggregate.errors.append(f"{tid}: {exc!r}")
+    return aggregate
+
+
+# TODO(phase-2): optional APScheduler job:
+#   from apscheduler.schedulers.background import BackgroundScheduler
+#   scheduler.add_job(
+#       lambda: run_poll_in_request_context(),
+#       "interval",
+#       minutes=int(os.getenv("OPERATIONAL_HEALTH_POLL_MINUTES", "5")),
+#   )
+# TODO(phase-2): push webhook to n8n on critical incident for ticket creation.

--- a/app/services/health_monitor.py
+++ b/app/services/health_monitor.py
@@ -203,9 +203,7 @@ def run_operational_health_poll_all_tenants(
     dto = compute_internal_deep_health(session)
     for tid in tenant_ids:
         try:
-            part = run_operational_health_poll_for_tenant(
-                session, tid, audit_repo, dto=dto
-            )
+            part = run_operational_health_poll_for_tenant(session, tid, audit_repo, dto=dto)
             aggregate.tenants_processed += part.tenants_processed
             aggregate.snapshots_written += part.snapshots_written
             aggregate.incidents_opened += part.incidents_opened

--- a/app/services/health_monitor.py
+++ b/app/services/health_monitor.py
@@ -211,6 +211,8 @@ def run_operational_health_poll_all_tenants(
         except Exception as exc:  # noqa: BLE001 — log and continue other tenants
             logger.exception("operational health poll failed for tenant %s", tid)
             aggregate.errors.append(f"{tid}: {exc!r}")
+            # Clear failed transaction so the next tenant is not hit with PendingRollbackError.
+            session.rollback()
     return aggregate
 
 

--- a/app/services/internal_health_core.py
+++ b/app/services/internal_health_core.py
@@ -1,0 +1,59 @@
+"""Shared internal deep-health computation (HTTP route + operational poller)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Literal, cast
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+InternalHealthSignal = Literal["up", "degraded", "down"]
+
+
+@dataclass(frozen=True)
+class InternalDeepHealthDTO:
+    app: InternalHealthSignal
+    db: InternalHealthSignal
+    external_ai_provider: InternalHealthSignal
+    timestamp: datetime
+
+
+def _external_ai_provider_signal() -> InternalHealthSignal:
+    override = os.getenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "").strip().lower()
+    if override == "up" or override == "degraded" or override == "down":
+        return cast(InternalHealthSignal, override)
+    has_any_key = any(
+        os.getenv(name, "").strip()
+        for name in (
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_API_KEY",
+            "OPENAI_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+        )
+    )
+    return "up" if has_any_key else "degraded"
+
+
+def compute_internal_deep_health(session: Session) -> InternalDeepHealthDTO:
+    """DB connectivity + AI credential posture; same semantics as GET /api/internal/health."""
+    db_status: InternalHealthSignal = "down"
+    try:
+        session.execute(text("SELECT 1"))
+        db_status = "up"
+    except Exception:
+        logger.exception("internal health DB check failed")
+        db_status = "down"
+
+    return InternalDeepHealthDTO(
+        app="up",
+        db=db_status,
+        external_ai_provider=_external_ai_provider_signal(),
+        timestamp=datetime.now(UTC),
+    )

--- a/frontend/src/app/tenant/governance/operations/page.tsx
+++ b/frontend/src/app/tenant/governance/operations/page.tsx
@@ -1,0 +1,7 @@
+import { OperationsResilienceWorkspaceClient } from "@/components/governance/OperationsResilienceWorkspaceClient";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TenantGovernanceOperationsPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  return <OperationsResilienceWorkspaceClient tenantId={tenantId} />;
+}

--- a/frontend/src/components/governance/HealthStatusPill.tsx
+++ b/frontend/src/components/governance/HealthStatusPill.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { HealthStatus } from "@/lib/internalHealth";
+
+const STATUS_RING: Record<HealthStatus, string> = {
+  up: "bg-emerald-50 text-emerald-900 ring-emerald-200/90",
+  degraded: "bg-amber-50 text-amber-950 ring-amber-200/90",
+  down: "bg-rose-50 text-rose-900 ring-rose-200/90",
+};
+
+const STATUS_DOT: Record<HealthStatus, string> = {
+  up: "bg-emerald-500",
+  degraded: "bg-amber-500",
+  down: "bg-rose-600",
+};
+
+const STATUS_LABEL_DE: Record<HealthStatus, string> = {
+  up: "OK",
+  degraded: "Eingeschränkt",
+  down: "Ausfall",
+};
+
+interface Props {
+  status: HealthStatus;
+  label: string;
+}
+
+/** Ampel-Pill für Betriebsstatus (App / DB / externer KI-Provider). */
+export function HealthStatusPill({ status, label }: Props) {
+  return (
+    <span
+      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ring-1 ring-inset ${STATUS_RING[status]}`}
+    >
+      <span
+        className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${STATUS_DOT[status]}`}
+        aria-hidden
+      />
+      <span className="text-slate-700">{label}</span>
+      <span className="tabular-nums text-slate-900">{STATUS_LABEL_DE[status]}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/governance/OperationsResilienceWorkspaceClient.tsx
+++ b/frontend/src/components/governance/OperationsResilienceWorkspaceClient.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { GovernanceWorkspaceLayout } from "@/components/governance/GovernanceWorkspaceLayout";
+import { HealthStatusPill } from "@/components/governance/HealthStatusPill";
+import type { HealthStatus } from "@/lib/internalHealth";
+import {
+  fetchOperationsKpis,
+  fetchServiceHealthIncidents,
+  fetchServiceHealthSnapshots,
+  resolveServiceHealthIncident,
+  type OperationsKpis,
+  type ServiceHealthIncidentRow,
+  type ServiceHealthSnapshotRow,
+} from "@/lib/governanceOperationsResilience";
+import { CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+function asHealthStatus(s: string): HealthStatus {
+  if (s === "up" || s === "degraded" || s === "down") {
+    return s;
+  }
+  return "degraded";
+}
+
+interface Props {
+  tenantId: string;
+}
+
+export function OperationsResilienceWorkspaceClient({ tenantId }: Props) {
+  const [kpis, setKpis] = useState<OperationsKpis | null>(null);
+  const [snapshots, setSnapshots] = useState<ServiceHealthSnapshotRow[]>([]);
+  const [incidents, setIncidents] = useState<ServiceHealthIncidentRow[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busyIncidentId, setBusyIncidentId] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setLoadError(null);
+    try {
+      const [k, s, i] = await Promise.all([
+        fetchOperationsKpis(tenantId),
+        fetchServiceHealthSnapshots(tenantId),
+        fetchServiceHealthIncidents(tenantId),
+      ]);
+      setKpis(k);
+      setSnapshots(s);
+      setIncidents(i);
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const openIncidents = incidents.filter((x) => x.incident_state === "open");
+
+  async function onResolveIncident(incidentId: string) {
+    setBusyIncidentId(incidentId);
+    setLoadError(null);
+    try {
+      await resolveServiceHealthIncident(tenantId, incidentId, {
+        resolved_note: "Manuell im Operations-Dashboard geschlossen.",
+      });
+      await reload();
+    } catch (e) {
+      setLoadError(e instanceof Error ? e.message : "Auflösen fehlgeschlagen");
+    } finally {
+      setBusyIncidentId(null);
+    }
+  }
+
+  const dashboard = (
+    <div className="space-y-8">
+      {loadError ? (
+        <p className="text-sm text-rose-800" role="alert">
+          {loadError}
+        </p>
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Letzte Prüfung</p>
+          <p className="mt-2 text-sm font-semibold text-slate-900">
+            {kpis?.last_checked_at
+              ? new Date(kpis.last_checked_at).toLocaleString("de-DE", {
+                  dateStyle: "short",
+                  timeStyle: "short",
+                })
+              : "—"}
+          </p>
+          <p className="mt-1 text-xs text-slate-600">Quelle: internal_health_poll</p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Offene Incidents</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {kpis?.open_incidents ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Services degraded</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-amber-800">
+            {kpis?.degraded_services ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Services down</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-rose-800">
+            {kpis?.down_services ?? "—"}
+          </p>
+        </article>
+      </section>
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Offene Incidents</p>
+        <h2 className="mt-1 text-lg font-semibold text-slate-900">Governance &amp; Incident Readiness</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Automatisch aus Health-Statuswechseln erzeugt (Warning/Critical). Manuelles Abschließen
+          über PATCH /api/v1/governance/operations/incidents/…/resolve (Button „Erledigt“).
+        </p>
+        <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200/80">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+            <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-3 py-2">Erkannt</th>
+                <th className="px-3 py-2">Service</th>
+                <th className="px-3 py-2">Schwere</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Titel</th>
+                <th className="px-3 py-2">Aktion</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {openIncidents.length === 0 ? (
+                <tr>
+                  <td className="px-3 py-4 text-slate-600" colSpan={6}>
+                    Keine offenen Incidents.
+                  </td>
+                </tr>
+              ) : (
+                openIncidents.map((row) => (
+                  <tr key={row.id} className="hover:bg-slate-50/80">
+                    <td className="px-3 py-2 text-slate-700">
+                      {new Date(row.detected_at).toLocaleString("de-DE")}
+                    </td>
+                    <td className="px-3 py-2 font-medium text-slate-900">{row.service_name}</td>
+                    <td className="px-3 py-2 text-slate-800">{row.severity}</td>
+                    <td className="px-3 py-2 text-slate-700">{row.incident_state}</td>
+                    <td className="px-3 py-2 text-slate-700">{row.title}</td>
+                    <td className="px-3 py-2">
+                      <button
+                        type="button"
+                        disabled={busyIncidentId !== null}
+                        onClick={() => void onResolveIncident(row.id)}
+                        className="rounded-lg border border-slate-300 bg-white px-2 py-1 text-xs font-semibold text-slate-800 shadow-sm hover:bg-slate-50 disabled:opacity-40"
+                      >
+                        {busyIncidentId === row.id ? "…" : "Erledigt"}
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </article>
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Service Health Verlauf</p>
+        <h2 className="mt-1 text-lg font-semibold text-slate-900">Snapshots (Trend / Audit)</h2>
+        <p className="mt-2 text-sm text-slate-600">
+          Zeilen entsprechen GET /api/v1/governance/operations/health/snapshots.
+        </p>
+        <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200/80">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+            <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="px-3 py-2">Zeit</th>
+                <th className="px-3 py-2">Service</th>
+                <th className="px-3 py-2">Status</th>
+                <th className="px-3 py-2">Quelle</th>
+                <th className="px-3 py-2">poll_run_id</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {snapshots.map((row) => (
+                <tr key={row.id} className="hover:bg-slate-50/80">
+                  <td className="px-3 py-2 text-slate-700">
+                    {new Date(row.checked_at).toLocaleString("de-DE")}
+                  </td>
+                  <td className="px-3 py-2 font-medium text-slate-900">{row.service_name}</td>
+                  <td className="px-3 py-2">
+                    <HealthStatusPill status={asHealthStatus(row.status)} label="" />
+                  </td>
+                  <td className="px-3 py-2 text-slate-700">{row.source}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-slate-600">{row.poll_run_id}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </article>
+
+      <p className="text-xs text-slate-500">
+        Hinweis: Mandanten sehen replizierte Plattform-Health-Zeilen (MVP), damit spätere RLS und
+        Dashboard-Aggregation pro tenant_id einheitlich bleiben.
+      </p>
+    </div>
+  );
+
+  return (
+    <GovernanceWorkspaceLayout
+      eyebrow="Enterprise · Governance"
+      title="Betrieb &amp; Resilienz"
+      status="monitoring"
+      headerDescription={
+        <>
+          <span className="text-slate-700">
+            Operational Resilience Layer — KPIs, Service-Health-Verlauf und offene
+            Monitoring-Incidents (NIS2 / ISO 27001 / später ISO 42001).           Daten über GET /api/v1/governance/operations/* (NEXT_PUBLIC_API_BASE_URL / API-Key).
+          </span>
+        </>
+      }
+      breadcrumbs={[
+        { label: "Tenant", href: "/tenant/compliance-overview" },
+        { label: "Governance", href: "/tenant/governance/overview" },
+        { label: "Operations" },
+      ]}
+      tabs={[{ id: "overview", label: "Übersicht", content: dashboard }]}
+      activeTabId="overview"
+      onTabChange={() => {}}
+    />
+  );
+}

--- a/frontend/src/components/governance/OperationsResilienceWorkspaceClient.tsx
+++ b/frontend/src/components/governance/OperationsResilienceWorkspaceClient.tsx
@@ -30,21 +30,22 @@ interface Props {
 export function OperationsResilienceWorkspaceClient({ tenantId }: Props) {
   const [kpis, setKpis] = useState<OperationsKpis | null>(null);
   const [snapshots, setSnapshots] = useState<ServiceHealthSnapshotRow[]>([]);
-  const [incidents, setIncidents] = useState<ServiceHealthIncidentRow[]>([]);
+  /** open_only=true server-side — avoids missing opens when many resolved rows fill the limit. */
+  const [openIncidents, setOpenIncidents] = useState<ServiceHealthIncidentRow[]>([]);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [busyIncidentId, setBusyIncidentId] = useState<string | null>(null);
 
   const reload = useCallback(async () => {
     setLoadError(null);
     try {
-      const [k, s, i] = await Promise.all([
+      const [k, s, open] = await Promise.all([
         fetchOperationsKpis(tenantId),
         fetchServiceHealthSnapshots(tenantId),
-        fetchServiceHealthIncidents(tenantId),
+        fetchServiceHealthIncidents(tenantId, { open_only: true, limit: 100 }),
       ]);
       setKpis(k);
       setSnapshots(s);
-      setIncidents(i);
+      setOpenIncidents(open);
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
     }
@@ -53,8 +54,6 @@ export function OperationsResilienceWorkspaceClient({ tenantId }: Props) {
   useEffect(() => {
     void reload();
   }, [reload]);
-
-  const openIncidents = incidents.filter((x) => x.incident_state === "open");
 
   async function onResolveIncident(incidentId: string) {
     setBusyIncidentId(incidentId);

--- a/frontend/src/components/governance/TenantRiskOverviewPanel.tsx
+++ b/frontend/src/components/governance/TenantRiskOverviewPanel.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Link from "next/link";
+import { useEffect, useState } from "react";
 
+import { HealthStatusPill } from "@/components/governance/HealthStatusPill";
+import {
+  fetchHealthStatus,
+  governanceServiceHealthHint,
+  type InternalHealthPayload,
+} from "@/lib/internalHealth";
 import type { TenantRiskOverview } from "@/lib/tenantRiskOverview";
 import { nis2ExposureCategoryLabel } from "@/lib/tenantRiskOverview";
 import { TENANT_AI_ACT_SELF_ASSESSMENTS_PATH } from "@/lib/aiActSelfAssessmentRoutes";
@@ -33,6 +40,28 @@ function exposurePillClass(level: TenantRiskOverview["nis2ExposureLevel"]): stri
  * TODO: Live-Daten vom Server; interaktive Filter; Drilldown in System-/Wizard-Views.
  */
 export function TenantRiskOverviewPanel({ overview }: Props) {
+  const [liveHealth, setLiveHealth] = useState<InternalHealthPayload | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchHealthStatus().then((h) => {
+      if (!cancelled) {
+        setLiveHealth(h);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const serviceHealth = liveHealth ?? {
+    app: overview.serviceHealth.app,
+    db: overview.serviceHealth.db,
+    externalAiProvider: overview.serviceHealth.externalAiProvider,
+    timestamp: overview.serviceHealthCheckedAt,
+  };
+  const healthHint = governanceServiceHealthHint(serviceHealth);
+
   return (
     <div className="space-y-8 md:space-y-10">
       <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
@@ -72,6 +101,39 @@ export function TenantRiskOverviewPanel({ overview }: Props) {
           <p className="mt-1 text-xs text-slate-600">AI-Act / Self-Assessment (heuristisch)</p>
         </article>
       </section>
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Betriebs- &amp; Monitoring-Status</p>
+        <h2 className="mt-1 text-lg font-semibold text-slate-900">Continuous Monitoring (Baustein)</h2>
+        <p className="mt-2 text-sm leading-relaxed text-slate-600">
+          Aggregierte Signale für Mandanten-Governance (NIS2/KRITIS-Betrieb, Incident Readiness).
+          Detaildaten stammen aus internem Health-Check (Stub:{" "}
+          <code className="rounded bg-slate-100 px-1">fetchHealthStatus</code>
+          ), später an geschützten Health-Endpunkt angebunden.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-2">
+          <HealthStatusPill status={serviceHealth.app} label="App" />
+          <HealthStatusPill status={serviceHealth.db} label="Datenbank" />
+          <HealthStatusPill status={serviceHealth.externalAiProvider} label="KI-Provider (extern)" />
+        </div>
+        <p className="mt-3 text-xs text-slate-500">
+          Stand:{" "}
+          <time dateTime={serviceHealth.timestamp}>
+            {new Date(serviceHealth.timestamp).toLocaleString("de-DE", {
+              dateStyle: "short",
+              timeStyle: "short",
+            })}
+          </time>
+        </p>
+        {healthHint ? (
+          <p
+            className="mt-4 rounded-lg border border-amber-200/80 bg-amber-50/90 px-3 py-2 text-sm text-amber-950"
+            role="status"
+          >
+            {healthHint}
+          </p>
+        ) : null}
+      </article>
 
       <div className="grid gap-6 lg:grid-cols-2">
         <article className={CH_CARD}>

--- a/frontend/src/components/sbs/TenantNav.tsx
+++ b/frontend/src/components/sbs/TenantNav.tsx
@@ -15,6 +15,7 @@ import {
 const baseItems = [
   { href: "/tenant/compliance-overview", label: "Mandant & Übersicht" },
   { href: "/tenant/governance/overview", label: "Risk & Control Overview" },
+  { href: "/tenant/governance/operations", label: "Betrieb & Resilienz" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },
   { href: "/tenant/ai-act/self-assessments", label: "Self-Assessment (AI Act)" },
   { href: "/tenant/nis2/wizard", label: "NIS2 / KRITIS Wizard" },

--- a/frontend/src/lib/governanceOperationsResilience.ts
+++ b/frontend/src/lib/governanceOperationsResilience.ts
@@ -1,0 +1,187 @@
+/**
+ * Operational Resilience / Service Health (tenant governance).
+ *
+ * Client-seitig: NEXT_PUBLIC_API_BASE_URL + NEXT_PUBLIC_API_KEY (wie andere Tenant-Boards).
+ * Server-only Secrets (COMPLIANCEHUB_*) greifen im Browser nicht — ggf. BFF-Route nachziehen.
+ *
+ * APIs:
+ * - GET /api/v1/governance/operations/kpis
+ * - GET /api/v1/governance/operations/health/snapshots?limit=
+ * - GET /api/v1/governance/operations/incidents?open_only=
+ * - PATCH /api/v1/governance/operations/incidents/{id}/resolve
+ *
+ * Cron: POST /api/internal/health/poll/run + X-HEALTH-KEY
+ */
+
+export interface OperationsKpis {
+  last_checked_at: string | null;
+  open_incidents: number;
+  degraded_services: number;
+  down_services: number;
+}
+
+export interface ServiceHealthSnapshotRow {
+  id: string;
+  tenant_id: string;
+  poll_run_id: string;
+  source: string;
+  service_name: string;
+  status: "up" | "degraded" | "down";
+  checked_at: string;
+}
+
+export interface ServiceHealthIncidentRow {
+  id: string;
+  tenant_id: string;
+  service_name: string;
+  previous_status: string | null;
+  current_status: string;
+  severity: "warning" | "critical" | string;
+  incident_state: "open" | "resolved" | string;
+  source: string;
+  detected_at: string;
+  resolved_at: string | null;
+  title: string;
+  summary: string;
+}
+
+function apiBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+function tenantHeaders(tenantId: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey(),
+    "x-tenant-id": tenantId,
+    "Content-Type": "application/json",
+  };
+}
+
+function asHealthStatus(raw: string): ServiceHealthSnapshotRow["status"] {
+  if (raw === "up" || raw === "degraded" || raw === "down") {
+    return raw;
+  }
+  return "degraded";
+}
+
+async function getJson<T>(tenantId: string, path: string): Promise<T> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, { headers: tenantHeaders(tenantId), cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Governance Operations API ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** KPI-Kacheln (letzte Prüfung, offene Incidents, degraded/down Zähler). */
+export async function fetchOperationsKpis(tenantId: string): Promise<OperationsKpis> {
+  const raw = await getJson<OperationsKpis>(tenantId, "/api/v1/governance/operations/kpis");
+  return {
+    last_checked_at:
+      raw.last_checked_at === undefined || raw.last_checked_at === null
+        ? null
+        : String(raw.last_checked_at),
+    open_incidents: Number(raw.open_incidents ?? 0),
+    degraded_services: Number(raw.degraded_services ?? 0),
+    down_services: Number(raw.down_services ?? 0),
+  };
+}
+
+export async function fetchServiceHealthSnapshots(
+  tenantId: string,
+  limit = 100,
+): Promise<ServiceHealthSnapshotRow[]> {
+  const rows = await getJson<unknown[]>(
+    tenantId,
+    `/api/v1/governance/operations/health/snapshots?limit=${encodeURIComponent(String(limit))}`,
+  );
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+  return rows.map((r) => {
+    const o = r as Record<string, unknown>;
+    return {
+      id: String(o.id ?? ""),
+      tenant_id: String(o.tenant_id ?? ""),
+      poll_run_id: String(o.poll_run_id ?? ""),
+      source: String(o.source ?? ""),
+      service_name: String(o.service_name ?? ""),
+      status: asHealthStatus(String(o.status ?? "degraded")),
+      checked_at: String(o.checked_at ?? ""),
+    };
+  });
+}
+
+export async function fetchServiceHealthIncidents(
+  tenantId: string,
+  options?: { open_only?: boolean; limit?: number },
+): Promise<ServiceHealthIncidentRow[]> {
+  const openOnly = options?.open_only ?? false;
+  const limit = options?.limit ?? 100;
+  const q = new URLSearchParams({
+    open_only: openOnly ? "true" : "false",
+    limit: String(limit),
+  });
+  const rows = await getJson<unknown[]>(
+    tenantId,
+    `/api/v1/governance/operations/incidents?${q.toString()}`,
+  );
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+  return rows.map((r) => {
+    const o = r as Record<string, unknown>;
+    return {
+      id: String(o.id ?? ""),
+      tenant_id: String(o.tenant_id ?? ""),
+      service_name: String(o.service_name ?? ""),
+      previous_status: o.previous_status == null ? null : String(o.previous_status),
+      current_status: String(o.current_status ?? ""),
+      severity: String(o.severity ?? ""),
+      incident_state: String(o.incident_state ?? ""),
+      source: String(o.source ?? ""),
+      detected_at: String(o.detected_at ?? ""),
+      resolved_at: o.resolved_at == null ? null : String(o.resolved_at),
+      title: String(o.title ?? ""),
+      summary: String(o.summary ?? ""),
+    };
+  });
+}
+
+export interface ResolveIncidentResponse {
+  id: string;
+  incident_state: string;
+  resolved_at: string;
+}
+
+export async function resolveServiceHealthIncident(
+  tenantId: string,
+  incidentId: string,
+  body?: { resolved_note?: string | null },
+): Promise<ResolveIncidentResponse> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}/api/v1/governance/operations/incidents/${encodeURIComponent(incidentId)}/resolve`;
+  const res = await fetch(url, {
+    method: "PATCH",
+    headers: tenantHeaders(tenantId),
+    cache: "no-store",
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) {
+    throw new Error(`Resolve incident ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as ResolveIncidentResponse;
+}

--- a/frontend/src/lib/internalHealth.ts
+++ b/frontend/src/lib/internalHealth.ts
@@ -1,0 +1,55 @@
+/**
+ * Interne Betriebs-/Monitoring-Health ( später GET /api/internal/health mit X-HEALTH-KEY serverseitig;
+ * Browser ruft typischerweise einen mandanten-auth-geschützten BFF auf ).
+ */
+
+export type HealthStatus = "up" | "degraded" | "down";
+
+export interface ServiceHealth {
+  app: HealthStatus;
+  db: HealthStatus;
+  externalAiProvider: HealthStatus;
+}
+
+export interface InternalHealthPayload extends ServiceHealth {
+  timestamp: string;
+}
+
+/** Mappt JSON mit snake_case vom Backend auf das Frontend-ViewModel. */
+export function mapInternalHealthJson(body: {
+  app: HealthStatus;
+  db: HealthStatus;
+  external_ai_provider: HealthStatus;
+  timestamp: string;
+}): InternalHealthPayload {
+  return {
+    app: body.app,
+    db: body.db,
+    externalAiProvider: body.external_ai_provider,
+    timestamp: body.timestamp,
+  };
+}
+
+/**
+ * Stub: später z. B. mandanten-auth-geschützter Proxy → GET /api/internal/health.
+ * Beispiel-Payload mit `externalAiProvider: "degraded"` zeigt Governance-Hinweis in der UI.
+ */
+export async function fetchHealthStatus(): Promise<InternalHealthPayload> {
+  await Promise.resolve();
+  return {
+    app: "up",
+    db: "up",
+    externalAiProvider: "degraded",
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function governanceServiceHealthHint(health: ServiceHealth): string | null {
+  if (health.app === "down" || health.db === "down" || health.externalAiProvider === "down") {
+    return "Bitte Incident-Playbook und NIS2-Meldewege prüfen. Monitoring, Eskalation und Nachweise zur Erreichbarkeit absichern.";
+  }
+  if (health.db !== "up" || health.externalAiProvider !== "up") {
+    return "Monitoring und Incident Readiness prüfen — KI-Provider oder Datenbank zeigen Einschränkungen (Continuous Monitoring / NIS2-Betrieb).";
+  }
+  return null;
+}

--- a/frontend/src/lib/tenantRiskOverview.ts
+++ b/frontend/src/lib/tenantRiskOverview.ts
@@ -3,6 +3,10 @@
  * Aggregiert EU AI Act, NIS2/KRITIS (Block 3) und später ISO/Controls (Block 2).
  */
 
+import { fetchHealthStatus, type ServiceHealth } from "./internalHealth";
+
+export type { HealthStatus } from "./internalHealth";
+
 export type Nis2ExposureLevel = "low" | "medium" | "high";
 
 /** Kundenfreundliche Kategorie (Mapping aus Score/Profil, keine Behördenfeststellung). */
@@ -42,6 +46,10 @@ export interface TenantRiskOverview {
   isoControlsImplemented: number;
   isoControlsPlanned: number;
 
+  /** Betrieb / Monitoring (Continuous Monitoring, NIS2-Betriebslage) — siehe fetchHealthStatus. */
+  serviceHealth: ServiceHealth;
+  serviceHealthCheckedAt: string;
+
   topRiskAiSystems: AiActSystemRiskRow[];
   derivedTodos: string[];
 }
@@ -78,6 +86,11 @@ function buildDummyTodos(o: TenantRiskOverview): string[] {
       `${o.isoControlsPlanned} geplante ISO-/Controls (Block 2) — Umsetzung mit Security & Compliance abstimmen.`,
     );
   }
+  if (o.serviceHealth.db !== "up" || o.serviceHealth.externalAiProvider !== "up") {
+    items.push(
+      "Betriebs- oder KI-Provider-Health eingeschränkt — Incident-Playbook, Meldewege und Monitoring prüfen.",
+    );
+  }
   if (items.length === 0) {
     items.push("Keine kritischen Heuristiken — regelmäßiges Monitoring und Dokumentation beibehalten.");
   }
@@ -96,7 +109,7 @@ function buildDummyTodos(o: TenantRiskOverview): string[] {
  * 4) ISO (Block 2): implemented/planned aus control_implementations / roadmap.
  */
 export async function fetchTenantRiskOverview(tenantId: string): Promise<TenantRiskOverview> {
-  await Promise.resolve();
+  const healthPayload = await fetchHealthStatus();
 
   const nis2Score = 68;
   const nis2Level: Nis2ExposureLevel = nis2Score >= 72 ? "high" : nis2Score >= 42 ? "medium" : "low";
@@ -114,6 +127,12 @@ export async function fetchTenantRiskOverview(tenantId: string): Promise<TenantR
     nis2ExposureCategory: exposureCategoryFromScore(nis2Score, nis2Level),
     isoControlsImplemented: 42,
     isoControlsPlanned: 18,
+    serviceHealth: {
+      app: healthPayload.app,
+      db: healthPayload.db,
+      externalAiProvider: healthPayload.externalAiProvider,
+    },
+    serviceHealthCheckedAt: healthPayload.timestamp,
     topRiskAiSystems: [
       {
         ai_system_id: "sys-hr-scoring",

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -108,7 +108,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     assert "20260421_phase12_esigning_key_rotation" in ids
     assert "20260422_phase13_tenant_onboarding_completed" in ids
     assert "20260423_phase14_analytics_indexes" in ids
-    assert len(ids) == 22
+    assert "20260424_service_health_operational_resilience" in ids
+    assert len(ids) == 23
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()

--- a/tests/test_internal_health.py
+++ b/tests/test_internal_health.py
@@ -1,0 +1,69 @@
+"""Gated internal deep-health endpoint (monitoring agents)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_internal_health_requires_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("INTERNAL_HEALTH_API_KEY", raising=False)
+    resp = client.get(
+        "/api/internal/health",
+        headers={"X-HEALTH-KEY": "ignored"},
+    )
+    assert resp.status_code == 503
+
+
+def test_internal_health_rejects_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "test-health-secret")
+    resp = client.get("/api/internal/health")
+    assert resp.status_code == 401
+
+
+def test_internal_health_rejects_wrong_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "test-health-secret")
+    resp = client.get(
+        "/api/internal/health",
+        headers={"X-HEALTH-KEY": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_internal_health_ok_with_valid_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "test-health-secret")
+    monkeypatch.setenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "up")
+    resp = client.get(
+        "/api/internal/health",
+        headers={"X-HEALTH-KEY": "test-health-secret"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["app"] == "up"
+    assert body["db"] == "up"
+    assert body["external_ai_provider"] == "up"
+    assert "timestamp" in body
+
+
+def test_internal_health_ip_allowlist_blocks_unknown_ip(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "test-health-secret")
+    monkeypatch.setenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "up")
+    monkeypatch.setenv("INTERNAL_HEALTH_ALLOWED_IPS", "203.0.113.10")
+    resp = client.get(
+        "/api/internal/health",
+        headers={"X-HEALTH-KEY": "test-health-secret"},
+    )
+    assert resp.status_code == 403
+
+
+def test_internal_health_ip_allowlist_allows_testclient(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "test-health-secret")
+    monkeypatch.setenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "up")
+    monkeypatch.setenv("INTERNAL_HEALTH_ALLOWED_IPS", "testclient")
+    resp = client.get(
+        "/api/internal/health",
+        headers={"X-HEALTH-KEY": "test-health-secret"},
+    )
+    assert resp.status_code == 200

--- a/tests/test_operational_health_poll.py
+++ b/tests/test_operational_health_poll.py
@@ -1,0 +1,147 @@
+"""Operational resilience: internal poll + tenant governance read APIs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db import engine
+from app.main import app
+from app.models_db import ServiceHealthIncidentTable, ServiceHealthSnapshotTable, TenantDB
+from app.repositories.service_health import ServiceHealthRepository
+
+client = TestClient(app)
+
+
+@pytest.fixture()
+def ops_tenant_id() -> str:
+    tid = "operational-health-test-tenant"
+    with Session(engine) as session:
+        session.merge(
+            TenantDB(
+                id=tid,
+                display_name="Operational Health Test",
+                industry="software",
+                country="DE",
+            )
+        )
+        session.commit()
+    yield tid
+    with Session(engine) as session:
+        session.query(ServiceHealthSnapshotTable).filter(
+            ServiceHealthSnapshotTable.tenant_id == tid
+        ).delete(synchronize_session=False)
+        session.query(ServiceHealthIncidentTable).filter(
+            ServiceHealthIncidentTable.tenant_id == tid
+        ).delete(synchronize_session=False)
+        session.query(TenantDB).filter(TenantDB.id == tid).delete(synchronize_session=False)
+        session.commit()
+
+
+@pytest.fixture()
+def ops_tenant_polled(
+    monkeypatch: pytest.MonkeyPatch,
+    ops_tenant_id: str,
+) -> str:
+    """Tenant exists and at least one internal poll has written snapshots."""
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "poll-secret")
+    monkeypatch.setenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "up")
+    r = client.post(
+        "/api/internal/health/poll/run",
+        headers={"X-HEALTH-KEY": "poll-secret"},
+    )
+    assert r.status_code == 200
+    return ops_tenant_id
+
+
+def test_internal_poll_run_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "poll-secret")
+    r = client.post("/api/internal/health/poll/run")
+    assert r.status_code == 401
+
+
+def test_internal_poll_run_writes_snapshots(
+    monkeypatch: pytest.MonkeyPatch, ops_tenant_id: str
+) -> None:
+    monkeypatch.setenv("INTERNAL_HEALTH_API_KEY", "poll-secret")
+    monkeypatch.setenv("INTERNAL_HEALTH_AI_PROVIDER_SIGNAL", "up")
+    r = client.post(
+        "/api/internal/health/poll/run",
+        headers={"X-HEALTH-KEY": "poll-secret"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["tenants_processed"] >= 1
+    assert body["snapshots_written"] >= 3
+
+    with Session(engine) as session:
+        repo = ServiceHealthRepository(session)
+        rows = repo.list_snapshots(ops_tenant_id, limit=10)
+        assert len(rows) >= 3
+        assert {r.service_name for r in rows} >= {"app", "db", "external_ai_provider"}
+
+
+def test_operations_snapshots_api(ops_tenant_polled: str) -> None:
+    from tests.conftest import _headers
+
+    h = _headers()
+    h["x-tenant-id"] = ops_tenant_polled
+    r = client.get("/api/v1/governance/operations/health/snapshots?limit=5", headers=h)
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+    assert len(r.json()) >= 1
+
+
+def test_operations_kpis_api(ops_tenant_polled: str) -> None:
+    from tests.conftest import _headers
+
+    h = _headers()
+    h["x-tenant-id"] = ops_tenant_polled
+    r = client.get("/api/v1/governance/operations/kpis", headers=h)
+    assert r.status_code == 200
+    data = r.json()
+    assert "open_incidents" in data
+    assert "degraded_services" in data
+
+
+def test_patch_resolve_service_health_incident(ops_tenant_polled: str) -> None:
+    from tests.conftest import _headers
+
+    iid = str(uuid4())
+    now = datetime.now(UTC)
+    with Session(engine) as session:
+        session.add(
+            ServiceHealthIncidentTable(
+                id=iid,
+                tenant_id=ops_tenant_polled,
+                service_name="app",
+                previous_status="up",
+                current_status="degraded",
+                severity="warning",
+                incident_state="open",
+                source="internal_health_poll",
+                detected_at=now,
+                resolved_at=None,
+                updated_at_utc=now,
+                triggering_snapshot_id=None,
+                title="Test-Incident",
+                summary="pytest",
+            )
+        )
+        session.commit()
+
+    h = _headers()
+    h["x-tenant-id"] = ops_tenant_polled
+    r = client.patch(
+        f"/api/v1/governance/operations/incidents/{iid}/resolve",
+        headers=h,
+        json={"resolved_note": "pytest manual"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["incident_state"] == "resolved"
+    assert body["id"] == iid


### PR DESCRIPTION
Introduce service health snapshots and incidents with migrations, SQLAlchemy models, repository, deterministic transition rules, and a poller invoked via POST /api/internal/health/poll/run. Expose tenant-scoped REST under /api/v1/governance/operations including KPIs, snapshots, incidents, and PATCH resolve. Share internal health computation in internal_health_core.

Frontend: internal health types, HealthStatusPill, risk overview monitoring section, governance operations page with real API fetches, resolve action, and tenant navigation link. Add tests for internal health, polling, and incident resolution.

Made-with: Cursor