### PR TITLE
fix(compass): rollback session on readiness failure, low confidence p…

### DIFF
--- a/app/services/compliance_compass_service.py
+++ b/app/services/compliance_compass_service.py
@@ -61,6 +61,14 @@ def _strategic_score(session: Session, tenant_id: str) -> tuple[int, str]:
         return rs.score, str(rs.level)
     except Exception:  # pragma: no cover - defensiv gegen DB-Edge-Cases
         logger.exception("compliance_compass: readiness failed tenant=%s", tenant_id)
+        # Sonst bleibt die Session ggf. in fehlgeschlagenem Zustand (PendingRollbackError).
+        try:
+            session.rollback()
+        except Exception:  # pragma: no cover
+            logger.exception(
+                "compliance_compass: rollback after readiness fail tenant=%s",
+                tenant_id,
+            )
         return 0, "basic"
 
 
@@ -127,16 +135,17 @@ def _confidence_0_100(
     strategic: int,
     events_24h: int,
 ) -> int:
-    c = 0.58
+    # Niedriger Prior: ohne Signale kein künstlich hoher Confidence-Wert (dünne Datenlage).
+    c = 0.22
     if has_tasks:
-        c += 0.14
+        c += 0.20
     if has_runs:
-        c += 0.14
+        c += 0.20
     if strategic > 0:
-        c += 0.10
+        c += 0.19
     if events_24h > 0:
-        c += 0.10
-    return _clamp_int(c * 100.0)
+        c += 0.19
+    return _clamp_int(min(1.0, c) * 100.0)
 
 
 def _narrative(

--- a/tests/test_compliance_compass_service.py
+++ b/tests/test_compliance_compass_service.py
@@ -1,0 +1,27 @@
+"""Unit tests for compliance_compass_service (Codex: rollback, confidence prior)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.services.compliance_compass_service import _confidence_0_100, _strategic_score
+
+
+def test_confidence_baseline_is_low_without_signals() -> None:
+    assert _confidence_0_100(False, False, 0, 0) == 22
+
+
+def test_confidence_max_with_all_signals() -> None:
+    assert _confidence_0_100(True, True, 1, 3) == 100
+
+
+def test_strategic_score_rollback_after_readiness_failure() -> None:
+    session = MagicMock()
+    with patch(
+        "app.services.compliance_compass_service.compute_readiness_score",
+        side_effect=RuntimeError("transient db"),
+    ):
+        score, level = _strategic_score(session, "tenant-a")
+    assert score == 0
+    assert level == "basic"
+    session.rollback.assert_called_once()


### PR DESCRIPTION
…rior

- Call session.rollback() when compute_readiness_score fails so follow-up queries do not hit PendingRollbackError (Codex P1).
- Start confidence at 22% and add bounded bonuses for tasks, runs, readiness, and events so zero-signal tenants are not inflated to ~58 (Codex P2).
- Add unit tests for confidence edges and rollback behavior.

Made-with: Cursor