### PR TITLE
feat(governance): Compliance Compass, workflow hardening, developer g…

### DIFF
--- a/app/compliance_compass_models.py
+++ b/app/compliance_compass_models.py
@@ -39,9 +39,7 @@ class CompassProvenanceOut(BaseModel):
     """Rückverfolgbarkeit der Signalquellen (ohne PII) — RAI-Transparenz."""
 
     readiness_score: int = Field(ge=0, le=100)
-    readiness_level: str = Field(
-        description="Level Readiness-Modell: basic / managed / embedded"
-    )
+    readiness_level: str = Field(description="Level Readiness-Modell: basic / managed / embedded")
     workflow_open_or_active: int = Field(
         ge=0,
         description="Tasks: open+in_progress+escalated",
@@ -98,9 +96,6 @@ class ComplianceCompassSnapshotOut(BaseModel):
     provenance: CompassProvenanceOut
 
     privacy_de: str = Field(
-        default=(
-            "Berechnung pro Mandant. Keine personenbezogenen Details in "
-            "dieser Antwort."
-        ),
+        default=("Berechnung pro Mandant. Keine personenbezogenen Details in dieser Antwort."),
         description="Trust-Strip Text (UI).",
     )

--- a/app/compliance_compass_models.py
+++ b/app/compliance_compass_models.py
@@ -1,0 +1,106 @@
+"""Compliance Compass — fusionsbasiertes Vertrauens- & Steuerungssignal (MVP, deterministisch)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+COMPASS_VERSION = "compass-2026.1"
+
+
+class CompassPillarKey:
+    """Stabile API-Schlüssel (Frontend-Filter, Analytics)."""
+
+    STRATEGIC_MATURITY = "strategic_maturity"
+    EXECUTION_FIDELITY = "execution_fidelity"
+    OPERATIONAL_CADENCE = "operational_cadence"
+    CONTROL_RESILIENCE = "control_resilience"
+
+
+class CompassPillarOut(BaseModel):
+    """Eine Säule des Kompasses (0–100), mit kurzer Begründung (DE, Nutzer-UI)."""
+
+    key: str = Field(description="Stabiler Säulen-Key, z. B. strategic_maturity")
+    label_de: str = Field(description="Kurzlabel auf Deutsch (Executive UI).")
+    score_0_100: int = Field(ge=0, le=100)
+    weight_in_fusion: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Gewicht innerhalb des gewichteten Fusions-Index (Summe = 1.0).",
+    )
+    detail_de: str = Field(
+        default="",
+        description="1 Zeile, warum der Score so liegt (MVP, deterministisch).",
+    )
+
+
+class CompassProvenanceOut(BaseModel):
+    """Rückverfolgbarkeit der Signalquellen (ohne PII) — RAI-Transparenz."""
+
+    readiness_score: int = Field(ge=0, le=100)
+    readiness_level: str = Field(
+        description="Level Readiness-Modell: basic / managed / embedded"
+    )
+    workflow_open_or_active: int = Field(
+        ge=0,
+        description="Tasks: open+in_progress+escalated",
+    )
+    workflow_overdue: int = Field(ge=0)
+    workflow_escalated: int = Field(
+        ge=0,
+        description="Task-Status escalated (alle, nicht nur offen)",
+    )
+    workflow_events_24h: int = Field(
+        ge=0,
+        description="governance_workflow_events (24h) im Mandanten",
+    )
+    last_run_completed_at_utc: datetime | None = None
+    rule_bundle_version_last_run: str = Field(
+        default="",
+        description="Zuletzt in einem Run beobachtete Regelversion (kann leer sein).",
+    )
+    explainability_de: str = Field(
+        default=(
+            "Der Index kombiniert Mandantssignale (Readiness, Workflow, Eskalation, "
+            "Sync). Keine PII in dieser API-Antwort."
+        )
+    )
+
+
+class ComplianceCompassSnapshotOut(BaseModel):
+    """Eine Abfrage — Executive-Dashboard, Board-ready."""
+
+    tenant_id: str
+    as_of_utc: datetime
+    model_version: str = Field(
+        default=COMPASS_VERSION,
+        description="Semantik-Version; bei Algorithmus-Änderung hochzählen.",
+    )
+    fusion_index_0_100: int = Field(
+        ge=0,
+        le=100,
+        description="Fusions-Index 0–100 (CISO & Board, deterministisch).",
+    )
+    confidence_0_100: int = Field(
+        ge=0,
+        le=100,
+        description="Signal-Vollständigkeit; niedriger = dünne Datenlage.",
+    )
+    posture: str = Field(
+        description="Kurzlabel: strong | steady | watch | elevated (nicht regulatorisch).",
+    )
+    narrative_de: str = Field(
+        default="",
+        description="2–3 Sätze, Executive-Sprache, deutsch.",
+    )
+    pillars: list[CompassPillarOut] = Field(default_factory=list)
+    provenance: CompassProvenanceOut
+
+    privacy_de: str = Field(
+        default=(
+            "Berechnung pro Mandant. Keine personenbezogenen Details in "
+            "dieser Antwort."
+        ),
+        description="Trust-Strip Text (UI).",
+    )

--- a/app/compliance_compass_routes.py
+++ b/app/compliance_compass_routes.py
@@ -1,0 +1,32 @@
+"""Compliance Compass — fusionsbasiertes Steuerungssignal (Mandant, x-api-key + x-tenant-id)."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.orm import Session
+
+from app.auth_dependencies import get_api_key_and_tenant
+from app.compliance_compass_models import ComplianceCompassSnapshotOut
+from app.db import get_session
+from app.services.compliance_compass_service import build_compass_snapshot
+
+router = APIRouter(
+    prefix="/api/v1/governance/compass",
+    tags=["governance", "compliance-compass"],
+)
+
+
+@router.get(
+    "/snapshot",
+    response_model=ComplianceCompassSnapshotOut,
+    status_code=status.HTTP_200_OK,
+    summary="Aktuellen Compliance-Kompass (Fusions-Index) für den Mandanten abrufen",
+    description="Readiness + Workflow-Signale, ohne PII, Board-tauglich.",
+)
+def get_compass_snapshot(
+    tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
+    session: Annotated[Session, Depends(get_session)],
+) -> ComplianceCompassSnapshotOut:
+    return build_compass_snapshot(session, tenant_id)

--- a/app/main.py
+++ b/app/main.py
@@ -146,6 +146,7 @@ from app.compliance_calendar_models import (
     ComplianceDeadlineResponse,
     ComplianceDeadlineUpdate,
 )
+from app.compliance_compass_routes import router as compliance_compass_router
 from app.compliance_gap_models import (
     REQUIREMENTS,
     REQUIREMENTS_BY_ID,
@@ -223,7 +224,6 @@ from app.governance_controls_routes import router as governance_controls_router
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturityBoardSummaryParseResult
 from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
-from app.compliance_compass_routes import router as compliance_compass_router
 from app.governance_workflow_routes import router as governance_workflow_router
 from app.incident_drilldown_models import TenantIncidentDrilldownOut
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview

--- a/app/main.py
+++ b/app/main.py
@@ -223,6 +223,7 @@ from app.governance_controls_routes import router as governance_controls_router
 from app.governance_maturity_models import GovernanceMaturityResponse
 from app.governance_maturity_summary_models import GovernanceMaturityBoardSummaryParseResult
 from app.governance_taxonomy import GovernanceAuditAction, GovernanceAuditEntity
+from app.compliance_compass_routes import router as compliance_compass_router
 from app.governance_workflow_routes import router as governance_workflow_router
 from app.incident_drilldown_models import TenantIncidentDrilldownOut
 from app.incident_models import AIIncidentBySystemEntry, AIIncidentOverview
@@ -582,6 +583,7 @@ app.include_router(operations_resilience_router)
 app.include_router(governance_controls_router)
 app.include_router(governance_audit_readiness_router)
 app.include_router(governance_workflow_router)
+app.include_router(compliance_compass_router)
 app.include_router(board_reporting_router)
 app.include_router(remediation_automation_router)
 app.include_router(remediation_actions_router)

--- a/app/services/compliance_compass_service.py
+++ b/app/services/compliance_compass_service.py
@@ -43,9 +43,13 @@ def _clamp_int(n: float | int) -> int:
 
 
 def _count_tasks(session: Session, tenant_id: str, *extra) -> int:
-    q = select(func.count()).select_from(GovernanceWorkflowTaskTable).where(
-        GovernanceWorkflowTaskTable.tenant_id == tenant_id,
-        *extra,
+    q = (
+        select(func.count())
+        .select_from(GovernanceWorkflowTaskTable)
+        .where(
+            GovernanceWorkflowTaskTable.tenant_id == tenant_id,
+            *extra,
+        )
     )
     r = session.execute(q)
     return int(r.scalar() or 0)
@@ -150,9 +154,7 @@ def _narrative(
         "elevated": "mit erhöhtem Steuerungsbedarf",
     }.get(posture, "")
 
-    base = (
-        f"Der Compliance-Kompass-Fusionsindex: {fusion}/100 — {posture_de}."
-    )
+    base = f"Der Compliance-Kompass-Fusionsindex: {fusion}/100 — {posture_de}."
     if not weakest or not strongest:
         return base
     if weakest.key == strongest.key:

--- a/app/services/compliance_compass_service.py
+++ b/app/services/compliance_compass_service.py
@@ -1,0 +1,307 @@
+"""
+Compliance Compass — Fusions-Index aus Readiness + Governance-Workflow-Signalen.
+
+Deterministisch, erklärbar, mandanten-isoliert (kein LLM im MVP; später optional erweiterbar).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, func, select
+
+from app.compliance_compass_models import (
+    COMPASS_VERSION,
+    CompassPillarKey,
+    CompassPillarOut,
+    CompassProvenanceOut,
+    ComplianceCompassSnapshotOut,
+)
+from app.models_db import (
+    GovernanceWorkflowEventTable,
+    GovernanceWorkflowRunTable,
+    GovernanceWorkflowTaskTable,
+)
+from app.services.governance_workflow_service import OPEN_TASK_STATUSES
+from app.services.readiness_score_service import compute_readiness_score
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+W_STRATEGIC = 0.38
+W_EXEC = 0.27
+W_CADENCE = 0.20
+W_RES = 0.15
+
+
+def _clamp_int(n: float | int) -> int:
+    return max(0, min(100, int(round(n))))
+
+
+def _count_tasks(session: Session, tenant_id: str, *extra) -> int:
+    q = select(func.count()).select_from(GovernanceWorkflowTaskTable).where(
+        GovernanceWorkflowTaskTable.tenant_id == tenant_id,
+        *extra,
+    )
+    r = session.execute(q)
+    return int(r.scalar() or 0)
+
+
+def _strategic_score(session: Session, tenant_id: str) -> tuple[int, str]:
+    try:
+        rs = compute_readiness_score(session, tenant_id)
+        return rs.score, str(rs.level)
+    except Exception:  # pragma: no cover - defensiv gegen DB-Edge-Cases
+        logger.exception("compliance_compass: readiness failed tenant=%s", tenant_id)
+        return 0, "basic"
+
+
+def _execution_score(
+    open_active: int,
+    overdue: int,
+) -> tuple[int, str]:
+    """0–100: niedriger Druck in Backlog & Überfälligkeiten = höher."""
+    p_open = min(1.0, open_active / 40.0)
+    p_over = min(1.0, overdue / 12.0) if overdue else 0.0
+    raw = 100.0 * (1.0 - 0.55 * p_open - 0.45 * p_over)
+    detail = f"Offen/aktiv: {open_active}; überfällig: {overdue}."
+    return _clamp_int(raw), detail
+
+
+def _cadence_score(
+    last_completed: datetime | None,
+) -> tuple[int, str]:
+    if last_completed is None:
+        return 50, "Noch kein abgeschlossener Regel-Sync im Sichtfenster (neutral)."
+    now = datetime.now(UTC)
+    if last_completed.tzinfo is None:
+        last_completed = last_completed.replace(tzinfo=UTC)
+    delta: timedelta = now - last_completed
+    hours = delta.total_seconds() / 3600.0
+    if hours <= 48:
+        s = 92
+        detail = f"Letzter Run vor {int(hours)}h — rhythmische Synchronisierung sichtbar."
+    elif hours <= 24 * 7:
+        s = 78
+        detail = "Regel-Sync in den letzten 7 Tagen; Kadenz im normierten Band."
+    elif hours <= 24 * 30:
+        s = 64
+        detail = "Längere Pause seit letztem Lauf; Sync für aktuelle Lage empfohlen."
+    else:
+        s = 48
+        detail = "Letzter abgeschlossener Lauf >30 Tage her; operatives Pulsrisiko."
+    return s, detail
+
+
+def _resilience_score(escalated: int) -> tuple[int, str]:
+    s = 100 - min(55, int(escalated) * 9)
+    s = _clamp_int(s)
+    if escalated == 0:
+        detail = "Keine eskalierten Workflow-Tasks im abgefragten Bestand (Status escalated)."
+    else:
+        detail = f"Eskalierte Tasks: {int(escalated)} — fachlich erhöhter Fokus/Review."
+    return s, detail
+
+
+def _posture(fusion: int) -> str:
+    if fusion >= 76:
+        return "strong"
+    if fusion >= 58:
+        return "steady"
+    if fusion >= 40:
+        return "watch"
+    return "elevated"
+
+
+def _confidence_0_100(
+    has_tasks: bool,
+    has_runs: bool,
+    strategic: int,
+    events_24h: int,
+) -> int:
+    c = 0.58
+    if has_tasks:
+        c += 0.14
+    if has_runs:
+        c += 0.14
+    if strategic > 0:
+        c += 0.10
+    if events_24h > 0:
+        c += 0.10
+    return _clamp_int(c * 100.0)
+
+
+def _narrative(
+    fusion: int,
+    pillars: list[CompassPillarOut],
+    posture: str,
+) -> str:
+    p_map = {p.key: p for p in pillars}
+    weakest = min(pillars, key=lambda x: x.score_0_100) if pillars else None
+    strongest = max(pillars, key=lambda x: x.score_0_100) if pillars else None
+    posture_de = {
+        "strong": "in einem überwiegend stabilen Korridor",
+        "steady": "solide, mit klarer Verbesserung möglich",
+        "watch": "mit sichtbaren Reibflächen",
+        "elevated": "mit erhöhtem Steuerungsbedarf",
+    }.get(posture, "")
+
+    base = (
+        f"Der Compliance-Kompass-Fusionsindex: {fusion}/100 — {posture_de}."
+    )
+    if not weakest or not strongest:
+        return base
+    if weakest.key == strongest.key:
+        return f"{base} Detaillierte Hebel: Siehe Säulen-Scores."
+    st = p_map[strongest.key]
+    hebel = f"Größter Hebel: {weakest.label_de} ({weakest.score_0_100})."
+    stärke = f"Stärkste: {st.label_de} ({st.score_0_100})."
+    return f"{base} {stärke} {hebel}"
+
+
+def build_compass_snapshot(
+    session: Session,
+    tenant_id: str,
+) -> ComplianceCompassSnapshotOut:
+    now = datetime.now(UTC)
+    strategic, level = _strategic_score(session, tenant_id)
+
+    openish = _count_tasks(
+        session,
+        tenant_id,
+        GovernanceWorkflowTaskTable.status.in_(list(OPEN_TASK_STATUSES)),
+    )
+    escalated_n = _count_tasks(
+        session,
+        tenant_id,
+        GovernanceWorkflowTaskTable.status == "escalated",
+    )
+    overdue = _count_tasks(
+        session,
+        tenant_id,
+        and_(
+            GovernanceWorkflowTaskTable.status.in_(list(OPEN_TASK_STATUSES)),
+            GovernanceWorkflowTaskTable.due_at_utc.isnot(None),
+            GovernanceWorkflowTaskTable.due_at_utc < now,
+        ),
+    )
+
+    exec_s, exec_detail = _execution_score(openish, overdue)
+    res_s, res_detail = _resilience_score(escalated_n)
+
+    # Letzter abgeschlossener Run
+    run_row = session.execute(
+        select(
+            GovernanceWorkflowRunTable.completed_at_utc,
+            GovernanceWorkflowRunTable.rule_bundle_version,
+        )
+        .where(
+            GovernanceWorkflowRunTable.tenant_id == tenant_id,
+            GovernanceWorkflowRunTable.status == "completed",
+        )
+        .order_by(GovernanceWorkflowRunTable.started_at_utc.desc())
+        .limit(1)
+    ).one_or_none()
+    last_c = run_row[0] if run_row else None
+    last_ver = (run_row[1] or "") if run_row else ""
+    if last_c and last_c.tzinfo is None and isinstance(last_c, datetime):
+        last_c = last_c.replace(tzinfo=UTC)
+    has_runs = run_row is not None
+    cad_s, cad_detail = _cadence_score(last_c)
+
+    since = now - timedelta(hours=24)
+    ev_n = int(
+        session.execute(
+            select(func.count())
+            .select_from(GovernanceWorkflowEventTable)
+            .where(
+                GovernanceWorkflowEventTable.tenant_id == tenant_id,
+                GovernanceWorkflowEventTable.at_utc >= since,
+            )
+        ).scalar()
+        or 0
+    )
+    has_tasks = (
+        int(
+            session.execute(
+                select(func.count())
+                .select_from(GovernanceWorkflowTaskTable)
+                .where(GovernanceWorkflowTaskTable.tenant_id == tenant_id)
+            ).scalar()
+            or 0
+        )
+        > 0
+    )
+
+    fusion_01 = (
+        W_STRATEGIC * (strategic / 100.0)
+        + W_EXEC * (exec_s / 100.0)
+        + W_CADENCE * (cad_s / 100.0)
+        + W_RES * (res_s / 100.0)
+    )
+    fusion = _clamp_int(fusion_01 * 100.0)
+    posture = _posture(fusion)
+    conf = _confidence_0_100(
+        has_tasks=has_tasks,
+        has_runs=has_runs,
+        strategic=strategic,
+        events_24h=ev_n,
+    )
+
+    pillars = [
+        CompassPillarOut(
+            key=CompassPillarKey.STRATEGIC_MATURITY,
+            label_de="Strategische Reife (Readiness)",
+            score_0_100=strategic,
+            weight_in_fusion=W_STRATEGIC,
+            detail_de=f"Gewichteter AI- & Compliance-Readiness-Score: {strategic} (Level {level}).",
+        ),
+        CompassPillarOut(
+            key=CompassPillarKey.EXECUTION_FIDELITY,
+            label_de="Exekutions- & Backlog-Integrität",
+            score_0_100=exec_s,
+            weight_in_fusion=W_EXEC,
+            detail_de=exec_detail,
+        ),
+        CompassPillarOut(
+            key=CompassPillarKey.OPERATIONAL_CADENCE,
+            label_de="Operative Kadenz (Regel-Sync)",
+            score_0_100=cad_s,
+            weight_in_fusion=W_CADENCE,
+            detail_de=cad_detail,
+        ),
+        CompassPillarOut(
+            key=CompassPillarKey.CONTROL_RESILIENCE,
+            label_de="Eskalations- & Lage-Bandbreite",
+            score_0_100=res_s,
+            weight_in_fusion=W_RES,
+            detail_de=res_detail,
+        ),
+    ]
+
+    provenance = CompassProvenanceOut(
+        readiness_score=strategic,
+        readiness_level=level,
+        workflow_open_or_active=openish,
+        workflow_overdue=overdue,
+        workflow_escalated=escalated_n,
+        workflow_events_24h=ev_n,
+        last_run_completed_at_utc=last_c,
+        rule_bundle_version_last_run=last_ver,
+    )
+
+    return ComplianceCompassSnapshotOut(
+        tenant_id=tenant_id,
+        as_of_utc=now,
+        model_version=COMPASS_VERSION,
+        fusion_index_0_100=fusion,
+        confidence_0_100=conf,
+        posture=posture,
+        narrative_de=_narrative(fusion, pillars, posture),
+        pillars=pillars,
+        provenance=provenance,
+    )

--- a/docs/governance-workflows.md
+++ b/docs/governance-workflows.md
@@ -1,0 +1,33 @@
+# Governance Workflows (Developer-DX)
+
+Kurzüberblick für die deterministische Workflow-Orchestration (Tasks, Runs, Events, UI).
+
+## Task-Status (API-Modell)
+
+- **Erlaubte Werte (PATCH):** `open` · `in_progress` · `done` · `cancelled` · `escalated` (Pydantic `Literal`, gleiche Quelle im Backend-ORM).
+- **Semantik (MVP):** `open` = noch nicht in Bearbeitung, `in_progress` = Bearbeitung läuft, `done` / `cancelled` = **Endzustand**, `escalated` = fachlich eskaliert, oft mit höherer Eskalationsstufe/Visibility.
+- **Hinweis UI:** Begriffe wie `blocked` oder `deferred` erscheinen in der Produktsprache ggf. als Anzeige-Label – in der **API** werden sie nicht persistiert, sondern über einen der fünf erlaubten Stati abgebildet.
+- **Übergänge (Client-Guard, nicht API-Zwang im MVP):** In der Web-App werden Wechsel von `done` / `cancelled` zu jedem **anderen** Status unterbunden, um fälschliches „Wiederöffnen“ im UI zu verhindern; ein bewusstes Re-Open wäre eine API-/Prozess-Erweiterung.
+
+## Zuweisung entfernen (Unassign)
+
+- **Client:** `PATCH /api/v1/governance/workflows/tasks/{id}` mit JSON-Body `{"assignee_user_id": null}` (explizit `null`, kein leeres String-Literal – das Feld ist optional/nullable).
+- **Semantik:** `null` bedeutet *nicht zugewiesen*; ein gesetzter String ist die Mandanten-interne User- oder Owner-ID.
+- **Tests:** `tests/test_governance_workflow_api.py` deckt `assignee_user_id: None` (Python) bzw. JSON-`null` ab.
+
+## Neue Quellen, `dedupe_key` und `RULE_BUNDLE_VERSION`
+
+- **Neue `source_type`-Werte:** 1) Materialisierung in `app/services/governance_workflow_service.py` (Konsistenz der Objekt-Referenz/Join), 2) ggf. Literal/Erweiterung in Pydantic, 3) `WORKFLOW_SOURCE_TYPE_VALUES` in `frontend/src/lib/governanceWorkflowTypes.ts` und **Filter-Option** in der Governance-Workflow-UI, 4) sinnvolles Mapping in `governance_workflow` Events/Payload, falls sichtbar.
+- **`dedupe_key` (pro Tenant):** Stabil pro fachlichem Ereignis, damit derselbe Regel-Run keine Task-Duplikate erzeugt (siehe `_materialize`-Hilfsfunktionen: gleiches „Sinnes-Objekt“ → gleiche Schlüssel-Strategie). Bei neuen Quellen dieselbe disziplinierte Schlüsseldefinition verwenden.
+- **`RULE_BUNDLE_VERSION`:** Konstante im Service; jede inhaltlich relevante Regel-Änderung hochzählen, damit **Runs, Audit-Trail und `recent_runs`** die verwendete Regelversion pro Lauf anzeigen und Regressionen eingeordnet werden können.
+
+## `events_written` / Event-KPIs
+
+- **`events_written`:** Lauf-Metrik, wie viele `governance_workflow_events` **während** dieses `run_deterministic_sync` geschrieben wurden (Tally im Regel-Loop, nicht 24h-Gesamt).
+- **Ort in der API:** Sichtbar im **Body von `POST .../workflows/run`** (Response) und in **`summary.events_written` der Run-Zeile** (Dashboard-`recent_runs` → Feld `summary`).
+- **Einsatz:** Operatives Monitoring (Spike nach Rule-Bundle-Change), Korrelation mit `tasks_materialized` im `summary`, Board-/Tenant-Dashboard-„Ereignisse pro Sync“.
+- **24h-Events:** `kpis.workflow_events_24h` bezieht sich rollierend auf die Tabelle, nicht auf einen einzelnen Lauf (semantische Differenz zu `events_written`).
+
+## Tests
+
+- `tests/test_governance_workflow_api.py`: u. a. 422 bei ungültigem `status` für `PATCH /tasks/...`, explizites `assignee_user_id: null`, `POST /run` mit `events_written` ≥ 0.

--- a/frontend/src/app/tenant/governance/compass/page.tsx
+++ b/frontend/src/app/tenant/governance/compass/page.tsx
@@ -1,0 +1,29 @@
+import { ComplianceCompassClient } from "@/components/tenant/ComplianceCompassClient";
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { CH_SHELL } from "@/lib/boardLayout";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TenantComplianceCompassPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+
+  return (
+    <div className={CH_SHELL}>
+      <EnterprisePageHeader
+        eyebrow="Enterprise · Governance"
+        title="Compliance Compass"
+        description={
+          <>
+            Fusions-Index für Führung und GRC: strategische Reife, Ausführung, Sync-Kadenz und
+            Lagebild – transparent pro Mandant, deterministisch berechnet; keine Rechtsberatung.
+          </>
+        }
+        breadcrumbs={[
+          { label: "Tenant", href: "/tenant/compliance-overview" },
+          { label: "Governance", href: "/tenant/governance/overview" },
+          { label: "Compass" },
+        ]}
+      />
+      <ComplianceCompassClient tenantId={tenantId} />
+    </div>
+  );
+}

--- a/frontend/src/components/governance/GovernanceWorkflowsWorkspaceClient.tsx
+++ b/frontend/src/components/governance/GovernanceWorkflowsWorkspaceClient.tsx
@@ -15,13 +15,24 @@ import {
   patchWorkflowTask,
   postTestNotification,
   postWorkflowRun,
+  WorkflowApiError,
   type GovernanceWorkflowDashboardDto,
   type WorkflowEventDto,
   type WorkflowNotificationDeliveryDto,
   type WorkflowNotificationDto,
+  type WorkflowRunListItem,
   type WorkflowTaskListItemDto,
   type WorkflowTaskDetailDto,
 } from "@/lib/governanceWorkflowApi";
+import {
+  getEventsCountFromRunSummary,
+  isAllowedStatusTransition,
+  isWorkflowTaskStatus,
+  assertWorkflowTaskStatus,
+  WORKFLOW_SOURCE_TYPE_VALUES,
+  WORKFLOW_TASK_STATUS_VALUES,
+  type WorkflowTaskStatus,
+} from "@/lib/governanceWorkflowTypes";
 
 interface Props {
   tenantId: string;
@@ -35,6 +46,34 @@ function priorityTone(
   return "success";
 }
 
+function runDurationLabel(startedAt: string, completedAt: string | null): string {
+  if (!completedAt) return "…";
+  const ms = new Date(completedAt).getTime() - new Date(startedAt).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 2000) return `${ms} ms`;
+  return `${(ms / 1000).toFixed(1)} s`;
+}
+
+function taskActionErrorText(e: unknown): string {
+  if (e instanceof WorkflowApiError && e.status === 422) {
+    return "Ungültiger Status – bitte Seite aktualisieren oder Workflow-Status prüfen.";
+  }
+  if (e instanceof Error) {
+    return e.message;
+  }
+  return "Aktualisierung fehlgeschlagen";
+}
+
+function pickDefaultTargetStatus(current: string): WorkflowTaskStatus {
+  if (!isWorkflowTaskStatus(current)) {
+    return "open";
+  }
+  const next = WORKFLOW_TASK_STATUS_VALUES.find(
+    (s) => s !== current && isAllowedStatusTransition(current, s)
+  );
+  return next ?? current;
+}
+
 export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
   const [activeTab, setActiveTab] = useState<"main" | "events" | "notif">("main");
   const [dash, setDash] = useState<GovernanceWorkflowDashboardDto | null>(null);
@@ -42,7 +81,7 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
   const [events, setEvents] = useState<WorkflowEventDto[]>([]);
   const [notifs, setNotifs] = useState<WorkflowNotificationDto[]>([]);
   const [deliv, setDeliv] = useState<WorkflowNotificationDeliveryDto[]>([]);
-  const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ kind: "success" | "error"; text: string } | null>(null);
   const [busy, setBusy] = useState(false);
   const [fStatus, setFStatus] = useState("");
   const [fSource, setFSource] = useState("");
@@ -51,6 +90,17 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
   const [fFw, setFFw] = useState("");
   const [selTask, setSelTask] = useState<WorkflowTaskDetailDto | null>(null);
   const [selId, setSelId] = useState<string | null>(null);
+  const [targetStatus, setTargetStatus] = useState<WorkflowTaskStatus>("open");
+
+  const recentRuns: WorkflowRunListItem[] = dash?.recent_runs ?? [];
+  const lastRun = recentRuns[0];
+  const previousRun = recentRuns[1];
+  const lastRunEventCount = getEventsCountFromRunSummary(lastRun?.summary);
+  const previousRunEventCount = getEventsCountFromRunSummary(previousRun?.summary);
+  const eventTrend =
+    lastRun && previousRun
+      ? lastRunEventCount - previousRunEventCount
+      : null;
 
   const loadAll = useCallback(async () => {
     try {
@@ -73,7 +123,10 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
       setNotifs(n);
       setDeliv(dlv);
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+      setNotice({
+        kind: "error",
+        text: e instanceof Error ? e.message : "Laden fehlgeschlagen",
+      });
     }
   }, [tenantId, fStatus, fSource, fAsg, fSev, fFw]);
 
@@ -88,21 +141,31 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
     }
     void (async () => {
       try {
-        setSelTask(await fetchWorkflowTaskDetail(tenantId, selId));
+        setNotice(null);
+        const d = await fetchWorkflowTaskDetail(tenantId, selId);
+        setSelTask(d);
+        setTargetStatus(pickDefaultTargetStatus(d.status));
       } catch (e) {
-        setErr(e instanceof Error ? e.message : "Detail fehlgeschlagen");
+        setNotice({
+          kind: "error",
+          text: e instanceof Error ? e.message : "Detail fehlgeschlagen",
+        });
       }
     })();
   }, [selId, tenantId]);
 
   async function onRun() {
     setBusy(true);
-    setErr(null);
+    setNotice(null);
     try {
-      await postWorkflowRun(tenantId);
+      const r = await postWorkflowRun(tenantId);
+      setNotice({
+        kind: "success",
+        text: `Regel-Sync abgeschlossen: ${r.events_written} Ereignis(se), ${r.tasks_materialized} Task(s) materialisiert.`,
+      });
       await loadAll();
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "Lauf fehlgeschlagen");
+      setNotice({ kind: "error", text: e instanceof Error ? e.message : "Lauf fehlgeschlagen" });
     } finally {
       setBusy(false);
     }
@@ -110,12 +173,64 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
 
   async function onTestNotif() {
     setBusy(true);
-    setErr(null);
+    setNotice(null);
     try {
       await postTestNotification(tenantId);
+      setNotice({ kind: "success", text: "Test-Benachrichtigung erstellt (Audit-Trail)." });
       await loadAll();
     } catch (e) {
-      setErr(e instanceof Error ? e.message : "Test fehlgeschlagen");
+      setNotice({ kind: "error", text: e instanceof Error ? e.message : "Test fehlgeschlagen" });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function applyStatusChange() {
+    if (!selTask) return;
+    try {
+      assertWorkflowTaskStatus(targetStatus);
+    } catch (e) {
+      setNotice({
+        kind: "error",
+        text: e instanceof Error ? e.message : "Ungültiger Status",
+      });
+      return;
+    }
+    if (!isAllowedStatusTransition(selTask.status, targetStatus)) {
+      setNotice({
+        kind: "error",
+        text: "Dieser Statuswechsel ist in der UI nicht vorgesehen (abgeschlossene Tasks werden nicht erneut geöffnet).",
+      });
+      return;
+    }
+    setBusy(true);
+    setNotice(null);
+    try {
+      await patchWorkflowTask(tenantId, selTask.id, { status: targetStatus });
+      const d = await fetchWorkflowTaskDetail(tenantId, selTask.id);
+      setSelTask(d);
+      setTargetStatus(pickDefaultTargetStatus(d.status));
+      setNotice({ kind: "success", text: "Status aktualisiert." });
+      await loadAll();
+    } catch (e) {
+      setNotice({ kind: "error", text: taskActionErrorText(e) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUnassign() {
+    if (!selTask) return;
+    setBusy(true);
+    setNotice(null);
+    try {
+      await patchWorkflowTask(tenantId, selTask.id, { assignee_user_id: null });
+      const d = await fetchWorkflowTaskDetail(tenantId, selTask.id);
+      setSelTask(d);
+      setNotice({ kind: "success", text: "Zuweisung entfernt." });
+      await loadAll();
+    } catch (e) {
+      setNotice({ kind: "error", text: taskActionErrorText(e) });
     } finally {
       setBusy(false);
     }
@@ -150,13 +265,49 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
         </article>
       </section>
 
-      <p className="text-xs text-slate-500">
-        Regel-Bundle:{" "}
-        <span className="font-mono">
-          {dash?.rule_bundle_version ?? "—"}
-        </span>
-        · Ereignisse 24h: {dash?.kpis.workflow_events_24h ?? "—"}
-      </p>
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <article className={`${CH_CARD} border-indigo-200/80`}>
+          <p className={CH_SECTION_LABEL}>Events im letzten Run (Summary)</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-indigo-900">
+            {lastRun != null ? lastRunEventCount : "—"}
+          </p>
+          {lastRun == null ? (
+            <p className="mt-1 text-xs text-slate-500">Noch kein Run in der Historie.</p>
+          ) : (
+            <p className="mt-1 text-xs text-slate-600">
+              {eventTrend === null ? (
+                "Kein vorheriger Run zum Vergleich"
+              ) : eventTrend > 0 ? (
+                <span>
+                  Gegenüber vorherigem Run:{" "}
+                  <span className="font-medium text-rose-700">+{eventTrend} Events</span>
+                </span>
+              ) : eventTrend < 0 ? (
+                <span>
+                  Gegenüber vorherigem Run:{" "}
+                  <span className="font-medium text-emerald-800">{eventTrend} Events</span>
+                </span>
+              ) : (
+                "Gleich wie im vorherigen Run"
+              )}
+            </p>
+          )}
+        </article>
+        <article className={`${CH_CARD} sm:col-span-1 border-slate-200/80`}>
+          <p className={CH_SECTION_LABEL}>Regel-Sync (Kurzinfo)</p>
+          <p className="mt-1 text-sm text-slate-700">
+            <span className="font-mono text-xs">
+              {dash?.rule_bundle_version ?? "—"}
+            </span>
+            <span className="mx-1.5 text-slate-300">|</span>
+            Ereignisse 24h: {dash?.kpis.workflow_events_24h ?? "—"}
+          </p>
+          <p className="mt-2 text-xs text-slate-500">
+            <code>events_written</code> = während <code>run_sync</code> erzeugte Workflow-Events; siehe
+            Run-Tabelle.
+          </p>
+        </article>
+      </section>
 
       <div className="flex flex-wrap gap-2">
         <button type="button" className={CH_BTN_PRIMARY} onClick={() => void onRun()} disabled={busy}>
@@ -181,20 +332,27 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
             onChange={(e) => setFStatus(e.target.value)}
           >
             <option value="">(alle)</option>
-            <option value="open">open</option>
-            <option value="in_progress">in_progress</option>
-            <option value="escalated">escalated</option>
-            <option value="done">done</option>
+            {WORKFLOW_TASK_STATUS_VALUES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
           </select>
         </label>
         <label className="text-xs font-medium text-slate-600">
           Quelle
-          <input
-            className="mt-1 block min-w-[8rem] rounded border border-slate-300 px-2 py-1.5 text-sm"
+          <select
+            className="mt-1 block min-w-[12rem] rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
             value={fSource}
             onChange={(e) => setFSource(e.target.value)}
-            placeholder="z.B. governance_control"
-          />
+          >
+            <option value="">(alle / frei)</option>
+            {WORKFLOW_SOURCE_TYPE_VALUES.map((s) => (
+              <option key={s} value={s}>
+                {s}
+              </option>
+            ))}
+          </select>
         </label>
         <label className="text-xs font-medium text-slate-600">
           Bearbeiter
@@ -229,6 +387,54 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
           />
         </label>
       </div>
+
+      <article className={`${CH_CARD} overflow-hidden`}>
+        <p className={CH_SECTION_LABEL}>Run-Historie (letzte {recentRuns.length})</p>
+        <div className="mt-2 overflow-x-auto text-sm">
+          <table className="min-w-full divide-y divide-slate-200 text-left text-xs">
+            <thead className="bg-slate-50/90 text-slate-500">
+              <tr>
+                <th className="px-2 py-2">Start (lokal)</th>
+                <th className="px-2 py-2">Dauer</th>
+                <th className="px-2 py-2">neue Tasks</th>
+                <th className="px-2 py-2">Events (summary)</th>
+                <th className="px-2 py-2">Status / Bundle</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {recentRuns.length === 0 ? (
+                <tr>
+                  <td colSpan={5} className="px-2 py-3 text-slate-600">
+                    Noch keine Runs. „Regel-Sync ausführen“ klicken.
+                  </td>
+                </tr>
+              ) : (
+                recentRuns.map((run) => {
+                  const s = run.summary;
+                  const tasksN =
+                    s && typeof s.tasks_materialized === "number" ? s.tasks_materialized : "—";
+                  const evN = getEventsCountFromRunSummary(s);
+                  return (
+                    <tr key={run.id}>
+                      <td className="px-2 py-1.5 whitespace-nowrap">
+                        {new Date(run.started_at_utc).toLocaleString("de-DE")}
+                      </td>
+                      <td className="px-2 py-1.5">
+                        {runDurationLabel(run.started_at_utc, run.completed_at_utc ?? null)}
+                      </td>
+                      <td className="px-2 py-1.5 tabular-nums">{tasksN}</td>
+                      <td className="px-2 py-1.5 tabular-nums">{evN}</td>
+                      <td className="px-2 py-1.5">
+                        {run.status} · <span className="font-mono"> {run.rule_bundle_version}</span>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
+            </tbody>
+          </table>
+        </div>
+      </article>
 
       <article className={`${CH_CARD} overflow-hidden`}>
         <p className={CH_SECTION_LABEL}>Workflow Tasks</p>
@@ -302,6 +508,18 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
           <p className={CH_SECTION_LABEL}>Task-Detail</p>
           <dl className="mt-3 grid gap-2 sm:grid-cols-2 text-sm">
             <div>
+              <dt className="text-xs text-slate-500">Aktueller Status</dt>
+              <dd>
+                <StatusBadge status={selTask.status} tone="neutral" />
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-slate-500">Bearbeiter (assignee_user_id)</dt>
+              <dd className="font-mono text-xs break-all">
+                {selTask.assignee_user_id ?? "— (nicht zugewiesen)"}
+              </dd>
+            </div>
+            <div>
               <dt className="text-xs text-slate-500">Quelle (Objekt)</dt>
               <dd>
                 {selTask.source_type} — <span className="font-mono text-xs">{selTask.source_id}</span>
@@ -343,40 +561,50 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
               )}
             </ol>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <button
-              type="button"
-              className={CH_BTN_SECONDARY}
-              onClick={async () => {
-                setBusy(true);
-                try {
-                  await patchWorkflowTask(tenantId, selTask.id, { status: "in_progress" });
-                  setSelTask(await fetchWorkflowTaskDetail(tenantId, selTask.id));
-                  await loadAll();
-                } finally {
-                  setBusy(false);
-                }
-              }}
-            >
-              Status: in progress
-            </button>
-            <button
-              type="button"
-              className={CH_BTN_PRIMARY}
-              onClick={async () => {
-                setBusy(true);
-                try {
-                  await patchWorkflowTask(tenantId, selTask.id, { status: "done" });
-                  setSelId(null);
-                  setSelTask(null);
-                  await loadAll();
-                } finally {
-                  setBusy(false);
-                }
-              }}
-            >
-              Status: done
-            </button>
+          <div className="mt-4 space-y-3">
+            <div className="flex flex-wrap items-end gap-2">
+              <label className="text-xs font-medium text-slate-600">
+                Neuer Status
+                <select
+                  className="mt-1 block min-w-[12rem] rounded border border-slate-300 bg-white px-2 py-1.5 text-sm"
+                  value={targetStatus}
+                  onChange={(e) => setTargetStatus(e.target.value as WorkflowTaskStatus)}
+                >
+                  {WORKFLOW_TASK_STATUS_VALUES.map((s) => {
+                    const allowed = isAllowedStatusTransition(selTask.status, s);
+                    return (
+                      <option key={s} value={s} disabled={!allowed}>
+                        {s}
+                        {!allowed ? " (gesperrt)" : ""}
+                      </option>
+                    );
+                  })}
+                </select>
+              </label>
+              <button
+                type="button"
+                className={CH_BTN_PRIMARY}
+                disabled={busy}
+                onClick={() => void applyStatusChange()}
+              >
+                Status übernehmen
+              </button>
+            </div>
+            {selTask.assignee_user_id ? (
+              <div>
+                <button
+                  type="button"
+                  className={CH_BTN_SECONDARY}
+                  disabled={busy}
+                  onClick={() => void onUnassign()}
+                >
+                  Zuweisung entfernen (null)
+                </button>
+                <p className="mt-1 text-xs text-slate-500">
+                  Setzt <code>assignee_user_id</code> per JSON <code>null</code> (explizit unassigned).
+                </p>
+              </div>
+            ) : null}
           </div>
         </article>
       ) : null}
@@ -479,7 +707,7 @@ export function GovernanceWorkflowsWorkspaceClient({ tenantId }: Props) {
           { label: "Governance", href: "/tenant/governance/overview" },
           { label: "Workflows", href: "/tenant/governance/workflows" },
         ]}
-        toast={err ? { kind: "error", text: err } : null}
+        toast={notice}
         tabs={[
           { id: "main", label: "Übersicht", content: mainTab },
           { id: "events", label: "Ereignisse", content: eventsTab },

--- a/frontend/src/components/sbs/TenantNav.tsx
+++ b/frontend/src/components/sbs/TenantNav.tsx
@@ -17,6 +17,7 @@ const baseItems = [
   { href: "/tenant/governance/overview", label: "Risk & Control Overview" },
   { href: "/tenant/governance/controls", label: "Unified Controls" },
   { href: "/tenant/governance/audits", label: "Audit Readiness" },
+  { href: "/tenant/governance/compass", label: "Compliance Compass" },
   { href: "/tenant/governance/workflows", label: "Workflows & Tasks" },
   { href: "/tenant/governance/operations", label: "Betrieb & Resilienz" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },

--- a/frontend/src/components/tenant/ComplianceCompassClient.tsx
+++ b/frontend/src/components/tenant/ComplianceCompassClient.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { fetchComplianceCompass, type ComplianceCompassSnapshot } from "@/lib/complianceCompassApi";
+
+const SF = "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif";
+
+function postureLabel(p: string): { de: string; chip: string } {
+  const m: Record<string, { de: string; chip: string }> = {
+    strong: { de: "Robust", chip: "bg-emerald-500/15 text-emerald-800 ring-1 ring-emerald-500/20" },
+    steady: { de: "Stabil", chip: "bg-sky-500/10 text-sky-900 ring-1 ring-sky-500/15" },
+    watch: { de: "Beobachten", chip: "bg-amber-500/12 text-amber-900 ring-1 ring-amber-500/20" },
+    elevated: { de: "Erhöhtes Tempo", chip: "bg-rose-500/10 text-rose-900 ring-1 ring-rose-500/20" },
+  };
+  return m[p] ?? { de: p, chip: "bg-slate-200/60 text-slate-800" };
+}
+
+function FusionRing({ value, size = 200 }: { value: number; size?: number }) {
+  const r = 42;
+  const vb = 100;
+  const cx = vb / 2;
+  const c = 2 * Math.PI * r;
+  const p = Math.max(0, Math.min(1, value / 100));
+  const dash = c * p;
+  const off = c - dash;
+  const stroke = 7;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox={`0 0 ${vb} ${vb}`}
+      className="shrink-0 drop-shadow-sm"
+      aria-hidden
+    >
+      <defs>
+        <linearGradient id="cc-ring" x1="0" y1="0" x2="1" y2="1">
+          <stop offset="0%" stopColor="#0ea5e9" stopOpacity="0.95" />
+          <stop offset="55%" stopColor="#6366f1" stopOpacity="0.9" />
+          <stop offset="100%" stopColor="#22c55e" stopOpacity="0.95" />
+        </linearGradient>
+      </defs>
+      <circle
+        cx={cx}
+        cy={cx}
+        r={r}
+        fill="none"
+        stroke="rgba(15,23,42,0.08)"
+        strokeWidth={stroke}
+      />
+      <circle
+        cx={cx}
+        cy={cx}
+        r={r}
+        fill="none"
+        stroke="url(#cc-ring)"
+        strokeWidth={stroke}
+        strokeLinecap="round"
+        strokeDasharray={c}
+        strokeDashoffset={off}
+        transform={`rotate(-90 ${cx} ${cx})`}
+        className="transition-all duration-700 ease-out"
+      />
+    </svg>
+  );
+}
+
+type Props = { tenantId: string };
+
+export function ComplianceCompassClient({ tenantId }: Props) {
+  const [data, setData] = useState<ComplianceCompassSnapshot | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr(null);
+    try {
+      setData(await fetchComplianceCompass(tenantId));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Laden fehlgeschlagen");
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const pMeta = data ? postureLabel(data.posture) : null;
+
+  return (
+    <div
+      className="min-h-[calc(100vh-8rem)] -mx-4 -mt-2 rounded-[2rem] bg-gradient-to-b from-slate-50 via-white to-slate-100/80 px-4 py-8 sm:px-8"
+      style={{ fontFamily: SF }}
+    >
+      {err ? (
+        <div
+          className="rounded-2xl border border-rose-200/60 bg-rose-50/80 px-4 py-3 text-sm text-rose-900"
+          role="status"
+        >
+          {err}
+        </div>
+      ) : null}
+
+      {loading && !data ? (
+        <div className="flex h-64 items-center justify-center text-slate-400">Laden…</div>
+      ) : null}
+
+      {data && (
+        <div className="mx-auto max-w-5xl space-y-10">
+          <header className="text-center sm:text-left">
+            <p className="text-xs font-medium uppercase tracking-[0.2em] text-slate-400">Compliance Compass</p>
+            <h1
+              className="mt-2 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl"
+            >
+              Fusions-Intelligence
+            </h1>
+            <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-500 sm:text-base">
+              Ein klarer Nordstern-Index aus Reife, Ausführung, Kadenz und Lagebild
+              (deterministisch, mandantisoliert, ohne LLM im API-Kern).
+            </p>
+          </header>
+
+          <section
+            className="relative overflow-hidden rounded-[1.75rem] border border-white/70 bg-white/60 p-6 shadow-[0_24px_80px_rgba(15,23,42,0.06)] backdrop-blur-2xl sm:p-9"
+          >
+            <div className="flex flex-col items-center gap-8 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex flex-col items-center gap-1 sm:items-start">
+                <p className="text-[11px] font-medium uppercase tracking-widest text-slate-400">
+                  Fusions-Index
+                </p>
+                <div className="relative">
+                  <FusionRing value={data.fusion_index_0_100} size={220} />
+                  <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
+                    <span
+                      className="text-5xl font-extralight tabular-nums tracking-tight text-slate-900"
+                      style={{ fontFeatureSettings: '"tnum" 1' }}
+                    >
+                      {data.fusion_index_0_100}
+                    </span>
+                    <span className="text-[0.7rem] font-medium uppercase tracking-[0.18em] text-slate-500">
+                      von 100
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div className="max-w-xl space-y-4 text-center sm:text-left">
+                <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+                  {pMeta ? (
+                    <span
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${pMeta.chip}`}
+                    >
+                      {pMeta.de}
+                    </span>
+                  ) : null}
+                  <span className="text-xs text-slate-500">
+                    Modell {data.model_version} · Vertrauen in Daten: {data.confidence_0_100}
+                  </span>
+                </div>
+                <p className="text-base font-normal leading-7 text-slate-800">{data.narrative_de}</p>
+                <button
+                  type="button"
+                  onClick={() => void load()}
+                  className="rounded-full border border-slate-200/80 bg-white/80 px-4 py-1.5 text-sm font-medium text-slate-700 shadow-sm transition hover:border-slate-300 hover:bg-white"
+                >
+                  Aktualisieren
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <h2 className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">Säulen</h2>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              {data.pillars.map((p) => (
+                <div
+                  key={p.key}
+                  className="group rounded-2xl border border-white/80 bg-gradient-to-b from-white/90 to-slate-50/80 p-5 shadow-[0_12px_40px_rgba(15,23,42,0.04)] backdrop-blur"
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <h3 className="text-sm font-medium text-slate-900">{p.label_de}</h3>
+                    <span className="text-2xl font-light tabular-nums text-slate-800">{p.score_0_100}</span>
+                  </div>
+                  <p className="mt-1 text-xs text-slate-500">Gewicht: {Math.round(p.weight_in_fusion * 100)} %</p>
+                  <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-slate-200/60">
+                    <div
+                      className="h-full rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-emerald-500 transition-all duration-500"
+                      style={{ width: `${p.score_0_100}%` }}
+                    />
+                  </div>
+                  <p className="mt-3 text-sm leading-relaxed text-slate-600">{p.detail_de}</p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <section className="grid gap-4 sm:grid-cols-2">
+            <div className="rounded-2xl border border-slate-200/60 bg-white/50 p-5 text-sm text-slate-600 shadow-sm backdrop-blur">
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-slate-400">Datenhoheit</h3>
+              <p className="mt-2 text-sm leading-relaxed text-slate-700">{data.privacy_de}</p>
+            </div>
+            <div className="rounded-2xl border border-slate-200/60 bg-slate-900/90 p-5 text-sm text-slate-100 shadow-lg backdrop-blur">
+              <h3 className="text-xs font-semibold uppercase tracking-widest text-slate-300">Provenance (API)</h3>
+              <ul className="mt-2 space-y-1 font-mono text-[0.7rem] leading-5 text-slate-200">
+                <li>readiness: {data.provenance.readiness_score} ({data.provenance.readiness_level})</li>
+                <li>open/in_progress/escal: {data.provenance.workflow_open_or_active}</li>
+                <li>overdue: {data.provenance.workflow_overdue} · escalated: {data.provenance.workflow_escalated}</li>
+                <li>events 24h: {data.provenance.workflow_events_24h}</li>
+                {data.provenance.rule_bundle_version_last_run ? (
+                  <li>last bundle: {data.provenance.rule_bundle_version_last_run}</li>
+                ) : null}
+              </ul>
+              <p className="mt-3 text-xs leading-5 text-slate-400">{data.provenance.explainability_de}</p>
+            </div>
+          </section>
+
+          <p className="text-center text-[0.7rem] text-slate-400 sm:text-left">
+            Stand: {new Date(data.as_of_utc).toLocaleString("de-DE", { timeZone: "UTC" })} UTC ·
+            tenant <span className="font-mono text-slate-500">{data.tenant_id}</span>
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/lib/complianceCompassApi.ts
+++ b/frontend/src/lib/complianceCompassApi.ts
@@ -1,0 +1,70 @@
+/**
+ * Compliance Compass — fusionsbasiertes GRC-Signal (tenant-scoped).
+ */
+
+function apiBase(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
+    process.env.COMPLIANCEHUB_API_BASE_URL?.trim() ||
+    "http://localhost:8000"
+  );
+}
+
+function apiKey(): string {
+  return (
+    process.env.NEXT_PUBLIC_API_KEY?.trim() ||
+    process.env.COMPLIANCEHUB_API_KEY?.trim() ||
+    "tenant-overview-key"
+  );
+}
+
+const PATH = "/api/v1/governance/compass/snapshot";
+
+export interface CompassPillar {
+  key: string;
+  label_de: string;
+  score_0_100: number;
+  weight_in_fusion: number;
+  detail_de: string;
+}
+
+export interface CompassProvenance {
+  readiness_score: number;
+  readiness_level: string;
+  workflow_open_or_active: number;
+  workflow_overdue: number;
+  workflow_escalated: number;
+  workflow_events_24h: number;
+  last_run_completed_at_utc: string | null;
+  rule_bundle_version_last_run: string;
+  explainability_de: string;
+}
+
+export interface ComplianceCompassSnapshot {
+  tenant_id: string;
+  as_of_utc: string;
+  model_version: string;
+  fusion_index_0_100: number;
+  confidence_0_100: number;
+  posture: string;
+  narrative_de: string;
+  pillars: CompassPillar[];
+  provenance: CompassProvenance;
+  privacy_de: string;
+}
+
+export async function fetchComplianceCompass(
+  tenantId: string
+): Promise<ComplianceCompassSnapshot> {
+  const r = await fetch(`${apiBase()}${PATH}`, {
+    headers: {
+      "x-api-key": apiKey(),
+      "x-tenant-id": tenantId,
+    },
+    next: { revalidate: 0 },
+  });
+  if (!r.ok) {
+    throw new Error(`Compliance Compass ${r.status}`);
+  }
+  return (await r.json()) as ComplianceCompassSnapshot;
+}

--- a/frontend/src/lib/governanceWorkflowApi.ts
+++ b/frontend/src/lib/governanceWorkflowApi.ts
@@ -2,6 +2,10 @@
  * Governance Workflow Orchestration (deterministische Regeln, mandantisoliert).
  */
 
+import type { WorkflowRunListItem, WorkflowRunResponse, WorkflowRunSummary } from "@/lib/governanceWorkflowTypes";
+
+export type { WorkflowRunListItem, WorkflowRunResponse, WorkflowRunSummary } from "@/lib/governanceWorkflowTypes";
+
 function apiBase(): string {
   return (
     process.env.NEXT_PUBLIC_API_BASE_URL?.trim() ||
@@ -29,6 +33,17 @@ function headers(tenantId: string, extra?: Record<string, string>): Record<strin
 
 const BASE = "/api/v1/governance/workflows";
 
+export class WorkflowApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly detail: string = ""
+  ) {
+    super(message);
+    this.name = "WorkflowApiError";
+  }
+}
+
 export interface GovernanceWorkflowKpisDto {
   open_tasks: number;
   overdue_tasks: number;
@@ -40,13 +55,7 @@ export interface GovernanceWorkflowKpisDto {
 export interface GovernanceWorkflowDashboardDto {
   kpis: GovernanceWorkflowKpisDto;
   rule_bundle_version: string;
-  recent_runs: {
-    id: string;
-    status: string;
-    rule_bundle_version: string;
-    started_at_utc: string;
-    completed_at_utc: string | null;
-  }[];
+  recent_runs: WorkflowRunListItem[];
   templates: {
     id: string;
     code: string;
@@ -67,18 +76,17 @@ export async function fetchWorkflowDashboard(
 
 export async function postWorkflowRun(
   tenantId: string
-): Promise<{ run_id: string; tasks_materialized: number; notifications_queued: number }> {
+): Promise<WorkflowRunResponse> {
   const r = await fetch(`${apiBase()}${BASE}/run`, {
     method: "POST",
     headers: headers(tenantId),
     body: JSON.stringify({ rule_profile: "default" }),
   });
-  if (!r.ok) throw new Error(`Run ${r.status}: ${await r.text()}`);
-  return (await r.json()) as {
-    run_id: string;
-    tasks_materialized: number;
-    notifications_queued: number;
-  };
+  if (!r.ok) {
+    const t = await r.text();
+    throw new WorkflowApiError(`Run ${r.status}`, r.status, t);
+  }
+  return (await r.json()) as WorkflowRunResponse;
 }
 
 export interface WorkflowTaskListItemDto {
@@ -211,6 +219,21 @@ export async function fetchWorkflowTaskDetail(
   return (await r.json()) as WorkflowTaskDetailDto;
 }
 
+function parseErrorDetailFromBody(raw: string): string {
+  try {
+    const j = JSON.parse(raw) as { detail?: unknown };
+    if (typeof j.detail === "string" && j.detail) {
+      return j.detail;
+    }
+  } catch {
+    // ignore
+  }
+  if (raw.length > 0 && raw.length < 500) {
+    return raw;
+  }
+  return "Ungültige Anforderung";
+}
+
 export async function patchWorkflowTask(
   tenantId: string,
   taskId: string,
@@ -221,8 +244,19 @@ export async function patchWorkflowTask(
     headers: headers(tenantId),
     body: JSON.stringify(body),
   });
-  if (!r.ok) throw new Error(`PATCH task ${r.status}: ${await r.text()}`);
-  return (await r.json()) as WorkflowTaskListItemDto;
+  const text = await r.text();
+  if (r.status === 422) {
+    const d = parseErrorDetailFromBody(text);
+    throw new WorkflowApiError(
+      "Ungültiger Task-Status oder Konflikt (422)",
+      422,
+      d
+    );
+  }
+  if (!r.ok) {
+    throw new WorkflowApiError(`PATCH task ${r.status}`, r.status, text);
+  }
+  return JSON.parse(text) as WorkflowTaskListItemDto;
 }
 
 export async function postTestNotification(

--- a/frontend/src/lib/governanceWorkflowTypes.ts
+++ b/frontend/src/lib/governanceWorkflowTypes.ts
@@ -1,0 +1,112 @@
+/**
+ * Governance Workflow — clientseitige Domäne (1:1 mit API, app/governance_workflow_service.py:
+ * WORKFLOW_TASK_ALLOWED_STATUSES, Source-Typen aus _materialize-Regeln).
+ *
+ * "blocked" / "deferred" sind hier absichtlich nicht als Task-Status: die API speichert nur
+ * open | in_progress | done | cancelled | escalated.
+ */
+
+/** Laut API PATCH / ggf. ORM-Validierung (keine freien Strings). */
+export const WORKFLOW_TASK_STATUS_VALUES = [
+  "open",
+  "in_progress",
+  "done",
+  "cancelled",
+  "escalated",
+] as const;
+
+export type WorkflowTaskStatus = (typeof WORKFLOW_TASK_STATUS_VALUES)[number];
+
+/**
+ * Bekannte source_type-Werte aus dem Backend (Materialisierung pro Quell-Entität).
+ * Beim Hinzufügen neuer Quellen: Service + Pydantic + diesen Union erweitern.
+ */
+export const WORKFLOW_SOURCE_TYPE_VALUES = [
+  "remediation_action",
+  "governance_control",
+  "board_report_action",
+  "service_health_incident",
+] as const;
+
+export type WorkflowSourceType = (typeof WORKFLOW_SOURCE_TYPE_VALUES)[number];
+
+/** task.priority bzw. Filter "severity" (entspricht Remediation-/Task-Priorität). */
+export const WORKFLOW_PRIORITY_VALUES = ["critical", "high", "medium", "low"] as const;
+
+export type WorkflowTaskPriority = (typeof WORKFLOW_PRIORITY_VALUES)[number];
+
+/** Run.summary_json bzw. POST /run-Response-Teilfelder. */
+export interface WorkflowRunSummary {
+  tasks_materialized?: number;
+  /** Anzahl während des Laufs erzeugter governance_workflow_events (Backend: events_written). */
+  events_written?: number;
+  remediation_overdue?: number;
+  service_incidents?: number;
+  board_actions?: number;
+  evidence_gaps?: number;
+  overdue_reviews?: number;
+  remediation_notification_events?: number;
+}
+
+export interface WorkflowRunListItem {
+  id: string;
+  tenant_id?: string;
+  status: string;
+  rule_bundle_version: string;
+  summary: WorkflowRunSummary;
+  started_at_utc: string;
+  completed_at_utc: string | null;
+}
+
+export interface WorkflowRunResponse {
+  run_id: string;
+  status: string;
+  tasks_materialized: number;
+  events_written: number;
+  notifications_queued: number;
+  rule_bundle_version: string;
+}
+
+export function isWorkflowTaskStatus(s: string): s is WorkflowTaskStatus {
+  return (WORKFLOW_TASK_STATUS_VALUES as readonly string[]).includes(s);
+}
+
+/** Strikte Prüfung (Client-Guard, vor PATCH). */
+export function assertWorkflowTaskStatus(s: string): asserts s is WorkflowTaskStatus {
+  if (!isWorkflowTaskStatus(s)) {
+    throw new Error(`Ungültiger Task-Status: ${s}`);
+  }
+}
+
+const TERMINAL: readonly WorkflowTaskStatus[] = ["done", "cancelled"];
+
+/**
+ * UI-Regel: von abgeschlossen/storniert kein „Wiedereröffnen“ zum Bearbeiten (MVP).
+ * (API-Änderung für bewusstes Re-Open wäre Phase 2.)
+ */
+export function isAllowedStatusTransition(
+  from: string,
+  to: WorkflowTaskStatus
+): boolean {
+  if (from === to) return true;
+  if (!isWorkflowTaskStatus(from)) {
+    return true;
+  }
+  if (TERMINAL.includes(from) && from !== to) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Liest events_written aus Run-Summary (Key wie Backend: events_written; alias event_count
+ * wird nicht erwartet).
+ */
+export function getEventsCountFromRunSummary(
+  s: WorkflowRunSummary | undefined | null
+): number {
+  if (!s || typeof s.events_written !== "number" || !Number.isFinite(s.events_written)) {
+    return 0;
+  }
+  return s.events_written;
+}

--- a/tests/test_compliance_compass_api.py
+++ b/tests/test_compliance_compass_api.py
@@ -1,0 +1,57 @@
+"""Compliance Compass API — Shape & Mandanten-Isolation."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+COMPASS = "/api/v1/governance/compass/snapshot"
+
+
+def _h(tid: str) -> dict[str, str]:
+    return {"x-api-key": "board-kpi-key", "x-tenant-id": tid}
+
+
+def test_compass_snapshot_200_and_shape() -> None:
+    r = client.get(COMPASS, headers=_h("board-kpi-tenant"))
+    assert r.status_code == 200, r.text
+    j = r.json()
+    assert j["tenant_id"] == "board-kpi-tenant"
+    for k in (
+        "as_of_utc",
+        "model_version",
+        "fusion_index_0_100",
+        "confidence_0_100",
+        "posture",
+        "narrative_de",
+        "pillars",
+        "provenance",
+        "privacy_de",
+    ):
+        assert k in j
+    assert 0 <= j["fusion_index_0_100"] <= 100
+    assert 0 <= j["confidence_0_100"] <= 100
+    assert isinstance(j["pillars"], list) and len(j["pillars"]) == 4
+    prov = j["provenance"]
+    for k2 in (
+        "readiness_score",
+        "workflow_open_or_active",
+        "workflow_overdue",
+        "workflow_escalated",
+        "workflow_events_24h",
+    ):
+        assert k2 in prov
+
+
+def test_compass_tenant_a_ne_b() -> None:
+    a = client.get(COMPASS, headers=_h("board-kpi-tenant")).json()
+    b = client.get(COMPASS, headers=_h("demo-seed-tenant-1")).json()
+    assert a["tenant_id"] != b["tenant_id"]
+
+
+def test_compass_401_or_400_without_auth() -> None:
+    r = client.get(COMPASS, headers={})
+    assert r.status_code in (400, 401)

--- a/tests/test_governance_workflow_api.py
+++ b/tests/test_governance_workflow_api.py
@@ -37,6 +37,20 @@ def test_workflow_dashboard_shape() -> None:
     }
 
 
+def test_dashboard_recent_run_summary_has_events_written_after_sync() -> None:
+    h = _headers()
+    r = client.post(f"{BASE}/run", headers=h, json={"rule_profile": "default"})
+    assert r.status_code == 201, r.text
+    d = client.get(BASE, headers=h)
+    assert d.status_code == 200, d.text
+    runs = d.json().get("recent_runs", [])
+    assert len(runs) >= 1
+    s0 = runs[0].get("summary") or {}
+    assert "events_written" in s0
+    assert isinstance(s0["events_written"], int)
+    assert s0["events_written"] >= 0
+
+
 def test_workflow_run_and_test_notification() -> None:
     h = _headers()
     run = client.post(f"{BASE}/run", headers=h, json={"rule_profile": "default"})


### PR DESCRIPTION
…uide

Add GET /api/v1/governance/compass/snapshot with a deterministic fusion index from readiness and governance workflow signals, plus Pydantic models and API tests.

Add Apple-style /tenant/governance/compass page, client fetch helper, and TenantNav entry. Harden workflow workspace with typed statuses, unassign, run KPIs/history, 422 handling, and governance workflow TypeScript types.

Add docs/governance-workflows.md and extend governance workflow API tests for run summary and dashboard run metrics.

Made-with: Cursor