### PR TITLE
feat(governance): remediation actions layer with API, UI, tests

### DIFF
--- a/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
+++ b/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
@@ -63,10 +63,7 @@ def apply(engine: Engine) -> bool:
             )
         )
         conn.execute(
-            text(
-                "CREATE INDEX ix_remediation_actions_rule_key "
-                "ON remediation_actions (rule_key)"
-            )
+            text("CREATE INDEX ix_remediation_actions_rule_key ON remediation_actions (rule_key)")
         )
         conn.execute(
             text(
@@ -121,9 +118,7 @@ def apply(engine: Engine) -> bool:
             """)
         )
         conn.execute(
-            text(
-                "CREATE INDEX idx_rc_tenant_action ON remediation_comments (tenant_id, action_id)"
-            )
+            text("CREATE INDEX idx_rc_tenant_action ON remediation_comments (tenant_id, action_id)")
         )
 
         conn.execute(

--- a/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
+++ b/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
@@ -62,7 +62,12 @@ def apply(engine: Engine) -> bool:
                 "ON remediation_actions (tenant_id, category)"
             )
         )
-        conn.execute(text("CREATE INDEX ix_remediation_actions_rule_key ON remediation_actions (rule_key)"))
+        conn.execute(
+            text(
+                "CREATE INDEX ix_remediation_actions_rule_key "
+                "ON remediation_actions (rule_key)"
+            )
+        )
         conn.execute(
             text(
                 "CREATE UNIQUE INDEX uq_remediation_actions_tenant_dedupe "

--- a/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
+++ b/app/db_migrations/migrations/m20260428_remediation_actions_layer.py
@@ -1,0 +1,147 @@
+"""Remediation & action tracking (tenant-scoped, linkable entities, dedupe-safe generation)."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260428_remediation_actions_layer"
+DISPLAY_NAME = "remediation_actions_layer"
+
+
+def satisfied(engine: Engine) -> bool:
+    return table_exists(engine, "remediation_actions")
+
+
+def apply(engine: Engine) -> bool:
+    if table_exists(engine, "remediation_actions"):
+        return False
+    with engine.begin() as conn:
+        conn.execute(
+            text("""
+            CREATE TABLE remediation_actions (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                title VARCHAR(500) NOT NULL,
+                description TEXT,
+                status VARCHAR(32) NOT NULL DEFAULT 'open',
+                priority VARCHAR(16) NOT NULL DEFAULT 'medium',
+                owner VARCHAR(320),
+                due_at_utc DATETIME,
+                category VARCHAR(32) NOT NULL DEFAULT 'manual',
+                rule_key VARCHAR(64),
+                dedupe_key VARCHAR(255),
+                deferred_note TEXT,
+                created_at_utc DATETIME NOT NULL,
+                updated_at_utc DATETIME NOT NULL,
+                created_by VARCHAR(255)
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_remediation_actions_tenant_status "
+                "ON remediation_actions (tenant_id, status)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_remediation_actions_tenant_due "
+                "ON remediation_actions (tenant_id, due_at_utc)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_remediation_actions_tenant_category "
+                "ON remediation_actions (tenant_id, category)"
+            )
+        )
+        conn.execute(text("CREATE INDEX ix_remediation_actions_rule_key ON remediation_actions (rule_key)"))
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX uq_remediation_actions_tenant_dedupe "
+                "ON remediation_actions (tenant_id, dedupe_key)"
+                " WHERE dedupe_key IS NOT NULL"
+            )
+        )
+
+        conn.execute(
+            text("""
+            CREATE TABLE remediation_action_links (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                action_id VARCHAR(36) NOT NULL,
+                entity_type VARCHAR(64) NOT NULL,
+                entity_id VARCHAR(255) NOT NULL,
+                FOREIGN KEY(action_id) REFERENCES remediation_actions (id) ON DELETE CASCADE
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_ral_tenant_action ON remediation_action_links "
+                "(tenant_id, action_id)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_ral_tenant_entity ON remediation_action_links "
+                "(tenant_id, entity_type, entity_id)"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE UNIQUE INDEX uq_ral_tenant_action_entity ON remediation_action_links "
+                "(tenant_id, action_id, entity_type, entity_id)"
+            )
+        )
+
+        conn.execute(
+            text("""
+            CREATE TABLE remediation_comments (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                action_id VARCHAR(36) NOT NULL,
+                body TEXT NOT NULL,
+                created_by VARCHAR(255),
+                created_at_utc DATETIME NOT NULL,
+                FOREIGN KEY(action_id) REFERENCES remediation_actions (id) ON DELETE CASCADE
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_rc_tenant_action ON remediation_comments (tenant_id, action_id)"
+            )
+        )
+
+        conn.execute(
+            text("""
+            CREATE TABLE remediation_status_history (
+                id VARCHAR(36) NOT NULL PRIMARY KEY,
+                tenant_id VARCHAR(255) NOT NULL,
+                action_id VARCHAR(36) NOT NULL,
+                from_status VARCHAR(32),
+                to_status VARCHAR(32) NOT NULL,
+                changed_at_utc DATETIME NOT NULL,
+                changed_by VARCHAR(255),
+                note TEXT,
+                FOREIGN KEY(action_id) REFERENCES remediation_actions (id) ON DELETE CASCADE
+            )
+            """)
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX idx_rsh_tenant_action_time ON remediation_status_history "
+                "(tenant_id, action_id, changed_at_utc)"
+            )
+        )
+
+    logger.info("Applied migration %s (%s)", MIGRATION_ID, DISPLAY_NAME)
+    return True

--- a/app/governance_taxonomy.py
+++ b/app/governance_taxonomy.py
@@ -23,6 +23,7 @@ class GovernanceAuditEntity(StrEnum):
     GOVERNANCE_CONTROL_EVIDENCE = "governance_control_evidence"
     GOVERNANCE_AUDIT_CASE = "governance_audit_case"
     BOARD_REPORT = "board_report"
+    REMEDIATION_ACTION = "remediation_action"
 
 
 class GovernanceAuditAction(StrEnum):
@@ -58,6 +59,10 @@ class GovernanceAuditAction(StrEnum):
     GOVERNANCE_AUDIT_CASE_CREATE = "governance_audit_case.create"
     GOVERNANCE_AUDIT_CASE_CONTROL_ATTACH = "governance_audit_case.control.attach"
     BOARD_REPORT_GENERATE = "board_report.generate"
+    REMEDIATION_ACTION_CREATE = "remediation_action.create"
+    REMEDIATION_ACTION_UPDATE = "remediation_action.update"
+    REMEDIATION_ACTION_COMMENT = "remediation_action.comment"
+    REMEDIATION_ACTION_GENERATE = "remediation_action.generate"
 
 
 class NIS2DeadlinePolicy:

--- a/app/main.py
+++ b/app/main.py
@@ -135,6 +135,7 @@ from app.authority_audit_preparation_pack_models import (
     PreparationPackFocus,
 )
 from app.board_reporting_routes import router as board_reporting_router
+from app.remediation_actions_routes import router as remediation_actions_router
 from app.classification_models import (
     ClassificationOverrideRequest,
     ClassificationQuestionnaire,
@@ -579,6 +580,7 @@ app.include_router(operations_resilience_router)
 app.include_router(governance_controls_router)
 app.include_router(governance_audit_readiness_router)
 app.include_router(board_reporting_router)
+app.include_router(remediation_actions_router)
 
 logger = logging.getLogger(__name__)
 

--- a/app/main.py
+++ b/app/main.py
@@ -135,7 +135,6 @@ from app.authority_audit_preparation_pack_models import (
     PreparationPackFocus,
 )
 from app.board_reporting_routes import router as board_reporting_router
-from app.remediation_actions_routes import router as remediation_actions_router
 from app.classification_models import (
     ClassificationOverrideRequest,
     ClassificationQuestionnaire,
@@ -292,6 +291,7 @@ from app.rbac.dependencies import require_permission
 from app.rbac.permissions import Permission
 from app.rbac.roles import EnterpriseRole
 from app.readiness_score_models import ReadinessScoreExplainResponse, ReadinessScoreResponse
+from app.remediation_actions_routes import router as remediation_actions_router
 from app.repositories.advisor_tenants import AdvisorTenantRepository
 from app.repositories.ai_act_docs import AIActDocRepository
 from app.repositories.ai_governance_actions import AIGovernanceActionRepository

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -1441,6 +1441,116 @@ class BoardReportMetricHistoryTable(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
 
 
+class RemediationActionTable(Base):
+    """Steuerbare Maßnahme zu Gaps, Reviews, Incidents und Board Actions (mandantenisoliert)."""
+
+    __tablename__ = "remediation_actions"
+    __table_args__ = (
+        Index("idx_remediation_actions_tenant_status", "tenant_id", "status"),
+        Index("idx_remediation_actions_tenant_due", "tenant_id", "due_at_utc"),
+        Index("idx_remediation_actions_tenant_category", "tenant_id", "category"),
+        UniqueConstraint("tenant_id", "dedupe_key", name="uq_remediation_actions_tenant_dedupe"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    title: Mapped[str] = mapped_column(String(500), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="open")
+    priority: Mapped[str] = mapped_column(String(16), nullable=False, default="medium")
+    owner: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    due_at_utc: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    category: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="manual",
+    )
+    rule_key: Mapped[str | None] = mapped_column(String(64), nullable=True, index=True)
+    dedupe_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    deferred_note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+
+class RemediationActionLinkTable(Base):
+    """Verknüpfung einer Maßnahme mit Controls, Audits, Incidents, Reports, Requirements."""
+
+    __tablename__ = "remediation_action_links"
+    __table_args__ = (
+        Index("idx_ral_tenant_action", "tenant_id", "action_id"),
+        Index("idx_ral_tenant_entity", "tenant_id", "entity_type", "entity_id"),
+        UniqueConstraint(
+            "tenant_id",
+            "action_id",
+            "entity_type",
+            "entity_id",
+            name="uq_ral_tenant_action_entity",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    action_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("remediation_actions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    entity_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(255), nullable=False)
+
+
+class RemediationCommentTable(Base):
+    """Kommentarthread zu einer Maßnahme."""
+
+    __tablename__ = "remediation_comments"
+    __table_args__ = (Index("idx_rc_tenant_action", "tenant_id", "action_id"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    action_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("remediation_actions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    body: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
+class RemediationStatusHistoryTable(Base):
+    """Immutable Statusübergänge (Audit Trail)."""
+
+    __tablename__ = "remediation_status_history"
+    __table_args__ = (
+        Index("idx_rsh_tenant_action_time", "tenant_id", "action_id", "changed_at_utc"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    action_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("remediation_actions.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    from_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    to_status: Mapped[str] = mapped_column(String(32), nullable=False)
+    changed_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    changed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
 class GovernanceEvidenceRequirementTable(Base):
     """Tenant-level evidence type expectations per framework (advisor-tunable; defaults in code)."""
 

--- a/app/remediation_actions_models.py
+++ b/app/remediation_actions_models.py
@@ -1,0 +1,113 @@
+"""Pydantic schemas for remediation & action tracking (governance layer)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class RemediationLinkCreate(BaseModel):
+    entity_type: str = Field(..., max_length=64, examples=["governance_control"])
+    entity_id: str = Field(..., max_length=255)
+
+
+class RemediationActionCreate(BaseModel):
+    title: str = Field(..., max_length=500)
+    description: str | None = Field(default=None, max_length=8000)
+    priority: str = Field(default="medium", pattern="^(critical|high|medium|low)$")
+    owner: str | None = Field(default=None, max_length=320)
+    due_at_utc: datetime | None = None
+    category: str = Field(
+        default="manual",
+        pattern="^(manual|audit|control|incident|board|ai_act|nis2)$",
+    )
+    links: list[RemediationLinkCreate] = Field(default_factory=list)
+
+
+class RemediationActionUpdate(BaseModel):
+    title: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, max_length=8000)
+    status: str | None = Field(
+        default=None,
+        pattern="^(open|in_progress|blocked|done|accepted_risk)$",
+    )
+    priority: str | None = Field(default=None, pattern="^(critical|high|medium|low)$")
+    owner: str | None = Field(default=None, max_length=320)
+    due_at_utc: datetime | None = None
+    deferred_note: str | None = Field(default=None, max_length=8000)
+
+
+class RemediationCommentCreate(BaseModel):
+    body: str = Field(..., min_length=1, max_length=8000)
+
+
+class RemediationLinkRead(BaseModel):
+    entity_type: str
+    entity_id: str
+
+
+class RemediationCommentRead(BaseModel):
+    id: str
+    body: str
+    created_by: str | None
+    created_at_utc: datetime
+
+
+class RemediationStatusHistoryRead(BaseModel):
+    id: str
+    from_status: str | None
+    to_status: str
+    changed_at_utc: datetime
+    changed_by: str | None
+    note: str | None
+
+
+class RemediationActionListItemRead(BaseModel):
+    id: str
+    title: str
+    status: str
+    priority: str
+    owner: str | None
+    due_at_utc: datetime | None
+    category: str
+    rule_key: str | None
+    updated_at_utc: datetime
+    links: list[RemediationLinkRead] = Field(default_factory=list)
+
+
+class RemediationSummaryRead(BaseModel):
+    open_actions: int
+    overdue_actions: int
+    blocked_actions: int
+    due_this_week: int
+
+
+class RemediationActionListResponse(BaseModel):
+    items: list[RemediationActionListItemRead]
+    summary: RemediationSummaryRead
+
+
+class RemediationActionDetailRead(BaseModel):
+    id: str
+    tenant_id: str
+    title: str
+    description: str | None
+    status: str
+    priority: str
+    owner: str | None
+    due_at_utc: datetime | None
+    category: str
+    rule_key: str | None
+    deferred_note: str | None
+    created_at_utc: datetime
+    updated_at_utc: datetime
+    created_by: str | None
+    links: list[RemediationLinkRead]
+    comments: list[RemediationCommentRead]
+    status_history: list[RemediationStatusHistoryRead]
+
+
+class RemediationGenerateResponse(BaseModel):
+    created_count: int
+    rule_keys_touched: list[str]

--- a/app/remediation_actions_models.py
+++ b/app/remediation_actions_models.py
@@ -36,6 +36,11 @@ class RemediationActionUpdate(BaseModel):
     owner: str | None = Field(default=None, max_length=320)
     due_at_utc: datetime | None = None
     deferred_note: str | None = Field(default=None, max_length=8000)
+    status_change_note: str | None = Field(
+        default=None,
+        max_length=2000,
+        description="Optionaler Audit-Kommentar zur Statusänderung (erscheint in der Historie).",
+    )
 
 
 class RemediationCommentCreate(BaseModel):
@@ -70,6 +75,7 @@ class RemediationActionListItemRead(BaseModel):
     priority: str
     owner: str | None
     due_at_utc: datetime | None
+    is_overdue: bool = False
     category: str
     rule_key: str | None
     updated_at_utc: datetime
@@ -78,6 +84,7 @@ class RemediationActionListItemRead(BaseModel):
 
 class RemediationSummaryRead(BaseModel):
     open_actions: int
+    backlog_actions: int
     overdue_actions: int
     blocked_actions: int
     due_this_week: int
@@ -97,6 +104,7 @@ class RemediationActionDetailRead(BaseModel):
     priority: str
     owner: str | None
     due_at_utc: datetime | None
+    is_overdue: bool = False
     category: str
     rule_key: str | None
     deferred_note: str | None
@@ -111,3 +119,4 @@ class RemediationActionDetailRead(BaseModel):
 class RemediationGenerateResponse(BaseModel):
     created_count: int
     rule_keys_touched: list[str]
+    evaluated_at_utc: datetime

--- a/app/remediation_actions_routes.py
+++ b/app/remediation_actions_routes.py
@@ -79,7 +79,9 @@ def _actor(request: Request) -> str:
 def _remediation_is_overdue(*, status: str, due_at_utc: datetime | None, now: datetime) -> bool:
     if due_at_utc is None or status not in ("open", "in_progress", "blocked"):
         return False
-    return due_at_utc < now
+    due = due_at_utc if due_at_utc.tzinfo is not None else due_at_utc.replace(tzinfo=UTC)
+    now_aware = now if now.tzinfo is not None else now.replace(tzinfo=UTC)
+    return due < now_aware
 
 
 def _ilike_search_term(raw: str) -> str:

--- a/app/remediation_actions_routes.py
+++ b/app/remediation_actions_routes.py
@@ -1,0 +1,446 @@
+"""Remediation & Action Tracking APIs — nachvollziehbare Regeln, Mandanten-Firewall, Audit Trail."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth_dependencies import get_api_key_and_tenant
+from app.db_tenant import get_async_db
+from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.models_db import (
+    AuditLogTable,
+    GovernanceControlTable,
+    RemediationActionLinkTable,
+    RemediationActionTable,
+    RemediationCommentTable,
+    RemediationStatusHistoryTable,
+)
+from app.remediation_actions_models import (
+    RemediationActionCreate,
+    RemediationActionDetailRead,
+    RemediationActionListItemRead,
+    RemediationActionListResponse,
+    RemediationActionUpdate,
+    RemediationCommentCreate,
+    RemediationCommentRead,
+    RemediationGenerateResponse,
+    RemediationLinkRead,
+    RemediationStatusHistoryRead,
+    RemediationSummaryRead,
+)
+from app.services.remediation_actions_service import (
+    ENTITY_GOVERNANCE_CONTROL,
+    generate_remediation_actions,
+    tenant_summary_counts,
+)
+
+router = APIRouter(
+    prefix="/api/v1/governance/remediation-actions",
+    tags=["governance", "remediation-actions"],
+)
+
+
+async def _audit_event(
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    actor: str,
+    action: str,
+    entity_id: str,
+    payload: dict[str, object],
+) -> None:
+    session.add(
+        AuditLogTable(
+            tenant_id=tenant_id,
+            actor=actor,
+            action=action,
+            entity_type=GovernanceAuditEntity.REMEDIATION_ACTION.value,
+            entity_id=entity_id,
+            after=json.dumps(payload),
+            outcome="success",
+            actor_role="compliance_officer",
+            created_at_utc=datetime.now(UTC),
+        )
+    )
+
+
+def _actor(request: Request) -> str:
+    return request.headers.get("x-actor-id", "api:governance-remediation")
+
+
+async def _load_links(
+    session: AsyncSession, tenant_id: str, action_ids: list[str]
+) -> dict[str, list]:
+    if not action_ids:
+        return {}
+    rows = (
+        await session.scalars(
+            select(RemediationActionLinkTable).where(
+                RemediationActionLinkTable.tenant_id == tenant_id,
+                RemediationActionLinkTable.action_id.in_(action_ids),
+            )
+        )
+    ).all()
+    out: dict[str, list] = {}
+    for r in rows:
+        out.setdefault(r.action_id, []).append(r)
+    return out
+
+
+@router.get("", response_model=RemediationActionListResponse)
+async def list_remediation_actions(
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+    status_filter: str | None = Query(None, alias="status"),
+    priority: str | None = None,
+    category: str | None = Query(
+        None, description="manual | audit | control | incident | board | ai_act | nis2"
+    ),
+    rule_key: str | None = None,
+    framework_tag: str | None = Query(
+        None, description="Filter über verknüpfte Controls, z. B. EU_AI_ACT"
+    ),
+    limit: int = Query(200, ge=1, le=500),
+) -> RemediationActionListResponse:
+    summary_raw = await tenant_summary_counts(session, tenant_id)
+    stmt = select(RemediationActionTable).where(RemediationActionTable.tenant_id == tenant_id)
+    if status_filter:
+        stmt = stmt.where(RemediationActionTable.status == status_filter)
+    if priority:
+        stmt = stmt.where(RemediationActionTable.priority == priority)
+    if category:
+        stmt = stmt.where(RemediationActionTable.category == category)
+    if rule_key:
+        stmt = stmt.where(RemediationActionTable.rule_key == rule_key)
+    if framework_tag:
+        subq = (
+            select(RemediationActionLinkTable.action_id)
+            .where(
+                RemediationActionLinkTable.tenant_id == tenant_id,
+                RemediationActionLinkTable.entity_type == ENTITY_GOVERNANCE_CONTROL,
+                RemediationActionLinkTable.entity_id.in_(
+                    select(GovernanceControlTable.id).where(
+                        GovernanceControlTable.tenant_id == tenant_id,
+                        GovernanceControlTable.framework_tags_json.like(f"%{framework_tag}%"),
+                    )
+                ),
+            )
+            .distinct()
+        )
+        stmt = stmt.where(RemediationActionTable.id.in_(subq))
+    stmt = stmt.order_by(RemediationActionTable.updated_at_utc.desc()).limit(limit)
+    rows = (await session.scalars(stmt)).all()
+    ids = [r.id for r in rows]
+    link_map = await _load_links(session, tenant_id, ids)
+    items: list[RemediationActionListItemRead] = []
+    for r in rows:
+        lk = link_map.get(r.id, [])
+        items.append(
+            RemediationActionListItemRead(
+                id=r.id,
+                title=r.title,
+                status=r.status,
+                priority=r.priority,
+                owner=r.owner,
+                due_at_utc=r.due_at_utc,
+                category=r.category,
+                rule_key=r.rule_key,
+                updated_at_utc=r.updated_at_utc,
+                links=[
+                    RemediationLinkRead(entity_type=x.entity_type, entity_id=x.entity_id)
+                    for x in lk
+                ],
+            )
+        )
+    return RemediationActionListResponse(
+        items=items,
+        summary=RemediationSummaryRead(
+            open_actions=summary_raw["open_actions"],
+            overdue_actions=summary_raw["overdue_actions"],
+            blocked_actions=summary_raw["blocked_actions"],
+            due_this_week=summary_raw["due_this_week"],
+        ),
+    )
+
+
+@router.post("", response_model=RemediationActionDetailRead, status_code=status.HTTP_201_CREATED)
+async def create_remediation_action(
+    body: RemediationActionCreate,
+    request: Request,
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+) -> RemediationActionDetailRead:
+    actor = _actor(request)
+    aid = str(uuid4())
+    now = datetime.now(UTC)
+    for link in body.links:
+        if link.entity_type == ENTITY_GOVERNANCE_CONTROL:
+            ctl = await session.get(GovernanceControlTable, link.entity_id)
+            if ctl is None or ctl.tenant_id != tenant_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid governance_control link for this tenant.",
+                )
+
+    session.add(
+        RemediationActionTable(
+            id=aid,
+            tenant_id=tenant_id,
+            title=body.title,
+            description=body.description,
+            status="open",
+            priority=body.priority,
+            owner=body.owner,
+            due_at_utc=body.due_at_utc,
+            category=body.category,
+            rule_key=None,
+            dedupe_key=None,
+            deferred_note=None,
+            created_at_utc=now,
+            updated_at_utc=now,
+            created_by=actor,
+        )
+    )
+    for link in body.links:
+        session.add(
+            RemediationActionLinkTable(
+                id=str(uuid4()),
+                tenant_id=tenant_id,
+                action_id=aid,
+                entity_type=link.entity_type,
+                entity_id=link.entity_id,
+            )
+        )
+    session.add(
+        RemediationStatusHistoryTable(
+            id=str(uuid4()),
+            tenant_id=tenant_id,
+            action_id=aid,
+            from_status=None,
+            to_status="open",
+            changed_at_utc=now,
+            changed_by=actor,
+            note="Erstellt",
+        )
+    )
+    await _audit_event(
+        session,
+        tenant_id=tenant_id,
+        actor=actor,
+        action=GovernanceAuditAction.REMEDIATION_ACTION_CREATE.value,
+        entity_id=aid,
+        payload={"title": body.title, "category": body.category},
+    )
+    await session.commit()
+    res = await get_remediation_action(aid, tenant_id, session)
+    return res
+
+
+@router.post("/generate", response_model=RemediationGenerateResponse)
+async def generate_remediation_actions_endpoint(
+    request: Request,
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+) -> RemediationGenerateResponse:
+    actor = _actor(request)
+    n, touched = await generate_remediation_actions(session, tenant_id=tenant_id, actor=actor)
+    await _audit_event(
+        session,
+        tenant_id=tenant_id,
+        actor=actor,
+        action=GovernanceAuditAction.REMEDIATION_ACTION_GENERATE.value,
+        entity_id=tenant_id,
+        payload={"created_count": n, "rule_keys": touched},
+    )
+    await session.commit()
+    return RemediationGenerateResponse(created_count=n, rule_keys_touched=touched)
+
+
+@router.get("/{action_id}", response_model=RemediationActionDetailRead)
+async def get_remediation_action(
+    action_id: str,
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+) -> RemediationActionDetailRead:
+    row = await session.get(RemediationActionTable, action_id)
+    if row is None or row.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Remediation action not found.")
+    links = (
+        await session.scalars(
+            select(RemediationActionLinkTable).where(
+                RemediationActionLinkTable.tenant_id == tenant_id,
+                RemediationActionLinkTable.action_id == action_id,
+            )
+        )
+    ).all()
+    comments = (
+        await session.scalars(
+            select(RemediationCommentTable)
+            .where(
+                RemediationCommentTable.tenant_id == tenant_id,
+                RemediationCommentTable.action_id == action_id,
+            )
+            .order_by(RemediationCommentTable.created_at_utc)
+        )
+    ).all()
+    hist = (
+        await session.scalars(
+            select(RemediationStatusHistoryTable)
+            .where(
+                RemediationStatusHistoryTable.tenant_id == tenant_id,
+                RemediationStatusHistoryTable.action_id == action_id,
+            )
+            .order_by(RemediationStatusHistoryTable.changed_at_utc)
+        )
+    ).all()
+    return RemediationActionDetailRead(
+        id=row.id,
+        tenant_id=row.tenant_id,
+        title=row.title,
+        description=row.description,
+        status=row.status,
+        priority=row.priority,
+        owner=row.owner,
+        due_at_utc=row.due_at_utc,
+        category=row.category,
+        rule_key=row.rule_key,
+        deferred_note=row.deferred_note,
+        created_at_utc=row.created_at_utc,
+        updated_at_utc=row.updated_at_utc,
+        created_by=row.created_by,
+        links=[
+            RemediationLinkRead(entity_type=x.entity_type, entity_id=x.entity_id) for x in links
+        ],
+        comments=[
+            RemediationCommentRead(
+                id=c.id,
+                body=c.body,
+                created_by=c.created_by,
+                created_at_utc=c.created_at_utc,
+            )
+            for c in comments
+        ],
+        status_history=[
+            RemediationStatusHistoryRead(
+                id=h.id,
+                from_status=h.from_status,
+                to_status=h.to_status,
+                changed_at_utc=h.changed_at_utc,
+                changed_by=h.changed_by,
+                note=h.note,
+            )
+            for h in hist
+        ],
+    )
+
+
+@router.patch("/{action_id}", response_model=RemediationActionDetailRead)
+async def patch_remediation_action(
+    action_id: str,
+    body: RemediationActionUpdate,
+    request: Request,
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+) -> RemediationActionDetailRead:
+    actor = _actor(request)
+    row = await session.get(RemediationActionTable, action_id)
+    if row is None or row.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Remediation action not found.")
+    if body.status == "accepted_risk":
+        note = body.deferred_note if body.deferred_note is not None else row.deferred_note
+        if not (note and str(note).strip()):
+            raise HTTPException(
+                status_code=400,
+                detail="deferred_note is required when status is accepted_risk",
+            )
+    prev_status = row.status
+    if body.title is not None:
+        row.title = body.title
+    if body.description is not None:
+        row.description = body.description
+    if body.priority is not None:
+        row.priority = body.priority
+    if body.owner is not None:
+        row.owner = body.owner
+    if body.due_at_utc is not None:
+        row.due_at_utc = body.due_at_utc
+    if body.deferred_note is not None:
+        row.deferred_note = body.deferred_note
+    if body.status is not None:
+        row.status = body.status
+    row.updated_at_utc = datetime.now(UTC)
+    if body.status is not None and body.status != prev_status:
+        session.add(
+            RemediationStatusHistoryTable(
+                id=str(uuid4()),
+                tenant_id=tenant_id,
+                action_id=action_id,
+                from_status=prev_status,
+                to_status=body.status,
+                changed_at_utc=row.updated_at_utc,
+                changed_by=actor,
+                note=None,
+            )
+        )
+    await _audit_event(
+        session,
+        tenant_id=tenant_id,
+        actor=actor,
+        action=GovernanceAuditAction.REMEDIATION_ACTION_UPDATE.value,
+        entity_id=action_id,
+        payload={"patch": body.model_dump(exclude_none=True)},
+    )
+    await session.commit()
+    return await get_remediation_action(action_id, tenant_id, session)
+
+
+@router.post(
+    "/{action_id}/comments",
+    response_model=RemediationCommentRead,
+    status_code=status.HTTP_201_CREATED,
+)
+async def post_remediation_comment(
+    action_id: str,
+    body: RemediationCommentCreate,
+    request: Request,
+    tenant_id: str = Depends(get_api_key_and_tenant),
+    session: AsyncSession = Depends(get_async_db),
+) -> RemediationCommentRead:
+    actor = _actor(request)
+    row = await session.get(RemediationActionTable, action_id)
+    if row is None or row.tenant_id != tenant_id:
+        raise HTTPException(status_code=404, detail="Remediation action not found.")
+    cid = str(uuid4())
+    now = datetime.now(UTC)
+    session.add(
+        RemediationCommentTable(
+            id=cid,
+            tenant_id=tenant_id,
+            action_id=action_id,
+            body=body.body,
+            created_by=actor,
+            created_at_utc=now,
+        )
+    )
+    row.updated_at_utc = now
+    await _audit_event(
+        session,
+        tenant_id=tenant_id,
+        actor=actor,
+        action=GovernanceAuditAction.REMEDIATION_ACTION_COMMENT.value,
+        entity_id=action_id,
+        payload={"comment_id": cid},
+    )
+    await session.commit()
+    return RemediationCommentRead(
+        id=cid,
+        body=body.body,
+        created_by=actor,
+        created_at_utc=now,
+    )

--- a/app/remediation_actions_routes.py
+++ b/app/remediation_actions_routes.py
@@ -382,9 +382,7 @@ async def get_remediation_action(
         priority=row.priority,
         owner=row.owner,
         due_at_utc=row.due_at_utc,
-        is_overdue=_remediation_is_overdue(
-            status=row.status, due_at_utc=row.due_at_utc, now=now
-        ),
+        is_overdue=_remediation_is_overdue(status=row.status, due_at_utc=row.due_at_utc, now=now),
         category=row.category,
         rule_key=row.rule_key,
         deferred_note=row.deferred_note,

--- a/app/remediation_actions_routes.py
+++ b/app/remediation_actions_routes.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from sqlalchemy import select
+from sqlalchemy import asc, case, desc, nulls_last, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth_dependencies import get_api_key_and_tenant
@@ -15,6 +15,7 @@ from app.db_tenant import get_async_db
 from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
 from app.models_db import (
     AuditLogTable,
+    GovernanceAuditCaseTable,
     GovernanceControlTable,
     RemediationActionLinkTable,
     RemediationActionTable,
@@ -35,6 +36,7 @@ from app.remediation_actions_models import (
     RemediationSummaryRead,
 )
 from app.services.remediation_actions_service import (
+    ENTITY_GOVERNANCE_AUDIT_CASE,
     ENTITY_GOVERNANCE_CONTROL,
     generate_remediation_actions,
     tenant_summary_counts,
@@ -74,6 +76,17 @@ def _actor(request: Request) -> str:
     return request.headers.get("x-actor-id", "api:governance-remediation")
 
 
+def _remediation_is_overdue(*, status: str, due_at_utc: datetime | None, now: datetime) -> bool:
+    if due_at_utc is None or status not in ("open", "in_progress", "blocked"):
+        return False
+    return due_at_utc < now
+
+
+def _ilike_search_term(raw: str) -> str:
+    t = raw.strip()
+    return t.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 async def _load_links(
     session: AsyncSession, tenant_id: str, action_ids: list[str]
 ) -> dict[str, list]:
@@ -106,9 +119,20 @@ async def list_remediation_actions(
     framework_tag: str | None = Query(
         None, description="Filter über verknüpfte Controls, z. B. EU_AI_ACT"
     ),
+    search: str | None = Query(
+        None,
+        max_length=200,
+        description="Teilstring-Suche im Titel (mandanten-isoliert, LIKE mit Escape).",
+    ),
+    sort: str = Query(
+        "updated_desc",
+        pattern="^(updated_desc|due_asc|due_desc|priority_desc)$",
+        description="Sortierung der Liste",
+    ),
     limit: int = Query(200, ge=1, le=500),
 ) -> RemediationActionListResponse:
-    summary_raw = await tenant_summary_counts(session, tenant_id)
+    now = datetime.now(UTC)
+    summary_raw = await tenant_summary_counts(session, tenant_id, now=now)
     stmt = select(RemediationActionTable).where(RemediationActionTable.tenant_id == tenant_id)
     if status_filter:
         stmt = stmt.where(RemediationActionTable.status == status_filter)
@@ -118,6 +142,10 @@ async def list_remediation_actions(
         stmt = stmt.where(RemediationActionTable.category == category)
     if rule_key:
         stmt = stmt.where(RemediationActionTable.rule_key == rule_key)
+    if search and search.strip():
+        term = _ilike_search_term(search)
+        if term:
+            stmt = stmt.where(RemediationActionTable.title.ilike(f"%{term}%", escape="\\"))
     if framework_tag:
         subq = (
             select(RemediationActionLinkTable.action_id)
@@ -134,7 +162,30 @@ async def list_remediation_actions(
             .distinct()
         )
         stmt = stmt.where(RemediationActionTable.id.in_(subq))
-    stmt = stmt.order_by(RemediationActionTable.updated_at_utc.desc()).limit(limit)
+    prio_rank = case(
+        (RemediationActionTable.priority == "critical", 4),
+        (RemediationActionTable.priority == "high", 3),
+        (RemediationActionTable.priority == "medium", 2),
+        else_=1,
+    )
+    if sort == "due_asc":
+        stmt = stmt.order_by(
+            nulls_last(asc(RemediationActionTable.due_at_utc)),
+            desc(RemediationActionTable.updated_at_utc),
+        )
+    elif sort == "due_desc":
+        stmt = stmt.order_by(
+            nulls_last(desc(RemediationActionTable.due_at_utc)),
+            desc(RemediationActionTable.updated_at_utc),
+        )
+    elif sort == "priority_desc":
+        stmt = stmt.order_by(
+            desc(prio_rank),
+            desc(RemediationActionTable.updated_at_utc),
+        )
+    else:
+        stmt = stmt.order_by(desc(RemediationActionTable.updated_at_utc))
+    stmt = stmt.limit(limit)
     rows = (await session.scalars(stmt)).all()
     ids = [r.id for r in rows]
     link_map = await _load_links(session, tenant_id, ids)
@@ -149,6 +200,9 @@ async def list_remediation_actions(
                 priority=r.priority,
                 owner=r.owner,
                 due_at_utc=r.due_at_utc,
+                is_overdue=_remediation_is_overdue(
+                    status=r.status, due_at_utc=r.due_at_utc, now=now
+                ),
                 category=r.category,
                 rule_key=r.rule_key,
                 updated_at_utc=r.updated_at_utc,
@@ -162,6 +216,7 @@ async def list_remediation_actions(
         items=items,
         summary=RemediationSummaryRead(
             open_actions=summary_raw["open_actions"],
+            backlog_actions=summary_raw["backlog_actions"],
             overdue_actions=summary_raw["overdue_actions"],
             blocked_actions=summary_raw["blocked_actions"],
             due_this_week=summary_raw["due_this_week"],
@@ -186,6 +241,13 @@ async def create_remediation_action(
                 raise HTTPException(
                     status_code=400,
                     detail="Invalid governance_control link for this tenant.",
+                )
+        elif link.entity_type == ENTITY_GOVERNANCE_AUDIT_CASE:
+            ac = await session.get(GovernanceAuditCaseTable, link.entity_id)
+            if ac is None or ac.tenant_id != tenant_id:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Invalid governance_audit_case link for this tenant.",
                 )
 
     session.add(
@@ -249,17 +311,28 @@ async def generate_remediation_actions_endpoint(
     session: AsyncSession = Depends(get_async_db),
 ) -> RemediationGenerateResponse:
     actor = _actor(request)
-    n, touched = await generate_remediation_actions(session, tenant_id=tenant_id, actor=actor)
+    evaluated_at = datetime.now(UTC)
+    n, touched = await generate_remediation_actions(
+        session, tenant_id=tenant_id, actor=actor, now=evaluated_at
+    )
     await _audit_event(
         session,
         tenant_id=tenant_id,
         actor=actor,
         action=GovernanceAuditAction.REMEDIATION_ACTION_GENERATE.value,
         entity_id=tenant_id,
-        payload={"created_count": n, "rule_keys": touched},
+        payload={
+            "created_count": n,
+            "rule_keys": touched,
+            "evaluated_at_utc": evaluated_at.isoformat(),
+        },
     )
     await session.commit()
-    return RemediationGenerateResponse(created_count=n, rule_keys_touched=touched)
+    return RemediationGenerateResponse(
+        created_count=n,
+        rule_keys_touched=touched,
+        evaluated_at_utc=evaluated_at,
+    )
 
 
 @router.get("/{action_id}", response_model=RemediationActionDetailRead)
@@ -268,6 +341,7 @@ async def get_remediation_action(
     tenant_id: str = Depends(get_api_key_and_tenant),
     session: AsyncSession = Depends(get_async_db),
 ) -> RemediationActionDetailRead:
+    now = datetime.now(UTC)
     row = await session.get(RemediationActionTable, action_id)
     if row is None or row.tenant_id != tenant_id:
         raise HTTPException(status_code=404, detail="Remediation action not found.")
@@ -308,6 +382,9 @@ async def get_remediation_action(
         priority=row.priority,
         owner=row.owner,
         due_at_utc=row.due_at_utc,
+        is_overdue=_remediation_is_overdue(
+            status=row.status, due_at_utc=row.due_at_utc, now=now
+        ),
         category=row.category,
         rule_key=row.rule_key,
         deferred_note=row.deferred_note,
@@ -375,6 +452,10 @@ async def patch_remediation_action(
     if body.status is not None:
         row.status = body.status
     row.updated_at_utc = datetime.now(UTC)
+    hist_note: str | None = None
+    if body.status_change_note is not None:
+        stripped = body.status_change_note.strip()
+        hist_note = stripped if stripped else None
     if body.status is not None and body.status != prev_status:
         session.add(
             RemediationStatusHistoryTable(
@@ -385,7 +466,7 @@ async def patch_remediation_action(
                 to_status=body.status,
                 changed_at_utc=row.updated_at_utc,
                 changed_by=actor,
-                note=None,
+                note=hist_note,
             )
         )
     await _audit_event(

--- a/app/services/remediation_actions_service.py
+++ b/app/services/remediation_actions_service.py
@@ -12,6 +12,7 @@ from app.models_db import (
     AISystemTable,
     BoardReportActionTable,
     GovernanceAuditCaseControlTable,
+    GovernanceAuditCaseTable,
     GovernanceControlEvidenceTable,
     GovernanceControlReviewTable,
     GovernanceControlTable,
@@ -34,6 +35,7 @@ RULE_AI_ACT_HIGH_BASELINE = "ai_act_high_risk_baseline"
 RULE_NIS2_BASELINE_PRIORITY = "nis2_baseline_priority"
 
 ENTITY_GOVERNANCE_CONTROL = "governance_control"
+ENTITY_GOVERNANCE_AUDIT_CASE = "governance_audit_case"
 ENTITY_BOARD_REPORT_ACTION = "board_report_action"
 ENTITY_BOARD_REPORT = "board_report"
 ENTITY_SERVICE_HEALTH_INCIDENT = "service_health_incident"
@@ -336,15 +338,21 @@ async def generate_remediation_actions(
             owner=None,
         )
 
-    # 8) Audit-Scope: Controls ohne Evidence, nicht „implemented“ (anderes Dedupe als Regel 1).
-    scoped = (
-        await session.scalars(
-            select(GovernanceAuditCaseControlTable.control_id)
+    # 8) Audit-Scope: je Audit-Case + Control ohne Evidence, nicht „implemented“ (Dedupe pro Case).
+    scoped_pairs = (
+        await session.execute(
+            select(
+                GovernanceAuditCaseControlTable.audit_case_id,
+                GovernanceAuditCaseControlTable.control_id,
+            )
             .where(GovernanceAuditCaseControlTable.tenant_id == tenant_id)
             .distinct()
         )
     ).all()
-    for cid in scoped[:200]:
+    for audit_case_id, cid in scoped_pairs[:200]:
+        ac = await session.get(GovernanceAuditCaseTable, audit_case_id)
+        if ac is None or ac.tenant_id != tenant_id:
+            continue
         ctl = await session.get(GovernanceControlTable, cid)
         if ctl is None or ctl.tenant_id != tenant_id:
             continue
@@ -359,19 +367,22 @@ async def generate_remediation_actions(
         )
         if has_ev > 0:
             continue
-        dk = f"audit_scope_no_evidence:{cid}"
+        dk = f"audit_scope_no_evidence:{audit_case_id}:{cid}"
         await _create(
             dedupe_key=dk,
             title=f"Audit Readiness: Nachweis vorbereiten — {ctl.title}",
             description=(
-                "Kontrolle ist einem Audit Case zugeordnet, ist aber nicht umgesetzt und ohne "
-                "Evidence — Umsetzung oder Nachweisplan für Audit Readiness."
+                f"Kontrolle ist Audit-Case {audit_case_id} zugeordnet, ist aber nicht umgesetzt "
+                "und ohne Evidence — Umsetzung oder Nachweisplan für Audit Readiness."
             ),
             category="audit",
             rule_key=RULE_EVIDENCE_GAP,
             priority="medium",
             due=ts + timedelta(days=21),
-            links=[(ENTITY_GOVERNANCE_CONTROL, cid)],
+            links=[
+                (ENTITY_GOVERNANCE_AUDIT_CASE, audit_case_id),
+                (ENTITY_GOVERNANCE_CONTROL, cid),
+            ],
             owner=ctl.owner,
         )
 
@@ -420,8 +431,16 @@ async def tenant_summary_counts(
             RemediationActionTable.due_at_utc <= week_end,
         ),
     )
+    backlog_actions = await _scalar_int(
+        session,
+        select(func.count()).where(
+            RemediationActionTable.tenant_id == tenant_id,
+            RemediationActionTable.status.in_(active_states),
+        ),
+    )
     return {
         "open_actions": open_actions,
+        "backlog_actions": backlog_actions,
         "overdue_actions": overdue_actions,
         "blocked_actions": blocked_actions,
         "due_this_week": due_this_week,

--- a/app/services/remediation_actions_service.py
+++ b/app/services/remediation_actions_service.py
@@ -1,0 +1,428 @@
+"""Deterministic remediation candidates — kein LLM; merge-fähige Dedupe-Schlüssel."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from sqlalchemy import Select, func, not_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models_db import (
+    AISystemTable,
+    BoardReportActionTable,
+    GovernanceAuditCaseControlTable,
+    GovernanceControlEvidenceTable,
+    GovernanceControlReviewTable,
+    GovernanceControlTable,
+    NIS2IncidentTable,
+    RemediationActionLinkTable,
+    RemediationActionTable,
+    ServiceHealthIncidentTable,
+)
+
+# Framework tags (same literals as governance_control_models.FrameworkTag).
+TAG_EU_AI_ACT = "EU_AI_ACT"
+TAG_NIS2 = "NIS2"
+
+RULE_EVIDENCE_GAP = "evidence_gap"
+RULE_WEAK_CONTROL = "weak_control"
+RULE_OVERDUE_REVIEW = "overdue_review"
+RULE_SERVICE_INCIDENT_CRITICAL = "service_incident_critical"
+RULE_BOARD_ACTION_OPEN = "board_action_open"
+RULE_AI_ACT_HIGH_BASELINE = "ai_act_high_risk_baseline"
+RULE_NIS2_BASELINE_PRIORITY = "nis2_baseline_priority"
+
+ENTITY_GOVERNANCE_CONTROL = "governance_control"
+ENTITY_BOARD_REPORT_ACTION = "board_report_action"
+ENTITY_BOARD_REPORT = "board_report"
+ENTITY_SERVICE_HEALTH_INCIDENT = "service_health_incident"
+ENTITY_GOVERNANCE_REVIEW = "governance_control_review"
+ENTITY_AI_SYSTEM = "ai_system"
+
+
+def _norm_ai_high(risk_level: str) -> bool:
+    rl = risk_level.strip().lower()
+    return rl in {"high", "unacceptable"}
+
+
+async def _scalar_int(session: AsyncSession, stmt: Select) -> int:
+    return int((await session.execute(stmt)).scalar_one())
+
+
+async def _dedupe_exists(session: AsyncSession, tenant_id: str, dedupe_key: str) -> bool:
+    row = (
+        await session.scalars(
+            select(RemediationActionTable.id).where(
+                RemediationActionTable.tenant_id == tenant_id,
+                RemediationActionTable.dedupe_key == dedupe_key,
+            )
+        )
+    ).first()
+    return row is not None
+
+
+async def _open_critical_incident_density(session: AsyncSession, tenant_id: str) -> int:
+    ops = await _scalar_int(
+        session,
+        select(func.count()).where(
+            ServiceHealthIncidentTable.tenant_id == tenant_id,
+            ServiceHealthIncidentTable.incident_state == "open",
+            ServiceHealthIncidentTable.severity == "critical",
+        ),
+    )
+    nis2 = await _scalar_int(
+        session,
+        select(func.count()).where(
+            NIS2IncidentTable.tenant_id == tenant_id,
+            NIS2IncidentTable.workflow_status.in_(["detected", "reported", "contained"]),
+            NIS2IncidentTable.severity.in_(["high", "critical"]),
+        ),
+    )
+    return ops + nis2
+
+
+async def generate_remediation_actions(
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    actor: str,
+    now: datetime | None = None,
+) -> tuple[int, list[str]]:
+    """Apply small, auditable rules. Returns (created_count, ordered rule_keys with any insert)."""
+    ts = now or datetime.now(UTC)
+    created = 0
+    touched: set[str] = set()
+
+    async def _create(
+        *,
+        dedupe_key: str,
+        title: str,
+        description: str,
+        category: str,
+        rule_key: str,
+        priority: str,
+        due: datetime | None,
+        links: list[tuple[str, str]],
+        owner: str | None = None,
+    ) -> None:
+        nonlocal created
+        if await _dedupe_exists(session, tenant_id, dedupe_key):
+            return
+        aid = str(uuid4())
+        session.add(
+            RemediationActionTable(
+                id=aid,
+                tenant_id=tenant_id,
+                title=title,
+                description=description,
+                status="open",
+                priority=priority,
+                owner=owner,
+                due_at_utc=due,
+                category=category,
+                rule_key=rule_key,
+                dedupe_key=dedupe_key,
+                created_at_utc=ts,
+                updated_at_utc=ts,
+                created_by=actor,
+            )
+        )
+        for entity_type, entity_id in links:
+            session.add(
+                RemediationActionLinkTable(
+                    id=str(uuid4()),
+                    tenant_id=tenant_id,
+                    action_id=aid,
+                    entity_type=entity_type,
+                    entity_id=entity_id,
+                )
+            )
+        created += 1
+        touched.add(rule_key)
+
+    # 1) Evidence gap — implemented controls ohne Evidence (wie Board KPI „evidence gaps“).
+    evidence_gap_stmt = (
+        select(
+            GovernanceControlTable.id, GovernanceControlTable.title, GovernanceControlTable.owner
+        )
+        .where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.status == "implemented",
+            not_(
+                GovernanceControlTable.id.in_(
+                    select(GovernanceControlEvidenceTable.control_id).where(
+                        GovernanceControlEvidenceTable.tenant_id == tenant_id,
+                    )
+                )
+            ),
+        )
+        .limit(150)
+    )
+    for cid, title, owner in (await session.execute(evidence_gap_stmt)).all():
+        dk = f"{RULE_EVIDENCE_GAP}:{cid}"
+        await _create(
+            dedupe_key=dk,
+            title=f"Nachweis nachreichen: {title}",
+            description=(
+                "Kontrolle ist als umgesetzt markiert, aber es liegt kein Evidence-Datensatz vor. "
+                "Bitte Nachweis anlegen oder Status korrigieren."
+            ),
+            category="audit",
+            rule_key=RULE_EVIDENCE_GAP,
+            priority="high",
+            due=ts + timedelta(days=14),
+            links=[(ENTITY_GOVERNANCE_CONTROL, str(cid))],
+            owner=owner,
+        )
+
+    # 2) Schwache / überfällige Controls (angepasst an Board „open critical controls“).
+    weak_stmt = (
+        select(
+            GovernanceControlTable.id, GovernanceControlTable.title, GovernanceControlTable.owner
+        )
+        .where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.status.in_(["overdue", "needs_review"]),
+        )
+        .limit(150)
+    )
+    for cid, title, owner in (await session.execute(weak_stmt)).all():
+        dk = f"{RULE_WEAK_CONTROL}:{cid}"
+        await _create(
+            dedupe_key=dk,
+            title=f"Kontrolle nachziehen: {title}",
+            description=(
+                "Status überfällig oder Review erforderlich — Umsetzung oder Review planen."
+            ),
+            category="control",
+            rule_key=RULE_WEAK_CONTROL,
+            priority="medium",
+            due=ts + timedelta(days=21),
+            links=[(ENTITY_GOVERNANCE_CONTROL, str(cid))],
+            owner=owner,
+        )
+
+    # 3) Überfällige Reviews.
+    overdue_rev_stmt = select(GovernanceControlReviewTable).where(
+        GovernanceControlReviewTable.tenant_id == tenant_id,
+        GovernanceControlReviewTable.completed_at.is_(None),
+        GovernanceControlReviewTable.due_at < ts,
+    )
+    for rev in (await session.scalars(overdue_rev_stmt)).unique().all():
+        dk = f"{RULE_OVERDUE_REVIEW}:{rev.id}"
+        await _create(
+            dedupe_key=dk,
+            title="Überfälliges Control-Review durchführen",
+            description=(
+                f"Review für Kontrolle {rev.control_id} ist überfällig (Fälligkeit "
+                f"{rev.due_at.isoformat()})."
+            ),
+            category="audit",
+            rule_key=RULE_OVERDUE_REVIEW,
+            priority="high",
+            due=ts + timedelta(days=7),
+            links=[
+                (ENTITY_GOVERNANCE_REVIEW, rev.id),
+                (ENTITY_GOVERNANCE_CONTROL, rev.control_id),
+            ],
+            owner=rev.reviewer,
+        )
+
+    # 4) Kritische Service-Health-Incidents (offen).
+    crit_inc_stmt = select(ServiceHealthIncidentTable).where(
+        ServiceHealthIncidentTable.tenant_id == tenant_id,
+        ServiceHealthIncidentTable.incident_state == "open",
+        ServiceHealthIncidentTable.severity == "critical",
+    )
+    for inc in (await session.scalars(crit_inc_stmt)).unique().all():
+        dk = f"{RULE_SERVICE_INCIDENT_CRITICAL}:{inc.id}"
+        await _create(
+            dedupe_key=dk,
+            title=f"Incident-Remediation: {inc.title}",
+            description=inc.summary
+            or "Kritisches Service-Incident — Ursachenanalyse und Maßnahmenplan.",
+            category="incident",
+            rule_key=RULE_SERVICE_INCIDENT_CRITICAL,
+            priority="critical",
+            due=ts + timedelta(days=3),
+            links=[(ENTITY_SERVICE_HEALTH_INCIDENT, inc.id)],
+            owner=None,
+        )
+
+    # 5) Offene Board-Report-Actions → übernehmen als Remediation (Dedupe pro Board-Action-ID).
+    board_stmt = select(BoardReportActionTable).where(
+        BoardReportActionTable.tenant_id == tenant_id,
+        BoardReportActionTable.status == "open",
+    )
+    for ba in (await session.scalars(board_stmt)).unique().all():
+        dk = f"{RULE_BOARD_ACTION_OPEN}:{ba.id}"
+        await _create(
+            dedupe_key=dk,
+            title=ba.action_title,
+            description=ba.action_detail or "Maßnahme aus Management Pack / Board Report.",
+            category="board",
+            rule_key=RULE_BOARD_ACTION_OPEN,
+            priority=ba.priority
+            if ba.priority in {"critical", "high", "medium", "low"}
+            else "medium",
+            due=ba.due_at,
+            links=[
+                (ENTITY_BOARD_REPORT_ACTION, ba.id),
+                (ENTITY_BOARD_REPORT, ba.report_id),
+            ],
+            owner=ba.owner,
+        )
+
+    # 6) AI Act high risk ohne ausreichende EU-AI-Act-Kontrollen (Baselinesignal).
+    high_ai = (
+        await session.scalars(
+            select(AISystemTable).where(
+                AISystemTable.tenant_id == tenant_id,
+            )
+        )
+    ).all()
+    high_ids = [s for s in high_ai if _norm_ai_high(s.risk_level)]
+    eu_ai_impl = await _scalar_int(
+        session,
+        select(func.count()).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.status == "implemented",
+            GovernanceControlTable.framework_tags_json.like(f"%{TAG_EU_AI_ACT}%"),
+        ),
+    )
+    if len(high_ids) > 0 and eu_ai_impl == 0:
+        dk = RULE_AI_ACT_HIGH_BASELINE
+        await _create(
+            dedupe_key=dk,
+            title="KI-Governance-Baseline für Hochrisiko-Systeme etablieren",
+            description=(
+                f"{len(high_ids)} KI-System(e) mit hohem Risiko, aber keine umgesetzte EU_AI_ACT-"
+                "Kontrolle im Unified-Control-Register. Mindestens eine umgesetzte Kontrolle "
+                "anlegen und verknüpfen."
+            ),
+            category="ai_act",
+            rule_key=RULE_AI_ACT_HIGH_BASELINE,
+            priority="critical",
+            due=ts + timedelta(days=30),
+            links=[(ENTITY_AI_SYSTEM, s.id) for s in high_ids[:20]],
+            owner=None,
+        )
+
+    # 7) NIS2 Exposure hoch + wenige Baseline-Kontrollen (wie Board KPI „open_critical_incidents“).
+    exposure = await _open_critical_incident_density(session, tenant_id)
+    nis2_impl = await _scalar_int(
+        session,
+        select(func.count()).where(
+            GovernanceControlTable.tenant_id == tenant_id,
+            GovernanceControlTable.status == "implemented",
+            GovernanceControlTable.framework_tags_json.like(f"%{TAG_NIS2}%"),
+        ),
+    )
+    if exposure >= 5 and nis2_impl < 3:
+        dk = RULE_NIS2_BASELINE_PRIORITY
+        await _create(
+            dedupe_key=dk,
+            title="NIS2-Basiskontrollen priorisieren",
+            description=(
+                f"Offene kritische Incident-Lage ({exposure} Summe Ops+NIS2) bei nur {nis2_impl} "
+                "umgesetzten NIS2-Kontrollen. Baseline-Kontrollen beschleunigen."
+            ),
+            category="nis2",
+            rule_key=RULE_NIS2_BASELINE_PRIORITY,
+            priority="high",
+            due=ts + timedelta(days=14),
+            links=[],
+            owner=None,
+        )
+
+    # 8) Audit-Scope: Controls ohne Evidence, nicht „implemented“ (anderes Dedupe als Regel 1).
+    scoped = (
+        await session.scalars(
+            select(GovernanceAuditCaseControlTable.control_id)
+            .where(GovernanceAuditCaseControlTable.tenant_id == tenant_id)
+            .distinct()
+        )
+    ).all()
+    for cid in scoped[:200]:
+        ctl = await session.get(GovernanceControlTable, cid)
+        if ctl is None or ctl.tenant_id != tenant_id:
+            continue
+        if ctl.status == "implemented":
+            continue
+        has_ev = await _scalar_int(
+            session,
+            select(func.count()).where(
+                GovernanceControlEvidenceTable.tenant_id == tenant_id,
+                GovernanceControlEvidenceTable.control_id == cid,
+            ),
+        )
+        if has_ev > 0:
+            continue
+        dk = f"audit_scope_no_evidence:{cid}"
+        await _create(
+            dedupe_key=dk,
+            title=f"Audit Readiness: Nachweis vorbereiten — {ctl.title}",
+            description=(
+                "Kontrolle ist einem Audit Case zugeordnet, ist aber nicht umgesetzt und ohne "
+                "Evidence — Umsetzung oder Nachweisplan für Audit Readiness."
+            ),
+            category="audit",
+            rule_key=RULE_EVIDENCE_GAP,
+            priority="medium",
+            due=ts + timedelta(days=21),
+            links=[(ENTITY_GOVERNANCE_CONTROL, cid)],
+            owner=ctl.owner,
+        )
+
+    return created, sorted(touched)
+
+
+async def tenant_summary_counts(
+    session: AsyncSession, tenant_id: str, *, now: datetime | None = None
+) -> dict[str, int]:
+    """Aggregierte KPIs für Workspace-Kacheln (mandantenweit)."""
+    ts = now or datetime.now(UTC)
+    week_end = ts + timedelta(days=7)
+    active_states = ("open", "in_progress", "blocked")
+    open_like = ("open", "in_progress")
+
+    open_actions = await _scalar_int(
+        session,
+        select(func.count()).where(
+            RemediationActionTable.tenant_id == tenant_id,
+            RemediationActionTable.status.in_(open_like),
+        ),
+    )
+    overdue_actions = await _scalar_int(
+        session,
+        select(func.count()).where(
+            RemediationActionTable.tenant_id == tenant_id,
+            RemediationActionTable.status.in_(active_states),
+            RemediationActionTable.due_at_utc.is_not(None),
+            RemediationActionTable.due_at_utc < ts,
+        ),
+    )
+    blocked_actions = await _scalar_int(
+        session,
+        select(func.count()).where(
+            RemediationActionTable.tenant_id == tenant_id,
+            RemediationActionTable.status == "blocked",
+        ),
+    )
+    due_this_week = await _scalar_int(
+        session,
+        select(func.count()).where(
+            RemediationActionTable.tenant_id == tenant_id,
+            RemediationActionTable.status.in_(active_states),
+            RemediationActionTable.due_at_utc.is_not(None),
+            RemediationActionTable.due_at_utc >= ts,
+            RemediationActionTable.due_at_utc <= week_end,
+        ),
+    )
+    return {
+        "open_actions": open_actions,
+        "overdue_actions": overdue_actions,
+        "blocked_actions": blocked_actions,
+        "due_this_week": due_this_week,
+    }

--- a/frontend/src/app/tenant/governance/remediation/page.tsx
+++ b/frontend/src/app/tenant/governance/remediation/page.tsx
@@ -1,0 +1,7 @@
+import { RemediationWorkspaceClient } from "@/components/governance/RemediationWorkspaceClient";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TenantRemediationPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  return <RemediationWorkspaceClient tenantId={tenantId} />;
+}

--- a/frontend/src/components/governance/RemediationWorkspaceClient.tsx
+++ b/frontend/src/components/governance/RemediationWorkspaceClient.tsx
@@ -1,0 +1,466 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { GovernanceWorkspaceLayout } from "@/components/governance/GovernanceWorkspaceLayout";
+import { HealthStatusPill } from "@/components/governance/HealthStatusPill";
+import { StatusBadge } from "@/components/governance/StatusBadge";
+import {
+  fetchRemediationActionDetail,
+  fetchRemediationActions,
+  generateRemediationActions,
+  postRemediationComment,
+  type RemediationActionDetailDto,
+  type RemediationActionListItemDto,
+  type RemediationListResponseDto,
+} from "@/lib/remediationActionsApi";
+import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+interface Props {
+  tenantId: string;
+}
+
+function remediationTone(status: string): "success" | "warning" | "neutral" {
+  if (status === "done" || status === "accepted_risk") return "success";
+  if (status === "blocked" || status === "in_progress") return "warning";
+  return "neutral";
+}
+
+function sourceLabel(row: RemediationActionListItemDto): string {
+  const rk = row.rule_key;
+  if (rk?.startsWith("evidence")) return "Audit / Evidence";
+  if (rk === "weak_control") return "Control";
+  if (rk === "overdue_review") return "Audit / Review";
+  if (rk?.includes("incident")) return "Incident";
+  if (rk?.includes("board")) return "Board Report";
+  if (rk?.includes("ai_act")) return "AI Act";
+  if (rk?.includes("nis2")) return "NIS2";
+  switch (row.category) {
+    case "audit":
+      return "Audit";
+    case "control":
+      return "Control";
+    case "incident":
+      return "Incident";
+    case "board":
+      return "Board";
+    case "ai_act":
+      return "AI Act";
+    case "nis2":
+      return "NIS2";
+    default:
+      return "Manuell";
+  }
+}
+
+function linkHint(entityType: string): string {
+  switch (entityType) {
+    case "governance_control":
+      return "Control";
+    case "governance_audit_case":
+      return "Audit Case";
+    case "service_health_incident":
+      return "Ops Incident";
+    case "board_report":
+      return "Board Report";
+    case "board_report_action":
+      return "Board Action";
+    case "ai_system":
+      return "KI-System";
+    case "governance_control_review":
+      return "Review";
+    default:
+      return entityType;
+  }
+}
+
+export function RemediationWorkspaceClient({ tenantId }: Props) {
+  const [pack, setPack] = useState<RemediationListResponseDto | null>(null);
+  const [detail, setDetail] = useState<RemediationActionDetailDto | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [genBusy, setGenBusy] = useState(false);
+  const [comment, setComment] = useState("");
+
+  const [statusFilter, setStatusFilter] = useState("");
+  const [priorityFilter, setPriorityFilter] = useState("");
+  const [categoryFilter, setCategoryFilter] = useState("");
+  const [frameworkTag, setFrameworkTag] = useState("");
+
+  const reload = useCallback(async () => {
+    setError(null);
+    try {
+      const next = await fetchRemediationActions(tenantId, {
+        status: statusFilter || undefined,
+        priority: priorityFilter || undefined,
+        category: categoryFilter || undefined,
+        framework_tag: frameworkTag || undefined,
+        limit: 300,
+      });
+      setPack(next);
+      setSelectedId((sid) =>
+        sid && !next.items.some((i) => i.id === sid) ? null : sid,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    }
+  }, [tenantId, statusFilter, priorityFilter, categoryFilter, frameworkTag]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    void fetchRemediationActionDetail(tenantId, selectedId).then(
+      (d) => {
+        if (!cancelled) setDetail(d);
+      },
+      (e) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Detail fehlgeschlagen");
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [tenantId, selectedId]);
+
+  async function onGenerate() {
+    setGenBusy(true);
+    setError(null);
+    try {
+      await generateRemediationActions(tenantId);
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Generierung fehlgeschlagen");
+    } finally {
+      setGenBusy(false);
+    }
+  }
+
+  async function onPostComment() {
+    if (!selectedId || !comment.trim()) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await postRemediationComment(tenantId, selectedId, comment.trim());
+      setComment("");
+      const d = await fetchRemediationActionDetail(tenantId, selectedId);
+      setDetail(d);
+      await reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Kommentar fehlgeschlagen");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const summary = pack?.summary;
+  const healthIncidentLinked = useMemo(() => {
+    const rows = detail?.links ?? [];
+    return rows.some((l) => l.entity_type === "service_health_incident");
+  }, [detail]);
+
+  const tabContent = (
+    <div className="space-y-6">
+      {error ? (
+        <p className="text-sm text-rose-800" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Offene Maßnahmen</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
+            {summary?.open_actions ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Überfällig</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-rose-800">
+            {summary?.overdue_actions ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Blockiert</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-amber-900">
+            {summary?.blocked_actions ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Fällig diese Woche</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-[var(--sbs-navy-mid)]">
+            {summary?.due_this_week ?? "—"}
+          </p>
+        </article>
+      </section>
+
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Status
+          <select
+            className="mt-1 min-w-[10rem] rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+          >
+            <option value="">Alle</option>
+            <option value="open">open</option>
+            <option value="in_progress">in_progress</option>
+            <option value="blocked">blocked</option>
+            <option value="done">done</option>
+            <option value="accepted_risk">accepted_risk</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Priorität
+          <select
+            className="mt-1 min-w-[10rem] rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            value={priorityFilter}
+            onChange={(e) => setPriorityFilter(e.target.value)}
+          >
+            <option value="">Alle</option>
+            <option value="critical">critical</option>
+            <option value="high">high</option>
+            <option value="medium">medium</option>
+            <option value="low">low</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Quelle (Kategorie)
+          <select
+            className="mt-1 min-w-[12rem] rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value)}
+          >
+            <option value="">Alle</option>
+            <option value="manual">manual</option>
+            <option value="audit">audit</option>
+            <option value="control">control</option>
+            <option value="incident">incident</option>
+            <option value="board">board</option>
+            <option value="ai_act">ai_act</option>
+            <option value="nis2">nis2</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Framework-Tag (Control)
+          <input
+            className="mt-1 min-w-[12rem] rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            placeholder="z. B. EU_AI_ACT"
+            value={frameworkTag}
+            onChange={(e) => setFrameworkTag(e.target.value)}
+          />
+        </label>
+        <button type="button" className={CH_BTN_SECONDARY} onClick={() => void reload()}>
+          Aktualisieren
+        </button>
+        <button type="button" className={CH_BTN_PRIMARY} onClick={() => void onGenerate()} disabled={genBusy}>
+          {genBusy ? "Generiert…" : "Aus Signale generieren"}
+        </button>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-5">
+        <div className="lg:col-span-3">
+          <article className={`${CH_CARD} overflow-hidden`}>
+            <p className={CH_SECTION_LABEL}>Maßnahmenregister</p>
+            <div className="mt-3 overflow-x-auto rounded-xl border border-slate-200/80">
+              <table className="min-w-full divide-y divide-slate-200 text-left text-sm">
+                <thead className="bg-slate-50/90 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  <tr>
+                    <th className="px-3 py-2">Titel</th>
+                    <th className="px-3 py-2">Status</th>
+                    <th className="px-3 py-2">Priorität</th>
+                    <th className="px-3 py-2">Owner</th>
+                    <th className="px-3 py-2">Fällig</th>
+                    <th className="px-3 py-2">Quelle</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-slate-100 bg-white">
+                  {(pack?.items ?? []).length === 0 ? (
+                    <tr>
+                      <td className="px-3 py-6 text-slate-600" colSpan={6}>
+                        Keine Maßnahmen für die aktuelle Filterung.
+                      </td>
+                    </tr>
+                  ) : (
+                    (pack?.items ?? []).map((row) => (
+                      <tr
+                        key={row.id}
+                        className={`cursor-pointer hover:bg-slate-50/80 ${selectedId === row.id ? "bg-slate-50" : ""}`}
+                        onClick={() => setSelectedId(row.id)}
+                      >
+                        <td className="px-3 py-2 font-medium text-slate-900">{row.title}</td>
+                        <td className="px-3 py-2">
+                          <StatusBadge status={row.status} tone={remediationTone(row.status)} />
+                        </td>
+                        <td className="px-3 py-2 text-slate-700">{row.priority}</td>
+                        <td className="px-3 py-2 text-slate-600">{row.owner ?? "—"}</td>
+                        <td className="px-3 py-2 text-slate-600">
+                          {row.due_at_utc
+                            ? new Date(row.due_at_utc).toLocaleDateString("de-DE")
+                            : "—"}
+                        </td>
+                        <td className="px-3 py-2 text-slate-600">{sourceLabel(row)}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+
+        <div className="lg:col-span-2">
+          <article className={`${CH_CARD} min-h-[22rem]`}>
+            <p className={CH_SECTION_LABEL}>Detail</p>
+            {!selectedId ? (
+              <p className="mt-4 text-sm text-slate-600">Bitte eine Zeile auswählen.</p>
+            ) : !detail ? (
+              <p className="mt-4 text-sm text-slate-600">Lade Detail…</p>
+            ) : (
+              <div className="mt-4 space-y-4 text-sm text-slate-700">
+                <div className="flex flex-wrap items-center gap-2">
+                  <StatusBadge status={detail.status} tone={remediationTone(detail.status)} />
+                  <span className="text-xs text-slate-500">{detail.priority}</span>
+                  {healthIncidentLinked ? (
+                    <span className="inline-flex items-center gap-1 text-xs text-slate-600">
+                      <HealthStatusPill status="degraded" label="Service-Health Incident" />
+                    </span>
+                  ) : null}
+                </div>
+                <h3 className="text-base font-semibold text-slate-900">{detail.title}</h3>
+                {detail.description ? <p className="leading-relaxed">{detail.description}</p> : null}
+                <dl className="grid gap-2 text-xs">
+                  <div className="flex justify-between gap-2 border-b border-slate-100 py-1">
+                    <dt className="text-slate-500">Owner</dt>
+                    <dd>{detail.owner ?? "—"}</dd>
+                  </div>
+                  <div className="flex justify-between gap-2 border-b border-slate-100 py-1">
+                    <dt className="text-slate-500">Fällig</dt>
+                    <dd>
+                      {detail.due_at_utc
+                        ? new Date(detail.due_at_utc).toLocaleString("de-DE")
+                        : "—"}
+                    </dd>
+                  </div>
+                  <div className="flex justify-between gap-2 border-b border-slate-100 py-1">
+                    <dt className="text-slate-500">Regel</dt>
+                    <dd>{detail.rule_key ?? "—"}</dd>
+                  </div>
+                  {detail.deferred_note ? (
+                    <div className="rounded-lg bg-amber-50/80 px-2 py-2 text-amber-950">
+                      <strong className="font-semibold">Akzeptiertes Risiko:</strong>{" "}
+                      {detail.deferred_note}
+                    </div>
+                  ) : null}
+                </dl>
+
+                <div>
+                  <p className={CH_SECTION_LABEL}>Verknüpfungen</p>
+                  <ul className="mt-2 space-y-1 text-xs">
+                    {detail.links.map((l) => (
+                      <li key={`${l.entity_type}:${l.entity_id}`}>
+                        <span className="font-medium text-slate-800">{linkHint(l.entity_type)}</span>
+                        {": "}
+                        <code className="rounded bg-slate-100 px-1">{l.entity_id}</code>
+                        {l.entity_type === "board_report" ? (
+                          <>
+                            {" · "}
+                            <Link
+                              href={`/tenant/governance/board-reports/${encodeURIComponent(l.entity_id)}`}
+                              className="font-semibold text-[var(--sbs-navy-mid)] no-underline hover:underline"
+                            >
+                              Board Report
+                            </Link>
+                          </>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <p className={CH_SECTION_LABEL}>Kommentare</p>
+                  <ul className="mt-2 max-h-40 space-y-2 overflow-y-auto text-xs">
+                    {detail.comments.map((c) => (
+                      <li key={c.id} className="rounded-lg border border-slate-100 bg-slate-50/80 px-2 py-2">
+                        <p className="text-slate-800">{c.body}</p>
+                        <p className="mt-1 text-slate-500">
+                          {c.created_by ?? "—"} ·{" "}
+                          {new Date(c.created_at_utc).toLocaleString("de-DE")}
+                        </p>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-3 flex gap-2">
+                    <textarea
+                      className="min-h-[4rem] flex-1 rounded-lg border border-slate-300 px-2 py-2 text-sm"
+                      placeholder="Kommentar hinzufügen…"
+                      value={comment}
+                      onChange={(e) => setComment(e.target.value)}
+                    />
+                    <button
+                      type="button"
+                      className={`${CH_BTN_PRIMARY} self-end`}
+                      disabled={busy || !comment.trim()}
+                      onClick={() => void onPostComment()}
+                    >
+                      Senden
+                    </button>
+                  </div>
+                </div>
+
+                <div>
+                  <p className={CH_SECTION_LABEL}>Status-Historie</p>
+                  <ul className="mt-2 space-y-1 text-xs text-slate-600">
+                    {detail.status_history.map((h) => (
+                      <li key={h.id}>
+                        {(h.from_status ?? "∅")} → {h.to_status}{" "}
+                        <time dateTime={h.changed_at_utc}>
+                          ({new Date(h.changed_at_utc).toLocaleString("de-DE")})
+                        </time>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            )}
+          </article>
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="mx-auto max-w-7xl px-4 py-8">
+      <GovernanceWorkspaceLayout
+        title="Remediation & Maßnahmensteuerung"
+        eyebrow="Governance"
+        status="live"
+        headerDescription={
+          <div className="flex flex-wrap items-center gap-3">
+            <StatusBadge status="tenant_scoped" tone="neutral" />
+            <span className="text-sm text-slate-600">
+              Mandant <span className="font-mono text-xs">{tenantId}</span>
+            </span>
+          </div>
+        }
+        breadcrumbs={[
+          { label: "Tenant", href: "/tenant/compliance-overview" },
+          { label: "Governance", href: "/tenant/governance/overview" },
+          { label: "Remediation" },
+        ]}
+        tabs={[{ id: "register", label: "Maßnahmenregister", content: tabContent }]}
+        activeTabId="register"
+        onTabChange={() => {}}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/governance/RemediationWorkspaceClient.tsx
+++ b/frontend/src/components/governance/RemediationWorkspaceClient.tsx
@@ -54,12 +54,20 @@ function sourceLabel(row: RemediationActionListItemDto): string {
   }
 }
 
+const STATUS_LABEL_DE: Record<string, string> = {
+  open: "Offen",
+  in_progress: "In Bearbeitung",
+  blocked: "Blockiert",
+  done: "Erledigt",
+  accepted_risk: "Risiko akzeptiert",
+};
+
 function linkHint(entityType: string): string {
   switch (entityType) {
     case "governance_control":
       return "Control";
     case "governance_audit_case":
-      return "Audit Case";
+      return "Audit-Fall";
     case "service_health_incident":
       return "Ops Incident";
     case "board_report":
@@ -88,6 +96,16 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
   const [priorityFilter, setPriorityFilter] = useState("");
   const [categoryFilter, setCategoryFilter] = useState("");
   const [frameworkTag, setFrameworkTag] = useState("");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchDebounced, setSearchDebounced] = useState("");
+  const [sortKey, setSortKey] = useState<
+    "updated_desc" | "due_asc" | "due_desc" | "priority_desc"
+  >("updated_desc");
+
+  useEffect(() => {
+    const t = window.setTimeout(() => setSearchDebounced(searchInput.trim()), 400);
+    return () => window.clearTimeout(t);
+  }, [searchInput]);
 
   const reload = useCallback(async () => {
     setError(null);
@@ -97,6 +115,8 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
         priority: priorityFilter || undefined,
         category: categoryFilter || undefined,
         framework_tag: frameworkTag || undefined,
+        search: searchDebounced || undefined,
+        sort: sortKey,
         limit: 300,
       });
       setPack(next);
@@ -106,7 +126,15 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
     } catch (e) {
       setError(e instanceof Error ? e.message : "Laden fehlgeschlagen");
     }
-  }, [tenantId, statusFilter, priorityFilter, categoryFilter, frameworkTag]);
+  }, [
+    tenantId,
+    statusFilter,
+    priorityFilter,
+    categoryFilter,
+    frameworkTag,
+    searchDebounced,
+    sortKey,
+  ]);
 
   useEffect(() => {
     void reload();
@@ -175,11 +203,18 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
         </p>
       ) : null}
 
-      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
         <article className={`${CH_CARD} border-slate-200/80`}>
-          <p className={CH_SECTION_LABEL}>Offene Maßnahmen</p>
+          <p className={CH_SECTION_LABEL}>Offen + In Arbeit</p>
           <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-900">
             {summary?.open_actions ?? "—"}
+          </p>
+        </article>
+        <article className={`${CH_CARD} border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Aktiver Backlog</p>
+          <p className="mt-1 text-xs text-slate-500">inkl. blockiert</p>
+          <p className="mt-1 text-3xl font-semibold tabular-nums text-slate-900">
+            {summary?.backlog_actions ?? "—"}
           </p>
         </article>
         <article className={`${CH_CARD} border-slate-200/80`}>
@@ -203,6 +238,40 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
       </section>
 
       <div className="flex flex-wrap items-end gap-3">
+        <label className="flex min-w-[12rem] flex-col text-xs font-medium text-slate-600">
+          Titelsuche
+          <input
+            type="search"
+            className="mt-1 rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            placeholder="z. B. Evidence, Board, Incident…"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            autoComplete="off"
+          />
+        </label>
+        <label className="flex flex-col text-xs font-medium text-slate-600">
+          Sortierung
+          <select
+            className="mt-1 min-w-[11rem] rounded-lg border border-slate-300 bg-white px-2 py-2 text-sm"
+            value={sortKey}
+            onChange={(e) => {
+              const v = e.target.value;
+              if (
+                v === "updated_desc" ||
+                v === "due_asc" ||
+                v === "due_desc" ||
+                v === "priority_desc"
+              ) {
+                setSortKey(v);
+              }
+            }}
+          >
+            <option value="updated_desc">Zuletzt geändert</option>
+            <option value="due_asc">Fälligkeit (aufsteigend)</option>
+            <option value="due_desc">Fälligkeit (absteigend)</option>
+            <option value="priority_desc">Priorität</option>
+          </select>
+        </label>
         <label className="flex flex-col text-xs font-medium text-slate-600">
           Status
           <select
@@ -211,11 +280,11 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
             onChange={(e) => setStatusFilter(e.target.value)}
           >
             <option value="">Alle</option>
-            <option value="open">open</option>
-            <option value="in_progress">in_progress</option>
-            <option value="blocked">blocked</option>
-            <option value="done">done</option>
-            <option value="accepted_risk">accepted_risk</option>
+            <option value="open">{STATUS_LABEL_DE.open}</option>
+            <option value="in_progress">{STATUS_LABEL_DE.in_progress}</option>
+            <option value="blocked">{STATUS_LABEL_DE.blocked}</option>
+            <option value="done">{STATUS_LABEL_DE.done}</option>
+            <option value="accepted_risk">{STATUS_LABEL_DE.accepted_risk}</option>
           </select>
         </label>
         <label className="flex flex-col text-xs font-medium text-slate-600">
@@ -303,9 +372,16 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
                         <td className="px-3 py-2 text-slate-700">{row.priority}</td>
                         <td className="px-3 py-2 text-slate-600">{row.owner ?? "—"}</td>
                         <td className="px-3 py-2 text-slate-600">
-                          {row.due_at_utc
-                            ? new Date(row.due_at_utc).toLocaleDateString("de-DE")
-                            : "—"}
+                          {row.due_at_utc ? (
+                            <span className="inline-flex flex-col gap-0.5">
+                              <span>{new Date(row.due_at_utc).toLocaleDateString("de-DE")}</span>
+                              {row.is_overdue === true ? (
+                                <span className="text-xs font-medium text-rose-700">überfällig</span>
+                              ) : null}
+                            </span>
+                          ) : (
+                            "—"
+                          )}
                         </td>
                         <td className="px-3 py-2 text-slate-600">{sourceLabel(row)}</td>
                       </tr>
@@ -344,10 +420,15 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
                   </div>
                   <div className="flex justify-between gap-2 border-b border-slate-100 py-1">
                     <dt className="text-slate-500">Fällig</dt>
-                    <dd>
+                    <dd className="text-right">
                       {detail.due_at_utc
                         ? new Date(detail.due_at_utc).toLocaleString("de-DE")
                         : "—"}
+                      {detail.is_overdue === true ? (
+                        <span className="mt-0.5 block text-xs font-medium text-rose-700">
+                          überfällig (aktiver Status)
+                        </span>
+                      ) : null}
                     </dd>
                   </div>
                   <div className="flex justify-between gap-2 border-b border-slate-100 py-1">
@@ -421,11 +502,17 @@ export function RemediationWorkspaceClient({ tenantId }: Props) {
                   <p className={CH_SECTION_LABEL}>Status-Historie</p>
                   <ul className="mt-2 space-y-1 text-xs text-slate-600">
                     {detail.status_history.map((h) => (
-                      <li key={h.id}>
-                        {(h.from_status ?? "∅")} → {h.to_status}{" "}
-                        <time dateTime={h.changed_at_utc}>
-                          ({new Date(h.changed_at_utc).toLocaleString("de-DE")})
-                        </time>
+                      <li key={h.id} className="rounded border border-slate-100/80 bg-white/60 px-2 py-1.5">
+                        <span>
+                          {(h.from_status ?? "∅")} → {h.to_status}{" "}
+                          <time dateTime={h.changed_at_utc} className="text-slate-500">
+                            ({new Date(h.changed_at_utc).toLocaleString("de-DE")}
+                            {h.changed_by ? ` · ${h.changed_by}` : ""})
+                          </time>
+                        </span>
+                        {h.note ? (
+                          <p className="mt-1 text-slate-700">Anmerkung: {h.note}</p>
+                        ) : null}
                       </li>
                     ))}
                   </ul>

--- a/frontend/src/components/governance/TenantRiskOverviewPanel.tsx
+++ b/frontend/src/components/governance/TenantRiskOverviewPanel.tsx
@@ -226,9 +226,14 @@ export function TenantRiskOverviewPanel({ overview }: Props) {
         <p className="mt-4 text-xs text-slate-500">
           TODO: Regeln serverseitig versionieren; mit Audit-Trail und Verantwortlichen verknüpfen.
         </p>
-        <Link href="/tenant/cross-regulation-dashboard" className={`${CH_PAGE_NAV_LINK} mt-3 inline-block`}>
-          Cross-Regulation-Dashboard
-        </Link>
+        <div className="mt-3 flex flex-wrap gap-x-6 gap-y-2">
+          <Link href="/tenant/governance/remediation" className={CH_PAGE_NAV_LINK}>
+            Remediation &amp; Maßnahmen
+          </Link>
+          <Link href="/tenant/cross-regulation-dashboard" className={CH_PAGE_NAV_LINK}>
+            Cross-Regulation-Dashboard
+          </Link>
+        </div>
       </article>
     </div>
   );

--- a/frontend/src/lib/remediationActionsApi.ts
+++ b/frontend/src/lib/remediationActionsApi.ts
@@ -1,5 +1,6 @@
 export interface RemediationSummaryDto {
   open_actions: number;
+  backlog_actions: number;
   overdue_actions: number;
   blocked_actions: number;
   due_this_week: number;
@@ -17,6 +18,7 @@ export interface RemediationActionListItemDto {
   priority: string;
   owner: string | null;
   due_at_utc: string | null;
+  is_overdue: boolean;
   category: string;
   rule_key: string | null;
   updated_at_utc: string;
@@ -53,6 +55,7 @@ export interface RemediationActionDetailDto {
   priority: string;
   owner: string | null;
   due_at_utc: string | null;
+  is_overdue: boolean;
   category: string;
   rule_key: string | null;
   deferred_note: string | null;
@@ -67,6 +70,7 @@ export interface RemediationActionDetailDto {
 export interface RemediationGenerateResponseDto {
   created_count: number;
   rule_keys_touched: string[];
+  evaluated_at_utc: string;
 }
 
 function apiBase(): string {
@@ -97,6 +101,8 @@ export async function fetchRemediationActions(
     category?: string;
     rule_key?: string;
     framework_tag?: string;
+    search?: string;
+    sort?: "updated_desc" | "due_asc" | "due_desc" | "priority_desc";
     limit?: number;
   } = {},
 ): Promise<RemediationListResponseDto> {
@@ -106,6 +112,8 @@ export async function fetchRemediationActions(
   if (params.category) qs.set("category", params.category);
   if (params.rule_key) qs.set("rule_key", params.rule_key);
   if (params.framework_tag) qs.set("framework_tag", params.framework_tag);
+  if (params.search?.trim()) qs.set("search", params.search.trim());
+  if (params.sort) qs.set("sort", params.sort);
   if (params.limit != null) qs.set("limit", String(params.limit));
   const q = qs.toString();
   const base = apiBase().replace(/\/$/, "");

--- a/frontend/src/lib/remediationActionsApi.ts
+++ b/frontend/src/lib/remediationActionsApi.ts
@@ -1,0 +1,161 @@
+export interface RemediationSummaryDto {
+  open_actions: number;
+  overdue_actions: number;
+  blocked_actions: number;
+  due_this_week: number;
+}
+
+export interface RemediationLinkDto {
+  entity_type: string;
+  entity_id: string;
+}
+
+export interface RemediationActionListItemDto {
+  id: string;
+  title: string;
+  status: string;
+  priority: string;
+  owner: string | null;
+  due_at_utc: string | null;
+  category: string;
+  rule_key: string | null;
+  updated_at_utc: string;
+  links: RemediationLinkDto[];
+}
+
+export interface RemediationListResponseDto {
+  items: RemediationActionListItemDto[];
+  summary: RemediationSummaryDto;
+}
+
+export interface RemediationCommentDto {
+  id: string;
+  body: string;
+  created_by: string | null;
+  created_at_utc: string;
+}
+
+export interface RemediationStatusHistoryDto {
+  id: string;
+  from_status: string | null;
+  to_status: string;
+  changed_at_utc: string;
+  changed_by: string | null;
+  note: string | null;
+}
+
+export interface RemediationActionDetailDto {
+  id: string;
+  tenant_id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  owner: string | null;
+  due_at_utc: string | null;
+  category: string;
+  rule_key: string | null;
+  deferred_note: string | null;
+  created_at_utc: string;
+  updated_at_utc: string;
+  created_by: string | null;
+  links: RemediationLinkDto[];
+  comments: RemediationCommentDto[];
+  status_history: RemediationStatusHistoryDto[];
+}
+
+export interface RemediationGenerateResponseDto {
+  created_count: number;
+  rule_keys_touched: string[];
+}
+
+function apiBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+function headers(tenantId: string): Record<string, string> {
+  return { "x-api-key": apiKey(), "x-tenant-id": tenantId, "Content-Type": "application/json" };
+}
+
+export async function fetchRemediationActions(
+  tenantId: string,
+  params: {
+    status?: string;
+    priority?: string;
+    category?: string;
+    rule_key?: string;
+    framework_tag?: string;
+    limit?: number;
+  } = {},
+): Promise<RemediationListResponseDto> {
+  const qs = new URLSearchParams();
+  if (params.status) qs.set("status", params.status);
+  if (params.priority) qs.set("priority", params.priority);
+  if (params.category) qs.set("category", params.category);
+  if (params.rule_key) qs.set("rule_key", params.rule_key);
+  if (params.framework_tag) qs.set("framework_tag", params.framework_tag);
+  if (params.limit != null) qs.set("limit", String(params.limit));
+  const q = qs.toString();
+  const base = apiBase().replace(/\/$/, "");
+  const path = `/api/v1/governance/remediation-actions${q ? `?${q}` : ""}`;
+  const res = await fetch(`${base}${path}`, { headers: headers(tenantId), cache: "no-store" });
+  if (!res.ok) throw new Error(`Remediation API ${res.status}`);
+  return (await res.json()) as RemediationListResponseDto;
+}
+
+export async function fetchRemediationActionDetail(
+  tenantId: string,
+  actionId: string,
+): Promise<RemediationActionDetailDto> {
+  const base = apiBase().replace(/\/$/, "");
+  const res = await fetch(
+    `${base}/api/v1/governance/remediation-actions/${encodeURIComponent(actionId)}`,
+    { headers: headers(tenantId), cache: "no-store" },
+  );
+  if (!res.ok) throw new Error(`Remediation detail ${res.status}`);
+  return (await res.json()) as RemediationActionDetailDto;
+}
+
+export async function generateRemediationActions(
+  tenantId: string,
+): Promise<RemediationGenerateResponseDto> {
+  const base = apiBase().replace(/\/$/, "");
+  const res = await fetch(`${base}/api/v1/governance/remediation-actions/generate`, {
+    method: "POST",
+    headers: headers(tenantId),
+    cache: "no-store",
+  });
+  if (!res.ok) throw new Error(`Remediation generate ${res.status}`);
+  return (await res.json()) as RemediationGenerateResponseDto;
+}
+
+export async function postRemediationComment(
+  tenantId: string,
+  actionId: string,
+  body: string,
+): Promise<RemediationCommentDto> {
+  const base = apiBase().replace(/\/$/, "");
+  const res = await fetch(
+    `${base}/api/v1/governance/remediation-actions/${encodeURIComponent(actionId)}/comments`,
+    {
+      method: "POST",
+      headers: headers(tenantId),
+      cache: "no-store",
+      body: JSON.stringify({ body }),
+    },
+  );
+  if (!res.ok) throw new Error(`Remediation comment ${res.status}`);
+  return (await res.json()) as RemediationCommentDto;
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "cryptography>=42.0.0",
   "python-multipart>=0.0.9",
   "sqlalchemy>=2.0",
+  "greenlet>=3.0",
   "pydantic[email]>=2.0",
   "uvicorn[standard]>=0.30",
   "httpx>=0.27",

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -112,7 +112,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     assert "20260425_governance_unified_controls" in ids
     assert "20260427_governance_audit_readiness" in ids
     assert "20260419_board_reporting_layer" in ids
-    assert len(ids) == 26
+    assert "20260428_remediation_actions_layer" in ids
+    assert len(ids) == 27
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()

--- a/tests/test_remediation_actions_api.py
+++ b/tests/test_remediation_actions_api.py
@@ -1,0 +1,165 @@
+"""Remediation & action tracking API (tenant-scoped, async DB)."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+BASE = "/api/v1/governance/remediation-actions"
+
+
+def _headers(tenant_id: str = "board-kpi-tenant") -> dict[str, str]:
+    return {
+        "x-api-key": "board-kpi-key",
+        "x-tenant-id": tenant_id,
+    }
+
+
+def test_remediation_list_summary_shape() -> None:
+    r = client.get(BASE, headers=_headers())
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "items" in body and "summary" in body
+    s = body["summary"]
+    assert set(s.keys()) >= {
+        "open_actions",
+        "overdue_actions",
+        "blocked_actions",
+        "due_this_week",
+    }
+
+
+def test_remediation_crud_comment_generate_flow() -> None:
+    h = _headers()
+    c = client.post(
+        "/api/v1/governance/controls",
+        headers=h,
+        json={
+            "title": "Remediation link fixture",
+            "description": "pytest",
+            "status": "not_started",
+            "framework_tags": ["EU_AI_ACT"],
+            "framework_mappings": [],
+        },
+    )
+    assert c.status_code == 201, c.text
+    cid = c.json()["id"]
+
+    create = client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": "Manuelle Maßnahme (pytest)",
+            "description": "Scope test",
+            "priority": "high",
+            "category": "manual",
+            "links": [{"entity_type": "governance_control", "entity_id": cid}],
+        },
+    )
+    assert create.status_code == 201, create.text
+    aid = create.json()["id"]
+    assert create.json()["status"] == "open"
+    assert create.json()["links"][0]["entity_id"] == cid
+
+    got = client.get(f"{BASE}/{aid}", headers=h)
+    assert got.status_code == 200
+    assert got.json()["title"] == "Manuelle Maßnahme (pytest)"
+    assert len(got.json()["status_history"]) >= 1
+
+    patch = client.patch(
+        f"{BASE}/{aid}",
+        headers=h,
+        json={"status": "in_progress"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["status"] == "in_progress"
+
+    cm = client.post(
+        f"{BASE}/{aid}/comments",
+        headers=h,
+        json={"body": "Kommentar pytest"},
+    )
+    assert cm.status_code == 201, cm.text
+
+    detail = client.get(f"{BASE}/{aid}", headers=h)
+    assert detail.status_code == 200
+    assert any(x["body"] == "Kommentar pytest" for x in detail.json()["comments"])
+
+    gen = client.post(f"{BASE}/generate", headers=h)
+    assert gen.status_code == 200, gen.text
+    assert "created_count" in gen.json()
+    assert "rule_keys_touched" in gen.json()
+
+
+def test_remediation_accepted_risk_requires_note() -> None:
+    h = _headers()
+    create = client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": "Risk acceptance fixture",
+            "priority": "low",
+            "category": "manual",
+            "links": [],
+        },
+    )
+    assert create.status_code == 201
+    aid = create.json()["id"]
+
+    bad = client.patch(
+        f"{BASE}/{aid}",
+        headers=h,
+        json={"status": "accepted_risk"},
+    )
+    assert bad.status_code == 400
+
+    ok = client.patch(
+        f"{BASE}/{aid}",
+        headers=h,
+        json={"status": "accepted_risk", "deferred_note": "Budget / Phase 2"},
+    )
+    assert ok.status_code == 200
+    assert ok.json()["status"] == "accepted_risk"
+
+
+def test_remediation_invalid_control_link_400() -> None:
+    h = _headers()
+    r = client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": "Bad link",
+            "priority": "medium",
+            "category": "manual",
+            "links": [
+                {
+                    "entity_type": "governance_control",
+                    "entity_id": "00000000-0000-0000-0000-000000000099",
+                }
+            ],
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_remediation_tenant_isolation_on_detail() -> None:
+    h = _headers("board-kpi-tenant")
+    create = client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": "Tenant A only",
+            "priority": "medium",
+            "category": "manual",
+            "links": [],
+        },
+    )
+    assert create.status_code == 201
+    aid = create.json()["id"]
+
+    other = _headers("other-remediation-tenant")
+    r = client.get(f"{BASE}/{aid}", headers=other)
+    assert r.status_code == 404

--- a/tests/test_remediation_actions_api.py
+++ b/tests/test_remediation_actions_api.py
@@ -26,10 +26,14 @@ def test_remediation_list_summary_shape() -> None:
     s = body["summary"]
     assert set(s.keys()) >= {
         "open_actions",
+        "backlog_actions",
         "overdue_actions",
         "blocked_actions",
         "due_this_week",
     }
+    assert isinstance(s["backlog_actions"], int)
+    if body["items"]:
+        assert "is_overdue" in body["items"][0]
 
 
 def test_remediation_crud_comment_generate_flow() -> None:
@@ -90,8 +94,19 @@ def test_remediation_crud_comment_generate_flow() -> None:
 
     gen = client.post(f"{BASE}/generate", headers=h)
     assert gen.status_code == 200, gen.text
-    assert "created_count" in gen.json()
-    assert "rule_keys_touched" in gen.json()
+    gj = gen.json()
+    assert "created_count" in gj
+    assert "rule_keys_touched" in gj
+    assert "evaluated_at_utc" in gj
+
+    patch_note = client.patch(
+        f"{BASE}/{aid}",
+        headers=h,
+        json={"status": "blocked", "status_change_note": "Ressource fehlt bis Q3"},
+    )
+    assert patch_note.status_code == 200, patch_note.text
+    hist = client.get(f"{BASE}/{aid}", headers=h).json()["status_history"]
+    assert any(h.get("note") == "Ressource fehlt bis Q3" for h in hist)
 
 
 def test_remediation_accepted_risk_requires_note() -> None:
@@ -143,6 +158,39 @@ def test_remediation_invalid_control_link_400() -> None:
         },
     )
     assert r.status_code == 400
+
+
+def test_remediation_list_search_and_sort() -> None:
+    h = _headers()
+    unique = "pytest_unique_title_marker_zz42"
+    c1 = client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": f"Sichtbar {unique}",
+            "priority": "high",
+            "category": "manual",
+            "links": [],
+        },
+    )
+    assert c1.status_code == 201, c1.text
+    client.post(
+        BASE,
+        headers=h,
+        json={
+            "title": "Anderer Titel ohne Marker",
+            "priority": "low",
+            "category": "manual",
+            "links": [],
+        },
+    )
+    r = client.get(f"{BASE}?search={unique}", headers=h)
+    assert r.status_code == 200, r.text
+    titles = [x["title"] for x in r.json()["items"]]
+    assert titles
+    assert all(unique in t for t in titles)
+    rs = client.get(f"{BASE}?sort=priority_desc&limit=5", headers=h)
+    assert rs.status_code == 200, rs.text
 
 
 def test_remediation_tenant_isolation_on_detail() -> None:


### PR DESCRIPTION
Add tenant-scoped remediation_actions tables and migration 20260428, deterministic generation service, FastAPI router under /api/v1/governance/remediation-actions, audit taxonomy entries, and Next.js workspace at /tenant/governance/remediation.

Declare greenlet dependency for SQLAlchemy async sessions. Extend migration ledger test count. Add pytest coverage for remediation endpoints (happy path, validation, isolation).

Made-with: Cursor