### PR TITLE
feat(governance): audit readiness and evidence completeness MVP

### DIFF
--- a/app/db_migrations/migrations/m20260427_governance_audit_readiness.py
+++ b/app/db_migrations/migrations/m20260427_governance_audit_readiness.py
@@ -1,0 +1,101 @@
+"""Audit readiness: audit cases, scoped frameworks/controls, optional evidence requirements."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260427_governance_audit_readiness"
+DISPLAY_NAME = "governance_audit_readiness"
+
+
+def satisfied(engine: Engine) -> bool:
+    return table_exists(engine, "governance_audit_cases")
+
+
+def apply(engine: Engine) -> bool:
+    if table_exists(engine, "governance_audit_cases"):
+        return False
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            CREATE TABLE governance_audit_cases (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                title VARCHAR(500) NOT NULL,
+                description TEXT,
+                status VARCHAR(32) NOT NULL DEFAULT 'active',
+                created_at_utc DATETIME NOT NULL,
+                updated_at_utc DATETIME NOT NULL,
+                created_by VARCHAR(255)
+            )
+            """)
+        )
+        conn.execute(
+            text("CREATE INDEX idx_gac_tenant ON governance_audit_cases (tenant_id, status)")
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_audit_case_frameworks (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                audit_case_id VARCHAR(36) NOT NULL,
+                framework_tag VARCHAR(64) NOT NULL
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_gacf_case ON governance_audit_case_frameworks "
+                "(tenant_id, audit_case_id)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_audit_case_controls (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                audit_case_id VARCHAR(36) NOT NULL,
+                control_id VARCHAR(36) NOT NULL,
+                attached_at_utc DATETIME NOT NULL
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX uq_gacc_case_control ON governance_audit_case_controls "
+                "(tenant_id, audit_case_id, control_id)"
+            )
+        )
+        conn.execute(
+            text("""
+            CREATE TABLE governance_evidence_requirements (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                framework_tag VARCHAR(64) NOT NULL,
+                evidence_type_key VARCHAR(64) NOT NULL,
+                label VARCHAR(500) NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 2
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX uq_ger_tenant_fw_type ON governance_evidence_requirements "
+                "(tenant_id, framework_tag, evidence_type_key)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_ger_tenant_fw ON governance_evidence_requirements "
+                "(tenant_id, framework_tag)"
+            )
+        )
+    logger.info("db_migration applied: %s", MIGRATION_ID)
+    return True

--- a/app/governance_audit_readiness_models.py
+++ b/app/governance_audit_readiness_models.py
@@ -1,0 +1,86 @@
+"""Pydantic schemas for audit readiness and evidence completeness (governance audits API)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class GovernanceAuditCaseCreate(BaseModel):
+    title: str = Field(..., min_length=1, max_length=500)
+    description: str | None = Field(default=None, max_length=8000)
+    framework_tags: list[str] = Field(
+        ...,
+        min_length=1,
+        description="In-scope frameworks, e.g. EU_AI_ACT, ISO_42001, ISO_27001, ISO_27701, NIS2",
+    )
+    control_ids: list[str] | None = Field(
+        default=None,
+        description=(
+            "If omitted, tenant controls whose tags intersect framework_tags are attached."
+        ),
+    )
+
+
+class GovernanceAuditCaseRead(BaseModel):
+    id: str
+    tenant_id: str
+    title: str
+    description: str | None
+    status: str
+    framework_tags: list[str]
+    control_ids: list[str]
+    created_at_utc: datetime
+    updated_at_utc: datetime
+    created_by: str | None
+
+
+class AuditReadinessFrameworkSlice(BaseModel):
+    framework_tag: str
+    controls_in_scope: int
+    controls_ready: int
+    evidence_gap_count: int
+    readiness_pct: float = Field(..., description="0–100, deterministic MVP aggregate.")
+
+
+class AuditEvidenceGapRow(BaseModel):
+    control_id: str
+    control_title: str
+    missing_evidence_type_key: str
+    label_hint: str
+    priority: int = Field(..., ge=1, le=3, description="1=critical … 3=normal (MVP heuristic).")
+    recommended_action_de: str
+
+
+class AuditReadinessSummaryRead(BaseModel):
+    audit_case_id: str
+    overall_readiness_pct: float
+    controls_total: int
+    controls_ready: int
+    evidence_gap_count: int
+    overdue_reviews_count: int
+    by_framework: list[AuditReadinessFrameworkSlice]
+    gaps: list[AuditEvidenceGapRow] = Field(default_factory=list)
+
+
+class AuditReadinessControlRow(BaseModel):
+    control_id: str
+    title: str
+    framework_tags: list[str]
+    status: str
+    owner: str | None
+    evidence_completeness_pct: float
+    missing_evidence_types: list[str]
+    next_review_at: datetime | None
+    is_ready: bool
+    review_overdue: bool
+
+
+class GovernanceAuditTrailRow(BaseModel):
+    created_at_utc: datetime
+    actor: str
+    action: str
+    entity_type: str
+    entity_id: str
+    outcome: str | None

--- a/app/governance_audit_readiness_routes.py
+++ b/app/governance_audit_readiness_routes.py
@@ -1,0 +1,198 @@
+"""Audit readiness & evidence completeness over unified controls (MVP)."""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.auth_dependencies import get_api_key_and_tenant
+from app.db import get_session
+from app.governance_audit_readiness_models import (
+    AuditReadinessControlRow,
+    AuditReadinessSummaryRead,
+    GovernanceAuditCaseCreate,
+    GovernanceAuditCaseRead,
+    GovernanceAuditTrailRow,
+)
+from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.models_db import AuditLogTable
+from app.rbac.roles import EnterpriseRole
+from app.repositories.audit_logs import AuditLogRepository
+from app.repositories.governance_audit_readiness import GovernanceAuditReadinessRepository
+from app.services.governance_audit import record_governance_audit
+
+
+def get_audit_log_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> AuditLogRepository:
+    return AuditLogRepository(session)
+
+
+def get_governance_audit_readiness_repository(
+    session: Annotated[Session, Depends(get_session)],
+) -> GovernanceAuditReadinessRepository:
+    return GovernanceAuditReadinessRepository(session)
+
+
+router = APIRouter(prefix="/api/v1/governance/audits", tags=["governance", "audits"])
+
+
+@router.get("", response_model=list[GovernanceAuditCaseRead])
+def list_audit_cases(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+) -> list[GovernanceAuditCaseRead]:
+    return repo.list_cases(tenant_id)
+
+
+@router.post("", response_model=GovernanceAuditCaseRead, status_code=status.HTTP_201_CREATED)
+def create_audit_case(
+    body: GovernanceAuditCaseCreate,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceAuditCaseRead:
+    created = repo.create_case(tenant_id, body, created_by="api:governance-audits")
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-audits",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_AUDIT_CASE_CREATE.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_AUDIT_CASE.value,
+        entity_id=created.id,
+        outcome="success",
+        before=None,
+        after=json.dumps({"title": created.title, "frameworks": created.framework_tags}),
+        correlation_id=None,
+        metadata={"control_count": len(created.control_ids)},
+    )
+    return created
+
+
+@router.get("/{audit_id}", response_model=GovernanceAuditCaseRead)
+def get_audit_case(
+    audit_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+) -> GovernanceAuditCaseRead:
+    row = repo.get_case(tenant_id, audit_id)
+    if row is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit case not found")
+    return row
+
+
+@router.get("/{audit_id}/readiness", response_model=AuditReadinessSummaryRead)
+def get_audit_readiness(
+    audit_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+) -> AuditReadinessSummaryRead:
+    summary = repo.build_readiness(tenant_id, audit_id)
+    if summary is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit case not found")
+    return summary
+
+
+@router.get("/{audit_id}/controls", response_model=list[AuditReadinessControlRow])
+def list_audit_case_controls(
+    audit_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+) -> list[AuditReadinessControlRow]:
+    rows = repo.list_control_rows(tenant_id, audit_id)
+    if rows is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit case not found")
+    return rows
+
+
+@router.get("/{audit_id}/trail", response_model=list[GovernanceAuditTrailRow])
+def list_audit_case_trail(
+    audit_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    session: Annotated[Session, Depends(get_session)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+) -> list[GovernanceAuditTrailRow]:
+    if repo.get_case(tenant_id, audit_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Audit case not found")
+    stmt = (
+        select(AuditLogTable)
+        .where(
+            AuditLogTable.tenant_id == tenant_id,
+            AuditLogTable.entity_type == GovernanceAuditEntity.GOVERNANCE_AUDIT_CASE.value,
+            AuditLogTable.entity_id == audit_id,
+        )
+        .order_by(AuditLogTable.created_at_utc.desc())
+        .limit(200)
+    )
+    rows = session.scalars(stmt).all()
+    return [
+        GovernanceAuditTrailRow(
+            created_at_utc=r.created_at_utc,
+            actor=r.actor,
+            action=r.action,
+            entity_type=r.entity_type,
+            entity_id=r.entity_id,
+            outcome=r.outcome,
+        )
+        for r in rows
+    ]
+
+
+@router.post(
+    "/{audit_id}/controls/{control_id}/attach",
+    response_model=GovernanceAuditCaseRead,
+)
+def attach_control_to_audit_case(
+    audit_id: str,
+    control_id: str,
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    repo: Annotated[
+        GovernanceAuditReadinessRepository,
+        Depends(get_governance_audit_readiness_repository),
+    ],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+) -> GovernanceAuditCaseRead:
+    updated = repo.attach_control(tenant_id, audit_id, control_id)
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Audit case or control not found",
+        )
+    record_governance_audit(
+        audit_repo,
+        tenant_id=tenant_id,
+        actor_id="api:governance-audits",
+        actor_role=EnterpriseRole.COMPLIANCE_OFFICER,
+        action=GovernanceAuditAction.GOVERNANCE_AUDIT_CASE_CONTROL_ATTACH.value,
+        entity_type=GovernanceAuditEntity.GOVERNANCE_AUDIT_CASE.value,
+        entity_id=audit_id,
+        outcome="success",
+        before=None,
+        after=json.dumps({"control_id": control_id}),
+        correlation_id=None,
+        metadata=None,
+    )
+    return updated

--- a/app/governance_taxonomy.py
+++ b/app/governance_taxonomy.py
@@ -21,6 +21,7 @@ class GovernanceAuditEntity(StrEnum):
     SERVICE_HEALTH_INCIDENT = "service_health_incident"
     GOVERNANCE_CONTROL = "governance_control"
     GOVERNANCE_CONTROL_EVIDENCE = "governance_control_evidence"
+    GOVERNANCE_AUDIT_CASE = "governance_audit_case"
 
 
 class GovernanceAuditAction(StrEnum):
@@ -53,6 +54,8 @@ class GovernanceAuditAction(StrEnum):
     GOVERNANCE_CONTROL_CREATE = "governance_control.create"
     GOVERNANCE_CONTROL_UPDATE = "governance_control.update"
     GOVERNANCE_CONTROL_EVIDENCE_ADD = "governance_control.evidence.add"
+    GOVERNANCE_AUDIT_CASE_CREATE = "governance_audit_case.create"
+    GOVERNANCE_AUDIT_CASE_CONTROL_ATTACH = "governance_audit_case.control.attach"
 
 
 class NIS2DeadlinePolicy:

--- a/app/main.py
+++ b/app/main.py
@@ -217,6 +217,7 @@ from app.feature_flags import (
     is_feature_enabled,
     require_tenant_llm_features,
 )
+from app.governance_audit_readiness_routes import router as governance_audit_readiness_router
 from app.governance_controls_routes import router as governance_controls_router
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturityBoardSummaryParseResult
@@ -575,6 +576,7 @@ app = FastAPI(
 app.add_middleware(TelemetryMiddleware)
 app.include_router(operations_resilience_router)
 app.include_router(governance_controls_router)
+app.include_router(governance_audit_readiness_router)
 
 logger = logging.getLogger(__name__)
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -1267,6 +1267,78 @@ class GovernanceControlStatusHistoryTable(Base):
     note: Mapped[str | None] = mapped_column(Text, nullable=True)
 
 
+class GovernanceAuditCaseTable(Base):
+    """Scoped audit / assurance engagement over unified controls (map-once, comply many)."""
+
+    __tablename__ = "governance_audit_cases"
+    __table_args__ = (Index("idx_gac_tenant", "tenant_id", "status"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="active")
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
+class GovernanceAuditCaseFrameworkTable(Base):
+    """Frameworks in scope for an audit case (AI Act, ISO 42001, ISO 27001, ISO 27701, NIS2)."""
+
+    __tablename__ = "governance_audit_case_frameworks"
+    __table_args__ = (Index("idx_gacf_case", "tenant_id", "audit_case_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    audit_case_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    framework_tag: Mapped[str] = mapped_column(String(64), nullable=False)
+
+
+class GovernanceAuditCaseControlTable(Base):
+    """Controls explicitly in scope for an audit case (subset of tenant register)."""
+
+    __tablename__ = "governance_audit_case_controls"
+    __table_args__ = (
+        Index("idx_gacc_case", "tenant_id", "audit_case_id"),
+        UniqueConstraint("tenant_id", "audit_case_id", "control_id", name="uq_gacc_case_control"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    audit_case_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    control_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
+    attached_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class GovernanceEvidenceRequirementTable(Base):
+    """Tenant-level evidence type expectations per framework (advisor-tunable; defaults in code)."""
+
+    __tablename__ = "governance_evidence_requirements"
+    __table_args__ = (
+        Index("idx_ger_tenant_fw", "tenant_id", "framework_tag"),
+        UniqueConstraint(
+            "tenant_id",
+            "framework_tag",
+            "evidence_type_key",
+            name="uq_ger_tenant_fw_type",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    framework_tag: Mapped[str] = mapped_column(String(64), nullable=False)
+    evidence_type_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    label: Mapped[str] = mapped_column(String(500), nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=2)
+
+
 class NIS2IncidentTable(Base):
     """NIS2 Art. 21 compliant incident response records — multi-tenant."""
 

--- a/app/repositories/governance_audit_readiness.py
+++ b/app/repositories/governance_audit_readiness.py
@@ -1,0 +1,329 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.governance_audit_readiness_models import (
+    AuditEvidenceGapRow,
+    AuditReadinessControlRow,
+    AuditReadinessFrameworkSlice,
+    AuditReadinessSummaryRead,
+    GovernanceAuditCaseCreate,
+    GovernanceAuditCaseRead,
+)
+from app.models_db import (
+    GovernanceAuditCaseControlTable,
+    GovernanceAuditCaseFrameworkTable,
+    GovernanceAuditCaseTable,
+    GovernanceControlEvidenceTable,
+    GovernanceControlTable,
+    GovernanceEvidenceRequirementTable,
+)
+from app.repositories.governance_controls import GovernanceControlRepository
+from app.services.governance_audit_readiness_rules import (
+    ControlSignals,
+    compute_control_metrics,
+    normalize_framework_tag,
+)
+
+
+class GovernanceAuditReadinessRepository:
+    def __init__(self, session: Session) -> None:
+        self._s = session
+
+    def _tenant_req_index(self, tenant_id: str) -> dict[str, list[tuple[str, str, int]]]:
+        stmt = select(GovernanceEvidenceRequirementTable).where(
+            GovernanceEvidenceRequirementTable.tenant_id == tenant_id,
+        )
+        rows = self._s.scalars(stmt).all()
+        idx: dict[str, list[tuple[str, str, int]]] = defaultdict(list)
+        for r in rows:
+            fw = normalize_framework_tag(r.framework_tag)
+            idx[fw].append((r.evidence_type_key, r.label, int(r.priority or 2)))
+        return dict(idx)
+
+    def list_cases(self, tenant_id: str, *, limit: int = 200) -> list[GovernanceAuditCaseRead]:
+        stmt = (
+            select(GovernanceAuditCaseTable)
+            .where(GovernanceAuditCaseTable.tenant_id == tenant_id)
+            .order_by(GovernanceAuditCaseTable.updated_at_utc.desc())
+            .limit(limit)
+        )
+        rows = self._s.scalars(stmt).all()
+        return [self._case_read(r.id, tenant_id) for r in rows]
+
+    def _framework_tags(self, tenant_id: str, audit_case_id: str) -> list[str]:
+        stmt = select(GovernanceAuditCaseFrameworkTable).where(
+            GovernanceAuditCaseFrameworkTable.tenant_id == tenant_id,
+            GovernanceAuditCaseFrameworkTable.audit_case_id == audit_case_id,
+        )
+        return [r.framework_tag for r in self._s.scalars(stmt).all()]
+
+    def _control_ids(self, tenant_id: str, audit_case_id: str) -> list[str]:
+        stmt = select(GovernanceAuditCaseControlTable).where(
+            GovernanceAuditCaseControlTable.tenant_id == tenant_id,
+            GovernanceAuditCaseControlTable.audit_case_id == audit_case_id,
+        )
+        return [r.control_id for r in self._s.scalars(stmt).all()]
+
+    def _case_read(self, audit_case_id: str, tenant_id: str) -> GovernanceAuditCaseRead:
+        row = self._s.get(GovernanceAuditCaseTable, audit_case_id)
+        assert row is not None and row.tenant_id == tenant_id
+        return GovernanceAuditCaseRead(
+            id=row.id,
+            tenant_id=row.tenant_id,
+            title=row.title,
+            description=row.description,
+            status=row.status,
+            framework_tags=self._framework_tags(tenant_id, audit_case_id),
+            control_ids=self._control_ids(tenant_id, audit_case_id),
+            created_at_utc=row.created_at_utc,
+            updated_at_utc=row.updated_at_utc,
+            created_by=row.created_by,
+        )
+
+    def get_case(self, tenant_id: str, audit_case_id: str) -> GovernanceAuditCaseRead | None:
+        row = self._s.get(GovernanceAuditCaseTable, audit_case_id)
+        if row is None or row.tenant_id != tenant_id:
+            return None
+        return self._case_read(audit_case_id, tenant_id)
+
+    def _auto_attach_controls(
+        self,
+        tenant_id: str,
+        audit_case_id: str,
+        framework_tags: list[str],
+    ) -> None:
+        ctrl_repo = GovernanceControlRepository(self._s)
+        items, _ = ctrl_repo.list_controls_page(
+            tenant_id,
+            framework_tag=None,
+            search=None,
+            offset=0,
+            limit=5000,
+        )
+        want = {normalize_framework_tag(t) for t in framework_tags}
+        now = datetime.now(UTC)
+        for c in items:
+            tags = {normalize_framework_tag(t) for t in c.framework_tags}
+            if want & tags:
+                self._attach_control_row(tenant_id, audit_case_id, c.id, now)
+
+    def _attach_control_row(
+        self,
+        tenant_id: str,
+        audit_case_id: str,
+        control_id: str,
+        now: datetime,
+    ) -> None:
+        exists = self._s.scalars(
+            select(GovernanceAuditCaseControlTable).where(
+                GovernanceAuditCaseControlTable.tenant_id == tenant_id,
+                GovernanceAuditCaseControlTable.audit_case_id == audit_case_id,
+                GovernanceAuditCaseControlTable.control_id == control_id,
+            )
+        ).first()
+        if exists is not None:
+            return
+        self._s.add(
+            GovernanceAuditCaseControlTable(
+                id=str(uuid4()),
+                tenant_id=tenant_id,
+                audit_case_id=audit_case_id,
+                control_id=control_id,
+                attached_at_utc=now,
+            )
+        )
+
+    def create_case(
+        self,
+        tenant_id: str,
+        body: GovernanceAuditCaseCreate,
+        *,
+        created_by: str | None,
+    ) -> GovernanceAuditCaseRead:
+        now = datetime.now(UTC)
+        aid = str(uuid4())
+        row = GovernanceAuditCaseTable(
+            id=aid,
+            tenant_id=tenant_id,
+            title=body.title,
+            description=body.description,
+            status="active",
+            created_at_utc=now,
+            updated_at_utc=now,
+            created_by=created_by,
+        )
+        self._s.add(row)
+        seen_fw: set[str] = set()
+        for ft in body.framework_tags:
+            n = normalize_framework_tag(ft)[:64]
+            if n in seen_fw:
+                continue
+            seen_fw.add(n)
+            self._s.add(
+                GovernanceAuditCaseFrameworkTable(
+                    id=str(uuid4()),
+                    tenant_id=tenant_id,
+                    audit_case_id=aid,
+                    framework_tag=n,
+                )
+            )
+        if body.control_ids:
+            for cid in body.control_ids:
+                self._attach_control_row(tenant_id, aid, cid[:36], now)
+        else:
+            self._auto_attach_controls(tenant_id, aid, body.framework_tags)
+        self._s.flush()
+        return self._case_read(aid, tenant_id)
+
+    def attach_control(
+        self, tenant_id: str, audit_case_id: str, control_id: str
+    ) -> GovernanceAuditCaseRead | None:
+        if self.get_case(tenant_id, audit_case_id) is None:
+            return None
+        cr = GovernanceControlRepository(self._s)
+        if cr.get_control(tenant_id, control_id) is None:
+            return None
+        self._attach_control_row(tenant_id, audit_case_id, control_id, datetime.now(UTC))
+        ac = self._s.get(GovernanceAuditCaseTable, audit_case_id)
+        assert ac is not None
+        ac.updated_at_utc = datetime.now(UTC)
+        self._s.flush()
+        return self._case_read(audit_case_id, tenant_id)
+
+    def _evidence_types_for_control(self, tenant_id: str, control_id: str) -> list[str]:
+        stmt = select(GovernanceControlEvidenceTable).where(
+            GovernanceControlEvidenceTable.tenant_id == tenant_id,
+            GovernanceControlEvidenceTable.control_id == control_id,
+        )
+        return [r.source_type for r in self._s.scalars(stmt).all()]
+
+    def build_readiness(
+        self, tenant_id: str, audit_case_id: str
+    ) -> AuditReadinessSummaryRead | None:
+        case = self.get_case(tenant_id, audit_case_id)
+        if case is None:
+            return None
+        cfw = {normalize_framework_tag(x) for x in case.framework_tags}
+        req_idx = self._tenant_req_index(tenant_id)
+        now = datetime.now(UTC)
+        ctrl_repo = GovernanceControlRepository(self._s)
+
+        controls_ready = 0
+        gap_rows: list[AuditEvidenceGapRow] = []
+        overdue_reviews = 0
+        fw_stats: dict[str, dict[str, int]] = {
+            fw: {"in": 0, "ready": 0, "gaps": 0} for fw in sorted(cfw)
+        }
+
+        for cid in case.control_ids:
+            row = self._s.get(GovernanceControlTable, cid)
+            if row is None or row.tenant_id != tenant_id:
+                continue
+            read = ctrl_repo.get_control(tenant_id, cid)
+            if read is None:
+                continue
+            sig = ControlSignals(
+                control_id=cid,
+                title=read.title,
+                framework_tags=list(read.framework_tags),
+                status=read.status,
+                owner=read.owner,
+                next_review_at=read.next_review_at,
+                evidence_source_types=self._evidence_types_for_control(tenant_id, cid),
+            )
+            comp, missing, ready, ro, gap_detail = compute_control_metrics(sig, cfw, req_idx, now)
+            if ready:
+                controls_ready += 1
+            if ro:
+                overdue_reviews += 1
+            tags = {normalize_framework_tag(t) for t in read.framework_tags}
+            for fw in sorted(cfw & tags):
+                fw_stats[fw]["in"] += 1
+                if ready:
+                    fw_stats[fw]["ready"] += 1
+            for gfw, ek, lab, pr in gap_detail:
+                fw_stats[gfw]["gaps"] += 1
+                gap_rows.append(
+                    AuditEvidenceGapRow(
+                        control_id=cid,
+                        control_title=read.title,
+                        missing_evidence_type_key=ek,
+                        label_hint=lab,
+                        priority=min(3, max(1, pr)),
+                        recommended_action_de=(
+                            f"Nachweis vom Typ „{lab}“ hinterlegen (source_type≈{ek})."
+                        ),
+                    )
+                )
+
+        total = len(case.control_ids)
+        overall = 100.0 if total == 0 else round(100.0 * controls_ready / total, 1)
+        by_fw = [
+            AuditReadinessFrameworkSlice(
+                framework_tag=fw,
+                controls_in_scope=st["in"],
+                controls_ready=st["ready"],
+                evidence_gap_count=st["gaps"],
+                readiness_pct=(
+                    100.0 if st["in"] == 0 else round(100.0 * st["ready"] / st["in"], 1)
+                ),
+            )
+            for fw, st in sorted(fw_stats.items())
+        ]
+        return AuditReadinessSummaryRead(
+            audit_case_id=audit_case_id,
+            overall_readiness_pct=overall,
+            controls_total=total,
+            controls_ready=controls_ready,
+            evidence_gap_count=len(gap_rows),
+            overdue_reviews_count=overdue_reviews,
+            by_framework=by_fw,
+            gaps=gap_rows,
+        )
+
+    def list_control_rows(
+        self, tenant_id: str, audit_case_id: str
+    ) -> list[AuditReadinessControlRow] | None:
+        case = self.get_case(tenant_id, audit_case_id)
+        if case is None:
+            return None
+        cfw = {normalize_framework_tag(x) for x in case.framework_tags}
+        req_idx = self._tenant_req_index(tenant_id)
+        now = datetime.now(UTC)
+        ctrl_repo = GovernanceControlRepository(self._s)
+        out: list[AuditReadinessControlRow] = []
+        for cid in case.control_ids:
+            read = ctrl_repo.get_control(tenant_id, cid)
+            if read is None:
+                continue
+            sig = ControlSignals(
+                control_id=cid,
+                title=read.title,
+                framework_tags=list(read.framework_tags),
+                status=read.status,
+                owner=read.owner,
+                next_review_at=read.next_review_at,
+                evidence_source_types=self._evidence_types_for_control(tenant_id, cid),
+            )
+            comp, missing, ready, ro, _ = compute_control_metrics(sig, cfw, req_idx, now)
+            out.append(
+                AuditReadinessControlRow(
+                    control_id=cid,
+                    title=read.title,
+                    framework_tags=list(read.framework_tags),
+                    status=read.status,
+                    owner=read.owner,
+                    evidence_completeness_pct=comp,
+                    missing_evidence_types=missing,
+                    next_review_at=read.next_review_at,
+                    is_ready=ready,
+                    review_overdue=ro,
+                )
+            )
+        return out

--- a/app/services/governance_audit_readiness_rules.py
+++ b/app/services/governance_audit_readiness_rules.py
@@ -1,0 +1,137 @@
+"""
+Deterministic audit readiness & evidence completeness (MVP).
+
+No ML: rules are explicit so advisors and auditors can explain outcomes.
+Combines unified-control status, next_review_at, and evidence source_type coverage
+against required evidence keys per in-scope framework (defaults + tenant overrides).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+# ---------------------------------------------------------------------------
+# Default evidence keys per framework tag (tenant DB rows extend/override per
+# framework_tag + evidence_type_key). Keys are matched case-insensitively
+# against governance_control_evidence.source_type.
+# ---------------------------------------------------------------------------
+DEFAULT_REQUIRED_EVIDENCE_BY_FRAMEWORK: dict[str, tuple[str, ...]] = {
+    "EU_AI_ACT": ("policy", "technical_record", "manual"),
+    "ISO_42001": ("policy", "manual"),
+    "ISO_27001": ("policy", "procedure"),
+    "ISO_27701": ("policy", "privacy_record"),
+    "NIS2": ("policy", "incident_evidence", "manual"),
+}
+
+
+def normalize_framework_tag(tag: str) -> str:
+    return tag.strip().upper().replace(" ", "_").replace("-", "_")
+
+
+def statuses_sufficient_for_readiness(status: str) -> bool:
+    """MVP: only implemented counts as fully compliant; extend later (e.g. monitored)."""
+    return status.strip().lower() == "implemented"
+
+
+def review_overdue(
+    *,
+    status: str,
+    next_review_at: datetime | None,
+    now: datetime,
+) -> bool:
+    """Aligns with governance control KPI semantics (explicit overdue + date drift)."""
+    st = status.strip().lower()
+    if st == "overdue":
+        return True
+    if next_review_at is None:
+        return False
+    dt = next_review_at
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    else:
+        dt = dt.astimezone(UTC)
+    return bool(st == "implemented" and dt < now)
+
+
+def evidence_type_satisfied(required_key: str, present_source_types: set[str]) -> bool:
+    rk = required_key.lower().strip()
+    if rk in present_source_types:
+        return True
+    for p in present_source_types:
+        if rk in p or p in rk:
+            return True
+    return False
+
+
+def merged_required_keys_for_framework(
+    framework_tag: str,
+    tenant_rows_for_fw: list[tuple[str, str, int]],
+) -> list[tuple[str, str, int]]:
+    """
+    Returns (evidence_type_key_lower, label, priority) for one framework.
+    Tenant rows override defaults for the same key; additional keys append.
+    """
+    fw = normalize_framework_tag(framework_tag)
+    defaults = DEFAULT_REQUIRED_EVIDENCE_BY_FRAMEWORK.get(fw, ("policy", "manual"))
+    out: dict[str, tuple[str, int]] = {}
+    for k in defaults:
+        kl = k.lower()
+        out[kl] = (k, 2)
+    for key, label, prio in tenant_rows_for_fw:
+        kl = key.lower()
+        out[kl] = (label or key, prio)
+    return sorted(((kl, lab, pr) for kl, (lab, pr) in out.items()), key=lambda x: (-x[2], x[0]))
+
+
+@dataclass(frozen=True)
+class ControlSignals:
+    control_id: str
+    title: str
+    framework_tags: list[str]
+    status: str
+    owner: str | None
+    next_review_at: datetime | None
+    evidence_source_types: list[str]
+
+
+def compute_control_metrics(
+    ctrl: ControlSignals,
+    case_frameworks: set[str],
+    tenant_req_index: dict[str, list[tuple[str, str, int]]],
+    now: datetime,
+) -> tuple[float, list[str], bool, bool, list[tuple[str, str, str, int]]]:
+    """
+    Returns (completeness_pct, missing_types, is_ready, review_overdue_flag, gap_rows).
+
+    gap_rows: (framework, missing_key, label, priority) for board / gap tab.
+    """
+    cfw = {normalize_framework_tag(x) for x in case_frameworks}
+    tags = {normalize_framework_tag(t) for t in ctrl.framework_tags}
+    active_fw = sorted(cfw & tags)
+    present = {str(x).lower().strip() for x in ctrl.evidence_source_types if x}
+
+    required_flat: list[tuple[str, str, int, str]] = []
+    for fw in active_fw:
+        rows = tenant_req_index.get(fw, [])
+        for ek, lab, pr in merged_required_keys_for_framework(fw, rows):
+            required_flat.append((ek, lab, pr, fw))
+
+    missing: list[str] = []
+    gap_detail: list[tuple[str, str, str, int]] = []
+    met = 0
+    total = len(required_flat)
+    for ek, lab, pr, fw in required_flat:
+        if evidence_type_satisfied(ek, present):
+            met += 1
+        else:
+            if ek.lower() not in {m.lower() for m in missing}:
+                missing.append(ek)
+            gap_detail.append((fw, ek, lab, pr))
+
+    completeness = 100.0 if total == 0 else round(100.0 * met / total, 1)
+    ro = review_overdue(status=ctrl.status, next_review_at=ctrl.next_review_at, now=now)
+    ready = (
+        statuses_sufficient_for_readiness(ctrl.status) and not ro and (total == 0 or met == total)
+    )
+    return completeness, missing, ready, ro, gap_detail

--- a/frontend/src/app/tenant/governance/audits/[auditId]/page.tsx
+++ b/frontend/src/app/tenant/governance/audits/[auditId]/page.tsx
@@ -1,0 +1,12 @@
+import { AuditReadinessWorkspaceClient } from "@/components/governance/AuditReadinessWorkspaceClient";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+interface Props {
+  params: Promise<{ auditId: string }>;
+}
+
+export default async function TenantGovernanceAuditDetailPage({ params }: Props) {
+  const { auditId } = await params;
+  const tenantId = await getWorkspaceTenantIdServer();
+  return <AuditReadinessWorkspaceClient tenantId={tenantId} auditId={auditId} />;
+}

--- a/frontend/src/app/tenant/governance/audits/page.tsx
+++ b/frontend/src/app/tenant/governance/audits/page.tsx
@@ -1,0 +1,7 @@
+import { AuditsHubClient } from "@/components/governance/AuditsHubClient";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TenantGovernanceAuditsPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  return <AuditsHubClient tenantId={tenantId} />;
+}

--- a/frontend/src/components/governance/AuditReadinessWorkspaceClient.tsx
+++ b/frontend/src/components/governance/AuditReadinessWorkspaceClient.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { GovernanceWorkspaceLayout } from "@/components/governance/GovernanceWorkspaceLayout";
+import { StatusBadge } from "@/components/governance/StatusBadge";
+import {
+  fetchAuditControlRows,
+  fetchAuditReadiness,
+  fetchAuditTrail,
+  type AuditReadinessControlRow,
+  type AuditReadinessSummary,
+  type GovernanceAuditTrailRow,
+} from "@/lib/auditReadinessApi";
+import { CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+interface Props {
+  tenantId: string;
+  auditId: string;
+}
+
+export function AuditReadinessWorkspaceClient({ tenantId, auditId }: Props) {
+  const [tab, setTab] = useState<"overview" | "controls" | "gaps" | "trail">("overview");
+  const [summary, setSummary] = useState<AuditReadinessSummary | null>(null);
+  const [controls, setControls] = useState<AuditReadinessControlRow[]>([]);
+  const [trail, setTrail] = useState<GovernanceAuditTrailRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    try {
+      const [s, c, t] = await Promise.all([
+        fetchAuditReadiness(tenantId, auditId),
+        fetchAuditControlRows(tenantId, auditId),
+        fetchAuditTrail(tenantId, auditId),
+      ]);
+      setSummary(s);
+      setControls(c);
+      setTrail(t);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    }
+  }, [tenantId, auditId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const kpi = summary ? (
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <article className={`${CH_CARD} border-slate-200/80`}>
+        <p className={CH_SECTION_LABEL}>Readiness (gesamt)</p>
+        <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+          {summary.overall_readiness_pct}%
+        </p>
+      </article>
+      <article className={`${CH_CARD} border-slate-200/80`}>
+        <p className={CH_SECTION_LABEL}>Controls bereit</p>
+        <p className="mt-2 text-3xl font-semibold tabular-nums text-emerald-800">
+          {summary.controls_ready} / {summary.controls_total}
+        </p>
+      </article>
+      <article className={`${CH_CARD} border-slate-200/80`}>
+        <p className={CH_SECTION_LABEL}>Evidence-Gaps</p>
+        <p className="mt-2 text-3xl font-semibold tabular-nums text-amber-900">
+          {summary.evidence_gap_count}
+        </p>
+      </article>
+      <article className={`${CH_CARD} border-slate-200/80`}>
+        <p className={CH_SECTION_LABEL}>Überfällige Reviews</p>
+        <p className="mt-2 text-3xl font-semibold tabular-nums text-rose-800">
+          {summary.overdue_reviews_count}
+        </p>
+      </article>
+    </section>
+  ) : null;
+
+  const overview = (
+    <div className="space-y-6">
+      {error ? (
+        <p className="text-sm text-rose-800" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {kpi}
+      {summary ? (
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Framework-Slices (deterministisch)</p>
+          <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200/80">
+            <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+              <thead className="bg-slate-50/90 text-xs font-semibold uppercase text-slate-500">
+                <tr>
+                  <th className="px-3 py-2">Framework</th>
+                  <th className="px-3 py-2">Im Scope</th>
+                  <th className="px-3 py-2">Bereit</th>
+                  <th className="px-3 py-2">Gaps</th>
+                  <th className="px-3 py-2">Readiness %</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-100">
+                {summary.by_framework.map((f) => (
+                  <tr key={f.framework_tag}>
+                    <td className="px-3 py-2 font-medium">{f.framework_tag}</td>
+                    <td className="px-3 py-2 tabular-nums">{f.controls_in_scope}</td>
+                    <td className="px-3 py-2 tabular-nums">{f.controls_ready}</td>
+                    <td className="px-3 py-2 tabular-nums">{f.evidence_gap_count}</td>
+                    <td className="px-3 py-2 tabular-nums">{f.readiness_pct}%</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </article>
+      ) : null}
+    </div>
+  );
+
+  const controlsTab = (
+    <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+        <thead className="bg-slate-50/90 text-xs font-semibold uppercase text-slate-500">
+          <tr>
+            <th className="px-3 py-2">Control</th>
+            <th className="px-3 py-2">Tags</th>
+            <th className="px-3 py-2">Status</th>
+            <th className="px-3 py-2">Owner</th>
+            <th className="px-3 py-2">Evidence %</th>
+            <th className="px-3 py-2">Review</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 bg-white">
+          {controls.map((r) => (
+            <tr key={r.control_id}>
+              <td className="px-3 py-2 font-medium text-slate-900">{r.title}</td>
+              <td className="px-3 py-2 text-xs text-slate-600">{(r.framework_tags ?? []).join(", ")}</td>
+              <td className="px-3 py-2">
+                <StatusBadge status={r.status} />
+              </td>
+              <td className="px-3 py-2 text-slate-700">{r.owner ?? "—"}</td>
+              <td className="px-3 py-2 tabular-nums">{r.evidence_completeness_pct}%</td>
+              <td className="px-3 py-2 text-xs text-slate-600">
+                {r.review_overdue ? (
+                  <span className="font-semibold text-rose-800">überfällig</span>
+                ) : r.next_review_at ? (
+                  new Date(r.next_review_at).toLocaleDateString("de-DE")
+                ) : (
+                  "—"
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const gapsTab = (
+    <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+        <thead className="bg-slate-50/90 text-xs font-semibold uppercase text-slate-500">
+          <tr>
+            <th className="px-3 py-2">Control</th>
+            <th className="px-3 py-2">Fehlender Evidence-Typ</th>
+            <th className="px-3 py-2">Priorität</th>
+            <th className="px-3 py-2">Empfohlene Aktion</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 bg-white">
+          {(summary?.gaps ?? []).map((g, i) => (
+            <tr key={`${g.control_id}-${g.missing_evidence_type_key}-${i}`}>
+              <td className="px-3 py-2 font-medium">{g.control_title}</td>
+              <td className="px-3 py-2 font-mono text-xs">{g.missing_evidence_type_key}</td>
+              <td className="px-3 py-2 tabular-nums">P{g.priority}</td>
+              <td className="px-3 py-2 text-slate-700">{g.recommended_action_de}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const trailTab = (
+    <div className="overflow-x-auto rounded-xl border border-slate-200/80">
+      <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+        <thead className="bg-slate-50/90 text-xs font-semibold uppercase text-slate-500">
+          <tr>
+            <th className="px-3 py-2">Zeit</th>
+            <th className="px-3 py-2">Actor</th>
+            <th className="px-3 py-2">Aktion</th>
+            <th className="px-3 py-2">Outcome</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100 bg-white">
+          {trail.map((r) => (
+            <tr key={`${r.created_at_utc}-${r.action}`}>
+              <td className="px-3 py-2 text-xs">
+                {new Date(r.created_at_utc).toLocaleString("de-DE")}
+              </td>
+              <td className="px-3 py-2 text-xs">{r.actor}</td>
+              <td className="px-3 py-2 font-mono text-[0.65rem]">{r.action}</td>
+              <td className="px-3 py-2 text-xs">{r.outcome ?? "—"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+
+  const tabs = [
+    { id: "overview" as const, label: "Overview", content: overview },
+    { id: "controls" as const, label: "Controls", content: controlsTab },
+    { id: "gaps" as const, label: "Evidence Gaps", content: gapsTab },
+    { id: "trail" as const, label: "Audit Trail", content: trailTab },
+  ];
+
+  return (
+    <GovernanceWorkspaceLayout
+      eyebrow="Enterprise · Audit Readiness"
+      title={`Audit ${auditId.slice(0, 8)}…`}
+      status="active"
+      headerDescription={
+        <span className="text-slate-700">
+          Evidence-Completeness und Review-Lage auf Basis des Unified Control Layer — regelbasiert,
+          ohne KI. Daten aus dem Readiness-Endpunkt dieses Audit-Falls.
+        </span>
+      }
+      breadcrumbs={[
+        { label: "Tenant", href: "/tenant/compliance-overview" },
+        { label: "Governance", href: "/tenant/governance/overview" },
+        { label: "Audits", href: "/tenant/governance/audits" },
+        { label: "Fall" },
+      ]}
+      tabs={tabs}
+      activeTabId={tab}
+      onTabChange={(id) => setTab(id as typeof tab)}
+    />
+  );
+}

--- a/frontend/src/components/governance/AuditsHubClient.tsx
+++ b/frontend/src/components/governance/AuditsHubClient.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+
+import { createAuditCase, fetchAuditCases, type GovernanceAuditCaseRow } from "@/lib/auditReadinessApi";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+const DEFAULT_FW = "NIS2,ISO_27001";
+
+interface Props {
+  tenantId: string;
+}
+
+export function AuditsHubClient({ tenantId }: Props) {
+  const [rows, setRows] = useState<GovernanceAuditCaseRow[]>([]);
+  const [title, setTitle] = useState("");
+  const [fw, setFw] = useState(DEFAULT_FW);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    setError(null);
+    try {
+      setRows(await fetchAuditCases(tenantId));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  async function onCreate() {
+    if (!title.trim()) {
+      setError("Titel eingeben.");
+      return;
+    }
+    setError(null);
+    const tags = fw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    try {
+      const created = await createAuditCase(tenantId, {
+        title: title.trim(),
+        framework_tags: tags,
+        control_ids: null,
+      });
+      window.location.href = `/tenant/governance/audits/${created.id}`;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Anlegen fehlgeschlagen");
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 px-4 py-8">
+      <div>
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Governance</p>
+        <h1 className="mt-1 text-2xl font-semibold text-slate-900">Audit Readiness</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          Fälle bündeln Frameworks und Controls; Readiness und Evidence-Gaps werden aus dem
+          Unified Control Layer berechnet.
+        </p>
+      </div>
+
+      {error ? (
+        <p className="text-sm text-rose-800" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Neuer Audit-Fall</p>
+        <label className="mt-3 block text-sm font-medium text-slate-700">
+          Titel
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            placeholder="z. B. ISO-27001-Überprüfung Q2"
+          />
+        </label>
+        <label className="mt-3 block text-sm font-medium text-slate-700">
+          Framework-Tags (Komma)
+          <input
+            value={fw}
+            onChange={(e) => setFw(e.target.value)}
+            className="mt-1 w-full rounded-lg border border-slate-200 px-3 py-2 font-mono text-sm"
+          />
+        </label>
+        <div className="mt-4 flex gap-2">
+          <button type="button" onClick={() => void onCreate()} className={CH_BTN_PRIMARY}>
+            Anlegen und öffnen
+          </button>
+          <button type="button" onClick={() => void reload()} className={CH_BTN_SECONDARY}>
+            Aktualisieren
+          </button>
+        </div>
+      </article>
+
+      <article className={CH_CARD}>
+        <p className={CH_SECTION_LABEL}>Bestehende Fälle</p>
+        <ul className="mt-4 divide-y divide-slate-100">
+          {rows.length === 0 ? (
+            <li className="py-4 text-sm text-slate-600">Noch keine Audit-Fälle.</li>
+          ) : (
+            rows.map((r) => (
+              <li key={r.id} className="flex flex-wrap items-center justify-between gap-2 py-3">
+                <div>
+                  <p className="font-medium text-slate-900">{r.title}</p>
+                  <p className="text-xs text-slate-500">
+                    {(r.framework_tags ?? []).join(" · ")} · {r.control_ids?.length ?? 0} Controls
+                  </p>
+                </div>
+                <Link
+                  href={`/tenant/governance/audits/${r.id}`}
+                  className="text-sm font-semibold text-[var(--sbs-navy-mid)] no-underline hover:underline"
+                >
+                  Öffnen
+                </Link>
+              </li>
+            ))
+          )}
+        </ul>
+      </article>
+    </div>
+  );
+}

--- a/frontend/src/components/governance/StatusBadge.tsx
+++ b/frontend/src/components/governance/StatusBadge.tsx
@@ -12,9 +12,13 @@ const TONE_CLASS: Record<GovernanceStatusTone, string> = {
 export function governanceStatusToneFromRunStatus(status: string): GovernanceStatusTone {
   switch (status) {
     case "completed":
+    case "implemented":
       return "success";
     case "in_review":
     case "in_progress":
+      return "warning";
+    case "overdue":
+    case "needs_review":
       return "warning";
     default:
       return "neutral";

--- a/frontend/src/components/sbs/TenantNav.tsx
+++ b/frontend/src/components/sbs/TenantNav.tsx
@@ -16,6 +16,7 @@ const baseItems = [
   { href: "/tenant/compliance-overview", label: "Mandant & Übersicht" },
   { href: "/tenant/governance/overview", label: "Risk & Control Overview" },
   { href: "/tenant/governance/controls", label: "Unified Controls" },
+  { href: "/tenant/governance/audits", label: "Audit Readiness" },
   { href: "/tenant/governance/operations", label: "Betrieb & Resilienz" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },
   { href: "/tenant/ai-act/self-assessments", label: "Self-Assessment (AI Act)" },

--- a/frontend/src/lib/auditReadinessApi.ts
+++ b/frontend/src/lib/auditReadinessApi.ts
@@ -1,0 +1,151 @@
+/**
+ * Audit readiness & evidence completeness — GET /api/v1/governance/audits/*.
+ */
+
+export interface GovernanceAuditCaseRow {
+  id: string;
+  tenant_id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  framework_tags: string[];
+  control_ids: string[];
+  created_at_utc: string;
+  updated_at_utc: string;
+  created_by: string | null;
+}
+
+export interface AuditReadinessSummary {
+  audit_case_id: string;
+  overall_readiness_pct: number;
+  controls_total: number;
+  controls_ready: number;
+  evidence_gap_count: number;
+  overdue_reviews_count: number;
+  by_framework: Array<{
+    framework_tag: string;
+    controls_in_scope: number;
+    controls_ready: number;
+    evidence_gap_count: number;
+    readiness_pct: number;
+  }>;
+  gaps: Array<{
+    control_id: string;
+    control_title: string;
+    missing_evidence_type_key: string;
+    label_hint: string;
+    priority: number;
+    recommended_action_de: string;
+  }>;
+}
+
+export interface AuditReadinessControlRow {
+  control_id: string;
+  title: string;
+  framework_tags: string[];
+  status: string;
+  owner: string | null;
+  evidence_completeness_pct: number;
+  missing_evidence_types: string[];
+  next_review_at: string | null;
+  is_ready: boolean;
+  review_overdue: boolean;
+}
+
+export interface GovernanceAuditTrailRow {
+  created_at_utc: string;
+  actor: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  outcome: string | null;
+}
+
+function apiBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+function tenantHeaders(tenantId: string): Record<string, string> {
+  return { "x-api-key": apiKey(), "x-tenant-id": tenantId };
+}
+
+function jsonHeaders(tenantId: string): Record<string, string> {
+  return { ...tenantHeaders(tenantId), "Content-Type": "application/json" };
+}
+
+async function getJson<T>(tenantId: string, path: string): Promise<T> {
+  const base = apiBase().replace(/\/$/, "");
+  const res = await fetch(`${base}${path}`, { headers: tenantHeaders(tenantId), cache: "no-store" });
+  if (!res.ok) {
+    throw new Error(`Audits ${res.status}`);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchAuditCases(tenantId: string): Promise<GovernanceAuditCaseRow[]> {
+  return getJson<GovernanceAuditCaseRow[]>(tenantId, "/api/v1/governance/audits");
+}
+
+export async function createAuditCase(
+  tenantId: string,
+  body: {
+    title: string;
+    description?: string | null;
+    framework_tags: string[];
+    control_ids?: string[] | null;
+  },
+): Promise<GovernanceAuditCaseRow> {
+  const base = apiBase().replace(/\/$/, "");
+  const res = await fetch(`${base}/api/v1/governance/audits`, {
+    method: "POST",
+    headers: jsonHeaders(tenantId),
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Create audit ${res.status}`);
+  }
+  return (await res.json()) as GovernanceAuditCaseRow;
+}
+
+export async function fetchAuditReadiness(
+  tenantId: string,
+  auditId: string,
+): Promise<AuditReadinessSummary> {
+  return getJson<AuditReadinessSummary>(
+    tenantId,
+    `/api/v1/governance/audits/${encodeURIComponent(auditId)}/readiness`,
+  );
+}
+
+export async function fetchAuditControlRows(
+  tenantId: string,
+  auditId: string,
+): Promise<AuditReadinessControlRow[]> {
+  return getJson<AuditReadinessControlRow[]>(
+    tenantId,
+    `/api/v1/governance/audits/${encodeURIComponent(auditId)}/controls`,
+  );
+}
+
+export async function fetchAuditTrail(
+  tenantId: string,
+  auditId: string,
+): Promise<GovernanceAuditTrailRow[]> {
+  return getJson<GovernanceAuditTrailRow[]>(
+    tenantId,
+    `/api/v1/governance/audits/${encodeURIComponent(auditId)}/trail`,
+  );
+}

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -110,7 +110,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     assert "20260423_phase14_analytics_indexes" in ids
     assert "20260424_service_health_operational_resilience" in ids
     assert "20260425_governance_unified_controls" in ids
-    assert len(ids) == 24
+    assert "20260427_governance_audit_readiness" in ids
+    assert len(ids) == 25
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()

--- a/tests/test_governance_audit_readiness_api.py
+++ b/tests/test_governance_audit_readiness_api.py
@@ -1,0 +1,103 @@
+"""Governance audit readiness API (tenant-scoped)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _headers(tenant_id: str = "board-kpi-tenant") -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": tenant_id,
+    }
+
+
+def test_audit_readiness_happy_path() -> None:
+    h = _headers()
+    future = (datetime.now(UTC) + timedelta(days=30)).isoformat()
+    c = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Audit readiness fixture control",
+            "status": "implemented",
+            "owner": "ciso@example.com",
+            "next_review_at": future,
+            "framework_tags": ["NIS2"],
+            "framework_mappings": [
+                {"framework": "NIS2", "clause_ref": "Art. 21", "mapping_note": "t"},
+            ],
+        },
+    )
+    assert c.status_code == 201, c.text
+    cid = c.json()["id"]
+    for st in ("policy", "incident_evidence", "manual"):
+        ev = client.post(
+            f"/api/v1/governance/controls/{cid}/evidence",
+            headers=h,
+            json={"title": f"Evidence {st}", "source_type": st},
+        )
+        assert ev.status_code == 201, ev.text
+
+    a = client.post(
+        "/api/v1/governance/audits",
+        headers=h,
+        json={
+            "title": "FY26 NIS2 readiness",
+            "description": "pytest",
+            "framework_tags": ["NIS2"],
+            "control_ids": [cid],
+        },
+    )
+    assert a.status_code == 201, a.text
+    aid = a.json()["id"]
+
+    r = client.get(f"/api/v1/governance/audits/{aid}/readiness", headers=h)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["controls_total"] == 1
+    assert body["controls_ready"] == 1
+    assert body["overall_readiness_pct"] == 100.0
+
+    rows = client.get(f"/api/v1/governance/audits/{aid}/controls", headers=h)
+    assert rows.status_code == 200
+    assert rows.json()[0]["is_ready"] is True
+
+    tr = client.get(f"/api/v1/governance/audits/{aid}/trail", headers=h)
+    assert tr.status_code == 200
+    assert len(tr.json()) >= 1
+
+
+def test_audit_attach_control() -> None:
+    h = _headers()
+    c = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Loose control for attach",
+            "status": "not_started",
+            "framework_tags": ["ISO_27001"],
+            "framework_mappings": [],
+        },
+    )
+    assert c.status_code == 201
+    cid = c.json()["id"]
+    a = client.post(
+        "/api/v1/governance/audits",
+        headers=h,
+        json={"title": "ISO audit", "framework_tags": ["ISO_27701"], "control_ids": []},
+    )
+    assert a.status_code == 201
+    aid = a.json()["id"]
+    att = client.post(
+        f"/api/v1/governance/audits/{aid}/controls/{cid}/attach",
+        headers=h,
+    )
+    assert att.status_code == 200
+    assert cid in att.json()["control_ids"]


### PR DESCRIPTION
- Add audit cases, scoped frameworks/controls, and optional evidence_requirements tables (migration + ORM).

- REST API under /api/v1/governance/audits with readiness aggregates, control rows, trail, and attach.

- Deterministic rules module: per-framework default evidence keys, status/review checks, no LLM.

- Frontend: /tenant/governance/audits hub and /audits/[auditId] workspace with KPIs and tabs.

Made-with: Cursor