### PR TITLE
feat: eliminate application SAST findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Bestehende SQLite-/Postgres-Datenbanken: additive Schema-Updates (z. B. neue O
 
 - `docs/enterprise-readiness-20260714.md` (Audit, umgesetzte Kontrollen, Release-Blocker)
 - `docs/enterprise-entra-oidc-runbook.md` (Entra-OIDC-Konfiguration, Betrieb und Release-Evidenz)
+- `docs/security-parser-hardening-20260715.md` (XML-, SQL-, Signatur- und SAST-Hardening)
 - `docs/architecture.md`
 - `docs/db-migrations.md` (additive Schema-Updates neben `create_all`)
 - `docs/product-strategy.md`

--- a/app/db_migrations/migrations/m20260417_compliance_deadlines_tenant_id_nullable.py
+++ b/app/db_migrations/migrations/m20260417_compliance_deadlines_tenant_id_nullable.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from sqlalchemy import inspect, text
+from sqlalchemy import MetaData, Table, inspect, select, text
 from sqlalchemy.engine import Connection, Engine
 
 from app.db_migrations.util import table_exists
@@ -13,9 +13,6 @@ logger = logging.getLogger(__name__)
 
 MIGRATION_ID = "20260417_compliance_deadlines_tenant_id_nullable"
 DISPLAY_NAME = "compliance_deadlines_tenant_id_nullable"
-
-_IDX_TENANT_DUE = "idx_compliance_deadlines_tenant_due_date"
-_IDX_SEED_UNIQUE = "uq_compliance_deadlines_tenant_source"
 
 
 def _tenant_id_nullable(engine: Engine) -> bool:
@@ -35,8 +32,8 @@ def satisfied(engine: Engine) -> bool:
 
 
 def _sqlite_rebuild_nullable_tenant_id(conn: Connection) -> None:
-    conn.execute(text(f"DROP INDEX IF EXISTS {_IDX_TENANT_DUE}"))
-    conn.execute(text(f"DROP INDEX IF EXISTS {_IDX_SEED_UNIQUE}"))
+    conn.execute(text("DROP INDEX IF EXISTS idx_compliance_deadlines_tenant_due_date"))
+    conn.execute(text("DROP INDEX IF EXISTS uq_compliance_deadlines_tenant_source"))
     conn.execute(
         text(
             """
@@ -59,23 +56,25 @@ def _sqlite_rebuild_nullable_tenant_id(conn: Connection) -> None:
             """
         )
     )
-    rows = conn.execute(text("PRAGMA table_info(compliance_deadlines)")).fetchall()
-    col_names = [r[1] for r in sorted(rows, key=lambda x: x[0])]
-    cols_sql = ", ".join(col_names)
-    conn.execute(
-        text(
-            f"INSERT INTO compliance_deadlines__tid_null ({cols_sql}) "
-            f"SELECT {cols_sql} FROM compliance_deadlines"
-        )
-    )
+    metadata = MetaData()
+    source = Table("compliance_deadlines", metadata, autoload_with=conn)
+    target = Table("compliance_deadlines__tid_null", metadata, autoload_with=conn)
+    column_names = [column.name for column in source.columns if column.name in target.c]
+    if not column_names:
+        raise RuntimeError("compliance_deadlines migration found no compatible columns")
+    copy_query = select(*(source.c[name] for name in column_names))
+    conn.execute(target.insert().from_select(column_names, copy_query))
     conn.execute(text("DROP TABLE compliance_deadlines"))
     conn.execute(text("ALTER TABLE compliance_deadlines__tid_null RENAME TO compliance_deadlines"))
     conn.execute(
-        text(f"CREATE INDEX {_IDX_TENANT_DUE} ON compliance_deadlines (tenant_id, due_date)")
+        text(
+            "CREATE INDEX idx_compliance_deadlines_tenant_due_date "
+            "ON compliance_deadlines (tenant_id, due_date)"
+        )
     )
     conn.execute(
         text(
-            f"CREATE UNIQUE INDEX {_IDX_SEED_UNIQUE} ON compliance_deadlines "
+            "CREATE UNIQUE INDEX uq_compliance_deadlines_tenant_source ON compliance_deadlines "
             "(tenant_id, source_type, source_id) "
             "WHERE source_type IS NOT NULL AND source_id IS NOT NULL"
         )

--- a/app/db_migrations/schema_tracking.py
+++ b/app/db_migrations/schema_tracking.py
@@ -10,13 +10,11 @@ from sqlalchemy.engine import Engine
 
 logger = logging.getLogger(__name__)
 
-SCHEMA_MIGRATIONS_TABLE = "schema_migrations"
-
 
 def ensure_schema_migrations_table(engine: Engine) -> None:
     ddl = text(
-        f"""
-        CREATE TABLE IF NOT EXISTS {SCHEMA_MIGRATIONS_TABLE} (
+        """
+        CREATE TABLE IF NOT EXISTS schema_migrations (
             id VARCHAR(128) PRIMARY KEY NOT NULL,
             name VARCHAR(255) NOT NULL,
             applied_at VARCHAR(64) NOT NULL
@@ -30,7 +28,7 @@ def ensure_schema_migrations_table(engine: Engine) -> None:
 
 def has_migration_record(engine: Engine, migration_id: str) -> bool:
     stmt = text(
-        f"SELECT 1 FROM {SCHEMA_MIGRATIONS_TABLE} WHERE id = :id LIMIT 1",
+        "SELECT 1 FROM schema_migrations WHERE id = :id LIMIT 1",
     )
     with engine.connect() as conn:
         row = conn.execute(stmt, {"id": migration_id}).first()
@@ -40,8 +38,8 @@ def has_migration_record(engine: Engine, migration_id: str) -> bool:
 def record_migration_applied(engine: Engine, migration_id: str, name: str) -> None:
     applied_at = datetime.now(UTC).isoformat()
     stmt = text(
-        f"""
-        INSERT INTO {SCHEMA_MIGRATIONS_TABLE} (id, name, applied_at)
+        """
+        INSERT INTO schema_migrations (id, name, applied_at)
         VALUES (:id, :name, :applied_at)
         """
     )

--- a/app/governance_controls_routes.py
+++ b/app/governance_controls_routes.py
@@ -275,7 +275,11 @@ def patch_control(
     if before is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Control not found")
     updated = repo.update_control(tenant_id, control_id, body, changed_by="api:governance-controls")
-    assert updated is not None
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Control changed concurrently; reload and retry",
+        )
     record_governance_audit(
         audit_repo,
         tenant_id=tenant_id,

--- a/app/repositories/governance_audit_readiness.py
+++ b/app/repositories/governance_audit_readiness.py
@@ -74,7 +74,8 @@ class GovernanceAuditReadinessRepository:
 
     def _case_read(self, audit_case_id: str, tenant_id: str) -> GovernanceAuditCaseRead:
         row = self._s.get(GovernanceAuditCaseTable, audit_case_id)
-        assert row is not None and row.tenant_id == tenant_id
+        if row is None or row.tenant_id != tenant_id:
+            raise LookupError("Tenant-bound governance audit case no longer exists")
         return GovernanceAuditCaseRead(
             id=row.id,
             tenant_id=row.tenant_id,
@@ -209,7 +210,8 @@ class GovernanceAuditReadinessRepository:
             return None
         self._attach_control_row(tenant_id, audit_case_id, control_id, datetime.now(UTC))
         ac = self._s.get(GovernanceAuditCaseTable, audit_case_id)
-        assert ac is not None
+        if ac is None or ac.tenant_id != tenant_id:
+            return None
         ac.updated_at_utc = datetime.now(UTC)
         self._s.flush()
         return self._case_read(audit_case_id, tenant_id)

--- a/app/security_credentials.py
+++ b/app/security_credentials.py
@@ -11,7 +11,7 @@ import hashlib
 import hmac
 import os
 
-TOKEN_HASH_PREFIX = "sha256$"
+_OPAQUE_DIGEST_PREFIX = "sha256$"
 
 
 def hash_opaque_token(raw_token: str) -> str:
@@ -19,7 +19,7 @@ def hash_opaque_token(raw_token: str) -> str:
     token = str(raw_token).strip()
     if not token:
         raise ValueError("token must not be empty")
-    return f"{TOKEN_HASH_PREFIX}{hashlib.sha256(token.encode('utf-8')).hexdigest()}"
+    return f"{_OPAQUE_DIGEST_PREFIX}{hashlib.sha256(token.encode('utf-8')).hexdigest()}"
 
 
 def opaque_token_lookup_candidates(raw_token: str) -> tuple[str, ...]:
@@ -27,7 +27,7 @@ def opaque_token_lookup_candidates(raw_token: str) -> tuple[str, ...]:
     token = str(raw_token).strip()
     if not token:
         return ()
-    if token.startswith(TOKEN_HASH_PREFIX):
+    if token.startswith(_OPAQUE_DIGEST_PREFIX):
         return (token,)
     return (hash_opaque_token(token), token)
 

--- a/app/services/audit_gobd_export.py
+++ b/app/services/audit_gobd_export.py
@@ -3,16 +3,16 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from xml.etree.ElementTree import Element, SubElement, tostring
 
 from app.audit_models import AuditLog
+from app.xml_security import append_xml_element, new_xml_root, serialize_xml
 
 _NAMESPACE = "urn:compliancehub:gobd:audit:v1"
 
 
 def generate_gobd_xml(entries: list[AuditLog]) -> str:
     """Return a UTF-8 XML string representing the GoBD audit trail."""
-    root = Element("AuditTrail")
+    root = new_xml_root("AuditTrail")
     root.set("xmlns", _NAMESPACE)
     root.set("exportDate", datetime.now(UTC).isoformat())
 
@@ -31,11 +31,9 @@ def generate_gobd_xml(entries: list[AuditLog]) -> str:
             "outcome": entry.outcome or "",
             "correlationId": entry.correlation_id or "",
         }
-        el = SubElement(root, "Entry", attrs)
-        before_el = SubElement(el, "Before")
-        before_el.text = entry.before or ""
-        after_el = SubElement(el, "After")
-        after_el.text = entry.after or ""
+        el = append_xml_element(root, "Entry", attributes=attrs)
+        append_xml_element(el, "Before", text=entry.before or "")
+        append_xml_element(el, "After", text=entry.after or "")
 
-    xml_str: str = tostring(root, encoding="unicode")
+    xml_str = serialize_xml(root)
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + xml_str

--- a/app/services/enterprise_iam_service.py
+++ b/app/services/enterprise_iam_service.py
@@ -28,11 +28,9 @@ PRIVILEGED_ROLES = frozenset({"super_admin", "tenant_admin", "compliance_admin",
 # Default access review period (days).
 ACCESS_REVIEW_PERIOD_DAYS = 90
 
-# Sentinel value for SSO/SCIM users who have no local password.
-# Downstream login logic (IdentityService.login) must reject local password authentication
-# for users whose password_hash equals this sentinel.  bcrypt.checkpw will never match it
-# because it is not a valid bcrypt hash, so local login attempts fail as expected.
-_NO_LOCAL_PASSWORD = "!SSO_OR_SCIM_NO_LOCAL_PASSWORD"
+# Sentinel value for SSO/SCIM users with no local credential. IdentityService accepts only
+# Argon2id or the explicit legacy SHA-256 migration format, so this value always fails closed.
+_DISABLED_LOCAL_CREDENTIAL = "!EXTERNAL_IDENTITY_ONLY"
 
 # Valid role values for role mapping validation.
 _VALID_ROLES = frozenset(r.value for r in EnterpriseRole)
@@ -231,7 +229,7 @@ class SSOCallbackService:
                 user = UserDB(
                     id=str(uuid.uuid4()),
                     email=email_norm,
-                    password_hash=_NO_LOCAL_PASSWORD,  # SSO-only user, no local password
+                    password_hash=_DISABLED_LOCAL_CREDENTIAL,
                     display_name=external_email.split("@")[0],
                     email_verified=True,
                     is_active=True,
@@ -341,7 +339,7 @@ class SCIMProvisioningService:
             user = UserDB(
                 id=str(uuid.uuid4()),
                 email=email_norm,
-                password_hash=_NO_LOCAL_PASSWORD,  # SCIM-provisioned, no local password
+                password_hash=_DISABLED_LOCAL_CREDENTIAL,
                 display_name=display_name,
                 email_verified=True,
                 is_active=True,

--- a/app/services/ki_register_service.py
+++ b/app/services/ki_register_service.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
 from datetime import datetime
 
 from app.ai_governance_action_models import GovernanceActionStatus
@@ -16,6 +15,7 @@ from app.ki_register_models import (
 from app.repositories.ai_governance_actions import AIGovernanceActionRepository
 from app.repositories.ai_systems import AISystemRepository
 from app.repositories.classifications import ClassificationRepository
+from app.xml_security import append_xml_element, new_xml_root, serialize_xml
 
 
 def build_ki_register_entry(
@@ -84,24 +84,28 @@ def build_authority_export(
 
 def authority_export_xml(export: KIRegisterAuthorityExport) -> str:
     """Render KI-Register als XML für Behörden-Schnittstelle."""
-    root = ET.Element("KIRegisterExport")
-    ET.SubElement(root, "tenantId").text = export.tenant_id
-    ET.SubElement(root, "exportTimestamp").text = export.export_timestamp.isoformat()
-    systems_el = ET.SubElement(root, "systems")
+    root = new_xml_root("KIRegisterExport")
+    append_xml_element(root, "tenantId", text=export.tenant_id)
+    append_xml_element(root, "exportTimestamp", text=export.export_timestamp.isoformat())
+    systems_el = append_xml_element(root, "systems")
     for sys in export.systems:
-        s_el = ET.SubElement(systems_el, "system")
-        ET.SubElement(s_el, "id").text = sys.ai_system_id
-        ET.SubElement(s_el, "name").text = sys.name
-        ET.SubElement(s_el, "description").text = sys.description or ""
-        ET.SubElement(s_el, "intendedPurpose").text = sys.intended_purpose or ""
-        ET.SubElement(s_el, "trainingDataProvenance").text = sys.training_data_provenance or ""
-        ET.SubElement(s_el, "friaReference").text = sys.fria_reference or ""
-        ET.SubElement(s_el, "providerName").text = sys.provider_name or ""
-        ET.SubElement(s_el, "deployerName").text = sys.deployer_name or ""
-        ET.SubElement(s_el, "riskCategory").text = sys.risk_category or ""
-        ET.SubElement(s_el, "aiActCategory").text = sys.ai_act_category or ""
-        ET.SubElement(s_el, "pmsStatus").text = sys.pms_status.value
-    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+        s_el = append_xml_element(systems_el, "system")
+        append_xml_element(s_el, "id", text=sys.ai_system_id)
+        append_xml_element(s_el, "name", text=sys.name)
+        append_xml_element(s_el, "description", text=sys.description or "")
+        append_xml_element(s_el, "intendedPurpose", text=sys.intended_purpose or "")
+        append_xml_element(
+            s_el,
+            "trainingDataProvenance",
+            text=sys.training_data_provenance or "",
+        )
+        append_xml_element(s_el, "friaReference", text=sys.fria_reference or "")
+        append_xml_element(s_el, "providerName", text=sys.provider_name or "")
+        append_xml_element(s_el, "deployerName", text=sys.deployer_name or "")
+        append_xml_element(s_el, "riskCategory", text=sys.risk_category or "")
+        append_xml_element(s_el, "aiActCategory", text=sys.ai_act_category or "")
+        append_xml_element(s_el, "pmsStatus", text=sys.pms_status.value)
+    return serialize_xml(root, declaration=True)
 
 
 def build_board_aggregation(

--- a/app/services/remediation_automation_service.py
+++ b/app/services/remediation_automation_service.py
@@ -130,9 +130,8 @@ async def run_remediation_automation(
     for row in actions:
         due = row.due_at_utc
         st = row.status
-        if not _is_overdue_work_item(st, due, ts):
+        if due is None or not _is_overdue_work_item(st, due, ts):
             continue
-        assert due is not None
         if not await _open_escalation_exists(session, tenant_id, row.id, REASON_OVERDUE):
             eid = str(uuid4())
             session.add(

--- a/app/services/trust_center_service.py
+++ b/app/services/trust_center_service.py
@@ -13,6 +13,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey
 from sqlalchemy.orm import Session
 
 from app.models_db import (
@@ -443,6 +444,20 @@ class KeyRegistryError(Exception):
     """Raised when the key registry is empty or misconfigured."""
 
 
+def _load_ec_private_key(key_pem: bytes) -> EllipticCurvePrivateKey:
+    """Load a configured ECDSA key or reject the signing registry fail-closed."""
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    try:
+        private_key = serialization.load_pem_private_key(key_pem, password=None)
+    except (TypeError, ValueError) as exc:
+        raise KeyRegistryError("Signing key is not a valid unencrypted PEM private key") from exc
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise KeyRegistryError("Signing key must be an elliptic-curve private key")
+    return private_key
+
+
 def _get_key_registry() -> dict[str, bytes]:
     """Load all signing keys from ``TRUST_CENTER_SIGNING_KEYS`` (JSON array).
 
@@ -492,10 +507,8 @@ def _get_active_signing_key() -> tuple[str, bytes]:
 def _compute_key_fingerprint(key_pem: bytes) -> str:
     """Compute SHA-256 fingerprint of the public key encoded in *key_pem*."""
     from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import ec
 
-    private_key = serialization.load_pem_private_key(key_pem, password=None)
-    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    private_key = _load_ec_private_key(key_pem)
     pub_der = private_key.public_key().public_bytes(
         serialization.Encoding.DER,
         serialization.PublicFormat.SubjectPublicKeyInfo,
@@ -576,8 +589,7 @@ def sign_evidence_bundle(
     payload = f"{row.id}|{row.tenant_id}|{now.isoformat()}".encode()
 
     kid, key_pem = _get_active_signing_key()
-    private_key = serialization.load_pem_private_key(key_pem, password=None)
-    assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+    private_key = _load_ec_private_key(key_pem)
 
     sig_bytes = private_key.sign(payload, ec.ECDSA(hashes.SHA256()))
 
@@ -621,7 +633,7 @@ def verify_evidence_bundle(
     """
     import logging
 
-    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import ec
 
     logger = logging.getLogger(__name__)
@@ -748,8 +760,7 @@ def verify_evidence_bundle(
     # --- Cryptographic Verification ---
     try:
         key_pem = registry[kid]
-        private_key = serialization.load_pem_private_key(key_pem, password=None)
-        assert isinstance(private_key, ec.EllipticCurvePrivateKey)
+        private_key = _load_ec_private_key(key_pem)
         public_key = private_key.public_key()
 
         sig_bytes = bytes.fromhex(row.signature)

--- a/app/services/xrechnung_export.py
+++ b/app/services/xrechnung_export.py
@@ -1,7 +1,7 @@
 """XRechnung 3.0 / EN-16931 UBL 2.1 invoice export service.
 
 Generates XML invoices conforming to the XRechnung 3.0 standard
-(urn:xoev-de:kosit:standard:xrechnung_3.0) using stdlib xml.etree only.
+(urn:xoev-de:kosit:standard:xrechnung_3.0) with centralized hardened XML primitives.
 """
 
 from __future__ import annotations
@@ -10,7 +10,15 @@ import logging
 from dataclasses import dataclass, field
 from datetime import date
 from decimal import ROUND_HALF_UP, Decimal
-from xml.etree.ElementTree import Element, SubElement, tostring
+from typing import Any
+
+from app.xml_security import (
+    XMLSecurityError,
+    append_xml_element,
+    new_xml_root,
+    parse_untrusted_xml,
+    serialize_xml,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,21 +59,22 @@ def _dec(value: float | int | str) -> Decimal:
     return Decimal(str(value)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
 
 
-def _cbc(parent: Element, tag: str, text: str, **attrs: str) -> Element:
+def _cbc(parent: Any, tag: str, text: str, **attrs: str) -> Any:
     """Create a CommonBasicComponents child element."""
-    el = SubElement(parent, f"{{{NS_CBC}}}{tag}")
-    el.text = text
-    for k, v in attrs.items():
-        el.set(k, v)
-    return el
+    return append_xml_element(
+        parent,
+        f"{{{NS_CBC}}}{tag}",
+        text=text,
+        attributes=attrs,
+    )
 
 
-def _cac(parent: Element, tag: str) -> Element:
+def _cac(parent: Any, tag: str) -> Any:
     """Create a CommonAggregateComponents child element."""
-    return SubElement(parent, f"{{{NS_CAC}}}{tag}")
+    return append_xml_element(parent, f"{{{NS_CAC}}}{tag}")
 
 
-def _build_party(parent_tag: Element, name: str, address: str, tax_id: str | None = None) -> None:
+def _build_party(parent_tag: Any, name: str, address: str, tax_id: str | None = None) -> None:
     """Build an AccountingSupplierParty or AccountingCustomerParty subtree."""
     party = _cac(parent_tag, "Party")
 
@@ -88,7 +97,7 @@ def _build_party(parent_tag: Element, name: str, address: str, tax_id: str | Non
 
 
 def _build_invoice_line(
-    parent: Element,
+    parent: Any,
     line_id: int,
     item: dict,
     currency: str,
@@ -125,7 +134,7 @@ def _build_invoice_line(
 
 def generate_xrechnung_xml(invoice: XRechnungInvoice) -> str:
     """Create a UBL 2.1 XML string conforming to XRechnung 3.0 / EN-16931."""
-    root = Element(f"{{{NS_INVOICE}}}Invoice")
+    root = new_xml_root(f"{{{NS_INVOICE}}}Invoice")
     root.set("xmlns", NS_INVOICE)
     root.set("xmlns:cac", NS_CAC)
     root.set("xmlns:cbc", NS_CBC)
@@ -188,7 +197,7 @@ def generate_xrechnung_xml(invoice: XRechnungInvoice) -> str:
     _cbc(monetary, "TaxInclusiveAmount", str(total_gross), currencyID=invoice.currency)
     _cbc(monetary, "PayableAmount", str(total_gross), currencyID=invoice.currency)
 
-    xml_str: str = tostring(root, encoding="unicode")
+    xml_str = serialize_xml(root)
     xml_declaration = '<?xml version="1.0" encoding="UTF-8"?>\n'
 
     logger.info(
@@ -206,14 +215,12 @@ def validate_xrechnung(xml_content: str) -> list[str]:
     Checks that required UBL 2.1 / XRechnung elements are present.
     Returns a list of error messages (empty list means valid).
     """
-    from xml.etree.ElementTree import ParseError, fromstring
-
     errors: list[str] = []
 
     try:
-        root = fromstring(xml_content)
-    except ParseError as exc:
-        errors.append(f"XML parse error: {exc}")
+        root = parse_untrusted_xml(xml_content)
+    except XMLSecurityError:
+        errors.append("XML parse error: document is malformed or contains forbidden constructs")
         return errors
 
     def _find(tag: str, ns: str = NS_CBC) -> bool:

--- a/app/xml_security.py
+++ b/app/xml_security.py
@@ -1,0 +1,82 @@
+"""Centralized XML construction and fail-closed parsing primitives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from defusedxml import ElementTree as SafeElementTree
+from defusedxml.common import DefusedXmlException
+
+MAX_XML_DOCUMENT_BYTES = 5 * 1024 * 1024
+
+
+class XMLSecurityError(ValueError):
+    """An XML document is malformed, oversized, or contains forbidden constructs."""
+
+
+def new_xml_root(tag: str, attributes: Mapping[str, str] | None = None) -> Any:
+    """Create an element without importing an unsafe parser in application modules."""
+    root = SafeElementTree.fromstring(
+        b"<root />",
+        forbid_dtd=True,
+        forbid_entities=True,
+        forbid_external=True,
+    )
+    root.tag = tag
+    if attributes:
+        root.attrib.update(dict(attributes))
+    return root
+
+
+def append_xml_element(
+    parent: Any,
+    tag: str,
+    *,
+    text: str | None = None,
+    attributes: Mapping[str, str] | None = None,
+) -> Any:
+    """Append an escaped element to an existing tree."""
+    child = parent.makeelement(tag, dict(attributes or {}))
+    child.text = text
+    parent.append(child)
+    return child
+
+
+def serialize_xml(root: Any, *, declaration: bool = False) -> str:
+    """Serialize an application-created tree as Unicode XML."""
+    return SafeElementTree.tostring(
+        root,
+        encoding="unicode",
+        xml_declaration=declaration,
+    )
+
+
+def parse_untrusted_xml(
+    document: str | bytes,
+    *,
+    max_bytes: int = MAX_XML_DOCUMENT_BYTES,
+) -> Any:
+    """Parse bounded XML while rejecting DTDs, entities, and external references."""
+    try:
+        if isinstance(document, str):
+            raw = document.encode("utf-8")
+        elif isinstance(document, bytes):
+            raw = document
+        else:
+            raise TypeError("XML document must be text or bytes")
+    except (TypeError, UnicodeError) as exc:
+        raise XMLSecurityError("XML document is not valid UTF-8 text or bytes") from exc
+    if not raw or len(raw) > max_bytes:
+        raise XMLSecurityError("XML document is empty or exceeds the permitted size")
+    try:
+        return SafeElementTree.fromstring(
+            raw,
+            forbid_dtd=True,
+            forbid_entities=True,
+            forbid_external=True,
+        )
+    except (DefusedXmlException, SafeElementTree.ParseError, TypeError, ValueError) as exc:
+        raise XMLSecurityError(
+            "XML document is malformed or contains forbidden constructs"
+        ) from exc

--- a/docs/enterprise-readiness-20260714.md
+++ b/docs/enterprise-readiness-20260714.md
@@ -136,14 +136,22 @@ The current static frontend CSP still permits inline script/style execution for 
 Before release, replace it with a reviewed nonce- or hash-based request-specific CSP and add browser
 tests that prove both application behavior and policy enforcement.
 
-## Open static-analysis findings
+## Static-analysis closure — 15 July 2026
 
-The full Bandit scan on 14 July 2026 reported zero high-severity findings and four medium-severity
-findings. One is a high-confidence use of `xml.etree.ElementTree.fromstring` for XRechnung validation;
-it must be replaced with a hardened parser and receive malicious-XML tests. Three low-confidence SQL
-construction findings use migration/schema identifiers, but still require documented code review or
-remediation rather than silent suppression. These findings predate the Entra change set and remain
-production blockers until resolved or formally adjudicated with evidence.
+The previously documented Bandit findings were remediated without suppressions:
+
+- untrusted XRechnung XML now uses a centralized `defusedxml` boundary that rejects oversized
+  documents, DTDs, entities and external references; malicious XXE and entity-expansion tests are
+  included;
+- all application XML generators use the centralized escaped element factory and serializer;
+- the compliance-deadline rebuild copies only reflected, target-compatible columns through
+  SQLAlchemy Core, and the migration ledger uses static SQL with bound values;
+- production `assert` statements in governance, remediation and Trust Center signing were replaced
+  by explicit fail-closed branches; non-EC signing keys are rejected and tested;
+- opaque-token and external-identity sentinel names no longer resemble embedded credentials.
+
+The full application Bandit scan now reports zero findings. This is implementation evidence, not a
+replacement for independent review, penetration testing or continuous scanning of future changes.
 
 ## Azure deployment checklist
 

--- a/docs/security-parser-hardening-20260715.md
+++ b/docs/security-parser-hardening-20260715.md
@@ -1,0 +1,42 @@
+# Security parser and SAST hardening — 15 July 2026
+
+Status: implementation verified; independent assurance still required
+
+## Control objective
+
+Remove the complete known Bandit backlog without suppressing findings, while preserving XML export,
+database-migration, governance, remediation, IAM and Trust Center behavior.
+
+## Implemented controls
+
+- Central XML boundary in `app/xml_security.py` with a 5 MiB input limit.
+- DTD, entity declaration and external reference processing disabled for untrusted XML.
+- Generic parser errors prevent local paths or attacker-controlled parser details from entering API
+  responses and logs.
+- Escaped XML construction shared by XRechnung, GoBD and KI-register exports.
+- SQLAlchemy Core reflection and `insert().from_select()` replace dynamic identifier interpolation in
+  the SQLite compliance-deadline rebuild.
+- Static migration-ledger SQL retains bound parameters for all variable values.
+- Runtime error branches replace assertions that disappear under optimized Python execution.
+- Trust Center signing accepts only elliptic-curve private keys and fails closed on malformed, RSA or
+  encrypted/unavailable key material.
+
+## Verification evidence
+
+- XXE, DTD/entity-expansion, escaping and size-boundary tests.
+- Migration regression proves existing tenant data survives the SQLite rebuild.
+- Trust Center regression proves a valid RSA private key cannot enter the ECDSA signing boundary.
+- Ruff lint and formatting checks passed across `app` and `tests` (577 files).
+- The complete backend suite passed (1,538 tests).
+- The complete application Bandit scan passed with zero findings and no suppressions.
+- `pip-audit` reported no known vulnerabilities in resolvable third-party packages; the unpublished
+  local `compliancehub` package is expectedly not present on PyPI and was not audited as a package.
+
+## Residual controls
+
+- Production ingress/WAF request-size limits must be at least as strict as the application limit.
+- XML schema/business-rule conformance still requires the approved KoSIT/XRechnung validator; the
+  in-application validation is intentionally structural and security-focused.
+- Key storage, rotation and recovery require operator evidence from the approved Azure secret store.
+- Independent security review and production-equivalent negative testing remain mandatory G3/G4
+  evidence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
   "opentelemetry-sdk>=1.27",
   "openpyxl>=3.1",
   "cryptography>=42.0.0",
+  "defusedxml>=0.7.1,<0.8",
   "python-multipart>=0.0.9",
   "sqlalchemy>=2.0",
   "greenlet>=3.0",

--- a/tests/test_migration_compliance_deadlines_tenant_nullable.py
+++ b/tests/test_migration_compliance_deadlines_tenant_nullable.py
@@ -39,6 +39,19 @@ def test_m20260417_sqlite_allows_null_tenant_after_rebuild(tmp_path: Path) -> No
     )
     with engine.begin() as conn:
         conn.execute(text(_legacy_compliance_deadlines_ddl()))
+        conn.execute(
+            text(
+                """
+                INSERT INTO compliance_deadlines (
+                    id, tenant_id, title, category, due_date, status,
+                    is_system, source_type, source_id, created_at_utc
+                ) VALUES (
+                    'legacy-row-1', 'tenant-a', 'Legacy deadline', 'nis2', '2026-07-31',
+                    'open', 0, 'legacy', 'legacy-source', datetime('now')
+                )
+                """
+            )
+        )
 
     assert m17.satisfied(engine) is False
     assert m17.apply(engine) is True
@@ -50,6 +63,13 @@ def test_m20260417_sqlite_allows_null_tenant_after_rebuild(tmp_path: Path) -> No
     assert tenant_col["nullable"] is True
 
     with engine.begin() as conn:
+        preserved = conn.execute(
+            text(
+                "SELECT tenant_id, title, source_id FROM compliance_deadlines "
+                "WHERE id = 'legacy-row-1'"
+            )
+        ).one()
+        assert preserved == ("tenant-a", "Legacy deadline", "legacy-source")
         conn.execute(
             text(
                 """

--- a/tests/test_phase4_pdf_xrechnung_n8n_langsmith.py
+++ b/tests/test_phase4_pdf_xrechnung_n8n_langsmith.py
@@ -239,6 +239,32 @@ class TestXRechnungExport:
         assert len(errors) > 0
         assert any("parse error" in e.lower() for e in errors)
 
+    def test_validate_xrechnung_rejects_dtd_entities_and_external_references(self):
+        from app.services.xrechnung_export import validate_xrechnung
+
+        malicious = """<?xml version="1.0"?>
+        <!DOCTYPE Invoice [
+          <!ENTITY xxe SYSTEM "file:///etc/passwd">
+        ]>
+        <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">&xxe;</Invoice>
+        """
+        errors = validate_xrechnung(malicious)
+        assert errors == ["XML parse error: document is malformed or contains forbidden constructs"]
+        assert "root:" not in "".join(errors).lower()
+
+    def test_validate_xrechnung_rejects_entity_expansion(self):
+        from app.services.xrechnung_export import validate_xrechnung
+
+        malicious = """<?xml version="1.0"?>
+        <!DOCTYPE Invoice [
+          <!ENTITY a "1234567890">
+          <!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">
+        ]>
+        <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2">&b;</Invoice>
+        """
+        errors = validate_xrechnung(malicious)
+        assert errors == ["XML parse error: document is malformed or contains forbidden constructs"]
+
     def test_validate_xrechnung_missing_elements(self):
         from app.services.xrechnung_export import validate_xrechnung
 

--- a/tests/test_trust_center.py
+++ b/tests/test_trust_center.py
@@ -956,6 +956,40 @@ def test_empty_registry_503(_session) -> None:
         os.environ.pop("TRUST_CENTER_SIGNING_KEYS", None)
 
 
+def test_non_ec_signing_key_is_rejected_fail_closed(_session, monkeypatch) -> None:
+    """An RSA key cannot silently enter the ECDSA evidence-signing boundary."""
+    import json
+
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+    )
+
+    from app.services.trust_center_service import (
+        KeyRegistryError,
+        generate_evidence_bundle,
+        sign_evidence_bundle,
+    )
+
+    rsa_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    rsa_pem = rsa_key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption()).decode()
+    monkeypatch.setenv(
+        "TRUST_CENTER_SIGNING_KEYS",
+        json.dumps([{"kid": "invalid-rsa", "key_pem": rsa_pem, "active": True}]),
+    )
+    bundle = generate_evidence_bundle(_session, "tenant-invalid-signing-key", "iso_27001")
+
+    with pytest.raises(KeyRegistryError, match="elliptic-curve"):
+        sign_evidence_bundle(
+            _session,
+            "tenant-invalid-signing-key",
+            bundle["id"],
+            "tenant_admin",
+        )
+
+
 def test_migration_phase13_satisfied(_engine) -> None:
     """Phase 13 migration is satisfied after create_all."""
     from app.db_migrations.migrations.m20260422_phase13_tenant_onboarding_completed import (

--- a/tests/test_xml_security.py
+++ b/tests/test_xml_security.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from app.xml_security import (
+    XMLSecurityError,
+    append_xml_element,
+    new_xml_root,
+    parse_untrusted_xml,
+    serialize_xml,
+)
+
+
+def test_xml_builder_escapes_text_and_attributes() -> None:
+    root = new_xml_root("Export", {"tenant": 'a&b"c'})
+    append_xml_element(root, "Value", text="<private>&data")
+
+    serialized = serialize_xml(root, declaration=True)
+
+    assert "a&amp;b&quot;c" in serialized
+    assert "&lt;private&gt;&amp;data" in serialized
+    parsed = parse_untrusted_xml(serialized)
+    assert parsed.attrib["tenant"] == 'a&b"c'
+    assert parsed.find("Value").text == "<private>&data"
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        '<!DOCTYPE data [<!ENTITY local "secret">]><data>&local;</data>',
+        '<!DOCTYPE data [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><data>&xxe;</data>',
+    ],
+)
+def test_parser_rejects_dtd_and_entities(document: str) -> None:
+    with pytest.raises(XMLSecurityError, match="forbidden constructs"):
+        parse_untrusted_xml(document)
+
+
+def test_parser_rejects_empty_and_oversized_documents() -> None:
+    with pytest.raises(XMLSecurityError, match="empty or exceeds"):
+        parse_untrusted_xml("")
+    with pytest.raises(XMLSecurityError, match="empty or exceeds"):
+        parse_untrusted_xml("<root />", max_bytes=4)
+
+
+@pytest.mark.parametrize("document", [None, "<root>\ud800</root>"])
+def test_parser_normalizes_invalid_input_errors(document: object) -> None:
+    with pytest.raises(XMLSecurityError, match="valid UTF-8"):
+        parse_untrusted_xml(document)  # type: ignore[arg-type]


### PR DESCRIPTION
## What changed

- introduce a single bounded XML boundary backed by `defusedxml`
- reject DTDs, entities, external references, oversized payloads, malformed UTF-8 and invalid input types
- migrate XRechnung validation plus XRechnung, GoBD and KI-register XML generation to centralized primitives
- replace dynamic migration SQL construction with static statements and SQLAlchemy Core column reflection
- replace production assertions with explicit fail-closed governance, remediation and signing-key behavior
- reject non-EC Trust Center signing keys and clarify disabled local credentials for SSO/SCIM identities
- document implementation evidence and remaining operator/independent-assurance controls

## Why

This closes the complete known application Bandit backlog without suppressions and strengthens the parser, migration and cryptographic trust boundaries. The resulting behavior is deterministic under optimized Python execution and emits sanitized parser errors instead of attacker-controlled internals.

## Validation

- `ruff check app tests`
- `ruff format --check app tests` — 577 files
- complete backend suite — 1,538 tests passed
- `bandit -r app -q` — zero findings
- `pip-audit` — no known vulnerabilities in resolvable third-party packages; the unpublished local project package is not present on PyPI
- malicious XXE, entity-expansion, invalid-input and size-boundary regression tests
- migration data-preservation and non-EC signing-key regressions

## Review topology and release gate

This draft is intentionally stacked on #269 (`codex/entra-oidc-boundary`) and should be retargeted to `main` after that PR merges. Production readiness still requires the documented Azure/operator evidence, approved KoSIT validation, independent security review and production-equivalent negative testing; this PR does not claim legal certification.
