### PR TITLE
feat(compass): governance integration & run observability

### DIFF
--- a/app/governance_audit_readiness_models.py
+++ b/app/governance_audit_readiness_models.py
@@ -3,8 +3,37 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
+
+CompassResult = Literal["ok", "warning", "error", "unknown"]
+
+
+class CompassAuditSignal(BaseModel):
+    """Governance-Signal aus dem letzten Compliance-Compass-Run für Audit/Board.
+
+    Deterministisch aus ``governance_workflow_events`` abgeleitet (kein LLM, kein PII).
+    """
+
+    latest_run_at: datetime | None = Field(
+        default=None,
+        description="Zeitstempel des jüngsten Compass-Runs (UTC); None falls nie gelaufen.",
+    )
+    result: CompassResult = Field(
+        default="unknown",
+        description="ok | warning (Low Confidence) | error (Run failed) | unknown.",
+    )
+    confidence_0_100: int | None = Field(default=None, ge=0, le=100)
+    fusion_index_0_100: int | None = Field(default=None, ge=0, le=100)
+    posture: str | None = Field(
+        default=None,
+        description="strong | steady | watch | elevated; None falls Run fehlgeschlagen.",
+    )
+    error_type: str | None = Field(
+        default=None,
+        description="Bei result=='error': technischer Exception-Typ (kein PII).",
+    )
 
 
 class GovernanceAuditCaseCreate(BaseModel):
@@ -62,6 +91,13 @@ class AuditReadinessSummaryRead(BaseModel):
     overdue_reviews_count: int
     by_framework: list[AuditReadinessFrameworkSlice]
     gaps: list[AuditEvidenceGapRow] = Field(default_factory=list)
+    compass_signal: CompassAuditSignal = Field(
+        default_factory=CompassAuditSignal,
+        description=(
+            "Letzter Compliance-Compass-Run (Confidence/Posture/Result) als "
+            "Governance-Kennzahl. ``result == 'unknown'`` falls noch kein Run lief."
+        ),
+    )
 
 
 class AuditReadinessControlRow(BaseModel):

--- a/app/repositories/governance_audit_readiness.py
+++ b/app/repositories/governance_audit_readiness.py
@@ -12,6 +12,7 @@ from app.governance_audit_readiness_models import (
     AuditReadinessControlRow,
     AuditReadinessFrameworkSlice,
     AuditReadinessSummaryRead,
+    CompassAuditSignal,
     GovernanceAuditCaseCreate,
     GovernanceAuditCaseRead,
 )
@@ -24,6 +25,7 @@ from app.models_db import (
     GovernanceEvidenceRequirementTable,
 )
 from app.repositories.governance_controls import GovernanceControlRepository
+from app.services.compliance_compass_service import get_latest_compass_signal
 from app.services.governance_audit_readiness_rules import (
     ControlSignals,
     compute_control_metrics,
@@ -292,6 +294,7 @@ class GovernanceAuditReadinessRepository:
             )
             for fw, st in sorted(fw_stats.items())
         ]
+        compass_signal = self._build_compass_signal(tenant_id)
         return AuditReadinessSummaryRead(
             audit_case_id=audit_case_id,
             overall_readiness_pct=overall,
@@ -301,6 +304,19 @@ class GovernanceAuditReadinessRepository:
             overdue_reviews_count=overdue_reviews,
             by_framework=by_fw,
             gaps=gap_rows,
+            compass_signal=compass_signal,
+        )
+
+    def _build_compass_signal(self, tenant_id: str) -> CompassAuditSignal:
+        """Liefert das jüngste Compass-Signal für den Tenant; "unknown" falls keines."""
+        sig = get_latest_compass_signal(self._s, tenant_id)
+        return CompassAuditSignal(
+            latest_run_at=sig.latest_run_at,
+            result=sig.result,  # type: ignore[arg-type]
+            confidence_0_100=sig.confidence_0_100,
+            fusion_index_0_100=sig.fusion_index_0_100,
+            posture=sig.posture,
+            error_type=sig.error_type,
         )
 
     def list_control_rows(

--- a/app/services/board_reporting_service.py
+++ b/app/services/board_reporting_service.py
@@ -14,8 +14,15 @@ from app.models_db import (
     GovernanceControlEvidenceTable,
     GovernanceControlReviewTable,
     GovernanceControlTable,
+    GovernanceWorkflowEventTable,
     NIS2IncidentTable,
     ServiceHealthIncidentTable,
+)
+from app.services.compliance_compass_service import (
+    COMPASS_EVENT_SOURCE_TYPE,
+    COMPASS_EVENT_TYPE_COMPLETED,
+    COMPASS_EVENT_TYPE_FAILED,
+    LOW_CONFIDENCE_THRESHOLD,
 )
 
 TrendDirection = Literal["up", "down", "stable"]
@@ -62,6 +69,56 @@ def _trend(curr: float, prev: float, *, stable_delta: float = 0.5) -> tuple[Tren
 async def _scalar_int(session: AsyncSession, stmt: Select[tuple[int]]) -> int:
     raw = await session.scalar(stmt)
     return int(raw or 0)
+
+
+@dataclass(slots=True)
+class _CompassEventSummary:
+    """Reduzierte Sicht auf den jüngsten Compass-Event für Board-Metriken."""
+
+    latest_at: datetime | None
+    event_type: str | None
+    confidence: int | None
+    fusion: int | None
+    posture: str | None
+
+
+async def _latest_compass_event(session: AsyncSession, tenant_id: str) -> _CompassEventSummary:
+    row = await session.scalar(
+        select(GovernanceWorkflowEventTable)
+        .where(
+            GovernanceWorkflowEventTable.tenant_id == tenant_id,
+            GovernanceWorkflowEventTable.source_type == COMPASS_EVENT_SOURCE_TYPE,
+            GovernanceWorkflowEventTable.event_type.in_(
+                [COMPASS_EVENT_TYPE_COMPLETED, COMPASS_EVENT_TYPE_FAILED]
+            ),
+        )
+        .order_by(GovernanceWorkflowEventTable.at_utc.desc())
+        .limit(1)
+    )
+    if row is None:
+        return _CompassEventSummary(None, None, None, None, None)
+    payload = row.payload_json or {}
+    confidence_raw = payload.get("confidence_0_100")
+    fusion_raw = payload.get("fusion_index_0_100")
+    return _CompassEventSummary(
+        latest_at=row.at_utc,
+        event_type=row.event_type,
+        confidence=int(confidence_raw) if isinstance(confidence_raw, int | float) else None,
+        fusion=int(fusion_raw) if isinstance(fusion_raw, int | float) else None,
+        posture=str(payload.get("posture")) if payload.get("posture") else None,
+    )
+
+
+def _compass_traffic_light(event_type: str | None, confidence: int | None) -> TrafficLight:
+    if event_type == COMPASS_EVENT_TYPE_FAILED:
+        return "red"
+    if confidence is None:
+        return "amber"
+    if confidence < LOW_CONFIDENCE_THRESHOLD:
+        return "red"
+    if confidence < 70:
+        return "amber"
+    return "green"
 
 
 async def compute_snapshot(
@@ -297,6 +354,49 @@ async def compute_snapshot(
             narrative_de="Anzahl AI-Systeme mit Risk-Level HIGH/HIGH_RISK im Register.",
         ),
     ]
+
+    # 8) Compass-Box: letzter Compliance-Compass-Run als Confidence/Fusion-KPI.
+    compass = await _latest_compass_event(session, tenant_id)
+    compass_light = _compass_traffic_light(compass.event_type, compass.confidence)
+    if compass.event_type == COMPASS_EVENT_TYPE_FAILED:
+        compass_narrative = (
+            "Letzter Compass-Run war fehlerhaft (Run-Pipeline). "
+            "Keine valide Confidence verfügbar."
+        )
+    elif compass.confidence is None:
+        compass_narrative = "Noch kein Compass-Run vorhanden — Run anstoßen für Board-Sicht."
+    else:
+        compass_narrative = (
+            f"Confidence {compass.confidence}/100 (Posture: {compass.posture or '-'})."
+        )
+    metrics.extend(
+        [
+            BoardMetric(
+                metric_key="compass_confidence_0_100",
+                label="Compass Confidence",
+                value=float(compass.confidence) if compass.confidence is not None else 0.0,
+                unit="score",
+                traffic_light=compass_light,
+                trend_direction="stable",
+                trend_delta=0.0,
+                narrative_de=compass_narrative,
+            ),
+            BoardMetric(
+                metric_key="compass_fusion_0_100",
+                label="Compass Fusion Index",
+                value=float(compass.fusion) if compass.fusion is not None else 0.0,
+                unit="score",
+                traffic_light=compass_light,
+                trend_direction="stable",
+                trend_delta=0.0,
+                narrative_de=(
+                    f"Fusions-Index {compass.fusion}/100"
+                    if compass.fusion is not None
+                    else "Fusions-Index noch nicht ermittelt."
+                ),
+            ),
+        ]
+    )
 
     top_risk_areas: list[str] = []
     if open_critical_controls >= 5:

--- a/app/services/board_reporting_service.py
+++ b/app/services/board_reporting_service.py
@@ -360,8 +360,7 @@ async def compute_snapshot(
     compass_light = _compass_traffic_light(compass.event_type, compass.confidence)
     if compass.event_type == COMPASS_EVENT_TYPE_FAILED:
         compass_narrative = (
-            "Letzter Compass-Run war fehlerhaft (Run-Pipeline). "
-            "Keine valide Confidence verfügbar."
+            "Letzter Compass-Run war fehlerhaft (Run-Pipeline). Keine valide Confidence verfügbar."
         )
     elif compass.confidence is None:
         compass_narrative = "Noch kein Compass-Run vorhanden — Run anstoßen für Board-Sicht."

--- a/app/services/compliance_compass_service.py
+++ b/app/services/compliance_compass_service.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.exc import SQLAlchemyError
@@ -33,6 +34,21 @@ if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
+
+
+# --- Governance-Integration: Event-Channel für Compass-Runs ----------------------------
+# Wir reusen die bestehende `governance_workflow_events`-Tabelle (siehe models_db) als
+# Audit-Spur. Vorteile: keine neue Migration, das Workflow-Dashboard zeigt Compass-Runs
+# automatisch, und die Workflow-Engine kann Events als Trigger lesen (Phase 3 EU AI Act:
+# Transparenz, Fehlerursache, kein PII-Leak — direkt unterstützt durch payload_json).
+COMPASS_EVENT_SOURCE_TYPE = "compliance_compass"
+COMPASS_EVENT_TYPE_COMPLETED = "compass.run.completed"
+COMPASS_EVENT_TYPE_FAILED = "compass.run.failed"
+COMPASS_EVENT_TYPE_LOW_CONFIDENCE = "compass.run.low_confidence"
+
+# Schwelle, ab der ein erfolgreicher Run zusätzlich als low_confidence-Event markiert wird.
+# Eng gewählt, damit der Workflow-Trigger nicht flutet (siehe governance_workflow_service).
+LOW_CONFIDENCE_THRESHOLD = 30
 
 
 class ComplianceCompassError(RuntimeError):
@@ -110,6 +126,52 @@ def _safe_rollback(session: Session, *, reason: str, tenant_id: str) -> None:
             reason,
             tenant_id,
         )
+
+
+def _append_compass_event(
+    session: Session,
+    *,
+    tenant_id: str,
+    run_id: str,
+    event_type: str,
+    severity: str,
+    message: str,
+    payload: dict[str, Any],
+) -> None:
+    """Append-only Audit-Eintrag in `governance_workflow_events` (sync session).
+
+    NIS2/AI-Act-Audit-Sicht: Erfolgreiche und fehlgeschlagene Runs sind nachvollziehbar,
+    Ursache (`error_type`) und Schweregrad sind erkennbar — ohne personenbezogene Daten.
+    Der Schreibfehler ist nicht fatal: er wird WARN-geloggt, der Snapshot bleibt nutzbar.
+    """
+    try:
+        session.add(
+            GovernanceWorkflowEventTable(
+                id=str(uuid4()),
+                tenant_id=tenant_id,
+                at_utc=datetime.now(UTC),
+                event_type=event_type,
+                severity=severity,
+                ref_task_id=None,
+                source_type=COMPASS_EVENT_SOURCE_TYPE,
+                source_id=run_id,
+                message=message[:2000],
+                payload_json=payload,
+            )
+        )
+        # Snapshot-Pipeline ist sonst read-only: ein expliziter Commit hier macht den
+        # Event-Eintrag dauerhaft, ohne fremde Writes mitzunehmen. Failures landen im
+        # except-Zweig und werden durch _safe_rollback bereinigt.
+        session.flush()
+        session.commit()
+    except SQLAlchemyError:
+        logger.warning(
+            "compliance_compass.event_log_failed tenant=%s run_id=%s event_type=%s",
+            tenant_id,
+            run_id,
+            event_type,
+        )
+        _safe_rollback(session, reason="event_log_failed", tenant_id=tenant_id)
 
 
 def _count_tasks(session: Session, tenant_id: str, *extra) -> int:
@@ -282,6 +344,8 @@ def _narrative(
 def _build_snapshot_unsafe(
     session: Session,
     tenant_id: str,
+    *,
+    run_id: str,
 ) -> ComplianceCompassSnapshotOut:
     """Eigentliche Snapshot-Berechnung. Wirft DB-/Infra-Fehler nach oben.
 
@@ -442,14 +506,137 @@ def build_compass_snapshot(
     Eine technische Fehlermeldung wird in den Logs hinterlegt; nach außen wird
     eine generische :class:`ComplianceCompassError` propagiert (kein Leaking
     interner Details, kein PII).
+
+    Jeder Run hinterlässt einen Audit-Eintrag in ``governance_workflow_events``
+    (Erfolg, Fehler oder zusätzlich `low_confidence`) — damit ist der Run für
+    NIS2/AI-Act-/ISO-42001-Auditfragen nachvollziehbar.
     """
+    run_id = str(uuid4())
     try:
-        return _build_snapshot_unsafe(session, tenant_id)
+        snapshot = _build_snapshot_unsafe(session, tenant_id, run_id=run_id)
     except SQLAlchemyError as exc:
+        exc_type = type(exc).__name__
         logger.exception(
-            "compliance_compass.snapshot_db_failed tenant=%s exc_type=%s",
+            "compliance_compass.snapshot_db_failed tenant=%s exc_type=%s run_id=%s",
             tenant_id,
-            type(exc).__name__,
+            exc_type,
+            run_id,
         )
         _safe_rollback(session, reason="snapshot_db_failed", tenant_id=tenant_id)
+        # Failure-Event auf einer frischen Transaktion (Rollback ist erfolgt).
+        _append_compass_event(
+            session,
+            tenant_id=tenant_id,
+            run_id=run_id,
+            event_type=COMPASS_EVENT_TYPE_FAILED,
+            severity="error",
+            message="compass snapshot build failed",
+            payload={
+                "error_type": exc_type,
+                "stage": "snapshot_pipeline",
+                "model_version": COMPASS_VERSION,
+            },
+        )
         raise ComplianceCompassError("compass_snapshot_unavailable") from exc
+
+    _append_compass_event(
+        session,
+        tenant_id=tenant_id,
+        run_id=run_id,
+        event_type=COMPASS_EVENT_TYPE_COMPLETED,
+        severity="info",
+        message=f"compass run completed posture={snapshot.posture}",
+        payload={
+            "fusion_index_0_100": snapshot.fusion_index_0_100,
+            "confidence_0_100": snapshot.confidence_0_100,
+            "posture": snapshot.posture,
+            "model_version": snapshot.model_version,
+            "readiness_level": snapshot.provenance.readiness_level,
+        },
+    )
+    if snapshot.confidence_0_100 < LOW_CONFIDENCE_THRESHOLD:
+        _append_compass_event(
+            session,
+            tenant_id=tenant_id,
+            run_id=run_id,
+            event_type=COMPASS_EVENT_TYPE_LOW_CONFIDENCE,
+            severity="warning",
+            message=(
+                f"compass confidence {snapshot.confidence_0_100} below "
+                f"threshold {LOW_CONFIDENCE_THRESHOLD}"
+            ),
+            payload={
+                "confidence_0_100": snapshot.confidence_0_100,
+                "threshold": LOW_CONFIDENCE_THRESHOLD,
+                "fusion_index_0_100": snapshot.fusion_index_0_100,
+                "posture": snapshot.posture,
+            },
+        )
+    return snapshot
+
+
+@dataclass(frozen=True, slots=True)
+class CompassRunSignal:
+    """Letzter Compass-Run als Governance-Signal (für Audit/Board/Workflow).
+
+    Werte spiegeln das jüngste ``compass.run.completed`` oder ``compass.run.failed``
+    Event des Tenants wider; ist kein Event vorhanden → ``result == "unknown"``.
+    """
+
+    latest_run_at: datetime | None
+    result: str  # ok | warning | error | unknown
+    confidence_0_100: int | None
+    fusion_index_0_100: int | None
+    posture: str | None
+    error_type: str | None
+
+
+def _classify_event_result(event_type: str, confidence: int | None) -> str:
+    if event_type == COMPASS_EVENT_TYPE_FAILED:
+        return "error"
+    if event_type == COMPASS_EVENT_TYPE_COMPLETED:
+        if confidence is not None and confidence < LOW_CONFIDENCE_THRESHOLD:
+            return "warning"
+        return "ok"
+    return "unknown"
+
+
+def get_latest_compass_signal(session: Session, tenant_id: str) -> CompassRunSignal:
+    """Liest den jüngsten Compass-Run-Event (Erfolg oder Fehler) aus dem Audit-Log.
+
+    Read-only, idempotent. Wird von Audit-Readiness, Board-Reporting und der
+    Workflow-Regel genutzt — damit die Integration deterministisch und ohne
+    KI-Magie funktioniert.
+    """
+    row = session.execute(
+        select(GovernanceWorkflowEventTable)
+        .where(
+            GovernanceWorkflowEventTable.tenant_id == tenant_id,
+            GovernanceWorkflowEventTable.source_type == COMPASS_EVENT_SOURCE_TYPE,
+            GovernanceWorkflowEventTable.event_type.in_(
+                [COMPASS_EVENT_TYPE_COMPLETED, COMPASS_EVENT_TYPE_FAILED]
+            ),
+        )
+        .order_by(GovernanceWorkflowEventTable.at_utc.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    if row is None:
+        return CompassRunSignal(
+            latest_run_at=None,
+            result="unknown",
+            confidence_0_100=None,
+            fusion_index_0_100=None,
+            posture=None,
+            error_type=None,
+        )
+    payload = row.payload_json or {}
+    confidence = payload.get("confidence_0_100")
+    fusion = payload.get("fusion_index_0_100")
+    return CompassRunSignal(
+        latest_run_at=row.at_utc,
+        result=_classify_event_result(row.event_type, confidence),
+        confidence_0_100=int(confidence) if isinstance(confidence, int | float) else None,
+        fusion_index_0_100=int(fusion) if isinstance(fusion, int | float) else None,
+        posture=str(payload.get("posture")) if payload.get("posture") else None,
+        error_type=str(payload.get("error_type")) if payload.get("error_type") else None,
+    )

--- a/app/services/governance_workflow_service.py
+++ b/app/services/governance_workflow_service.py
@@ -68,12 +68,26 @@ _TEMPLATE_CATALOG: list[dict[str, Any]] = [
         "description": "Umsetzung der Board-Action inkl. Owner, Termin, Nachweis im Audit-Case.",
         "default_sla_days": 7,
     },
+    {
+        "code": "tpl_compass_data_quality",
+        "title": "Compass Daten-/Konfigurationsprüfung",
+        "description": (
+            "Compass-Run liefert kritisch niedrige Confidence oder ist fehlgeschlagen. "
+            "Datenbasis (Controls, Evidence, Tasks) und Konfiguration prüfen."
+        ),
+        "default_sla_days": 3,
+    },
 ]
 
 SOURCE_REMEDIATION = "remediation_action"
 SOURCE_CONTROL = "governance_control"
 SOURCE_BOARD_ACTION = "board_report_action"
 SOURCE_SERVICE_INCIDENT = "service_health_incident"
+SOURCE_COMPASS = "compliance_compass"
+
+# Compass: nur sehr niedrige Confidence triggert einen Task (sonst Flutgefahr).
+# Failures triggern immer.
+COMPASS_TASK_CONFIDENCE_FLOOR = 30
 OPEN_TASK_STATUSES = ("open", "in_progress", "escalated")
 # Erlaubte Werte für PATCH / tasks (und gespeicherte Zustände) — alles andere wird abgelehnt
 WORKFLOW_TASK_ALLOWED_STATUSES = frozenset(
@@ -467,6 +481,105 @@ async def _rule_evidence_gaps(
     return c
 
 
+async def _rule_compass_low_confidence(
+    session: AsyncSession,
+    *,
+    tenant_id: str,
+    run_id: str,
+    now: datetime,
+    event_tally: list[int] | None = None,
+) -> int:
+    """
+    Regel: Letzter Compass-Run ist `failed` oder hat Confidence unter Floor → ein Task.
+
+    Eng gefasst, damit kein Task-Sturm entsteht:
+      * Idempotenz pro Tag und Tenant via dedupe_key (`wf:compass:lowconf:{tenant}:{YYYYMMDD}`).
+      * Nur das jüngste relevante Event wird betrachtet.
+      * Bei Erfolg ohne Low-Confidence: kein Task.
+
+    Phase-3-EU-AI-Act-Sicht: Niedrige Compass-Confidence ist ein Indikator für
+    schlechte Datenbasis im Governance-Stack — der Task „Daten-/Konfigurationsprüfung"
+    macht das auditierbar, ohne KI-Magie.
+    """
+    latest = await session.scalar(
+        select(GovernanceWorkflowEventTable)
+        .where(
+            GovernanceWorkflowEventTable.tenant_id == tenant_id,
+            GovernanceWorkflowEventTable.source_type == SOURCE_COMPASS,
+            GovernanceWorkflowEventTable.event_type.in_(
+                ["compass.run.completed", "compass.run.failed"]
+            ),
+        )
+        .order_by(desc(GovernanceWorkflowEventTable.at_utc))
+        .limit(1)
+    )
+    if latest is None:
+        return 0
+    payload = latest.payload_json or {}
+    event_type = latest.event_type
+    confidence_raw = payload.get("confidence_0_100")
+    confidence = (
+        int(confidence_raw) if isinstance(confidence_raw, int | float) else None
+    )
+    is_failure = event_type == "compass.run.failed"
+    is_low_conf = (
+        event_type == "compass.run.completed"
+        and confidence is not None
+        and confidence < COMPASS_TASK_CONFIDENCE_FLOOR
+    )
+    if not (is_failure or is_low_conf):
+        return 0
+
+    day_key = now.strftime("%Y%m%d")
+    dedupe_key = f"wf:compass:lowconf:{tenant_id}:{day_key}"
+    if is_failure:
+        title = "Compass-Run fehlgeschlagen — Daten/Konfiguration prüfen"
+        description = (
+            "Letzter Compass-Run wurde durch Infrastruktur-/Datenfehler abgebrochen. "
+            "Bitte Logs (governance_workflow_events) prüfen und Run wiederholen."
+        )
+        priority = "high"
+        source_ref = {
+            "event_type": event_type,
+            "error_type": payload.get("error_type"),
+        }
+    else:
+        title = (
+            f"Compass-Confidence kritisch ({confidence}/100) — "
+            "Daten- und Konfigurationsprüfung"
+        )
+        description = (
+            "Compass meldet sehr niedrige Confidence. Datenbasis (Controls, "
+            "Evidence, Tasks, Readiness) und Konfiguration im Governance-Stack prüfen."
+        )
+        priority = "medium"
+        source_ref = {
+            "event_type": event_type,
+            "confidence_0_100": confidence,
+            "threshold": COMPASS_TASK_CONFIDENCE_FLOOR,
+        }
+
+    due = now + timedelta(days=3)
+    t = await _materialize_task(
+        session,
+        tenant_id=tenant_id,
+        run_id=run_id,
+        title=title,
+        description=description,
+        source_type=SOURCE_COMPASS,
+        source_id=latest.source_id,
+        source_ref=source_ref,
+        dedupe_key=dedupe_key,
+        template_code="tpl_compass_data_quality",
+        assignee=None,
+        due_at=due,
+        priority=priority,
+        framework_tags=["EU_AI_ACT", "ISO_42001"],
+        event_tally=event_tally,
+    )
+    return 1 if t is not None else 0
+
+
 async def _rule_overdue_reviews(
     session: AsyncSession,
     *,
@@ -580,7 +693,14 @@ async def run_deterministic_sync(
         now=now,
         event_tally=event_tally,
     )
-    mat = t1 + t2 + t3 + t4 + t5
+    t6 = await _rule_compass_low_confidence(
+        session,
+        tenant_id=tenant_id,
+        run_id=run_id,
+        now=now,
+        event_tally=event_tally,
+    )
+    mat = t1 + t2 + t3 + t4 + t5 + t6
     ev_n = int(event_tally[0])
     end = _now()
     run.status = "completed"
@@ -592,6 +712,7 @@ async def run_deterministic_sync(
         "board_actions": t3,
         "evidence_gaps": t4,
         "overdue_reviews": t5,
+        "compass_low_confidence": t6,
         "remediation_notification_events": n_esc,
         "events_written": ev_n,
     }

--- a/app/services/governance_workflow_service.py
+++ b/app/services/governance_workflow_service.py
@@ -518,9 +518,7 @@ async def _rule_compass_low_confidence(
     payload = latest.payload_json or {}
     event_type = latest.event_type
     confidence_raw = payload.get("confidence_0_100")
-    confidence = (
-        int(confidence_raw) if isinstance(confidence_raw, int | float) else None
-    )
+    confidence = int(confidence_raw) if isinstance(confidence_raw, int | float) else None
     is_failure = event_type == "compass.run.failed"
     is_low_conf = (
         event_type == "compass.run.completed"
@@ -544,10 +542,7 @@ async def _rule_compass_low_confidence(
             "error_type": payload.get("error_type"),
         }
     else:
-        title = (
-            f"Compass-Confidence kritisch ({confidence}/100) — "
-            "Daten- und Konfigurationsprüfung"
-        )
+        title = f"Compass-Confidence kritisch ({confidence}/100) — Daten- und Konfigurationsprüfung"
         description = (
             "Compass meldet sehr niedrige Confidence. Datenbasis (Controls, "
             "Evidence, Tasks, Readiness) und Konfiguration im Governance-Stack prüfen."

--- a/tests/test_compliance_compass_observability.py
+++ b/tests/test_compliance_compass_observability.py
@@ -1,0 +1,251 @@
+"""Compliance Compass — Run-Observability + Governance-Andocken.
+
+Decken ab:
+- Erfolgreicher Run schreibt einen ``compass.run.completed``-Event.
+- DB-Fehler in der Pipeline schreibt zusätzlich ``compass.run.failed`` (mit error_type)
+  und liefert :class:`ComplianceCompassError` an den Aufrufer.
+- ``get_latest_compass_signal`` liefert deterministische Werte aus dem letzten Event
+  (Quelle: ``governance_workflow_events``), inkl. ``unknown`` für Tenants ohne Run.
+- Audit-Readiness-API liefert das ``compass_signal``-Feld erwartungsgemäß.
+- Board-Reporting nimmt den letzten Compass-Run als KPI auf.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.orm import Session
+
+from app.db import engine
+from app.main import app
+from app.models_db import GovernanceWorkflowEventTable
+from app.services.compliance_compass_service import (
+    COMPASS_EVENT_SOURCE_TYPE,
+    COMPASS_EVENT_TYPE_COMPLETED,
+    COMPASS_EVENT_TYPE_FAILED,
+    LOW_CONFIDENCE_THRESHOLD,
+    ComplianceCompassError,
+    build_compass_snapshot,
+    get_latest_compass_signal,
+)
+
+client = TestClient(app)
+
+
+def _h(tid: str) -> dict[str, str]:
+    return {"x-api-key": "board-kpi-key", "x-tenant-id": tid}
+
+
+def _events_for(tenant_id: str) -> list[GovernanceWorkflowEventTable]:
+    with Session(engine) as s:
+        rows = s.scalars(
+            select(GovernanceWorkflowEventTable)
+            .where(
+                GovernanceWorkflowEventTable.tenant_id == tenant_id,
+                GovernanceWorkflowEventTable.source_type == COMPASS_EVENT_SOURCE_TYPE,
+            )
+            .order_by(GovernanceWorkflowEventTable.at_utc.desc())
+        ).all()
+        # Detach so callers can read attributes after the session closes.
+        return [s.merge(r, load=False) for r in rows]
+
+
+# --------------------------------------------------------------------------------------
+# Successful run → completed event with audit-relevant payload (no PII).
+# --------------------------------------------------------------------------------------
+
+
+def test_successful_compass_run_writes_completed_event_with_payload() -> None:
+    tenant = "compass-obs-tenant-success"
+    r = client.get("/api/v1/governance/compass/snapshot", headers=_h(tenant))
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    events = _events_for(tenant)
+    completed = [e for e in events if e.event_type == COMPASS_EVENT_TYPE_COMPLETED]
+    assert len(completed) >= 1, "expected at least one compass.run.completed event"
+    payload = completed[0].payload_json or {}
+    assert payload.get("fusion_index_0_100") == body["fusion_index_0_100"]
+    assert payload.get("confidence_0_100") == body["confidence_0_100"]
+    assert payload.get("posture") == body["posture"]
+    assert payload.get("model_version") == body["model_version"]
+    # Defensive: kein offensichtlicher PII-Leak in Payload-Keys.
+    forbidden = {"email", "user_email", "name", "ip_address"}
+    assert forbidden.isdisjoint(set(payload.keys()))
+
+
+# --------------------------------------------------------------------------------------
+# DB failure → failed event + ComplianceCompassError, no PendingRollbackError after.
+# --------------------------------------------------------------------------------------
+
+
+def test_db_failure_writes_failed_event_and_raises_compass_error() -> None:
+    """Hinter ``_strategic_signal`` (welches Readiness-Failures bereits dämpft) bricht
+    eine harte DB-Exception aus dem Workflow-Score-Pfad — der Service muss rollbacken,
+    einen ``compass.run.failed``-Event schreiben und ``ComplianceCompassError`` werfen.
+    """
+    tenant = "compass-obs-tenant-failure"
+
+    def _boom(*_args, **_kwargs):
+        raise OperationalError("SELECT count(*)", {}, Exception("boom"))
+
+    with Session(engine) as s, patch(
+        "app.services.compliance_compass_service._count_tasks",
+        side_effect=_boom,
+    ):
+        try:
+            build_compass_snapshot(s, tenant)
+        except ComplianceCompassError:
+            pass
+        else:  # pragma: no cover - unerwartet
+            raise AssertionError("expected ComplianceCompassError")
+
+    events = _events_for(tenant)
+    failed = [e for e in events if e.event_type == COMPASS_EVENT_TYPE_FAILED]
+    assert len(failed) == 1
+    payload = failed[0].payload_json or {}
+    assert payload.get("error_type") == "OperationalError"
+    assert payload.get("stage") == "snapshot_pipeline"
+    assert failed[0].severity == "error"
+
+
+# --------------------------------------------------------------------------------------
+# get_latest_compass_signal: deterministische Ergebnisse für Audit/Board/Workflow.
+# --------------------------------------------------------------------------------------
+
+
+def test_latest_compass_signal_unknown_for_pristine_tenant() -> None:
+    with Session(engine) as s:
+        sig = get_latest_compass_signal(s, "compass-obs-pristine-tenant")
+    assert sig.result == "unknown"
+    assert sig.latest_run_at is None
+    assert sig.confidence_0_100 is None
+
+
+def test_latest_compass_signal_returns_warning_when_low_confidence() -> None:
+    tenant = "compass-obs-low-conf"
+    now = datetime.now(UTC)
+    with Session(engine) as s:
+        s.add(
+            GovernanceWorkflowEventTable(
+                id="evt-low-1",
+                tenant_id=tenant,
+                at_utc=now - timedelta(minutes=5),
+                event_type=COMPASS_EVENT_TYPE_COMPLETED,
+                severity="info",
+                ref_task_id=None,
+                source_type=COMPASS_EVENT_SOURCE_TYPE,
+                source_id="run-low-1",
+                message="seed",
+                payload_json={
+                    "fusion_index_0_100": 30,
+                    "confidence_0_100": LOW_CONFIDENCE_THRESHOLD - 5,
+                    "posture": "elevated",
+                    "model_version": "test",
+                    "readiness_level": "basic",
+                },
+            )
+        )
+        s.commit()
+        sig = get_latest_compass_signal(s, tenant)
+    assert sig.result == "warning"
+    assert sig.confidence_0_100 == LOW_CONFIDENCE_THRESHOLD - 5
+    assert sig.posture == "elevated"
+
+
+def test_latest_compass_signal_returns_error_for_failed_run() -> None:
+    tenant = "compass-obs-failed-state"
+    now = datetime.now(UTC)
+    with Session(engine) as s:
+        s.add(
+            GovernanceWorkflowEventTable(
+                id="evt-fail-1",
+                tenant_id=tenant,
+                at_utc=now,
+                event_type=COMPASS_EVENT_TYPE_FAILED,
+                severity="error",
+                ref_task_id=None,
+                source_type=COMPASS_EVENT_SOURCE_TYPE,
+                source_id="run-fail-1",
+                message="failure",
+                payload_json={
+                    "error_type": "OperationalError",
+                    "stage": "snapshot_pipeline",
+                    "model_version": "test",
+                },
+            )
+        )
+        s.commit()
+        sig = get_latest_compass_signal(s, tenant)
+    assert sig.result == "error"
+    assert sig.error_type == "OperationalError"
+    assert sig.confidence_0_100 is None
+
+
+# --------------------------------------------------------------------------------------
+# Audit-Readiness-API liefert compass_signal mit.
+# --------------------------------------------------------------------------------------
+
+
+def test_audit_readiness_summary_exposes_compass_signal() -> None:
+    h = _h("compass-obs-audit-tenant")
+    # Trigger einen Compass-Run, damit ein Event existiert.
+    snap = client.get("/api/v1/governance/compass/snapshot", headers=h)
+    assert snap.status_code == 200, snap.text
+
+    # Minimaler Audit-Case (kein Control nötig — compass_signal stammt aus events).
+    a = client.post(
+        "/api/v1/governance/audits",
+        headers=h,
+        json={
+            "title": "Compass-aware audit",
+            "framework_tags": ["EU_AI_ACT"],
+            "control_ids": [],
+        },
+    )
+    assert a.status_code == 201, a.text
+    aid = a.json()["id"]
+    r = client.get(f"/api/v1/governance/audits/{aid}/readiness", headers=h)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "compass_signal" in body
+    cs = body["compass_signal"]
+    assert cs["result"] in ("ok", "warning")  # Run war erfolgreich
+    assert cs["confidence_0_100"] == snap.json()["confidence_0_100"]
+    assert cs["latest_run_at"] is not None
+
+
+# --------------------------------------------------------------------------------------
+# Board-Reporting: Compass-Box in Metrics.
+# --------------------------------------------------------------------------------------
+
+
+def test_board_report_metrics_include_compass_box() -> None:
+    h = _h("compass-obs-board-tenant")
+    snap = client.get("/api/v1/governance/compass/snapshot", headers=h)
+    assert snap.status_code == 200, snap.text
+    confidence = snap.json()["confidence_0_100"]
+
+    period_start = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+    period_end = datetime.now(UTC).isoformat()
+    g = client.post(
+        "/api/v1/governance/board-reports/generate",
+        headers=h,
+        json={
+            "period_key": "2026-04",
+            "period_type": "monthly",
+            "period_start": period_start,
+            "period_end": period_end,
+            "title": "Compass Observability Test Pack",
+        },
+    )
+    assert g.status_code == 201, g.text
+    metrics = {m["metric_key"]: m for m in g.json()["summary"]["metrics"]}
+    assert "compass_confidence_0_100" in metrics
+    assert "compass_fusion_0_100" in metrics
+    assert metrics["compass_confidence_0_100"]["value"] == float(confidence)
+    assert metrics["compass_confidence_0_100"]["traffic_light"] in ("green", "amber", "red")

--- a/tests/test_compliance_compass_observability.py
+++ b/tests/test_compliance_compass_observability.py
@@ -93,9 +93,12 @@ def test_db_failure_writes_failed_event_and_raises_compass_error() -> None:
     def _boom(*_args, **_kwargs):
         raise OperationalError("SELECT count(*)", {}, Exception("boom"))
 
-    with Session(engine) as s, patch(
-        "app.services.compliance_compass_service._count_tasks",
-        side_effect=_boom,
+    with (
+        Session(engine) as s,
+        patch(
+            "app.services.compliance_compass_service._count_tasks",
+            side_effect=_boom,
+        ),
     ):
         try:
             build_compass_snapshot(s, tenant)

--- a/tests/test_governance_workflow_compass_rule.py
+++ b/tests/test_governance_workflow_compass_rule.py
@@ -1,0 +1,184 @@
+"""Workflow-Rule für kritische Compass-Signale.
+
+Verifiziert die deterministische Materialisierung von "Compass Daten-/
+Konfigurationsprüfung"-Tasks auf Basis der jüngsten Compass-Events.
+
+Gilt nur bei wirklich kritischen Fällen (failed-Run oder Confidence < Floor),
+um Task-Floods zu vermeiden — daher minimaler Coverage-Fokus.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import engine
+from app.main import app
+from app.models_db import GovernanceWorkflowEventTable, GovernanceWorkflowTaskTable
+from app.services.compliance_compass_service import (
+    COMPASS_EVENT_SOURCE_TYPE,
+    COMPASS_EVENT_TYPE_COMPLETED,
+    COMPASS_EVENT_TYPE_FAILED,
+)
+from app.services.governance_workflow_service import COMPASS_TASK_CONFIDENCE_FLOOR
+
+client = TestClient(app)
+
+
+def _h(tid: str) -> dict[str, str]:
+    return {"x-api-key": "board-kpi-key", "x-tenant-id": tid}
+
+
+def _seed_compass_event(
+    *,
+    tenant_id: str,
+    event_type: str,
+    confidence: int | None,
+    error_type: str | None = None,
+    at: datetime | None = None,
+) -> None:
+    when = at or datetime.now(UTC)
+    payload: dict[str, object] = {"model_version": "test"}
+    if confidence is not None:
+        payload["confidence_0_100"] = confidence
+        payload["fusion_index_0_100"] = confidence
+        payload["posture"] = "elevated"
+    if error_type:
+        payload["error_type"] = error_type
+        payload["stage"] = "snapshot_pipeline"
+    with Session(engine) as s:
+        s.add(
+            GovernanceWorkflowEventTable(
+                id=f"evt-{tenant_id}-{when.timestamp()}",
+                tenant_id=tenant_id,
+                at_utc=when,
+                event_type=event_type,
+                severity="error" if error_type else "info",
+                ref_task_id=None,
+                source_type=COMPASS_EVENT_SOURCE_TYPE,
+                source_id=f"run-{tenant_id}",
+                message="seed",
+                payload_json=payload,
+            )
+        )
+        s.commit()
+
+
+def _compass_tasks_for(tenant_id: str) -> list[GovernanceWorkflowTaskTable]:
+    with Session(engine) as s:
+        return list(
+            s.scalars(
+                select(GovernanceWorkflowTaskTable).where(
+                    GovernanceWorkflowTaskTable.tenant_id == tenant_id,
+                    GovernanceWorkflowTaskTable.source_type == COMPASS_EVENT_SOURCE_TYPE,
+                )
+            )
+        )
+
+
+def test_low_confidence_event_creates_compass_task() -> None:
+    tenant = "compass-rule-low-conf"
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_COMPLETED,
+        confidence=COMPASS_TASK_CONFIDENCE_FLOOR - 5,
+    )
+    r = client.post(
+        "/api/v1/governance/workflows/run",
+        headers=_h(tenant),
+        json={"rule_profile": "default"},
+    )
+    assert r.status_code == 201, r.text
+    tasks = _compass_tasks_for(tenant)
+    assert len(tasks) == 1
+    t = tasks[0]
+    assert "Compass-Confidence kritisch" in t.title
+    assert t.template_code == "tpl_compass_data_quality"
+    assert "EU_AI_ACT" in (t.framework_tags_json or [])
+
+
+def test_failed_event_creates_compass_task_marked_high_priority() -> None:
+    tenant = "compass-rule-failed"
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_FAILED,
+        confidence=None,
+        error_type="OperationalError",
+    )
+    r = client.post(
+        "/api/v1/governance/workflows/run",
+        headers=_h(tenant),
+        json={"rule_profile": "default"},
+    )
+    assert r.status_code == 201, r.text
+    tasks = _compass_tasks_for(tenant)
+    assert len(tasks) == 1
+    assert tasks[0].priority == "high"
+
+
+def test_healthy_event_does_not_create_task() -> None:
+    """Erfolgreicher Run mit hoher Confidence → kein Task (kein Flood)."""
+    tenant = "compass-rule-healthy"
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_COMPLETED,
+        confidence=85,
+    )
+    r = client.post(
+        "/api/v1/governance/workflows/run",
+        headers=_h(tenant),
+        json={"rule_profile": "default"},
+    )
+    assert r.status_code == 201, r.text
+    tasks = _compass_tasks_for(tenant)
+    assert tasks == []
+
+
+def test_compass_task_is_idempotent_within_same_day() -> None:
+    """Zwei Sync-Runs am selben Tag erzeugen dedupe-bedingt nur einen Task."""
+    tenant = "compass-rule-dedupe"
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_FAILED,
+        confidence=None,
+        error_type="OperationalError",
+    )
+    h = _h(tenant)
+    r1 = client.post(
+        "/api/v1/governance/workflows/run", headers=h, json={"rule_profile": "default"}
+    )
+    r2 = client.post(
+        "/api/v1/governance/workflows/run", headers=h, json={"rule_profile": "default"}
+    )
+    assert r1.status_code == 201 and r2.status_code == 201
+    assert len(_compass_tasks_for(tenant)) == 1
+
+
+def test_only_latest_event_drives_rule_decision() -> None:
+    """Letzter Event ist healthy → kein Task, auch wenn früher ein failed-Event lag."""
+    tenant = "compass-rule-recovery"
+    older = datetime.now(UTC) - timedelta(hours=2)
+    newer = datetime.now(UTC)
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_FAILED,
+        confidence=None,
+        error_type="OperationalError",
+        at=older,
+    )
+    _seed_compass_event(
+        tenant_id=tenant,
+        event_type=COMPASS_EVENT_TYPE_COMPLETED,
+        confidence=80,
+        at=newer,
+    )
+    r = client.post(
+        "/api/v1/governance/workflows/run",
+        headers=_h(tenant),
+        json={"rule_profile": "default"},
+    )
+    assert r.status_code == 201, r.text
+    assert _compass_tasks_for(tenant) == []


### PR DESCRIPTION
Compliance Compass dockt jetzt deterministisch an den Governance-Stack an:
- Jeder Run schreibt einen append-only Audit-Eintrag in governance_workflow_events (compass.run.completed/failed/low_confidence) mit PII-armer Payload (fusion, confidence, posture, error_type, stage).
- AuditReadinessSummary trägt ein neues compass_signal-Feld; Audit-Cases sehen damit den letzten Compass-Run als Governance-Kennzahl (result, confidence_0_100, fusion_index_0_100, latest_run_at).
- Board-Reporting-Snapshot enthält zwei zusätzliche BoardMetric-Tiles (compass_confidence_0_100, compass_fusion_0_100) mit Traffic-Light auf Basis des jüngsten Compass-Events.
- Workflow-Engine: neue Regel _rule_compass_low_confidence erzeugt einen "Compass Daten-/Konfigurationsprüfung"-Task, eng gefasst (failed-Run oder Confidence < 30) und Tages-dedupiert — kein Task-Flood. Neues Template tpl_compass_data_quality.

Keine neue Tabelle/Migration: governance_workflow_events wird wieder- verwendet. Keine externen Dependencies. Logging unterstützt NIS2/AI-Act/ ISO-42001-Auditfragen (Transparenz, Fehlerursache, kein PII-Leak).

Tests:
- test_compliance_compass_observability.py: completed/failed-Events, get_latest_compass_signal-Klassifikation, Audit-API-Field, Board-Tile.
- test_governance_workflow_compass_rule.py: Trigger-Pfade, Healthy=NoTask, Idempotenz pro Tag, "Latest-Event regiert" (Recovery).

Made-with: Cursor