### PR TITLE
feat(compass): phase 3 readiness hardening — transactions, confidence…

### DIFF
--- a/app/compliance_compass_routes.py
+++ b/app/compliance_compass_routes.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from app.auth_dependencies import get_api_key_and_tenant
 from app.compliance_compass_models import ComplianceCompassSnapshotOut
 from app.db import get_session
-from app.services.compliance_compass_service import build_compass_snapshot
+from app.services.compliance_compass_service import (
+    ComplianceCompassError,
+    build_compass_snapshot,
+)
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(
     prefix="/api/v1/governance/compass",
@@ -29,4 +35,13 @@ def get_compass_snapshot(
     tenant_id: Annotated[str, Depends(get_api_key_and_tenant)],
     session: Annotated[Session, Depends(get_session)],
 ) -> ComplianceCompassSnapshotOut:
-    return build_compass_snapshot(session, tenant_id)
+    try:
+        return build_compass_snapshot(session, tenant_id)
+    except ComplianceCompassError:
+        # Service hat die Session bereits zurückgerollt und Details geloggt;
+        # nach außen nur eine generische 503 ohne interne Hinweise.
+        logger.warning("compliance_compass.snapshot_503 tenant=%s", tenant_id)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="compass_snapshot_unavailable",
+        ) from None

--- a/app/services/compliance_compass_service.py
+++ b/app/services/compliance_compass_service.py
@@ -7,10 +7,12 @@ Deterministisch, erklärbar, mandanten-isoliert (kein LLM im MVP; später option
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import and_, func, select
+from sqlalchemy.exc import SQLAlchemyError
 
 from app.compliance_compass_models import (
     COMPASS_VERSION,
@@ -32,14 +34,82 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+class ComplianceCompassError(RuntimeError):
+    """Domain-Fehler, wenn der Compass-Snapshot wegen DB-/Infra-Problemen nicht gebaut werden kann.
+
+    Wird vom Router auf 503 abgebildet. Enthält *keine* tenant-spezifischen Details
+    (kein Leaky Abstraction nach außen), die volle Kontextkette steht in den Logs.
+    """
+
+
+# Pillar-Gewichte (Summe = 1.0); siehe docs/governance-workflows.md
 W_STRATEGIC = 0.38
 W_EXEC = 0.27
 W_CADENCE = 0.20
 W_RES = 0.15
 
+# Confidence-Modell: Prior + bounded Boni. Niedrig wenn Mandant ohne Signale.
+# Werte addieren sich auf 1.0 (0.22 + 4×~0.195) und werden zusätzlich durch min(1.0, …) gekappt.
+_CONFIDENCE_PRIOR = 0.22
+_CONFIDENCE_BONUS_TASKS = 0.20
+_CONFIDENCE_BONUS_RUNS = 0.20
+_CONFIDENCE_BONUS_READINESS = 0.19
+_CONFIDENCE_BONUS_EVENTS = 0.19
+
+# Posture-Schwellen (deterministisch, dokumentiert).
+_POSTURE_STRONG = 76
+_POSTURE_STEADY = 58
+_POSTURE_WATCH = 40
+
+# Cadence-Schwellen (in Stunden).
+_CADENCE_HOT_HOURS = 48
+_CADENCE_WEEK_HOURS = 24 * 7
+_CADENCE_MONTH_HOURS = 24 * 30
+
+# Execution-Druckpunkte (siehe Tests für Boundary-Verhalten).
+_EXEC_OPEN_CAP = 40.0
+_EXEC_OVERDUE_CAP = 12.0
+_EXEC_W_OPEN = 0.55
+_EXEC_W_OVERDUE = 0.45
+
+# Resilience-Strafen pro eskaliertem Task (max 55 Punkte Abzug).
+_RES_PENALTY_PER_ESCALATED = 9
+_RES_MAX_PENALTY = 55
+
+
+@dataclass(frozen=True, slots=True)
+class _ConfidenceSignals:
+    """Deterministische, getestete Eingangsgrößen der Confidence-Berechnung."""
+
+    has_tasks: bool
+    has_runs: bool
+    has_readiness: bool
+    has_events: bool
+
 
 def _clamp_int(n: float | int) -> int:
     return max(0, min(100, int(round(n))))
+
+
+def _safe_rollback(session: Session, *, reason: str, tenant_id: str) -> None:
+    """Rollbackt die Session defensiv und protokolliert auf WARN-Level.
+
+    Schluckt sekundäre Rollback-Fehler bewusst, um den Hauptfehlerpfad nicht zu maskieren.
+    """
+    try:
+        session.rollback()
+        logger.warning(
+            "compliance_compass.session_rollback reason=%s tenant=%s",
+            reason,
+            tenant_id,
+        )
+    except Exception:  # pragma: no cover - sekundärer Fehler nur loggen
+        logger.exception(
+            "compliance_compass.rollback_failed reason=%s tenant=%s",
+            reason,
+            tenant_id,
+        )
 
 
 def _count_tasks(session: Session, tenant_id: str, *extra) -> int:
@@ -55,21 +125,36 @@ def _count_tasks(session: Session, tenant_id: str, *extra) -> int:
     return int(r.scalar() or 0)
 
 
+@dataclass(frozen=True, slots=True)
+class _StrategicSignal:
+    score: int
+    level: str
+    success: bool
+
+
 def _strategic_score(session: Session, tenant_id: str) -> tuple[int, str]:
+    """Backward-kompatible Signatur. Intern delegiert an :func:`_strategic_signal`."""
+    s = _strategic_signal(session, tenant_id)
+    return s.score, s.level
+
+
+def _strategic_signal(session: Session, tenant_id: str) -> _StrategicSignal:
+    """Liefert Readiness-Score + Level + Erfolgsflag.
+
+    Bei Fehler in :func:`compute_readiness_score` wird die Session zurückgerollt,
+    damit nachfolgende Queries nicht in ``PendingRollbackError`` laufen, und ein
+    neutraler "basic"-Fallback geliefert (graceful degradation).
+    """
     try:
         rs = compute_readiness_score(session, tenant_id)
-        return rs.score, str(rs.level)
-    except Exception:  # pragma: no cover - defensiv gegen DB-Edge-Cases
-        logger.exception("compliance_compass: readiness failed tenant=%s", tenant_id)
-        # Sonst bleibt die Session ggf. in fehlgeschlagenem Zustand (PendingRollbackError).
-        try:
-            session.rollback()
-        except Exception:  # pragma: no cover
-            logger.exception(
-                "compliance_compass: rollback after readiness fail tenant=%s",
-                tenant_id,
-            )
-        return 0, "basic"
+        return _StrategicSignal(score=rs.score, level=str(rs.level), success=True)
+    except Exception:
+        logger.exception(
+            "compliance_compass.readiness_failed tenant=%s",
+            tenant_id,
+        )
+        _safe_rollback(session, reason="readiness_failed", tenant_id=tenant_id)
+        return _StrategicSignal(score=0, level="basic", success=False)
 
 
 def _execution_score(
@@ -77,9 +162,9 @@ def _execution_score(
     overdue: int,
 ) -> tuple[int, str]:
     """0–100: niedriger Druck in Backlog & Überfälligkeiten = höher."""
-    p_open = min(1.0, open_active / 40.0)
-    p_over = min(1.0, overdue / 12.0) if overdue else 0.0
-    raw = 100.0 * (1.0 - 0.55 * p_open - 0.45 * p_over)
+    p_open = min(1.0, open_active / _EXEC_OPEN_CAP)
+    p_over = min(1.0, overdue / _EXEC_OVERDUE_CAP) if overdue else 0.0
+    raw = 100.0 * (1.0 - _EXEC_W_OPEN * p_open - _EXEC_W_OVERDUE * p_over)
     detail = f"Offen/aktiv: {open_active}; überfällig: {overdue}."
     return _clamp_int(raw), detail
 
@@ -94,13 +179,13 @@ def _cadence_score(
         last_completed = last_completed.replace(tzinfo=UTC)
     delta: timedelta = now - last_completed
     hours = delta.total_seconds() / 3600.0
-    if hours <= 48:
+    if hours <= _CADENCE_HOT_HOURS:
         s = 92
         detail = f"Letzter Run vor {int(hours)}h — rhythmische Synchronisierung sichtbar."
-    elif hours <= 24 * 7:
+    elif hours <= _CADENCE_WEEK_HOURS:
         s = 78
         detail = "Regel-Sync in den letzten 7 Tagen; Kadenz im normierten Band."
-    elif hours <= 24 * 30:
+    elif hours <= _CADENCE_MONTH_HOURS:
         s = 64
         detail = "Längere Pause seit letztem Lauf; Sync für aktuelle Lage empfohlen."
     else:
@@ -110,7 +195,7 @@ def _cadence_score(
 
 
 def _resilience_score(escalated: int) -> tuple[int, str]:
-    s = 100 - min(55, int(escalated) * 9)
+    s = 100 - min(_RES_MAX_PENALTY, int(escalated) * _RES_PENALTY_PER_ESCALATED)
     s = _clamp_int(s)
     if escalated == 0:
         detail = "Keine eskalierten Workflow-Tasks im abgefragten Bestand (Status escalated)."
@@ -120,13 +205,31 @@ def _resilience_score(escalated: int) -> tuple[int, str]:
 
 
 def _posture(fusion: int) -> str:
-    if fusion >= 76:
+    if fusion >= _POSTURE_STRONG:
         return "strong"
-    if fusion >= 58:
+    if fusion >= _POSTURE_STEADY:
         return "steady"
-    if fusion >= 40:
+    if fusion >= _POSTURE_WATCH:
         return "watch"
     return "elevated"
+
+
+def _compute_confidence_score(signals: _ConfidenceSignals) -> int:
+    """Reine, getestete Confidence-Logik (ohne DB-Zugriff).
+
+    Niedriger Prior, kappt bei 1.0. Jeder Boolean ist ein binäres Signal,
+    das durch oberhalb dieser Funktion ermittelte Schwellen abgeleitet wird.
+    """
+    c = _CONFIDENCE_PRIOR
+    if signals.has_tasks:
+        c += _CONFIDENCE_BONUS_TASKS
+    if signals.has_runs:
+        c += _CONFIDENCE_BONUS_RUNS
+    if signals.has_readiness:
+        c += _CONFIDENCE_BONUS_READINESS
+    if signals.has_events:
+        c += _CONFIDENCE_BONUS_EVENTS
+    return _clamp_int(min(1.0, c) * 100.0)
 
 
 def _confidence_0_100(
@@ -135,17 +238,19 @@ def _confidence_0_100(
     strategic: int,
     events_24h: int,
 ) -> int:
-    # Niedriger Prior: ohne Signale kein künstlich hoher Confidence-Wert (dünne Datenlage).
-    c = 0.22
-    if has_tasks:
-        c += 0.20
-    if has_runs:
-        c += 0.20
-    if strategic > 0:
-        c += 0.19
-    if events_24h > 0:
-        c += 0.19
-    return _clamp_int(min(1.0, c) * 100.0)
+    """Public, backward-kompatible API; delegiert an :func:`_compute_confidence_score`.
+
+    ``strategic > 0`` wird als "Readiness vorhanden" interpretiert; Aufrufer mit
+    expliziter Erfolgsinformation sollten direkt :class:`_ConfidenceSignals` bauen.
+    """
+    return _compute_confidence_score(
+        _ConfidenceSignals(
+            has_tasks=bool(has_tasks),
+            has_runs=bool(has_runs),
+            has_readiness=int(strategic) > 0,
+            has_events=int(events_24h) > 0,
+        )
+    )
 
 
 def _narrative(
@@ -174,12 +279,19 @@ def _narrative(
     return f"{base} {stärke} {hebel}"
 
 
-def build_compass_snapshot(
+def _build_snapshot_unsafe(
     session: Session,
     tenant_id: str,
 ) -> ComplianceCompassSnapshotOut:
+    """Eigentliche Snapshot-Berechnung. Wirft DB-/Infra-Fehler nach oben.
+
+    Wird ausschließlich aus :func:`build_compass_snapshot` aufgerufen, das
+    Transaction-Handling und Domain-Error-Mapping kapselt.
+    """
     now = datetime.now(UTC)
-    strategic, level = _strategic_score(session, tenant_id)
+    strategic_sig = _strategic_signal(session, tenant_id)
+    strategic = strategic_sig.score
+    level = strategic_sig.level
 
     openish = _count_tasks(
         session,
@@ -204,7 +316,6 @@ def build_compass_snapshot(
     exec_s, exec_detail = _execution_score(openish, overdue)
     res_s, res_detail = _resilience_score(escalated_n)
 
-    # Letzter abgeschlossener Run
     run_row = session.execute(
         select(
             GovernanceWorkflowRunTable.completed_at_utc,
@@ -219,7 +330,7 @@ def build_compass_snapshot(
     ).one_or_none()
     last_c = run_row[0] if run_row else None
     last_ver = (run_row[1] or "") if run_row else ""
-    if last_c and last_c.tzinfo is None and isinstance(last_c, datetime):
+    if last_c and isinstance(last_c, datetime) and last_c.tzinfo is None:
         last_c = last_c.replace(tzinfo=UTC)
     has_runs = run_row is not None
     cad_s, cad_detail = _cadence_score(last_c)
@@ -256,11 +367,13 @@ def build_compass_snapshot(
     )
     fusion = _clamp_int(fusion_01 * 100.0)
     posture = _posture(fusion)
-    conf = _confidence_0_100(
-        has_tasks=has_tasks,
-        has_runs=has_runs,
-        strategic=strategic,
-        events_24h=ev_n,
+    conf = _compute_confidence_score(
+        _ConfidenceSignals(
+            has_tasks=has_tasks,
+            has_runs=has_runs,
+            has_readiness=strategic_sig.success,
+            has_events=ev_n > 0,
+        )
     )
 
     pillars = [
@@ -316,3 +429,27 @@ def build_compass_snapshot(
         pillars=pillars,
         provenance=provenance,
     )
+
+
+def build_compass_snapshot(
+    session: Session,
+    tenant_id: str,
+) -> ComplianceCompassSnapshotOut:
+    """Baut den Compass-Snapshot mit hartem Transaction-Schutz.
+
+    Bei jeder unerwarteten DB-Exception wird die Session zurückgerollt, damit
+    nachfolgende Requests im selben Worker keine ``PendingRollbackError`` sehen.
+    Eine technische Fehlermeldung wird in den Logs hinterlegt; nach außen wird
+    eine generische :class:`ComplianceCompassError` propagiert (kein Leaking
+    interner Details, kein PII).
+    """
+    try:
+        return _build_snapshot_unsafe(session, tenant_id)
+    except SQLAlchemyError as exc:
+        logger.exception(
+            "compliance_compass.snapshot_db_failed tenant=%s exc_type=%s",
+            tenant_id,
+            type(exc).__name__,
+        )
+        _safe_rollback(session, reason="snapshot_db_failed", tenant_id=tenant_id)
+        raise ComplianceCompassError("compass_snapshot_unavailable") from exc

--- a/tests/test_compliance_compass_api.py
+++ b/tests/test_compliance_compass_api.py
@@ -1,10 +1,13 @@
-"""Compliance Compass API — Shape & Mandanten-Isolation."""
+"""Compliance Compass API — Shape, Mandanten-Isolation, Error-Mapping."""
 
 from __future__ import annotations
+
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from app.main import app
+from app.services.compliance_compass_service import ComplianceCompassError
 
 client = TestClient(app)
 
@@ -55,3 +58,18 @@ def test_compass_tenant_a_ne_b() -> None:
 def test_compass_401_or_400_without_auth() -> None:
     r = client.get(COMPASS, headers={})
     assert r.status_code in (400, 401)
+
+
+def test_compass_returns_503_on_compass_error() -> None:
+    """ComplianceCompassError aus dem Service-Layer → HTTP 503 mit generischem Detail
+    (kein Leaking interner DB-Hinweise nach außen)."""
+    with patch(
+        "app.compliance_compass_routes.build_compass_snapshot",
+        side_effect=ComplianceCompassError("compass_snapshot_unavailable"),
+    ):
+        r = client.get(COMPASS, headers=_h("board-kpi-tenant"))
+    assert r.status_code == 503
+    body = r.json()
+    assert body["detail"] == "compass_snapshot_unavailable"
+    assert "boom" not in r.text.lower()
+    assert "operational" not in r.text.lower()

--- a/tests/test_compliance_compass_service.py
+++ b/tests/test_compliance_compass_service.py
@@ -1,10 +1,37 @@
-"""Unit tests for compliance_compass_service (Codex: rollback, confidence prior)."""
+"""Unit tests for compliance_compass_service.
+
+Decken ab:
+- Confidence-Logik (Min/Max/mittlere Kombinationen, Backward-API).
+- Strategic-Score Rollback bei Readiness-Fehler (Codex P1).
+- Snapshot-Pipeline bleibt nach Readiness-Fehler nutzbar (kein PendingRollbackError).
+- Posture-/Cadence-/Resilience-/Execution-Boundaries (deterministisch, erklärbar).
+- Domain-Error + Rollback bei harten DB-Fehlern in der Snapshot-Pipeline.
+"""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
-from app.services.compliance_compass_service import _confidence_0_100, _strategic_score
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from app.services.compliance_compass_service import (
+    ComplianceCompassError,
+    _cadence_score,
+    _compute_confidence_score,
+    _confidence_0_100,
+    _ConfidenceSignals,
+    _execution_score,
+    _posture,
+    _resilience_score,
+    _strategic_score,
+    build_compass_snapshot,
+)
+
+# --------------------------------------------------------------------------------------
+# Confidence
+# --------------------------------------------------------------------------------------
 
 
 def test_confidence_baseline_is_low_without_signals() -> None:
@@ -13,6 +40,43 @@ def test_confidence_baseline_is_low_without_signals() -> None:
 
 def test_confidence_max_with_all_signals() -> None:
     assert _confidence_0_100(True, True, 1, 3) == 100
+
+
+def test_confidence_only_readiness_present() -> None:
+    """Nur Readiness-Signal → Prior + Readiness-Bonus; deutlich unter Voll-Confidence."""
+    val = _confidence_0_100(False, False, 80, 0)
+    assert val == round((0.22 + 0.19) * 100)
+
+
+def test_confidence_tasks_and_runs_no_readiness_no_events() -> None:
+    val = _confidence_0_100(True, True, 0, 0)
+    assert val == round((0.22 + 0.20 + 0.20) * 100)
+
+
+def test_compute_confidence_with_named_signals_matches_legacy_api() -> None:
+    """Neue interne API muss exakt dieselben Werte liefern wie der Backward-Wrapper."""
+    legacy = _confidence_0_100(True, False, 50, 5)
+    structured = _compute_confidence_score(
+        _ConfidenceSignals(has_tasks=True, has_runs=False, has_readiness=True, has_events=True)
+    )
+    assert legacy == structured
+
+
+def test_compute_confidence_distinguishes_readiness_success_from_score() -> None:
+    """Wichtig: ein Readiness-Score von 0 bei *erfolgreicher* Berechnung darf
+    nicht wie ein Failure aussehen — die strukturierte API erlaubt diese Trennung."""
+    failed = _compute_confidence_score(
+        _ConfidenceSignals(has_tasks=False, has_runs=False, has_readiness=False, has_events=False)
+    )
+    succeeded_score_zero = _compute_confidence_score(
+        _ConfidenceSignals(has_tasks=False, has_runs=False, has_readiness=True, has_events=False)
+    )
+    assert succeeded_score_zero > failed
+
+
+# --------------------------------------------------------------------------------------
+# Strategic Score / Rollback
+# --------------------------------------------------------------------------------------
 
 
 def test_strategic_score_rollback_after_readiness_failure() -> None:
@@ -25,3 +89,158 @@ def test_strategic_score_rollback_after_readiness_failure() -> None:
     assert score == 0
     assert level == "basic"
     session.rollback.assert_called_once()
+
+
+def test_strategic_score_rolls_back_even_when_rollback_itself_raises() -> None:
+    """Sekundäre Rollback-Fehler dürfen den Aufrufer nicht crashen."""
+    session = MagicMock()
+    session.rollback.side_effect = RuntimeError("rollback failed")
+    with patch(
+        "app.services.compliance_compass_service.compute_readiness_score",
+        side_effect=RuntimeError("transient db"),
+    ):
+        score, level = _strategic_score(session, "tenant-x")
+    assert (score, level) == (0, "basic")
+
+
+# --------------------------------------------------------------------------------------
+# Posture / Cadence / Resilience / Execution Boundaries
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("fusion", "expected"),
+    [
+        (0, "elevated"),
+        (39, "elevated"),
+        (40, "watch"),
+        (57, "watch"),
+        (58, "steady"),
+        (75, "steady"),
+        (76, "strong"),
+        (100, "strong"),
+    ],
+)
+def test_posture_thresholds(fusion: int, expected: str) -> None:
+    assert _posture(fusion) == expected
+
+
+def test_cadence_score_is_neutral_when_no_run() -> None:
+    s, detail = _cadence_score(None)
+    assert s == 50
+    assert "neutral" in detail.lower()
+
+
+@pytest.mark.parametrize(
+    ("hours_ago", "expected_score"),
+    [
+        (1, 92),
+        (47, 92),
+        (49, 78),
+        (24 * 6, 78),
+        (24 * 8, 64),
+        # Knapp unterhalb der 30-Tage-Grenze (Verarbeitungszeit-Slop tolerieren).
+        (24 * 30 - 1, 64),
+        (24 * 31, 48),
+    ],
+)
+def test_cadence_score_boundaries(hours_ago: int, expected_score: int) -> None:
+    last = datetime.now(UTC) - timedelta(hours=hours_ago)
+    s, _ = _cadence_score(last)
+    assert s == expected_score
+
+
+def test_cadence_score_handles_naive_datetime() -> None:
+    """Datenbanken liefern teils naive UTC-Stempel (SQLite). Service muss tolerant sein."""
+    last = (datetime.now(UTC) - timedelta(hours=2)).replace(tzinfo=None)
+    s, _ = _cadence_score(last)
+    assert s == 92
+
+
+@pytest.mark.parametrize(
+    ("escalated", "expected"),
+    [
+        (0, 100),
+        (1, 91),
+        (5, 55),
+        (6, 46),
+        (7, 45),
+        (50, 45),
+    ],
+)
+def test_resilience_score_boundaries(escalated: int, expected: int) -> None:
+    s, _ = _resilience_score(escalated)
+    assert s == expected
+
+
+def test_execution_score_no_pressure_is_perfect() -> None:
+    s, _ = _execution_score(0, 0)
+    assert s == 100
+
+
+def test_execution_score_high_pressure_is_floored_at_zero() -> None:
+    s, _ = _execution_score(1000, 1000)
+    assert s == 0
+
+
+def test_execution_score_overdue_dominates_even_with_low_open() -> None:
+    low_open_high_overdue, _ = _execution_score(0, 50)
+    low_open_no_overdue, _ = _execution_score(0, 0)
+    assert low_open_high_overdue < low_open_no_overdue
+
+
+# --------------------------------------------------------------------------------------
+# Snapshot Pipeline: Rollback + Domain-Error
+# --------------------------------------------------------------------------------------
+
+
+def test_build_snapshot_raises_compass_error_and_rolls_back_on_db_failure() -> None:
+    """Wenn eine harte DB-Exception in der Pipeline auftritt, soll der Service
+    die Session rollbacken und einen sauberen Domain-Error werfen — *kein*
+    SQLAlchemy-Internalerror nach außen, kein PendingRollbackError danach."""
+    session = MagicMock()
+    session.execute.side_effect = OperationalError("SELECT 1", {}, Exception("boom"))
+
+    with patch(
+        "app.services.compliance_compass_service.compute_readiness_score",
+        return_value=MagicMock(score=42, level="managed"),
+    ):
+        with pytest.raises(ComplianceCompassError):
+            build_compass_snapshot(session, "tenant-rolling")
+
+    session.rollback.assert_called()
+
+
+def test_build_snapshot_keeps_session_usable_after_readiness_failure() -> None:
+    """Regressions-Test für Codex P1: nach Readiness-Fehler muss der weitere
+    Pipeline-Verlauf normal mit der Session arbeiten können (Rollback fand statt,
+    nachfolgende ``session.execute``-Aufrufe laufen ohne PendingRollbackError)."""
+    session = MagicMock()
+
+    counters: dict[str, int] = {"calls": 0}
+
+    def _execute_ok(*_args, **_kwargs):
+        counters["calls"] += 1
+        result = MagicMock()
+        result.scalar.return_value = 0
+        result.one_or_none.return_value = None
+        return result
+
+    session.execute.side_effect = _execute_ok
+
+    with patch(
+        "app.services.compliance_compass_service.compute_readiness_score",
+        side_effect=RuntimeError("readiness offline"),
+    ):
+        snapshot = build_compass_snapshot(session, "tenant-resilient")
+
+    # Snapshot wurde gebaut, Rollback fand genau einmal statt (vom strategic-score-Pfad),
+    # alle nachfolgenden Queries liefen erfolgreich auf derselben Session.
+    session.rollback.assert_called_once()
+    assert snapshot.tenant_id == "tenant-resilient"
+    assert snapshot.provenance.readiness_score == 0
+    assert snapshot.provenance.readiness_level == "basic"
+    # Confidence darf bei dünner Datenlage + fehlgeschlagenem Readiness nicht hoch sein.
+    assert snapshot.confidence_0_100 <= 30
+    # Mind. die Pipeline-Counts (open/escalated/overdue/runs/events/has_tasks) liefen erfolgreich.
+    assert counters["calls"] >= 5


### PR DESCRIPTION
…, observability

- Wrap build_compass_snapshot in SQLAlchemyError handler that rolls back the session and raises a new ComplianceCompassError, so a transient DB issue cannot leave a PendingRollbackError for follow-up requests in the worker.
- Extract confidence into a pure _compute_confidence_score(_ConfidenceSignals) with named module constants; keep _confidence_0_100 as backward-compatible wrapper. Track readiness *success* explicitly via _StrategicSignal so a legitimate score of 0 is no longer indistinguishable from a failed call.
- Add _safe_rollback helper with WARN-level structured logs (no PII), promote Posture/Cadence/Resilience/Execution thresholds to documented constants.
- Map ComplianceCompassError → HTTP 503 with generic detail in the router; no internal DB hints leak to the API surface.
- Tests: extend service unit suite from 3 to 33 cases (confidence mid-values, posture/cadence/resilience/execution boundaries, naive-datetime tolerance, secondary-rollback safety, snapshot-still-builds-after-readiness-failure regression for Codex P1, ComplianceCompassError + rollback on hard DB exception). Add API test asserting 503 mapping without leaking details.

Made-with: Cursor