### PR TITLE
feat(governance): unified control layer and controls workspace

### DIFF
--- a/app/db_migrations/migrations/m20260425_governance_unified_controls.py
+++ b/app/db_migrations/migrations/m20260425_governance_unified_controls.py
@@ -1,0 +1,157 @@
+"""Unified Control Layer: requirements, controls, framework mappings.
+
+Evidence, reviews, and status history live in sibling tables.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260425_governance_unified_controls"
+DISPLAY_NAME = "governance_unified_controls"
+
+
+def satisfied(engine: Engine) -> bool:
+    return table_exists(engine, "governance_controls")
+
+
+def apply(engine: Engine) -> bool:
+    if table_exists(engine, "governance_controls"):
+        return False
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            CREATE TABLE governance_requirements (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                requirement_key VARCHAR(128) NOT NULL,
+                title VARCHAR(500) NOT NULL,
+                description TEXT,
+                created_at_utc DATETIME NOT NULL
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX uq_governance_requirements_tenant_key "
+                "ON governance_requirements (tenant_id, requirement_key)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_controls (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                requirement_id VARCHAR(36),
+                title VARCHAR(500) NOT NULL,
+                description TEXT,
+                status VARCHAR(32) NOT NULL DEFAULT 'not_started',
+                owner VARCHAR(320),
+                next_review_at DATETIME,
+                framework_tags_json TEXT NOT NULL DEFAULT '[]',
+                source_inputs_json TEXT NOT NULL DEFAULT '{}',
+                created_at_utc DATETIME NOT NULL,
+                updated_at_utc DATETIME NOT NULL,
+                created_by VARCHAR(255)
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_governance_controls_tenant_status "
+                "ON governance_controls (tenant_id, status)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_governance_controls_tenant_review "
+                "ON governance_controls (tenant_id, next_review_at)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_control_framework_mappings (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                control_id VARCHAR(36) NOT NULL,
+                framework VARCHAR(64) NOT NULL,
+                clause_ref VARCHAR(256) NOT NULL,
+                mapping_note TEXT
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_gcfm_control ON governance_control_framework_mappings "
+                "(tenant_id, control_id)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_control_evidence (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                control_id VARCHAR(36) NOT NULL,
+                title VARCHAR(500) NOT NULL,
+                body_text TEXT,
+                source_type VARCHAR(64) NOT NULL DEFAULT 'manual',
+                source_ref VARCHAR(256),
+                created_at_utc DATETIME NOT NULL,
+                created_by VARCHAR(255)
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_gce_control ON governance_control_evidence "
+                "(tenant_id, control_id)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_control_reviews (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                control_id VARCHAR(36) NOT NULL,
+                due_at DATETIME NOT NULL,
+                completed_at DATETIME,
+                outcome VARCHAR(32),
+                reviewer VARCHAR(320),
+                notes TEXT
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_gcr_control ON governance_control_reviews (tenant_id, control_id)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_control_status_history (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                control_id VARCHAR(36) NOT NULL,
+                from_status VARCHAR(32),
+                to_status VARCHAR(32) NOT NULL,
+                changed_at_utc DATETIME NOT NULL,
+                changed_by VARCHAR(255),
+                note TEXT
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_gcsh_control ON governance_control_status_history "
+                "(tenant_id, control_id, changed_at_utc)"
+            )
+        )
+    logger.info("db_migration applied: %s", MIGRATION_ID)
+    return True

--- a/app/db_migrations/migrations/m20260426_governance_controls_materialized_suggestion_key.py
+++ b/app/db_migrations/migrations/m20260426_governance_controls_materialized_suggestion_key.py
@@ -1,0 +1,72 @@
+"""Add materialized_from_suggestion_key + partial unique index for idempotent from-suggestion."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import column_exists, index_exists, table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260426_governance_controls_materialized_suggestion_key"
+DISPLAY_NAME = "governance_controls_materialized_suggestion_key"
+
+IDX = "uq_gc_tenant_materialized_suggestion"
+
+
+def satisfied(engine: Engine) -> bool:
+    if not table_exists(engine, "governance_controls"):
+        return True
+    if not column_exists(engine, "governance_controls", "materialized_from_suggestion_key"):
+        return False
+    return index_exists(engine, "governance_controls", IDX)
+
+
+def apply(engine: Engine) -> bool:
+    if not table_exists(engine, "governance_controls"):
+        return False
+    if satisfied(engine):
+        return False
+
+    ddl_ran = False
+
+    if not column_exists(engine, "governance_controls", "materialized_from_suggestion_key"):
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "ALTER TABLE governance_controls ADD COLUMN "
+                    "materialized_from_suggestion_key VARCHAR(128)"
+                )
+            )
+            conn.execute(
+                text(
+                    """
+                    UPDATE governance_controls
+                    SET materialized_from_suggestion_key = substr(
+                        json_extract(source_inputs_json, '$.materialized_from_suggestion'),
+                        1, 128
+                    )
+                    WHERE json_extract(source_inputs_json, '$.materialized_from_suggestion')
+                        IS NOT NULL
+                    """
+                )
+            )
+        ddl_ran = True
+
+    if not index_exists(engine, "governance_controls", IDX):
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "CREATE UNIQUE INDEX uq_gc_tenant_materialized_suggestion "
+                    "ON governance_controls (tenant_id, materialized_from_suggestion_key) "
+                    "WHERE materialized_from_suggestion_key IS NOT NULL"
+                )
+            )
+        ddl_ran = True
+
+    if ddl_ran:
+        logger.info("db_migration applied: %s", MIGRATION_ID)
+    return ddl_ran

--- a/app/governance_control_models.py
+++ b/app/governance_control_models.py
@@ -1,0 +1,126 @@
+"""Pydantic schemas for Unified Control Layer (governance controls API)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ControlStatus = Literal[
+    "not_started",
+    "in_progress",
+    "implemented",
+    "needs_review",
+    "overdue",
+]
+
+FrameworkTag = Literal["EU_AI_ACT", "ISO_42001", "ISO_27001", "ISO_27701", "NIS2"]
+
+
+class FrameworkMappingCreate(BaseModel):
+    framework: str = Field(..., max_length=64, examples=["NIS2"])
+    clause_ref: str = Field(..., max_length=256, examples=["Art. 21 (1)"])
+    mapping_note: str | None = Field(default=None, max_length=4000)
+
+
+class FrameworkMappingRead(BaseModel):
+    id: str
+    framework: str
+    clause_ref: str
+    mapping_note: str | None = None
+
+
+class GovernanceControlCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=500)
+    description: str | None = Field(default=None, max_length=8000)
+    requirement_id: str | None = Field(default=None, max_length=36)
+    status: ControlStatus = "not_started"
+    owner: str | None = Field(default=None, max_length=320)
+    next_review_at: datetime | None = None
+    framework_tags: list[str] = Field(default_factory=list)
+    framework_mappings: list[FrameworkMappingCreate] = Field(default_factory=list)
+    source_inputs: dict = Field(
+        default_factory=dict,
+        description="Provenance / rule inputs (e.g. materialized_from_suggestion).",
+    )
+
+
+class GovernanceControlUpdate(BaseModel):
+    title: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, max_length=8000)
+    status: ControlStatus | None = None
+    owner: str | None = Field(default=None, max_length=320)
+    next_review_at: datetime | None = None
+    framework_tags: list[str] | None = None
+
+
+class GovernanceControlRead(BaseModel):
+    id: str
+    tenant_id: str
+    requirement_id: str | None
+    title: str
+    description: str | None
+    status: str
+    owner: str | None
+    next_review_at: datetime | None
+    framework_tags: list[str]
+    source_inputs: dict
+    created_at_utc: datetime
+    updated_at_utc: datetime
+    created_by: str | None
+    framework_mappings: list[FrameworkMappingRead] = Field(default_factory=list)
+
+
+class GovernanceControlEvidenceCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=500)
+    body_text: str | None = Field(default=None, max_length=16000)
+    source_type: str = Field(default="manual", max_length=64)
+    source_ref: str | None = Field(default=None, max_length=256)
+
+
+class GovernanceControlEvidenceRead(BaseModel):
+    id: str
+    control_id: str
+    title: str
+    body_text: str | None
+    source_type: str
+    source_ref: str | None
+    created_at_utc: datetime
+    created_by: str | None
+
+
+class GovernanceControlStatusHistoryRead(BaseModel):
+    id: str
+    control_id: str
+    from_status: str | None
+    to_status: str
+    changed_at_utc: datetime
+    changed_by: str | None
+    note: str | None
+
+
+class GovernanceControlMaterializeRequest(BaseModel):
+    """Idempotent: returns existing control if this suggestion_key was already materialized."""
+
+    suggestion_key: str = Field(..., min_length=1, max_length=128)
+
+
+class GovernanceControlsDashboardSummary(BaseModel):
+    total_controls: int
+    implemented: int
+    in_progress: int
+    not_started: int
+    needs_review: int
+    overdue_reviews: int
+
+
+class GovernanceControlSuggestion(BaseModel):
+    """Deterministic template; not persisted until user creates a control."""
+
+    suggestion_key: str
+    title: str
+    description: str
+    framework_tags: list[str]
+    framework_mappings: list[FrameworkMappingCreate]
+    triggered_by: dict = Field(default_factory=dict)

--- a/app/governance_controls_routes.py
+++ b/app/governance_controls_routes.py
@@ -10,6 +10,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from app.auth_dependencies import get_api_key_and_tenant
@@ -147,7 +148,20 @@ def materialize_control_from_suggestion(
             "triggered_by": match.triggered_by,
         },
     )
-    created = repo.create_control(tenant_id, create, created_by="api:governance-controls")
+    try:
+        created = repo.create_control(tenant_id, create, created_by="api:governance-controls")
+    except IntegrityError:
+        session.rollback()
+        dup = repo.find_materialized_suggestion(tenant_id, body.suggestion_key)
+        if dup is None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Materialize conflict; retry or contact support",
+            ) from None
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=jsonable_encoder(dup),
+        )
     record_governance_audit(
         audit_repo,
         tenant_id=tenant_id,

--- a/app/governance_controls_routes.py
+++ b/app/governance_controls_routes.py
@@ -1,0 +1,311 @@
+"""Unified Control Layer: tenant controls, evidence, dashboard (MVP)."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from sqlalchemy.orm import Session
+
+from app.auth_dependencies import get_api_key_and_tenant
+from app.db import get_session
+from app.governance_control_models import (
+    GovernanceControlCreate,
+    GovernanceControlEvidenceCreate,
+    GovernanceControlEvidenceRead,
+    GovernanceControlMaterializeRequest,
+    GovernanceControlRead,
+    GovernanceControlsDashboardSummary,
+    GovernanceControlStatusHistoryRead,
+    GovernanceControlSuggestion,
+    GovernanceControlUpdate,
+)
+from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.rbac.roles import EnterpriseRole
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.governance_controls import GovernanceControlRepository
+from app.services.governance_audit import record_governance_audit
+from app.services.governance_control_suggestions import suggest_governance_controls
+
+router = APIRouter(prefix="/api/v1/governance/controls", tags=["governance", "controls"])
+
+
+def get_audit_log_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> AuditLogRepository:
+    return AuditLogRepository(session)
+
+
+def get_governance_control_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> GovernanceControlRepository:
+    return GovernanceControlRepository(session)
+
+
+@router.get("/suggestions", response_model=list[GovernanceControlSuggestion])
+def list_control_suggestions(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    session: Annotated[Session, Depends(get_session)],
+) -> list[GovernanceControlSuggestion]:
+    """Deterministic templates from NIS2/KRITIS heuristics, AI register, operational health."""
+    return suggest_governance_controls(session, tenant_id)
+
+
+@router.get("/dashboard/summary", response_model=GovernanceControlsDashboardSummary)
+def controls_dashboard_summary(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+) -> GovernanceControlsDashboardSummary:
+    return repo.dashboard_summary(tenant_id)
+
+
+@router.get("/export")
+def export_controls_csv(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+) -> Response:
+    """Board / audit office: tabular export (UTF-8, semicolon for Excel DE)."""
+    rows = repo.list_controls_for_export(tenant_id)
+    buf = io.StringIO()
+    writer = csv.writer(buf, delimiter=";", quoting=csv.QUOTE_MINIMAL)
+    writer.writerow(
+        [
+            "id",
+            "title",
+            "status",
+            "owner",
+            "next_review_at_utc",
+            "framework_tags",
+            "framework_mappings",
+            "created_at_utc",
+            "updated_at_utc",
+        ]
+    )
+    for r in rows:
+        mappings = " | ".join(f"{m.framework}:{m.clause_ref}" for m in r.framework_mappings)
+        writer.writerow(
+            [
+                r.id,
+                r.title,
+                r.status,
+                r.owner or "",
+                r.next_review_at.isoformat() if r.next_review_at else "",
+                ",".join(r.framework_tags),
+                mappings,
+                r.created_at_utc.isoformat(),
+                r.updated_at_utc.isoformat(),
+            ]
+        )
+    return Response(
+        content="\ufeff" + buf.getvalue(),
+        media_type="text/csv; charset=utf-8",
+        headers={
+            "Content-Disposition": 'attachment; filename="governance_controls_export.csv"',
+        },
+    )
+
+
+@router.post(
+    "/from-suggestion",
+    response_model=GovernanceControlRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def materialize_control_from_suggestion(
+    body: GovernanceControlMaterializeRequest,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    session: Annotated[Session, Depends(get_session)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceControlRead | JSONResponse:
+    """Idempotent: existing materialization returns HTTP 200 with the same body (no duplicate)."""
+    existing = repo.find_materialized_suggestion(tenant_id, body.suggestion_key)
+    if existing is not None:
+        return JSONResponse(
+            status_code=status.HTTP_200_OK,
+            content=jsonable_encoder(existing),
+        )
+    suggestions = suggest_governance_controls(session, tenant_id)
+    match = next((s for s in suggestions if s.suggestion_key == body.suggestion_key), None)
+    if match is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Suggestion not applicable for this tenant or unknown key",
+        )
+    create = GovernanceControlCreate(
+        title=match.title,
+        description=match.description,
+        status="not_started",
+        framework_tags=list(match.framework_tags),
+        framework_mappings=list(match.framework_mappings),
+        source_inputs={
+            "materialized_from_suggestion": match.suggestion_key,
+            "triggered_by": match.triggered_by,
+        },
+    )
+    created = repo.create_control(tenant_id, create, created_by="api:governance-controls")
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-controls",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_CONTROL_CREATE.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_CONTROL.value,
+        entity_id=created.id,
+        outcome="success",
+        before=None,
+        after=json.dumps(
+            {"title": created.title, "materialized_from": match.suggestion_key},
+        ),
+        correlation_id=None,
+        metadata={"source": "from_suggestion"},
+    )
+    return created
+
+
+@router.get("", response_model=list[GovernanceControlRead])
+def list_controls(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+    response: Response,
+    framework_tag: Annotated[str | None, Query(description="Filter by framework tag")] = None,
+    search: Annotated[str | None, Query(max_length=200, description="Title substring")] = None,
+    offset: Annotated[int, Query(ge=0, le=50_000)] = 0,
+    limit: Annotated[int, Query(ge=1, le=500)] = 200,
+) -> list[GovernanceControlRead]:
+    items, total = repo.list_controls_page(
+        tenant_id,
+        framework_tag=framework_tag,
+        search=search,
+        offset=offset,
+        limit=limit,
+    )
+    response.headers["X-Total-Count"] = str(total)
+    response.headers["X-Page-Offset"] = str(offset)
+    response.headers["X-Page-Limit"] = str(limit)
+    return items
+
+
+@router.post("", response_model=GovernanceControlRead, status_code=status.HTTP_201_CREATED)
+def create_control(
+    body: GovernanceControlCreate,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceControlRead:
+    created = repo.create_control(tenant_id, body, created_by="api:governance-controls")
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-controls",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_CONTROL_CREATE.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_CONTROL.value,
+        entity_id=created.id,
+        outcome="success",
+        before=None,
+        after=json.dumps({"title": created.title, "status": created.status}),
+        correlation_id=None,
+        metadata={"framework_tags": created.framework_tags},
+    )
+    return created
+
+
+@router.get("/{control_id}/evidence", response_model=list[GovernanceControlEvidenceRead])
+def list_control_evidence(
+    control_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+) -> list[GovernanceControlEvidenceRead]:
+    if repo.get_control(tenant_id, control_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+    return repo.list_evidence(tenant_id, control_id)
+
+
+@router.get("/{control_id}/status-history", response_model=list[GovernanceControlStatusHistoryRead])
+def list_control_status_history(
+    control_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+) -> list[GovernanceControlStatusHistoryRead]:
+    if repo.get_control(tenant_id, control_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+    return repo.list_status_history(tenant_id, control_id)
+
+
+@router.get("/{control_id}", response_model=GovernanceControlRead)
+def get_control(
+    control_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+) -> GovernanceControlRead:
+    row = repo.get_control(tenant_id, control_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+    return row
+
+
+@router.patch("/{control_id}", response_model=GovernanceControlRead)
+def patch_control(
+    control_id: str,
+    body: GovernanceControlUpdate,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceControlRead:
+    before = repo.get_control(tenant_id, control_id)
+    if before is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+    updated = repo.update_control(tenant_id, control_id, body, changed_by="api:governance-controls")
+    assert updated is not None
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-controls",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_CONTROL_UPDATE.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_CONTROL.value,
+        entity_id=control_id,
+        outcome="success",
+        before=json.dumps({"status": before.status, "owner": before.owner}),
+        after=json.dumps({"status": updated.status, "owner": updated.owner}),
+        correlation_id=None,
+        metadata=None,
+    )
+    return updated
+
+
+@router.post(
+    "/{control_id}/evidence",
+    response_model=GovernanceControlEvidenceRead,
+    status_code=status.HTTP_201_CREATED,
+)
+def add_control_evidence(
+    control_id: str,
+    body: GovernanceControlEvidenceCreate,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[GovernanceControlRepository, Depends(get_governance_control_repository)],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceControlEvidenceRead:
+    ev = repo.add_evidence(tenant_id, control_id, body, created_by="api:governance-controls")
+    if ev is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-controls",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_CONTROL_EVIDENCE_ADD.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_CONTROL_EVIDENCE.value,
+        entity_id=ev.id,
+        outcome="success",
+        before=None,
+        after=json.dumps({"control_id": control_id, "title": ev.title}),
+        correlation_id=None,
+        metadata={"source_type": ev.source_type},
+    )
+    return ev

--- a/app/governance_taxonomy.py
+++ b/app/governance_taxonomy.py
@@ -19,6 +19,8 @@ class GovernanceAuditEntity(StrEnum):
     EVIDENCE_FILE = "evidence_file"
     SERVICE_HEALTH_SNAPSHOT = "service_health_snapshot"
     SERVICE_HEALTH_INCIDENT = "service_health_incident"
+    GOVERNANCE_CONTROL = "governance_control"
+    GOVERNANCE_CONTROL_EVIDENCE = "governance_control_evidence"
 
 
 class GovernanceAuditAction(StrEnum):
@@ -48,6 +50,9 @@ class GovernanceAuditAction(StrEnum):
     SERVICE_HEALTH_POLL_COMPLETED = "service_health.poll.completed"
     SERVICE_HEALTH_INCIDENT_DETECTED = "service_health.incident.detected"
     SERVICE_HEALTH_INCIDENT_RESOLVED = "service_health.incident.resolved"
+    GOVERNANCE_CONTROL_CREATE = "governance_control.create"
+    GOVERNANCE_CONTROL_UPDATE = "governance_control.update"
+    GOVERNANCE_CONTROL_EVIDENCE_ADD = "governance_control.evidence.add"
 
 
 class NIS2DeadlinePolicy:

--- a/app/main.py
+++ b/app/main.py
@@ -217,6 +217,7 @@ from app.feature_flags import (
     is_feature_enabled,
     require_tenant_llm_features,
 )
+from app.governance_controls_routes import router as governance_controls_router
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturityBoardSummaryParseResult
 from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
@@ -573,6 +574,7 @@ app = FastAPI(
 )
 app.add_middleware(TelemetryMiddleware)
 app.include_router(operations_resilience_router)
+app.include_router(governance_controls_router)
 
 logger = logging.getLogger(__name__)
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -1168,6 +1168,14 @@ class GovernanceControlTable(Base):
     __table_args__ = (
         Index("idx_governance_controls_tenant_status", "tenant_id", "status"),
         Index("idx_governance_controls_tenant_review", "tenant_id", "next_review_at"),
+        Index(
+            "uq_gc_tenant_materialized_suggestion",
+            "tenant_id",
+            "materialized_from_suggestion_key",
+            unique=True,
+            sqlite_where=text("materialized_from_suggestion_key IS NOT NULL"),
+            postgresql_where=text("materialized_from_suggestion_key IS NOT NULL"),
+        ),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
@@ -1180,6 +1188,9 @@ class GovernanceControlTable(Base):
     next_review_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     framework_tags_json: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     source_inputs_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    materialized_from_suggestion_key: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, default=None
+    )
     created_at_utc: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, nullable=False
     )

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -1139,6 +1139,123 @@ class ServiceHealthIncidentTable(Base):
     summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
 
 
+class GovernanceRequirementTable(Base):
+    """Normative obligation / requirement statement (tenant catalog; map-once anchor)."""
+
+    __tablename__ = "governance_requirements"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "requirement_key",
+            name="uq_governance_requirements_tenant_key",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    requirement_key: Mapped[str] = mapped_column(String(128), nullable=False)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class GovernanceControlTable(Base):
+    """Unified control implementation for map-once, comply-many (AI Act, ISO, NIS2, …)."""
+
+    __tablename__ = "governance_controls"
+    __table_args__ = (
+        Index("idx_governance_controls_tenant_status", "tenant_id", "status"),
+        Index("idx_governance_controls_tenant_review", "tenant_id", "next_review_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    requirement_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="not_started")
+    owner: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    next_review_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    framework_tags_json: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    source_inputs_json: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
+class GovernanceControlFrameworkMappingTable(Base):
+    """Clause-level mapping: one control → many framework references (audit narrative)."""
+
+    __tablename__ = "governance_control_framework_mappings"
+    __table_args__ = (Index("idx_gcfm_control", "tenant_id", "control_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    control_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    framework: Mapped[str] = mapped_column(String(64), nullable=False)
+    clause_ref: Mapped[str] = mapped_column(String(256), nullable=False)
+    mapping_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class GovernanceControlEvidenceTable(Base):
+    """Evidence artefact bound to a control (policies, logs, wizard exports, health links)."""
+
+    __tablename__ = "governance_control_evidence"
+    __table_args__ = (Index("idx_gce_control", "tenant_id", "control_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    control_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    body_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_type: Mapped[str] = mapped_column(String(64), nullable=False, default="manual")
+    source_ref: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
+class GovernanceControlReviewTable(Base):
+    """Planned or completed control review (ISO / internal audit cycle)."""
+
+    __tablename__ = "governance_control_reviews"
+    __table_args__ = (Index("idx_gcr_control", "tenant_id", "control_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    control_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    due_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    outcome: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    reviewer: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class GovernanceControlStatusHistoryTable(Base):
+    """Immutable status transitions for board / audit readiness."""
+
+    __tablename__ = "governance_control_status_history"
+    __table_args__ = (Index("idx_gcsh_control", "tenant_id", "control_id", "changed_at_utc"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    control_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    from_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    to_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    changed_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    changed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class NIS2IncidentTable(Base):
     """NIS2 Art. 21 compliant incident response records — multi-tenant."""
 

--- a/app/repositories/governance_controls.py
+++ b/app/repositories/governance_controls.py
@@ -98,8 +98,10 @@ class GovernanceControlRepository:
             total = len(out)
             return out[offset : offset + limit], total
 
-        count_stmt = select(func.count()).select_from(GovernanceControlTable).where(
-            GovernanceControlTable.tenant_id == tenant_id
+        count_stmt = (
+            select(func.count())
+            .select_from(GovernanceControlTable)
+            .where(GovernanceControlTable.tenant_id == tenant_id)
         )
         if search and search.strip():
             q = f"%{search.strip()[:200]}%"

--- a/app/repositories/governance_controls.py
+++ b/app/repositories/governance_controls.py
@@ -25,6 +25,14 @@ from app.models_db import (
 )
 
 
+def _as_utc_aware(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
+
+
 class GovernanceControlRepository:
     def __init__(self, session: Session) -> None:
         self._s = session
@@ -183,6 +191,10 @@ class GovernanceControlRepository:
         cid = str(uuid4())
         tags = [t[:64] for t in body.framework_tags]
         src = dict(body.source_inputs) if isinstance(body.source_inputs, dict) else {}
+        mat_key: str | None = None
+        raw_key = src.get("materialized_from_suggestion")
+        if isinstance(raw_key, str) and raw_key.strip():
+            mat_key = raw_key.strip()[:128]
         row = GovernanceControlTable(
             id=cid,
             tenant_id=tenant_id,
@@ -194,6 +206,7 @@ class GovernanceControlRepository:
             next_review_at=body.next_review_at,
             framework_tags_json=tags,
             source_inputs_json=src,
+            materialized_from_suggestion_key=mat_key,
             created_at_utc=now,
             updated_at_utc=now,
             created_by=created_by,
@@ -339,11 +352,20 @@ class GovernanceControlRepository:
     ) -> GovernanceControlRead | None:
         stmt = select(GovernanceControlTable).where(
             GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.materialized_from_suggestion_key == suggestion_key,
         )
-        for row in self._s.scalars(stmt).all():
-            src = row.source_inputs_json if isinstance(row.source_inputs_json, dict) else {}
+        row = self._s.scalars(stmt).first()
+        if row is not None:
+            return self._row_to_read(row)
+        stmt_legacy = select(GovernanceControlTable).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+        )
+        for legacy in self._s.scalars(stmt_legacy).all():
+            if legacy.materialized_from_suggestion_key:
+                continue
+            src = legacy.source_inputs_json if isinstance(legacy.source_inputs_json, dict) else {}
             if src.get("materialized_from_suggestion") == suggestion_key:
-                return self._row_to_read(row)
+                return self._row_to_read(legacy)
         return None
 
     def list_controls_for_export(
@@ -365,24 +387,24 @@ class GovernanceControlRepository:
         total = len(rows)
         status_keys = ("implemented", "in_progress", "not_started", "needs_review", "overdue")
         counts = {s: 0 for s in status_keys}
-        overdue = 0
+        overdue_reviews = 0
         for row in rows:
             st = row.status
             if st in counts:
                 counts[st] += 1
             else:
                 counts["not_started"] += 1
-            if (
-                row.next_review_at is not None
-                and row.next_review_at < now
-                and row.status == "implemented"
-            ):
-                overdue += 1
+            if st == "overdue":
+                overdue_reviews += 1
+            else:
+                deadline = _as_utc_aware(row.next_review_at)
+                if deadline is not None and deadline < now and row.status == "implemented":
+                    overdue_reviews += 1
         return GovernanceControlsDashboardSummary(
             total_controls=total,
             implemented=counts["implemented"],
             in_progress=counts["in_progress"],
             not_started=counts["not_started"],
             needs_review=counts["needs_review"],
-            overdue_reviews=overdue,
+            overdue_reviews=overdue_reviews,
         )

--- a/app/repositories/governance_controls.py
+++ b/app/repositories/governance_controls.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.governance_control_models import (
+    FrameworkMappingCreate,
+    FrameworkMappingRead,
+    GovernanceControlCreate,
+    GovernanceControlEvidenceCreate,
+    GovernanceControlEvidenceRead,
+    GovernanceControlRead,
+    GovernanceControlsDashboardSummary,
+    GovernanceControlStatusHistoryRead,
+    GovernanceControlUpdate,
+)
+from app.models_db import (
+    GovernanceControlEvidenceTable,
+    GovernanceControlFrameworkMappingTable,
+    GovernanceControlStatusHistoryTable,
+    GovernanceControlTable,
+)
+
+
+class GovernanceControlRepository:
+    def __init__(self, session: Session) -> None:
+        self._s = session
+
+    def _mappings_for(self, tenant_id: str, control_id: str) -> list[FrameworkMappingRead]:
+        stmt = select(GovernanceControlFrameworkMappingTable).where(
+            GovernanceControlFrameworkMappingTable.tenant_id == tenant_id,
+            GovernanceControlFrameworkMappingTable.control_id == control_id,
+        )
+        rows = self._s.scalars(stmt).all()
+        return [
+            FrameworkMappingRead(
+                id=r.id,
+                framework=r.framework,
+                clause_ref=r.clause_ref,
+                mapping_note=r.mapping_note,
+            )
+            for r in rows
+        ]
+
+    def _row_to_read(self, row: GovernanceControlTable) -> GovernanceControlRead:
+        tags = row.framework_tags_json if isinstance(row.framework_tags_json, list) else []
+        src = row.source_inputs_json if isinstance(row.source_inputs_json, dict) else {}
+        return GovernanceControlRead(
+            id=row.id,
+            tenant_id=row.tenant_id,
+            requirement_id=row.requirement_id,
+            title=row.title,
+            description=row.description,
+            status=row.status,
+            owner=row.owner,
+            next_review_at=row.next_review_at,
+            framework_tags=list(tags),
+            source_inputs=dict(src),
+            created_at_utc=row.created_at_utc,
+            updated_at_utc=row.updated_at_utc,
+            created_by=row.created_by,
+            framework_mappings=self._mappings_for(row.tenant_id, row.id),
+        )
+
+    _FILTER_SCAN_CAP = 5000
+
+    def _base_stmt(self, tenant_id: str, *, search: str | None):
+        stmt = select(GovernanceControlTable).where(GovernanceControlTable.tenant_id == tenant_id)
+        if search and search.strip():
+            q = f"%{search.strip()[:200]}%"
+            stmt = stmt.where(GovernanceControlTable.title.ilike(q))
+        return stmt.order_by(GovernanceControlTable.updated_at_utc.desc())
+
+    def list_controls_page(
+        self,
+        tenant_id: str,
+        *,
+        framework_tag: str | None = None,
+        search: str | None = None,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> tuple[list[GovernanceControlRead], int]:
+        """
+        Paginated list with accurate total when no framework_tag (SQL count + offset).
+
+        With framework_tag, tags are filtered in-process (JSON array portability); total
+        capped by _FILTER_SCAN_CAP for predictable cost on SQLite.
+        """
+        if framework_tag and framework_tag.strip():
+            stmt = self._base_stmt(tenant_id, search=search).limit(self._FILTER_SCAN_CAP)
+            rows = list(self._s.scalars(stmt).all())
+            out = [self._row_to_read(r) for r in rows]
+            tag = framework_tag.strip().upper()
+            out = [c for c in out if any(t.upper() == tag for t in c.framework_tags)]
+            total = len(out)
+            return out[offset : offset + limit], total
+
+        count_stmt = select(func.count()).select_from(GovernanceControlTable).where(
+            GovernanceControlTable.tenant_id == tenant_id
+        )
+        if search and search.strip():
+            q = f"%{search.strip()[:200]}%"
+            count_stmt = count_stmt.where(GovernanceControlTable.title.ilike(q))
+        total = int(self._s.scalar(count_stmt) or 0)
+
+        stmt = self._base_stmt(tenant_id, search=search).offset(offset).limit(limit)
+        rows = self._s.scalars(stmt).all()
+        return [self._row_to_read(r) for r in rows], total
+
+    def list_controls(
+        self,
+        tenant_id: str,
+        *,
+        framework_tag: str | None = None,
+        limit: int = 200,
+    ) -> list[GovernanceControlRead]:
+        items, _ = self.list_controls_page(
+            tenant_id, framework_tag=framework_tag, search=None, offset=0, limit=limit
+        )
+        return items
+
+    def get_control(self, tenant_id: str, control_id: str) -> GovernanceControlRead | None:
+        stmt = select(GovernanceControlTable).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.id == control_id,
+        )
+        row = self._s.scalars(stmt).first()
+        return self._row_to_read(row) if row else None
+
+    def _insert_mappings(
+        self,
+        tenant_id: str,
+        control_id: str,
+        mappings: list[FrameworkMappingCreate],
+    ) -> None:
+        for m in mappings:
+            self._s.add(
+                GovernanceControlFrameworkMappingTable(
+                    id=str(uuid4()),
+                    tenant_id=tenant_id,
+                    control_id=control_id,
+                    framework=m.framework[:64],
+                    clause_ref=m.clause_ref[:256],
+                    mapping_note=m.mapping_note,
+                )
+            )
+
+    def _append_status_history(
+        self,
+        tenant_id: str,
+        control_id: str,
+        from_status: str | None,
+        to_status: str,
+        changed_by: str | None,
+        note: str | None = None,
+    ) -> None:
+        self._s.add(
+            GovernanceControlStatusHistoryTable(
+                id=str(uuid4()),
+                tenant_id=tenant_id,
+                control_id=control_id,
+                from_status=from_status,
+                to_status=to_status,
+                changed_at_utc=datetime.now(UTC),
+                changed_by=changed_by,
+                note=note,
+            )
+        )
+
+    def create_control(
+        self,
+        tenant_id: str,
+        body: GovernanceControlCreate,
+        *,
+        created_by: str | None,
+    ) -> GovernanceControlRead:
+        now = datetime.now(UTC)
+        cid = str(uuid4())
+        tags = [t[:64] for t in body.framework_tags]
+        src = dict(body.source_inputs) if isinstance(body.source_inputs, dict) else {}
+        row = GovernanceControlTable(
+            id=cid,
+            tenant_id=tenant_id,
+            requirement_id=body.requirement_id,
+            title=body.title,
+            description=body.description,
+            status=body.status,
+            owner=body.owner,
+            next_review_at=body.next_review_at,
+            framework_tags_json=tags,
+            source_inputs_json=src,
+            created_at_utc=now,
+            updated_at_utc=now,
+            created_by=created_by,
+        )
+        self._s.add(row)
+        self._insert_mappings(tenant_id, cid, body.framework_mappings)
+        self._append_status_history(tenant_id, cid, None, body.status, created_by, "created")
+        self._s.flush()
+        return self._row_to_read(row)
+
+    def update_control(
+        self,
+        tenant_id: str,
+        control_id: str,
+        body: GovernanceControlUpdate,
+        *,
+        changed_by: str | None,
+    ) -> GovernanceControlRead | None:
+        stmt = select(GovernanceControlTable).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.id == control_id,
+        )
+        row = self._s.scalars(stmt).first()
+        if row is None:
+            return None
+        prev_status = row.status
+        if body.title is not None:
+            row.title = body.title
+        if body.description is not None:
+            row.description = body.description
+        if body.status is not None:
+            row.status = body.status
+        if body.owner is not None:
+            row.owner = body.owner
+        if body.next_review_at is not None:
+            row.next_review_at = body.next_review_at
+        if body.framework_tags is not None:
+            row.framework_tags_json = [t[:64] for t in body.framework_tags]
+        row.updated_at_utc = datetime.now(UTC)
+        if body.status is not None and body.status != prev_status:
+            self._append_status_history(
+                tenant_id,
+                control_id,
+                prev_status,
+                body.status,
+                changed_by,
+                "status_change",
+            )
+        self._s.flush()
+        return self._row_to_read(row)
+
+    def add_evidence(
+        self,
+        tenant_id: str,
+        control_id: str,
+        body: GovernanceControlEvidenceCreate,
+        *,
+        created_by: str | None,
+    ) -> GovernanceControlEvidenceRead | None:
+        if self.get_control(tenant_id, control_id) is None:
+            return None
+        eid = str(uuid4())
+        now = datetime.now(UTC)
+        ev = GovernanceControlEvidenceTable(
+            id=eid,
+            tenant_id=tenant_id,
+            control_id=control_id,
+            title=body.title,
+            body_text=body.body_text,
+            source_type=body.source_type[:64],
+            source_ref=body.source_ref[:256] if body.source_ref else None,
+            created_at_utc=now,
+            created_by=created_by,
+        )
+        self._s.add(ev)
+        self._s.flush()
+        return GovernanceControlEvidenceRead(
+            id=eid,
+            control_id=control_id,
+            title=body.title,
+            body_text=body.body_text,
+            source_type=body.source_type,
+            source_ref=body.source_ref,
+            created_at_utc=now,
+            created_by=created_by,
+        )
+
+    def list_evidence(self, tenant_id: str, control_id: str) -> list[GovernanceControlEvidenceRead]:
+        if self.get_control(tenant_id, control_id) is None:
+            return []
+        stmt = (
+            select(GovernanceControlEvidenceTable)
+            .where(
+                GovernanceControlEvidenceTable.tenant_id == tenant_id,
+                GovernanceControlEvidenceTable.control_id == control_id,
+            )
+            .order_by(GovernanceControlEvidenceTable.created_at_utc.desc())
+        )
+        rows = self._s.scalars(stmt).all()
+        return [
+            GovernanceControlEvidenceRead(
+                id=r.id,
+                control_id=r.control_id,
+                title=r.title,
+                body_text=r.body_text,
+                source_type=r.source_type,
+                source_ref=r.source_ref,
+                created_at_utc=r.created_at_utc,
+                created_by=r.created_by,
+            )
+            for r in rows
+        ]
+
+    def list_status_history(
+        self, tenant_id: str, control_id: str
+    ) -> list[GovernanceControlStatusHistoryRead]:
+        if self.get_control(tenant_id, control_id) is None:
+            return []
+        stmt = (
+            select(GovernanceControlStatusHistoryTable)
+            .where(
+                GovernanceControlStatusHistoryTable.tenant_id == tenant_id,
+                GovernanceControlStatusHistoryTable.control_id == control_id,
+            )
+            .order_by(GovernanceControlStatusHistoryTable.changed_at_utc.desc())
+        )
+        rows = self._s.scalars(stmt).all()
+        return [
+            GovernanceControlStatusHistoryRead(
+                id=r.id,
+                control_id=r.control_id,
+                from_status=r.from_status,
+                to_status=r.to_status,
+                changed_at_utc=r.changed_at_utc,
+                changed_by=r.changed_by,
+                note=r.note,
+            )
+            for r in rows
+        ]
+
+    def find_materialized_suggestion(
+        self, tenant_id: str, suggestion_key: str
+    ) -> GovernanceControlRead | None:
+        stmt = select(GovernanceControlTable).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+        )
+        for row in self._s.scalars(stmt).all():
+            src = row.source_inputs_json if isinstance(row.source_inputs_json, dict) else {}
+            if src.get("materialized_from_suggestion") == suggestion_key:
+                return self._row_to_read(row)
+        return None
+
+    def list_controls_for_export(
+        self, tenant_id: str, *, limit: int = 10000
+    ) -> list[GovernanceControlRead]:
+        stmt = (
+            select(GovernanceControlTable)
+            .where(GovernanceControlTable.tenant_id == tenant_id)
+            .order_by(GovernanceControlTable.updated_at_utc.desc())
+            .limit(min(limit, 50_000))
+        )
+        rows = self._s.scalars(stmt).all()
+        return [self._row_to_read(r) for r in rows]
+
+    def dashboard_summary(self, tenant_id: str) -> GovernanceControlsDashboardSummary:
+        now = datetime.now(UTC)
+        stmt = select(GovernanceControlTable).where(GovernanceControlTable.tenant_id == tenant_id)
+        rows = list(self._s.scalars(stmt).all())
+        total = len(rows)
+        status_keys = ("implemented", "in_progress", "not_started", "needs_review", "overdue")
+        counts = {s: 0 for s in status_keys}
+        overdue = 0
+        for row in rows:
+            st = row.status
+            if st in counts:
+                counts[st] += 1
+            else:
+                counts["not_started"] += 1
+            if (
+                row.next_review_at is not None
+                and row.next_review_at < now
+                and row.status == "implemented"
+            ):
+                overdue += 1
+        return GovernanceControlsDashboardSummary(
+            total_controls=total,
+            implemented=counts["implemented"],
+            in_progress=counts["in_progress"],
+            not_started=counts["not_started"],
+            needs_review=counts["needs_review"],
+            overdue_reviews=overdue,
+        )

--- a/app/services/governance_control_suggestions.py
+++ b/app/services/governance_control_suggestions.py
@@ -106,8 +106,7 @@ def suggest_governance_controls(
 
     tenant = session.get(TenantDB, tenant_id)
     if tenant is not None and (
-        (tenant.kritis_sector and tenant.kritis_sector.strip())
-        or tenant.nis2_scope == "in_scope"
+        (tenant.kritis_sector and tenant.kritis_sector.strip()) or tenant.nis2_scope == "in_scope"
     ):
         suggestions.append(
             GovernanceControlSuggestion(

--- a/app/services/governance_control_suggestions.py
+++ b/app/services/governance_control_suggestions.py
@@ -1,0 +1,146 @@
+"""
+Deterministic control suggestions (MVP) — no LLM.
+
+Inputs wired to existing repo artefacts:
+- TenantDB (NIS2/KRITIS sector, nis2_scope)
+- AISystemTable risk_level (EU AI Act register)
+- ServiceHealthIncidentTable (operational resilience)
+
+Later: rule engine / RAG over norm text; optional POST to materialize suggestions as controls.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from app.governance_control_models import (
+    FrameworkMappingCreate,
+    GovernanceControlSuggestion,
+)
+from app.models_db import AISystemTable, TenantDB
+from app.repositories.service_health import ServiceHealthRepository
+
+
+def suggest_governance_controls(
+    session: Session,
+    tenant_id: str,
+) -> list[GovernanceControlSuggestion]:
+    """
+    Return reusable control templates when signals indicate elevated exposure.
+
+    Rules (explicit, auditable):
+    1) Open service_health_incidents → monitoring / incident / BCM style controls
+       (feeds Operational Resilience + NIS2 Art.21 narrative overlap).
+    2) Any AI system with risk_level in (high, unacceptable) → AI Act + ISO 42001
+       logging / PMS / technical documentation posture.
+    3) Tenant marked KRITIS sector OR nis2_scope indicates in_scope with sector hint
+       → NIS2 + ISO 27001 supply-chain / governance controls (MVP heuristic).
+    """
+    suggestions: list[GovernanceControlSuggestion] = []
+
+    sh = ServiceHealthRepository(session)
+    if sh.count_open_incidents(tenant_id) > 0:
+        suggestions.append(
+            GovernanceControlSuggestion(
+                suggestion_key="ops_open_health_incidents",
+                title="Incident-Triage und Eskalationspfad (Monitoring)",
+                description=(
+                    "Offene service_health_incidents: formalisiertes Triage, "
+                    "Eskalation, Nachweise für NIS2-Betriebslage und BCM."
+                ),
+                framework_tags=["NIS2", "ISO_27001"],
+                framework_mappings=[
+                    FrameworkMappingCreate(
+                        framework="NIS2",
+                        clause_ref="Art. 21 (incident handling)",
+                        mapping_note="Anknüpfung an operational_health_incidents",
+                    ),
+                    FrameworkMappingCreate(
+                        framework="ISO_27001",
+                        clause_ref="Annex A.16 (Information security aspects of BCM)",
+                        mapping_note="BCM / Verfügbarkeit",
+                    ),
+                ],
+                triggered_by={"signal": "open_service_health_incidents"},
+            )
+        )
+
+    high_ai = session.scalar(
+        select(func.count())
+        .select_from(AISystemTable)
+        .where(
+            AISystemTable.tenant_id == tenant_id,
+            AISystemTable.risk_level.in_(("high", "unacceptable")),
+        )
+    )
+    if int(high_ai or 0) > 0:
+        suggestions.append(
+            GovernanceControlSuggestion(
+                suggestion_key="ai_act_high_risk_register",
+                title="Post-Market Surveillance & Logging (High-Risk KI)",
+                description=(
+                    "Mindestens ein KI-System mit hohem Risiko im Register — "
+                    "PMS, Logging und technische Dokumentation evidenzieren "
+                    "(EU AI Act / ISO 42001)."
+                ),
+                framework_tags=["EU_AI_ACT", "ISO_42001"],
+                framework_mappings=[
+                    FrameworkMappingCreate(
+                        framework="EU_AI_ACT",
+                        clause_ref="Art. 12 (record-keeping) / Art. 72 (post-market monitoring)",
+                        mapping_note="Anknüpfung an ai_systems.risk_level",
+                    ),
+                    FrameworkMappingCreate(
+                        framework="ISO_42001",
+                        clause_ref="Annex A — operational lifecycle controls",
+                        mapping_note="AI-Managementsystem",
+                    ),
+                ],
+                triggered_by={
+                    "signal": "ai_system_high_or_unacceptable",
+                    "count": int(high_ai or 0),
+                },
+            )
+        )
+
+    tenant = session.get(TenantDB, tenant_id)
+    if tenant is not None and (
+        (tenant.kritis_sector and tenant.kritis_sector.strip())
+        or tenant.nis2_scope == "in_scope"
+    ):
+        suggestions.append(
+            GovernanceControlSuggestion(
+                suggestion_key="nis2_governance_supply_chain",
+                title="Lieferketten- und Geschäftsleitungspflichten (NIS2)",
+                description=(
+                    "Mandant mit KRITIS-Sektor oder NIS2-In-Scope-Flag — "
+                    "Dokumentation zu Lieferanten, Risikoüberwachung und Management-Reviews."
+                ),
+                framework_tags=["NIS2", "ISO_27001", "ISO_27701"],
+                framework_mappings=[
+                    FrameworkMappingCreate(
+                        framework="NIS2",
+                        clause_ref="Art. 21 / supply chain",
+                        mapping_note="Heuristik: tenants.kritis_sector / nis2_scope",
+                    ),
+                    FrameworkMappingCreate(
+                        framework="ISO_27001",
+                        clause_ref="Annex A.5 / A.15",
+                        mapping_note="Lieferanten- und Zugangskontrollen",
+                    ),
+                    FrameworkMappingCreate(
+                        framework="ISO_27701",
+                        clause_ref="PIMS operational controls",
+                        mapping_note="Privacy Information Management",
+                    ),
+                ],
+                triggered_by={
+                    "signal": "tenant_nis2_kritis_heuristic",
+                    "kritis_sector": tenant.kritis_sector,
+                    "nis2_scope": tenant.nis2_scope,
+                },
+            )
+        )
+
+    return suggestions

--- a/frontend/src/app/tenant/governance/controls/page.tsx
+++ b/frontend/src/app/tenant/governance/controls/page.tsx
@@ -1,0 +1,7 @@
+import { GovernanceControlsWorkspaceClient } from "@/components/governance/GovernanceControlsWorkspaceClient";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TenantGovernanceControlsPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  return <GovernanceControlsWorkspaceClient tenantId={tenantId} />;
+}

--- a/frontend/src/components/governance/GovernanceControlsWorkspaceClient.tsx
+++ b/frontend/src/components/governance/GovernanceControlsWorkspaceClient.tsx
@@ -1,0 +1,567 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { GovernanceWorkspaceLayout } from "@/components/governance/GovernanceWorkspaceLayout";
+import {
+  downloadControlsCsv,
+  fetchControlEvidence,
+  fetchControlStatusHistory,
+  fetchControlsDashboardSummary,
+  fetchControlSuggestions,
+  fetchGovernanceControls,
+  postControlEvidence,
+  postMaterializeSuggestion,
+  type ControlsDashboardSummary,
+  type FrameworkFilterTag,
+  type GovernanceControlEvidenceRow,
+  type GovernanceControlRow,
+  type GovernanceControlStatusHistoryRow,
+  type GovernanceControlSuggestion,
+} from "@/lib/governanceControlsApi";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+const FRAMEWORK_FILTERS: Array<{ id: FrameworkFilterTag | "ALL"; label: string }> = [
+  { id: "ALL", label: "Alle" },
+  { id: "EU_AI_ACT", label: "EU AI Act" },
+  { id: "ISO_42001", label: "ISO 42001" },
+  { id: "ISO_27001", label: "ISO 27001" },
+  { id: "ISO_27701", label: "ISO 27701" },
+  { id: "NIS2", label: "NIS2 / KRITIS" },
+];
+
+const PAGE_SIZE = 50;
+
+interface Props {
+  tenantId: string;
+}
+
+function statusPillClass(status: string): string {
+  if (status === "implemented") {
+    return "bg-emerald-100 text-emerald-900 ring-emerald-200/80";
+  }
+  if (status === "in_progress") {
+    return "bg-sky-100 text-sky-950 ring-sky-200/80";
+  }
+  if (status === "overdue" || status === "needs_review") {
+    return "bg-amber-100 text-amber-950 ring-amber-200/80";
+  }
+  return "bg-slate-100 text-slate-800 ring-slate-200/80";
+}
+
+export function GovernanceControlsWorkspaceClient({ tenantId }: Props) {
+  const [summary, setSummary] = useState<ControlsDashboardSummary | null>(null);
+  const [rows, setRows] = useState<GovernanceControlRow[]>([]);
+  const [total, setTotal] = useState(0);
+  const [filter, setFilter] = useState<FrameworkFilterTag | "ALL">("ALL");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchDebounced, setSearchDebounced] = useState("");
+  const [suggestions, setSuggestions] = useState<GovernanceControlSuggestion[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [evidence, setEvidence] = useState<GovernanceControlEvidenceRow[]>([]);
+  const [history, setHistory] = useState<GovernanceControlStatusHistoryRow[]>([]);
+  const [detailTab, setDetailTab] = useState<"evidence" | "history">("evidence");
+  const [evidenceModalOpen, setEvidenceModalOpen] = useState(false);
+  const [evTitle, setEvTitle] = useState("");
+  const [evBody, setEvBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setSearchDebounced(searchInput), 400);
+    return () => window.clearTimeout(t);
+  }, [searchInput]);
+
+  useEffect(() => {
+    if (!evidenceModalOpen) {
+      return;
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setEvidenceModalOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [evidenceModalOpen]);
+
+  const loadList = useCallback(
+    async (append: boolean) => {
+      setError(null);
+      const offset = append ? rows.length : 0;
+      const page = await fetchGovernanceControls(tenantId, {
+        frameworkTag: filter === "ALL" ? undefined : filter,
+        search: searchDebounced.trim() || undefined,
+        offset,
+        limit: PAGE_SIZE,
+      });
+      setTotal(page.total);
+      setRows((prev) => (append ? [...prev, ...page.items] : page.items));
+    },
+    [tenantId, filter, searchDebounced, rows.length],
+  );
+
+  const reload = useCallback(async () => {
+    setError(null);
+    try {
+      const [s, sug] = await Promise.all([
+        fetchControlsDashboardSummary(tenantId),
+        fetchControlSuggestions(tenantId),
+      ]);
+      setSummary(s);
+      setSuggestions(sug);
+      const page = await fetchGovernanceControls(tenantId, {
+        frameworkTag: filter === "ALL" ? undefined : filter,
+        search: searchDebounced.trim() || undefined,
+        offset: 0,
+        limit: PAGE_SIZE,
+      });
+      setTotal(page.total);
+      setRows(page.items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    }
+  }, [tenantId, filter, searchDebounced]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setEvidence([]);
+      setHistory([]);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [ev, hi] = await Promise.all([
+          fetchControlEvidence(tenantId, selectedId),
+          fetchControlStatusHistory(tenantId, selectedId),
+        ]);
+        if (!cancelled) {
+          setEvidence(ev);
+          setHistory(hi);
+        }
+      } catch {
+        if (!cancelled) {
+          setEvidence([]);
+          setHistory([]);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, selectedId]);
+
+  const selectedRow = rows.find((r) => r.id === selectedId) ?? null;
+
+  async function onMaterialize(key: string) {
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await postMaterializeSuggestion(tenantId, key);
+      setSuccess("Control aus Vorschlag angelegt oder bereits vorhanden.");
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Materialisierung fehlgeschlagen");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onExport() {
+    setBusy(true);
+    setError(null);
+    try {
+      await downloadControlsCsv(tenantId);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Export fehlgeschlagen");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onSubmitEvidence() {
+    const cid = selectedId;
+    if (!cid || !evTitle.trim()) {
+      setError("Control auswählen und Titel angeben.");
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await postControlEvidence(tenantId, cid, {
+        title: evTitle.trim(),
+        body_text: evBody.trim() || null,
+        source_type: "manual",
+      });
+      setEvidenceModalOpen(false);
+      setEvTitle("");
+      setEvBody("");
+      setSuccess("Evidence gespeichert.");
+      const ev = await fetchControlEvidence(tenantId, cid);
+      setEvidence(ev);
+      void reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Evidence speichern fehlgeschlagen");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const canLoadMore = rows.length < total;
+
+  const dashboard = (
+    <div className="space-y-8">
+      {error ? (
+        <p className="text-sm text-rose-800" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {success ? (
+        <p className="text-sm text-emerald-800" role="status">
+          {success}
+        </p>
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Controls gesamt</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {summary?.total_controls ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Umgesetzt</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-emerald-800">
+            {summary?.implemented ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>In Arbeit</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-sky-800">
+            {summary?.in_progress ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Review fällig / Überfällig</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-amber-900">
+            {(summary?.needs_review ?? 0) + (summary?.overdue_reviews ?? 0)}
+          </p>
+          <p className="mt-1 text-xs text-slate-600">
+            needs_review {summary?.needs_review ?? 0} · overdue {summary?.overdue_reviews ?? 0}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Offen</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {summary?.not_started ?? "—"}
+          </p>
+        </article>
+      </section>
+
+      {suggestions.length > 0 ? (
+        <article className={`${CH_CARD} border-indigo-100 bg-indigo-50/40`}>
+          <p className={CH_SECTION_LABEL}>Deterministische Vorschläge</p>
+          <p className="mt-1 text-sm text-slate-700">
+            Basierend auf NIS2/KRITIS, KI-Register und Betriebs-Health — ohne KI-Blackbox.
+          </p>
+          <ul className="mt-4 space-y-3">
+            {suggestions.map((s) => (
+              <li
+                key={s.suggestion_key}
+                className="flex flex-col gap-2 rounded-lg border border-indigo-100 bg-white/90 p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <p className="font-semibold text-slate-900">{s.title}</p>
+                  <p className="text-xs text-slate-600">{s.description}</p>
+                  <p className="mt-1 text-[0.65rem] uppercase tracking-wide text-slate-500">
+                    {s.framework_tags.join(" · ")}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => void onMaterialize(s.suggestion_key)}
+                  className={CH_BTN_PRIMARY}
+                >
+                  Als Control anlegen
+                </button>
+              </li>
+            ))}
+          </ul>
+        </article>
+      ) : null}
+
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Framework-Filter
+          </span>
+          {FRAMEWORK_FILTERS.map((f) => (
+            <button
+              key={f.id}
+              type="button"
+              onClick={() => setFilter(f.id)}
+              className={
+                filter === f.id
+                  ? "rounded-full bg-[var(--sbs-navy-mid)] px-3 py-1 text-xs font-semibold text-white"
+                  : "rounded-full border border-slate-200 bg-white px-3 py-1 text-xs font-semibold text-slate-700 hover:bg-slate-50"
+              }
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+        <label className="flex min-w-[220px] flex-1 flex-col text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Suche (Titel)
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="z. B. Incident, Lieferkette…"
+            className="mt-1 rounded-lg border border-slate-200 px-3 py-2 text-sm font-normal text-slate-900"
+          />
+        </label>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={busy || !selectedId}
+          onClick={() => {
+            setEvTitle("");
+            setEvBody("");
+            setEvidenceModalOpen(true);
+          }}
+          className={CH_BTN_PRIMARY}
+        >
+          Evidence hinzufügen
+        </button>
+        <button type="button" onClick={() => void reload()} className={CH_BTN_SECONDARY} disabled={busy}>
+          Aktualisieren
+        </button>
+        <button type="button" onClick={() => void onExport()} className={CH_BTN_SECONDARY} disabled={busy}>
+          CSV exportieren
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_minmax(280px,340px)]">
+        <article className={CH_CARD}>
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <div>
+              <p className={CH_SECTION_LABEL}>Controls</p>
+              <h2 className="mt-1 text-lg font-semibold text-slate-900">Map once, comply many</h2>
+            </div>
+            <p className="text-xs text-slate-500">
+              {rows.length} von {total} geladen
+            </p>
+          </div>
+          <div className="mt-4 overflow-x-auto rounded-xl border border-slate-200/80">
+            <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+              <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <tr>
+                  <th className="px-3 py-2">Titel</th>
+                  <th className="px-3 py-2">Status</th>
+                  <th className="px-3 py-2">Owner</th>
+                  <th className="px-3 py-2">Nächstes Review</th>
+                  <th className="px-3 py-2">Tags</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100 bg-white">
+                {rows.length === 0 ? (
+                  <tr>
+                    <td className="px-3 py-6 text-slate-600" colSpan={5}>
+                      Keine Controls — Vorschläge nutzen oder per API POST anlegen.
+                    </td>
+                  </tr>
+                ) : (
+                  rows.map((r) => (
+                    <tr
+                      key={r.id}
+                      className={`cursor-pointer hover:bg-slate-50/80 ${
+                        selectedId === r.id ? "bg-sky-50/90" : ""
+                      }`}
+                      onClick={() => {
+                        setSelectedId(r.id);
+                        setSuccess(null);
+                      }}
+                    >
+                      <td className="px-3 py-2 font-medium text-slate-900">{r.title}</td>
+                      <td className="px-3 py-2">
+                        <span
+                          className={`inline-flex rounded-full px-2 py-0.5 text-[0.65rem] font-semibold ring-1 ring-inset ${statusPillClass(r.status)}`}
+                        >
+                          {r.status}
+                        </span>
+                      </td>
+                      <td className="px-3 py-2 text-slate-700">{r.owner ?? "—"}</td>
+                      <td className="px-3 py-2 text-slate-700">
+                        {r.next_review_at
+                          ? new Date(r.next_review_at).toLocaleDateString("de-DE")
+                          : "—"}
+                      </td>
+                      <td className="px-3 py-2 text-xs text-slate-600">
+                        {(r.framework_tags ?? []).join(", ") || "—"}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          {canLoadMore ? (
+            <div className="mt-4 flex justify-center">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void loadList(true)}
+                className={CH_BTN_SECONDARY}
+              >
+                Mehr laden
+              </button>
+            </div>
+          ) : null}
+        </article>
+
+        <aside className={`${CH_CARD} h-fit border-slate-200/80 lg:sticky lg:top-4`}>
+          <p className={CH_SECTION_LABEL}>Detail</p>
+          {!selectedRow ? (
+            <p className="mt-2 text-sm text-slate-600">Zeile wählen für Evidence-Liste und Status-Historie.</p>
+          ) : (
+            <>
+              <p className="mt-2 font-semibold text-slate-900">{selectedRow.title}</p>
+              <p className="mt-1 font-mono text-[0.65rem] text-slate-500">{selectedRow.id}</p>
+              <div className="mt-3 flex gap-1 border-b border-slate-200 pb-2">
+                <button
+                  type="button"
+                  onClick={() => setDetailTab("evidence")}
+                  className={
+                    detailTab === "evidence"
+                      ? "rounded-md bg-slate-900 px-2 py-1 text-xs font-semibold text-white"
+                      : "rounded-md px-2 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100"
+                  }
+                >
+                  Evidence ({evidence.length})
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDetailTab("history")}
+                  className={
+                    detailTab === "history"
+                      ? "rounded-md bg-slate-900 px-2 py-1 text-xs font-semibold text-white"
+                      : "rounded-md px-2 py-1 text-xs font-semibold text-slate-600 hover:bg-slate-100"
+                  }
+                >
+                  Historie ({history.length})
+                </button>
+              </div>
+              <ul className="mt-3 max-h-72 space-y-2 overflow-y-auto text-xs text-slate-700">
+                {detailTab === "evidence"
+                  ? evidence.map((e) => (
+                      <li key={e.id} className="rounded border border-slate-100 bg-slate-50/80 p-2">
+                        <span className="font-medium">{e.title}</span>
+                        <span className="block text-slate-500">
+                          {new Date(e.created_at_utc).toLocaleString("de-DE")} · {e.source_type}
+                        </span>
+                      </li>
+                    ))
+                  : history.map((h) => (
+                      <li key={h.id} className="rounded border border-slate-100 bg-slate-50/80 p-2">
+                        <span className="font-medium">
+                          {h.from_status ?? "—"} → {h.to_status}
+                        </span>
+                        <span className="block text-slate-500">
+                          {new Date(h.changed_at_utc).toLocaleString("de-DE")}
+                          {h.changed_by ? ` · ${h.changed_by}` : ""}
+                        </span>
+                      </li>
+                    ))}
+              </ul>
+            </>
+          )}
+        </aside>
+      </div>
+
+      {evidenceModalOpen ? (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="evidence-dialog-title"
+          onClick={() => setEvidenceModalOpen(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 id="evidence-dialog-title" className="text-lg font-semibold text-slate-900">
+              Evidence hinzufügen
+            </h3>
+            <p className="mt-1 text-sm text-slate-600">
+              Control: <span className="font-mono text-xs">{selectedId}</span>
+            </p>
+            <label className="mt-4 block text-sm font-medium text-slate-700">
+              Titel
+              <input
+                value={evTitle}
+                onChange={(e) => setEvTitle(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+                placeholder="Policy, Log-Export, Protokoll…"
+              />
+            </label>
+            <label className="mt-3 block text-sm font-medium text-slate-700">
+              Beschreibung (optional)
+              <textarea
+                value={evBody}
+                onChange={(e) => setEvBody(e.target.value)}
+                rows={3}
+                className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+              />
+            </label>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setEvidenceModalOpen(false)}
+                className={CH_BTN_SECONDARY}
+              >
+                Abbrechen
+              </button>
+              <button type="button" disabled={busy} onClick={() => void onSubmitEvidence()} className={CH_BTN_PRIMARY}>
+                Speichern
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <GovernanceWorkspaceLayout
+      eyebrow="Enterprise · Governance"
+      title="Unified Controls"
+      status="active"
+      headerDescription={
+        <span className="text-slate-700">
+          Obligationen und Maßnahmen normenübergreifend bündeln (EU AI Act, ISO 42001, ISO 27001/27701,
+          NIS2/KRITIS). Export und Pagination für Mandanten mit großem Register.
+        </span>
+      }
+      breadcrumbs={[
+        { label: "Tenant", href: "/tenant/compliance-overview" },
+        { label: "Governance", href: "/tenant/governance/overview" },
+        { label: "Controls" },
+      ]}
+      tabs={[{ id: "dash", label: "Übersicht", content: dashboard }]}
+      activeTabId="dash"
+      onTabChange={() => {}}
+    />
+  );
+}

--- a/frontend/src/components/sbs/TenantNav.tsx
+++ b/frontend/src/components/sbs/TenantNav.tsx
@@ -15,6 +15,7 @@ import {
 const baseItems = [
   { href: "/tenant/compliance-overview", label: "Mandant & Übersicht" },
   { href: "/tenant/governance/overview", label: "Risk & Control Overview" },
+  { href: "/tenant/governance/controls", label: "Unified Controls" },
   { href: "/tenant/governance/operations", label: "Betrieb & Resilienz" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },
   { href: "/tenant/ai-act/self-assessments", label: "Self-Assessment (AI Act)" },

--- a/frontend/src/lib/governanceControlsApi.ts
+++ b/frontend/src/lib/governanceControlsApi.ts
@@ -1,0 +1,259 @@
+/**
+ * Unified Control Layer — API client (GET /api/v1/governance/controls/*).
+ * Versioniert wie übrige ComplianceHub-APIs; Auth: NEXT_PUBLIC_* Keys im Browser.
+ */
+
+export type ControlStatus =
+  | "not_started"
+  | "in_progress"
+  | "implemented"
+  | "needs_review"
+  | "overdue";
+
+export type FrameworkFilterTag = "EU_AI_ACT" | "ISO_42001" | "ISO_27001" | "ISO_27701" | "NIS2";
+
+export interface GovernanceControlRow {
+  id: string;
+  tenant_id: string;
+  requirement_id: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  owner: string | null;
+  next_review_at: string | null;
+  framework_tags: string[];
+  source_inputs: Record<string, unknown>;
+  created_at_utc: string;
+  updated_at_utc: string;
+  created_by: string | null;
+  framework_mappings: Array<{
+    id: string;
+    framework: string;
+    clause_ref: string;
+    mapping_note: string | null;
+  }>;
+}
+
+export interface ControlsDashboardSummary {
+  total_controls: number;
+  implemented: number;
+  in_progress: number;
+  not_started: number;
+  needs_review: number;
+  overdue_reviews: number;
+}
+
+export interface GovernanceControlSuggestion {
+  suggestion_key: string;
+  title: string;
+  description: string;
+  framework_tags: string[];
+  framework_mappings: Array<{
+    framework: string;
+    clause_ref: string;
+    mapping_note: string | null;
+  }>;
+  triggered_by: Record<string, unknown>;
+}
+
+export interface GovernanceControlEvidenceRow {
+  id: string;
+  control_id: string;
+  title: string;
+  body_text: string | null;
+  source_type: string;
+  source_ref: string | null;
+  created_at_utc: string;
+  created_by: string | null;
+}
+
+export interface GovernanceControlStatusHistoryRow {
+  id: string;
+  control_id: string;
+  from_status: string | null;
+  to_status: string;
+  changed_at_utc: string;
+  changed_by: string | null;
+  note: string | null;
+}
+
+export interface GovernanceControlsListResult {
+  items: GovernanceControlRow[];
+  total: number;
+  offset: number;
+  limit: number;
+}
+
+function apiBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+function tenantHeaders(tenantId: string): Record<string, string> {
+  return {
+    "x-api-key": apiKey(),
+    "x-tenant-id": tenantId,
+  };
+}
+
+function jsonHeaders(tenantId: string): Record<string, string> {
+  return { ...tenantHeaders(tenantId), "Content-Type": "application/json" };
+}
+
+async function getJson<T>(tenantId: string, path: string): Promise<T> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}${path}`;
+  const res = await fetch(url, {
+    headers: tenantHeaders(tenantId),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Governance Controls ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchControlsDashboardSummary(
+  tenantId: string,
+): Promise<ControlsDashboardSummary> {
+  return getJson<ControlsDashboardSummary>(
+    tenantId,
+    "/api/v1/governance/controls/dashboard/summary",
+  );
+}
+
+export async function fetchGovernanceControls(
+  tenantId: string,
+  options?: {
+    frameworkTag?: FrameworkFilterTag | string;
+    search?: string;
+    offset?: number;
+    limit?: number;
+  },
+): Promise<GovernanceControlsListResult> {
+  const q = new URLSearchParams();
+  if (options?.frameworkTag) {
+    q.set("framework_tag", options.frameworkTag);
+  }
+  if (options?.search?.trim()) {
+    q.set("search", options.search.trim());
+  }
+  if (options?.offset != null) {
+    q.set("offset", String(options.offset));
+  }
+  if (options?.limit != null) {
+    q.set("limit", String(options.limit));
+  }
+  const suffix = q.toString() ? `?${q.toString()}` : "";
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}/api/v1/governance/controls${suffix}`;
+  const res = await fetch(url, {
+    headers: tenantHeaders(tenantId),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Governance Controls ${res.status}`);
+  }
+  const items = (await res.json()) as GovernanceControlRow[];
+  const total = Number(res.headers.get("X-Total-Count") ?? items.length);
+  const offset = Number(res.headers.get("X-Page-Offset") ?? options?.offset ?? 0);
+  const limit = Number(res.headers.get("X-Page-Limit") ?? options?.limit ?? 200);
+  return { items, total, offset, limit };
+}
+
+export async function fetchControlSuggestions(
+  tenantId: string,
+): Promise<GovernanceControlSuggestion[]> {
+  return getJson<GovernanceControlSuggestion[]>(tenantId, "/api/v1/governance/controls/suggestions");
+}
+
+export async function postMaterializeSuggestion(
+  tenantId: string,
+  suggestionKey: string,
+): Promise<GovernanceControlRow> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}/api/v1/governance/controls/from-suggestion`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: jsonHeaders(tenantId),
+    body: JSON.stringify({ suggestion_key: suggestionKey }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Materialize ${res.status}`);
+  }
+  return (await res.json()) as GovernanceControlRow;
+}
+
+export async function fetchControlEvidence(
+  tenantId: string,
+  controlId: string,
+): Promise<GovernanceControlEvidenceRow[]> {
+  return getJson<GovernanceControlEvidenceRow[]>(
+    tenantId,
+    `/api/v1/governance/controls/${encodeURIComponent(controlId)}/evidence`,
+  );
+}
+
+export async function fetchControlStatusHistory(
+  tenantId: string,
+  controlId: string,
+): Promise<GovernanceControlStatusHistoryRow[]> {
+  return getJson<GovernanceControlStatusHistoryRow[]>(
+    tenantId,
+    `/api/v1/governance/controls/${encodeURIComponent(controlId)}/status-history`,
+  );
+}
+
+export async function postControlEvidence(
+  tenantId: string,
+  controlId: string,
+  body: {
+    title: string;
+    body_text?: string | null;
+    source_type?: string;
+    source_ref?: string | null;
+  },
+): Promise<GovernanceControlEvidenceRow> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}/api/v1/governance/controls/${encodeURIComponent(controlId)}/evidence`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: jsonHeaders(tenantId),
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Evidence ${res.status}`);
+  }
+  return (await res.json()) as GovernanceControlEvidenceRow;
+}
+
+export async function downloadControlsCsv(tenantId: string): Promise<void> {
+  const base = apiBase().replace(/\/$/, "");
+  const url = `${base}/api/v1/governance/controls/export`;
+  const res = await fetch(url, {
+    headers: tenantHeaders(tenantId),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Export ${res.status}`);
+  }
+  const blob = await res.blob();
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(blob);
+  a.download = "governance_controls_export.csv";
+  a.click();
+  URL.revokeObjectURL(a.href);
+}

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -109,7 +109,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     assert "20260422_phase13_tenant_onboarding_completed" in ids
     assert "20260423_phase14_analytics_indexes" in ids
     assert "20260424_service_health_operational_resilience" in ids
-    assert len(ids) == 23
+    assert "20260425_governance_unified_controls" in ids
+    assert len(ids) == 24
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()

--- a/tests/test_governance_controls_api.py
+++ b/tests/test_governance_controls_api.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from fastapi.testclient import TestClient
 
 from app.main import app
@@ -121,3 +123,36 @@ def test_governance_controls_from_suggestion_unknown() -> None:
         json={"suggestion_key": "definitely_unknown_key_xyz"},
     )
     assert r.status_code == 404
+
+
+def test_governance_controls_dashboard_overdue_status_in_kpi() -> None:
+    """Codex: overdue_reviews must include explicit status=overdue, not only date-based."""
+    h = _headers()
+    past = (datetime.now(UTC) - timedelta(days=7)).isoformat()
+    c1 = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Explicit overdue status",
+            "status": "overdue",
+            "framework_tags": ["ISO_27001"],
+            "framework_mappings": [],
+        },
+    )
+    assert c1.status_code == 201, c1.text
+    c2 = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Implemented review past due",
+            "status": "implemented",
+            "next_review_at": past,
+            "framework_tags": ["ISO_27001"],
+            "framework_mappings": [],
+        },
+    )
+    assert c2.status_code == 201, c2.text
+    summ = client.get("/api/v1/governance/controls/dashboard/summary", headers=h)
+    assert summ.status_code == 200
+    data = summ.json()
+    assert data["overdue_reviews"] >= 2

--- a/tests/test_governance_controls_api.py
+++ b/tests/test_governance_controls_api.py
@@ -1,0 +1,123 @@
+"""Unified governance controls API (tenant-scoped)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _headers(tenant_id: str = "board-kpi-tenant") -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": tenant_id,
+    }
+
+
+def test_governance_controls_suggestions_ok() -> None:
+    r = client.get("/api/v1/governance/controls/suggestions", headers=_headers())
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)
+
+
+def test_governance_controls_crud_flow() -> None:
+    h = _headers()
+    create = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Test-Control Unified Layer",
+            "description": "pytest",
+            "status": "in_progress",
+            "owner": "owner@example.com",
+            "framework_tags": ["NIS2", "ISO_27001"],
+            "framework_mappings": [
+                {"framework": "NIS2", "clause_ref": "Art. 21", "mapping_note": "t"},
+            ],
+        },
+    )
+    assert create.status_code == 201, create.text
+    cid = create.json()["id"]
+
+    got = client.get(f"/api/v1/governance/controls/{cid}", headers=h)
+    assert got.status_code == 200
+    assert got.json()["title"] == "Test-Control Unified Layer"
+
+    lst = client.get("/api/v1/governance/controls", headers=h)
+    assert lst.status_code == 200
+    assert any(row["id"] == cid for row in lst.json())
+
+    summ = client.get("/api/v1/governance/controls/dashboard/summary", headers=h)
+    assert summ.status_code == 200
+    assert summ.json()["total_controls"] >= 1
+
+    ev = client.post(
+        f"/api/v1/governance/controls/{cid}/evidence",
+        headers=h,
+        json={"title": "Policy PDF", "source_type": "manual"},
+    )
+    assert ev.status_code == 201, ev.text
+
+    patch = client.patch(
+        f"/api/v1/governance/controls/{cid}",
+        headers=h,
+        json={"status": "implemented"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["status"] == "implemented"
+
+    ev_list = client.get(f"/api/v1/governance/controls/{cid}/evidence", headers=h)
+    assert ev_list.status_code == 200
+    assert isinstance(ev_list.json(), list)
+    assert len(ev_list.json()) >= 1
+
+    hist = client.get(f"/api/v1/governance/controls/{cid}/status-history", headers=h)
+    assert hist.status_code == 200
+    assert isinstance(hist.json(), list)
+
+    lst2 = client.get("/api/v1/governance/controls?offset=0&limit=10", headers=h)
+    assert lst2.status_code == 200
+    assert lst2.headers.get("X-Total-Count") is not None
+    assert int(lst2.headers["X-Total-Count"]) >= 1
+
+    export_r = client.get("/api/v1/governance/controls/export", headers=h)
+    assert export_r.status_code == 200
+    assert "text/csv" in (export_r.headers.get("content-type") or "")
+
+
+def test_governance_controls_materialize_idempotent() -> None:
+    h = _headers()
+    key = "pytest_suggestion_stub"
+    create = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Pre-materialized",
+            "status": "not_started",
+            "framework_tags": ["NIS2"],
+            "framework_mappings": [],
+            "source_inputs": {"materialized_from_suggestion": key},
+        },
+    )
+    assert create.status_code == 201, create.text
+    cid = create.json()["id"]
+
+    mat = client.post(
+        "/api/v1/governance/controls/from-suggestion",
+        headers=h,
+        json={"suggestion_key": key},
+    )
+    assert mat.status_code == 200
+    assert mat.json()["id"] == cid
+
+
+def test_governance_controls_from_suggestion_unknown() -> None:
+    h = _headers()
+    r = client.post(
+        "/api/v1/governance/controls/from-suggestion",
+        headers=h,
+        json={"suggestion_key": "definitely_unknown_key_xyz"},
+    )
+    assert r.status_code == 404


### PR DESCRIPTION
- Add SQLite migration and SQLAlchemy models for requirements, controls, framework mappings, evidence, reviews, and status history.

- Expose versioned REST API (/api/v1/governance/controls): CRUD, evidence, status history, dashboard summary, deterministic suggestions, CSV export, paginated list with X-Total-Count, idempotent POST /from-suggestion.

- Add Next.js route /tenant/governance/controls with KPIs, framework filters, search, suggestions, detail panel, evidence modal, and CSV download.

- Extend governance audit taxonomy, wire router in main, update migration ledger test.

Made-with: Cursor