### PR TITLE
feat: enforce nonce CSP and warning-free runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Bestehende SQLite-/Postgres-Datenbanken: additive Schema-Updates (z. B. neue O
 - `docs/enterprise-readiness-20260714.md` (Audit, umgesetzte Kontrollen, Release-Blocker)
 - `docs/enterprise-entra-oidc-runbook.md` (Entra-OIDC-Konfiguration, Betrieb und Release-Evidenz)
 - `docs/security-parser-hardening-20260715.md` (XML-, SQL-, Signatur- und SAST-Hardening)
+- `docs/security-csp-hardening-20260715.md` (Nonce-CSP, Browser-Evidenz, Runtime-I/O-Grenze)
 - `docs/architecture.md`
 - `docs/db-migrations.md` (additive Schema-Updates neben `create_all`)
 - `docs/product-strategy.md`

--- a/app/governance_workflow_routes.py
+++ b/app/governance_workflow_routes.py
@@ -275,7 +275,7 @@ async def patch_workflow_task(
     except ValueError as e:
         if e.args and e.args[0] == "invalid_workflow_task_status":
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="Invalid workflow task status. Allowed: open, in_progress, done, "
                 "cancelled, escalated",
             ) from e

--- a/app/main.py
+++ b/app/main.py
@@ -1586,7 +1586,7 @@ def post_nis2_kritis_kpi_suggestions(
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
     except llm_client_mod.LLMConfigurationError as exc:
@@ -4930,7 +4930,7 @@ def post_tenant_ai_system_kpi(
         )
     except ValueError as exc:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail=str(exc),
         ) from exc
 
@@ -8873,7 +8873,7 @@ def create_datev_extf_export(
 
     errors = validate_records(records)
     if errors:
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=errors)
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=errors)
 
     content = render_extf_export(
         records,
@@ -9146,7 +9146,7 @@ def create_xrechnung_export(
 
     if errors:
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
             detail={"validation_errors": errors},
         )
 

--- a/docs/enterprise-readiness-20260714.md
+++ b/docs/enterprise-readiness-20260714.md
@@ -132,9 +132,16 @@ residual-risk record. Production remains blocked until every item is closed.
     the same immutable release-evidence package. Re-run tests and scanning against the release commit
     and production configuration.
 
-The current static frontend CSP still permits inline script/style execution for Next.js compatibility.
-Before release, replace it with a reviewed nonce- or hash-based request-specific CSP and add browser
-tests that prove both application behavior and policy enforcement.
+## Frontend CSP closure — 15 July 2026
+
+The static frontend CSP was replaced by a request-specific nonce policy. Production no longer permits
+`unsafe-inline` or `unsafe-eval`; script and style attributes are explicitly blocked, nonce responses
+are non-cacheable, redirects retain the policy and a prebuild source gate prevents regression. All
+application React inline styles were migrated to static CSS or SVG geometry. Production-mode browser
+verification proved nonce uniqueness, framework nonce propagation, navigation and active rejection
+of an injected inline style without console or page errors. Detailed evidence and residual controls
+are recorded in `docs/security-csp-hardening-20260715.md`. A privacy-reviewed CSP-reporting pipeline
+and independent production-equivalent verification remain release requirements.
 
 ## Static-analysis closure — 15 July 2026
 

--- a/docs/security-csp-hardening-20260715.md
+++ b/docs/security-csp-hardening-20260715.md
@@ -1,0 +1,59 @@
+# Frontend CSP and runtime-boundary hardening — 15 July 2026
+
+Status: implementation and local production-browser verification complete; deployed review and
+independent assurance still required
+
+## Control objective
+
+Replace the static frontend policy that allowed inline script and style execution with a
+request-specific, fail-closed CSP, remove the two known Starlette/FastAPI deprecations at source and
+prevent mutable runtime files from entering Next.js output traces.
+
+## Implemented controls
+
+- Every matched request receives a fresh base64 nonce generated from `crypto.randomUUID()`.
+- The same nonce is forwarded to Next.js through request headers and returned in the response CSP,
+  allowing Next.js to nonce its framework scripts and generated inline assets.
+- Production `script-src` uses the nonce and `strict-dynamic`; `unsafe-inline` and `unsafe-eval` are
+  absent. Development retains only the React-required `unsafe-eval` exception.
+- `script-src-attr 'none'` and `style-src-attr 'none'` explicitly reject executable attributes;
+  frame, object and base/form targets are separately constrained.
+- Nonce-bearing responses are marked `private, no-store`, and authentication/tenant redirects retain
+  the same strict policy.
+- API origins are reduced to validated HTTP(S) origins before entering `connect-src`.
+- All 21 application React inline-style sites were replaced by static classes or accessible SVG
+  geometry. A prebuild gate rejects future inline-style attributes, `dangerouslySetInnerHTML`,
+  `unsafe-inline` and static CSP configuration.
+- Twelve mutable server-side file stores now use a single `server-only` runtime-I/O boundary that
+  requires absolute paths and prevents mutable files from being included in Turbopack output traces.
+- Starlette `TestClient` uses the explicit `httpx2` development dependency. All deprecated 422
+  constants use `HTTP_422_UNPROCESSABLE_CONTENT`.
+
+## Verification evidence
+
+- Frontend lint and the strict CSP prebuild gate passed.
+- All 270 frontend unit tests passed, including policy construction, nonce uniqueness, redirect CSP
+  preservation and inline-style-free visualization tests.
+- The Next.js 16.2.10 production build completed without TypeScript, Turbopack or NFT warnings.
+- All 1,538 backend tests passed with `StarletteDeprecationWarning` promoted to an error.
+- Bandit reported zero findings; `pip-audit` reported no known third-party vulnerabilities.
+- Two consecutive production-mode HTTP responses carried different nonces and `private, no-store`.
+- Browser verification confirmed meaningful rendering, interactive tab navigation, no error overlay,
+  no console/page errors, 26 of 26 scripts carrying nonces and the response nonce present in rendered
+  HTML.
+- Browser injection testing confirmed that an untrusted `style` attribute was not applied. The only
+  remaining DOM style attribute belongs to Next.js' internal route announcer; application DOM nodes
+  contain none.
+- A protected workspace URL returned a policy-bearing 307 and rendered the login route successfully.
+
+## Residual release controls
+
+- Add a privacy-reviewed CSP reporting endpoint and alerting pipeline before production enforcement
+  is considered fully observable; reports may contain URLs and therefore require retention and data
+  minimization controls.
+- Repeat the browser/header checks on the immutable Vercel preview and production candidate.
+- The centralized runtime-I/O boundary prevents unsafe tracing but does not make `/tmp` durable.
+  Product state must be migrated to approved Azure/Postgres/Blob persistence before production.
+- Any future third-party script, frame, font or telemetry integration requires an explicit threat and
+  privacy review plus a narrow policy amendment; no wildcard source is approved.
+- Independent penetration testing and security-owner approval remain required release evidence.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,39 +1,6 @@
 import type { NextConfig } from "next";
 
-function safeOrigin(value: string | undefined): string | null {
-  if (!value) return null;
-  try {
-    return new URL(value).origin;
-  } catch {
-    return null;
-  }
-}
-
-const apiOrigin = safeOrigin(process.env.NEXT_PUBLIC_API_BASE_URL);
-const connectSources = ["'self'", ...(apiOrigin ? [apiOrigin] : [])].join(" ");
-const scriptSources = [
-  "'self'",
-  "'unsafe-inline'",
-  ...(process.env.NODE_ENV === "production" ? [] : ["'unsafe-eval'"]),
-].join(" ");
-const contentSecurityPolicy = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  "object-src 'none'",
-  `script-src ${scriptSources}`,
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob:",
-  "font-src 'self' data:",
-  `connect-src ${connectSources}`,
-  "worker-src 'self' blob:",
-  "manifest-src 'self'",
-  ...(process.env.NODE_ENV === "production" ? ["upgrade-insecure-requests"] : []),
-].join("; ");
-
 const securityHeaders = [
-  { key: "Content-Security-Policy", value: contentSecurityPolicy },
   { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
   { key: "X-Content-Type-Options", value: "nosniff" },
   { key: "X-Frame-Options", value: "DENY" },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,12 +7,13 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "node scripts/verify-enterprise-readiness.mjs",
+    "prebuild": "node scripts/verify-csp.mjs && node scripts/verify-enterprise-readiness.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint --max-warnings=0",
     "test:unit": "vitest run",
-    "verify:enterprise": "node scripts/verify-enterprise-readiness.mjs"
+    "verify:enterprise": "node scripts/verify-enterprise-readiness.mjs",
+    "verify:csp": "node scripts/verify-csp.mjs"
   },
   "dependencies": {
     "@azure/msal-node": "5.4.0",

--- a/frontend/scripts/verify-csp.mjs
+++ b/frontend/scripts/verify-csp.mjs
@@ -1,0 +1,43 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join, resolve } from "node:path";
+
+const errors = [];
+const sourceRoot = resolve("src");
+const sourceExtensions = new Set([".js", ".jsx", ".mjs", ".ts", ".tsx"]);
+
+function scan(directory) {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+    const metadata = statSync(path);
+    if (metadata.isDirectory()) {
+      scan(path);
+      continue;
+    }
+    if (!sourceExtensions.has(extname(path)) || path.includes(".test.")) continue;
+
+    const content = readFileSync(path, "utf8");
+    if (/\bstyle\s*=/.test(content)) {
+      errors.push(`${path}: React inline style attributes are forbidden by the strict CSP`);
+    }
+    if (/\bdangerouslySetInnerHTML\s*=/.test(content)) {
+      errors.push(`${path}: dangerouslySetInnerHTML requires explicit security adjudication`);
+    }
+    if (content.includes("unsafe-inline")) {
+      errors.push(`${path}: CSP unsafe-inline bypass is forbidden`);
+    }
+  }
+}
+
+scan(sourceRoot);
+
+const nextConfig = readFileSync(resolve("next.config.ts"), "utf8");
+if (nextConfig.includes("Content-Security-Policy")) {
+  errors.push("next.config.ts: CSP must be generated per request in proxy.ts, not statically");
+}
+
+if (errors.length) {
+  process.stderr.write(`Strict CSP verification failed:\n- ${errors.join("\n- ")}\n`);
+  process.exit(1);
+}
+
+process.stdout.write("Strict CSP verification passed\n");

--- a/frontend/src/app/board/analytics/page.tsx
+++ b/frontend/src/app/board/analytics/page.tsx
@@ -10,6 +10,7 @@ import {
   CH_SKELETON,
 } from "@/lib/boardLayout";
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { SegmentedMetricBar } from "@/components/visualization/StrictCspMetrics";
 import { useUserRole } from "@/hooks/useUserRole";
 import { useWorkspaceTenantIdClient } from "@/hooks/useWorkspaceTenantIdClient";
 import { browserCsrfHeaders } from "@/lib/clientSessionHeaders";
@@ -124,17 +125,15 @@ function CoverageBar({ fw }: { fw: FrameworkCoverage }) {
           {fw.covered}/{fw.total_requirements} Anforderungen
         </span>
       </div>
-      <div className="flex h-3 w-full overflow-hidden rounded-full bg-slate-100">
-        {pctCovered > 0 && (
-          <div className="bg-emerald-500 transition-all" style={{ width: `${pctCovered}%` }} />
-        )}
-        {pctPartial > 0 && (
-          <div className="bg-amber-400 transition-all" style={{ width: `${pctPartial}%` }} />
-        )}
-        {pctPlanned > 0 && (
-          <div className="bg-slate-300 transition-all" style={{ width: `${pctPlanned}%` }} />
-        )}
-      </div>
+      <SegmentedMetricBar
+        label={`${fw.framework} Coverage-Verteilung`}
+        max={100}
+        segments={[
+          { label: "Vollständig", value: pctCovered, className: "fill-emerald-500" },
+          { label: "Teilweise", value: pctPartial, className: "fill-amber-400" },
+          { label: "Geplant", value: pctPlanned, className: "fill-slate-300" },
+        ]}
+      />
       <div className="flex gap-3 text-[0.65rem] text-slate-500">
         <span>🟢 Vollständig {fw.covered}</span>
         <span>🟡 Teilweise {fw.partial}</span>

--- a/frontend/src/app/board/eu-ai-act-readiness/page.tsx
+++ b/frontend/src/app/board/eu-ai-act-readiness/page.tsx
@@ -4,6 +4,10 @@ import Link from "next/link";
 import { ReadinessActionDraftButton } from "@/components/board/ReadinessActionDraftButton";
 import { GovernanceActionsTableWithEvidence } from "@/components/board/GovernanceActionsTableWithEvidence";
 import {
+  HorizontalMetricBar,
+  MetricRing,
+} from "@/components/visualization/StrictCspMetrics";
+import {
   fetchEuAiActReadiness,
   type EUAIActReadinessOverview,
   type ReadinessRequirementTraffic,
@@ -63,23 +67,18 @@ function requirementGapSummary(traffic: ReadinessRequirementTraffic): string {
 function ReadinessRing({ percent }: { percent: number }) {
   const p = Math.min(100, Math.max(0, percent));
   return (
-    <div
-      className="relative mx-auto h-36 w-36 shrink-0"
-      aria-hidden
+    <MetricRing
+      value={p}
+      label={`EU AI Act Readiness: ${p}%`}
+      className="mx-auto h-36 w-36"
     >
-      <div
-        className="absolute inset-0 rounded-full"
-        style={{
-          background: `conic-gradient(rgb(8 145 178) 0% ${p}%, rgb(226 232 240) ${p}% 100%)`,
-        }}
-      />
-      <div className="absolute inset-[12px] flex flex-col items-center justify-center rounded-full bg-white shadow-inner">
+      <div className="text-center">
         <span className="text-3xl font-semibold tabular-nums text-slate-900">{p}%</span>
-        <span className="text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
+        <span className="block text-[0.65rem] font-medium uppercase tracking-wide text-slate-500">
           Readiness
         </span>
       </div>
-    </div>
+    </MetricRing>
   );
 }
 
@@ -158,12 +157,13 @@ export default async function EuAiActReadinessPage() {
           <div className="min-w-0 space-y-6">
             <div>
               <p className={CH_SECTION_LABEL}>Fortschritt</p>
-              <div className="mt-2 h-3 overflow-hidden rounded-full bg-slate-100">
-                <div
-                  className="h-full rounded-full bg-gradient-to-r from-cyan-600 to-teal-500 transition-all"
-                  style={{ width: `${readinessPct}%` }}
-                />
-              </div>
+              <HorizontalMetricBar
+                value={readinessPct}
+                label={`Gesamt-Readiness: ${readinessPct}%`}
+                className="mt-2 h-3 w-full"
+                trackClassName="fill-slate-100"
+                indicatorClassName="fill-cyan-600"
+              />
               <p className="mt-2 text-sm text-slate-600">
                 Ziel empfohlen: ≥ 85&nbsp;% vor Stichtag.
               </p>

--- a/frontend/src/app/board/nis2-kritis/page.tsx
+++ b/frontend/src/app/board/nis2-kritis/page.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import Link from "next/link";
 
 import { KpiExplainButton } from "@/components/ai/KpiExplainButton";
+import { VerticalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   fetchBoardKpis,
   fetchNis2KritisKpiDrilldown,
@@ -61,10 +62,11 @@ function VerticalBucketChart({
               className="flex min-w-0 flex-1 flex-col items-center gap-2"
             >
               <div className="flex h-36 w-full items-end justify-center rounded-t-xl bg-slate-100/90 sm:h-40">
-                <div
-                  className="w-[72%] min-h-[3px] rounded-t-lg bg-gradient-to-t from-cyan-700 to-teal-400 shadow-sm transition-all"
-                  style={{ height: `${h}%` }}
-                  title={`${b.count} Systeme`}
+                <VerticalMetricBar
+                  value={h}
+                  label={`${b.count} Systeme im Bereich ${b.range_min_inclusive} bis ${hi} Prozent`}
+                  className="h-full min-h-[3px] w-[72%]"
+                  indicatorClassName="fill-cyan-700"
                 />
               </div>
               <span className="text-center text-[0.65rem] font-semibold leading-tight text-slate-600">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -36,6 +36,12 @@
   mask-image: linear-gradient(to bottom, black, transparent 82%);
 }
 
+.enterprise-ambient {
+  background:
+    radial-gradient(circle at 5% 0%, rgba(22, 104, 232, 0.13), transparent 42%),
+    radial-gradient(circle at 88% 2%, rgba(72, 212, 180, 0.12), transparent 38%);
+}
+
 .premium-surface {
   border: 1px solid rgba(110, 128, 151, 0.16);
   background: rgba(255, 255, 255, 0.82);

--- a/frontend/src/app/internal/advisor-metrics/page.tsx
+++ b/frontend/src/app/internal/advisor-metrics/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { SegmentedMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   type AdvisorMetricsDto,
   fetchAdvisorMetrics,
@@ -20,42 +21,39 @@ function pct(value: number | null | undefined): string {
   return `${(value * 100).toFixed(1)} %`;
 }
 
-function BarSegment({ color, ratio, label }: { color: string; ratio: number; label: string }) {
-  if (ratio <= 0) return null;
-  return (
-    <div
-      className={`flex items-center justify-center text-xs font-semibold text-white ${color}`}
-      style={{ width: `${Math.max(ratio * 100, 8)}%`, minWidth: "2rem" }}
-      title={label}
-    >
-      {label}
-    </div>
-  );
-}
-
 function DistributionBar({ data, total }: { data: Record<string, number>; total: number }) {
   if (total === 0) {
     return <p className="text-xs text-slate-500">Keine Daten</p>;
   }
   const colors: Record<string, string> = {
-    high: "bg-emerald-500",
-    medium: "bg-amber-500",
-    low: "bg-red-500",
-    bm25: "bg-cyan-600",
-    hybrid: "bg-violet-600",
-    answered: "bg-emerald-600",
-    escalated: "bg-rose-500",
+    high: "fill-emerald-500",
+    medium: "fill-amber-500",
+    low: "fill-red-500",
+    bm25: "fill-cyan-600",
+    hybrid: "fill-violet-600",
+    answered: "fill-emerald-600",
+    escalated: "fill-rose-500",
   };
+  const entries = Object.entries(data).filter(([, count]) => count > 0);
   return (
-    <div className="flex h-7 w-full overflow-hidden rounded-lg">
-      {Object.entries(data).map(([key, count]) => (
-        <BarSegment
-          key={key}
-          color={colors[key] ?? "bg-slate-400"}
-          ratio={count / total}
-          label={`${key}: ${count}`}
-        />
-      ))}
+    <div>
+      <SegmentedMetricBar
+        label="Advisor-Verteilung"
+        max={total}
+        className="h-3 w-full"
+        segments={entries.map(([key, count]) => ({
+          label: key,
+          value: count,
+          className: colors[key] ?? "fill-slate-400",
+        }))}
+      />
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-slate-600">
+        {entries.map(([key, count]) => (
+          <span key={key} className="tabular-nums">
+            {key}: {count}
+          </span>
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   CH_BTN_PRIMARY,
   CH_BTN_SECONDARY,
@@ -338,12 +339,12 @@ function Step2({
       </div>
       {state.frameworks.length > 0 && (
         <div className="mt-4 rounded-lg bg-slate-50 p-3">
-          <div className="h-2 overflow-hidden rounded-full bg-slate-200">
-            <div
-              className="h-full rounded-full bg-cyan-500 transition-all"
-              style={{ width: `${(state.frameworks.length / FRAMEWORKS.length) * 100}%` }}
-            />
-          </div>
+          <HorizontalMetricBar
+            value={state.frameworks.length}
+            max={FRAMEWORKS.length}
+            label="Ausgewählte Compliance-Frameworks"
+            indicatorClassName="fill-cyan-500"
+          />
           <p className="mt-1 text-xs text-slate-600">
             {state.frameworks.length} von {FRAMEWORKS.length} Frameworks ausgewählt
           </p>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -39,11 +39,7 @@ export default function HomePage() {
       />
       <div
         aria-hidden
-        className="pointer-events-none fixed inset-0 -z-10 opacity-80"
-        style={{
-          background:
-            "radial-gradient(circle at 5% 0%, rgba(22,104,232,0.13), transparent 42%), radial-gradient(circle at 88% 2%, rgba(72,212,180,0.12), transparent 38%)",
-        }}
+        className="enterprise-ambient pointer-events-none fixed inset-0 -z-10 opacity-80"
       />
 
       {/* Hero */}

--- a/frontend/src/app/tenant/compliance-mapping/page.tsx
+++ b/frontend/src/app/tenant/compliance-mapping/page.tsx
@@ -1,4 +1,5 @@
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   CH_BTN_SECONDARY,
   CH_CARD,
@@ -151,12 +152,13 @@ export default function TenantComplianceMappingPage() {
                 </span>
                 <span className="text-sm font-semibold text-slate-900">{fw.ratio}%</span>
               </div>
-              <div className="mt-2 h-2 rounded-full bg-slate-100">
-                <div
-                  className="h-2 rounded-full bg-cyan-500 transition-all"
-                  style={{ width: `${fw.ratio}%` }}
-                />
-              </div>
+              <HorizontalMetricBar
+                value={fw.ratio}
+                label={`${fw.label} Framework-Abdeckung: ${fw.ratio}%`}
+                className="mt-2 h-2 w-full"
+                trackClassName="fill-slate-100"
+                indicatorClassName="fill-cyan-500"
+              />
               <p className="mt-1 text-xs text-slate-500">
                 {fw.covered} von {fw.total} Controls abgedeckt
               </p>

--- a/frontend/src/app/tenant/cross-regulation-dashboard/CrossRegulationDashboardClient.tsx
+++ b/frontend/src/app/tenant/cross-regulation-dashboard/CrossRegulationDashboardClient.tsx
@@ -5,6 +5,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 
 import { AiKpiPortfolioStrip } from "@/components/ai/AiKpiPortfolioStrip";
 import { CrossRegulationLlmGapPanel } from "@/app/tenant/cross-regulation-dashboard/CrossRegulationLlmGapPanel";
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   fetchRequirementControlsDetail,
   type CrossRegFrameworkSummaryDto,
@@ -156,12 +157,11 @@ export function CrossRegulationDashboardClient({
                     {f.coverage_percent}%
                   </span>
                 </div>
-                <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-200">
-                  <div
-                    className="h-full rounded-full bg-cyan-600 transition-[width]"
-                    style={{ width: `${Math.min(100, f.coverage_percent)}%` }}
-                  />
-                </div>
+                <HorizontalMetricBar
+                  value={f.coverage_percent}
+                  label={`${f.name} Coverage: ${f.coverage_percent}%`}
+                  className="mt-1 h-2 w-full"
+                />
               </div>
               <dl className="mt-3 grid grid-cols-2 gap-2 text-xs text-slate-600">
                 <div>

--- a/frontend/src/app/tenant/eu-ai-act/page.tsx
+++ b/frontend/src/app/tenant/eu-ai-act/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import React, { useEffect, useState } from "react";
 
 import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   fetchNis2KritisKpis,
   TENANT_ID,
@@ -203,13 +204,14 @@ const STEP_TITLES: Record<WizardStep, string> = {
 // ─── Components ─────────────────────────────────────────────────────────────
 
 function ProgressBar({ value, className }: { value: number; className?: string }) {
+  const percentage = Math.round(value * 100);
   return (
-    <div className={cn("h-2 w-full rounded-full bg-slate-200", className)}>
-      <div
-        className="h-full rounded-full bg-emerald-500 transition-all"
-        style={{ width: `${Math.round(value * 100)}%` }}
-      />
-    </div>
+    <HorizontalMetricBar
+      value={percentage}
+      label={`Readiness: ${percentage}%`}
+      className={cn("h-2 w-full", className)}
+      indicatorClassName="fill-emerald-500"
+    />
   );
 }
 
@@ -951,12 +953,12 @@ export default function EUAIActPage() {
                     </span>
                   </div>
                   {recPct != null && (
-                    <div className="mt-1 h-1.5 w-full rounded-full bg-slate-200">
-                      <div
-                        className="h-full rounded-full bg-emerald-500/40"
-                        style={{ width: `${recPct}%` }}
-                      />
-                    </div>
+                    <HorizontalMetricBar
+                      value={recPct}
+                      label={`${NIS2_KPI_LABEL[kpiType]} Empfehlung: ${recPct}%`}
+                      className="mt-1 h-1.5 w-full"
+                      indicatorClassName="fill-emerald-500/40"
+                    />
                   )}
                   <label className="mt-2 block text-xs text-slate-500">
                     Evidenz (optional, z. B. NormEvidence-IDs)

--- a/frontend/src/components/admin/GtmCommandCenterClient.tsx
+++ b/frontend/src/components/admin/GtmCommandCenterClient.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { VerticalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import { GTM_READINESS_LABELS_DE, GTM_READINESS_SHORT_DE } from "@/lib/gtmAccountReadiness";
 import type {
   GtmDashboardSnapshot,
@@ -839,11 +840,12 @@ export function GtmCommandCenterClient({ adminConfigured }: Props) {
                 {snapshot.trends.inquiries_per_day_utc.map((d) => {
                   const h = maxDaily > 0 ? Math.max(4, (d.inquiries / maxDaily) * 100) : 4;
                   return (
-                    <div
+                    <VerticalMetricBar
                       key={d.day}
-                      className="min-w-0 flex-1 rounded-t bg-slate-700"
-                      style={{ height: `${h}%` }}
-                      title={`${d.day}: ${d.inquiries}`}
+                      className="h-full min-w-0 flex-1"
+                      value={h}
+                      label={`${d.day}: ${d.inquiries} Anfragen`}
+                      indicatorClassName="fill-slate-700"
                     />
                   );
                 })}

--- a/frontend/src/components/board/BoardReadinessCard.tsx
+++ b/frontend/src/components/board/BoardReadinessCard.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from "react";
 
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import {
   fetchTenantReadinessScore,
   postTenantReadinessScoreExplain,
@@ -60,12 +61,12 @@ function DimBar({
         <span title={hint}>{label}</span>
         <span className="tabular-nums text-slate-800">{v}</span>
       </div>
-      <div className="mt-0.5 h-1.5 overflow-hidden rounded-full bg-slate-100">
-        <div
-          className="h-full rounded-full bg-cyan-600 transition-[width]"
-          style={{ width: `${v}%` }}
-        />
-      </div>
+      <HorizontalMetricBar
+        value={v}
+        label={`${label}: ${v} von 100`}
+        className="mt-0.5 h-1.5 w-full"
+        trackClassName="fill-slate-100"
+      />
     </div>
   );
 }

--- a/frontend/src/components/home/HomeHeroSlides.tsx
+++ b/frontend/src/components/home/HomeHeroSlides.tsx
@@ -2,6 +2,11 @@
 
 import React, { useEffect, useState } from "react";
 
+import {
+  MetricRing,
+  VerticalMetricBar,
+} from "@/components/visualization/StrictCspMetrics";
+
 const slides = [
   {
     id: "kpis",
@@ -61,9 +66,10 @@ const slides = [
         <div className="mt-4 flex h-32 items-end gap-2 sm:gap-3">
           {[45, 72, 58, 88, 64].map((h, i) => (
             <div key={i} className="flex h-full min-w-0 flex-1 flex-col justify-end">
-              <div
-                className="w-full rounded-t-lg bg-gradient-to-t from-slate-800 to-slate-600 shadow-inner"
-                style={{ height: `${h}%` }}
+              <VerticalMetricBar
+                value={h}
+                label={`NIS2-Kennzahl ${i + 1}: ${h}%`}
+                indicatorClassName="fill-slate-700"
               />
             </div>
           ))}
@@ -99,17 +105,13 @@ const slides = [
         <div className="text-xs font-semibold uppercase tracking-wider text-slate-500">
           High-Risk Readiness
         </div>
-        <div className="relative mx-auto mt-3 h-28 w-28">
-          <div
-            className="absolute inset-0 rounded-full"
-            style={{
-              background: `conic-gradient(rgb(8 145 178) 0% 68%, rgb(226 232 240) 68% 100%)`,
-            }}
-          />
-          <div className="absolute inset-[10px] flex items-center justify-center rounded-full bg-white shadow-inner">
-            <span className="text-2xl font-semibold tabular-nums text-slate-900">68%</span>
-          </div>
-        </div>
+        <MetricRing
+          value={68}
+          label="EU AI Act High-Risk Readiness: 68 Prozent"
+          className="mx-auto mt-3 h-28 w-28"
+        >
+          <span className="text-2xl font-semibold tabular-nums text-slate-900">68%</span>
+        </MetricRing>
         <ul className="mt-4 space-y-2 text-left text-sm leading-snug text-slate-600">
           <li className="flex gap-2">
             <span className="shrink-0 text-cyan-600">·</span>

--- a/frontend/src/components/tenant/ComplianceCompassClient.tsx
+++ b/frontend/src/components/tenant/ComplianceCompassClient.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useState } from "react";
 
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import { fetchComplianceCompass, type ComplianceCompassSnapshot } from "@/lib/complianceCompassApi";
-
-const SF = "ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif";
 
 function postureLabel(p: string): { de: string; chip: string } {
   const m: Record<string, { de: string; chip: string }> = {
@@ -91,10 +90,7 @@ export function ComplianceCompassClient({ tenantId }: Props) {
   const pMeta = data ? postureLabel(data.posture) : null;
 
   return (
-    <div
-      className="min-h-[calc(100vh-8rem)] -mx-4 -mt-2 rounded-[2rem] bg-gradient-to-b from-slate-50 via-white to-slate-100/80 px-4 py-8 sm:px-8"
-      style={{ fontFamily: SF }}
-    >
+    <div className="min-h-[calc(100vh-8rem)] -mx-4 -mt-2 rounded-[2rem] bg-gradient-to-b from-slate-50 via-white to-slate-100/80 px-4 py-8 font-sans sm:px-8">
       {err ? (
         <div
           className="rounded-2xl border border-rose-200/60 bg-rose-50/80 px-4 py-3 text-sm text-rose-900"
@@ -134,10 +130,7 @@ export function ComplianceCompassClient({ tenantId }: Props) {
                 <div className="relative">
                   <FusionRing value={data.fusion_index_0_100} size={220} />
                   <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center text-center">
-                    <span
-                      className="text-5xl font-extralight tabular-nums tracking-tight text-slate-900"
-                      style={{ fontFeatureSettings: '"tnum" 1' }}
-                    >
+                    <span className="text-5xl font-extralight tabular-nums tracking-tight text-slate-900">
                       {data.fusion_index_0_100}
                     </span>
                     <span className="text-[0.7rem] font-medium uppercase tracking-[0.18em] text-slate-500">
@@ -184,12 +177,13 @@ export function ComplianceCompassClient({ tenantId }: Props) {
                     <span className="text-2xl font-light tabular-nums text-slate-800">{p.score_0_100}</span>
                   </div>
                   <p className="mt-1 text-xs text-slate-500">Gewicht: {Math.round(p.weight_in_fusion * 100)} %</p>
-                  <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-slate-200/60">
-                    <div
-                      className="h-full rounded-full bg-gradient-to-r from-sky-500 via-indigo-500 to-emerald-500 transition-all duration-500"
-                      style={{ width: `${p.score_0_100}%` }}
-                    />
-                  </div>
+                  <HorizontalMetricBar
+                    value={p.score_0_100}
+                    label={`${p.label_de}: ${p.score_0_100} von 100`}
+                    className="mt-3 h-1.5 w-full"
+                    trackClassName="fill-slate-200/60"
+                    indicatorClassName="fill-indigo-500"
+                  />
                   <p className="mt-3 text-sm leading-relaxed text-slate-600">{p.detail_de}</p>
                 </div>
               ))}

--- a/frontend/src/components/visualization/StrictCspMetrics.test.tsx
+++ b/frontend/src/components/visualization/StrictCspMetrics.test.tsx
@@ -1,0 +1,36 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  HorizontalMetricBar,
+  MetricRing,
+  SegmentedMetricBar,
+  VerticalMetricBar,
+} from "@/components/visualization/StrictCspMetrics";
+
+describe("strict CSP metric visualizations", () => {
+  it("encode dynamic geometry as SVG attributes without inline styles", () => {
+    const { container } = render(
+      <div>
+        <HorizontalMetricBar value={64} label="Readiness" />
+        <SegmentedMetricBar
+          label="Coverage"
+          max={100}
+          segments={[
+            { label: "Covered", value: 60, className: "fill-emerald-500" },
+            { label: "Partial", value: 25, className: "fill-amber-400" },
+          ]}
+        />
+        <VerticalMetricBar value={72} label="Incidents" />
+        <MetricRing value={68} label="EU AI Act readiness">
+          68%
+        </MetricRing>
+      </div>,
+    );
+
+    expect(container.querySelectorAll("[style]")).toHaveLength(0);
+    expect(container.querySelector('rect[width="64"]')).not.toBeNull();
+    expect(container.querySelector('rect[height="72"]')).not.toBeNull();
+    expect(container.querySelector('circle[stroke-dashoffset="32"]')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/visualization/StrictCspMetrics.tsx
+++ b/frontend/src/components/visualization/StrictCspMetrics.tsx
@@ -1,0 +1,197 @@
+import type { ReactNode } from "react";
+
+function clamp(value: number, min = 0, max = 100): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+export function HorizontalMetricBar({
+  value,
+  max = 100,
+  label,
+  className = "h-2 w-full",
+  trackClassName = "fill-slate-200",
+  indicatorClassName = "fill-cyan-600",
+}: {
+  value: number;
+  max?: number;
+  label: string;
+  className?: string;
+  trackClassName?: string;
+  indicatorClassName?: string;
+}) {
+  const safeMax = max > 0 && Number.isFinite(max) ? max : 100;
+  const safeValue = clamp(value, 0, safeMax);
+  const percentage = (safeValue / safeMax) * 100;
+
+  return (
+    <svg
+      viewBox="0 0 100 8"
+      preserveAspectRatio="none"
+      className={`block ${className}`}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={safeMax}
+      aria-valuenow={safeValue}
+    >
+      <title>{label}</title>
+      <rect x={0} y={0} width={100} height={8} rx={4} className={trackClassName} />
+      <rect
+        x={0}
+        y={0}
+        width={percentage}
+        height={8}
+        rx={4}
+        className={indicatorClassName}
+      />
+    </svg>
+  );
+}
+
+export type MetricSegment = {
+  label: string;
+  value: number;
+  className: string;
+};
+
+export function SegmentedMetricBar({
+  segments,
+  max,
+  label,
+  className = "h-3 w-full",
+  trackClassName = "fill-slate-100",
+}: {
+  segments: MetricSegment[];
+  max?: number;
+  label: string;
+  className?: string;
+  trackClassName?: string;
+}) {
+  const sum = segments.reduce((total, segment) => total + Math.max(0, segment.value), 0);
+  const safeMax = Math.max(max ?? 0, sum, 1);
+  const widths = segments.map(
+    (segment) => (clamp(segment.value, 0, safeMax) / safeMax) * 100,
+  );
+  const normalized = segments.map((segment, index) => ({
+    ...segment,
+    x: widths.slice(0, index).reduce((total, width) => total + width, 0),
+    width: widths[index],
+  }));
+
+  return (
+    <svg
+      viewBox="0 0 100 8"
+      preserveAspectRatio="none"
+      className={`block ${className}`}
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <rect x={0} y={0} width={100} height={8} rx={4} className={trackClassName} />
+      {normalized.map((segment) => (
+        <rect
+          key={segment.label}
+          x={segment.x}
+          y={0}
+          width={segment.width}
+          height={8}
+          className={segment.className}
+        >
+          <title>{`${segment.label}: ${segment.value}`}</title>
+        </rect>
+      ))}
+    </svg>
+  );
+}
+
+export function VerticalMetricBar({
+  value,
+  label,
+  className = "h-full w-full",
+  trackClassName = "fill-transparent",
+  indicatorClassName = "fill-slate-700",
+}: {
+  value: number;
+  label: string;
+  className?: string;
+  trackClassName?: string;
+  indicatorClassName?: string;
+}) {
+  const percentage = clamp(value);
+  return (
+    <svg
+      viewBox="0 0 100 100"
+      preserveAspectRatio="none"
+      className={`block ${className}`}
+      role="img"
+      aria-label={label}
+    >
+      <title>{label}</title>
+      <rect x={0} y={0} width={100} height={100} className={trackClassName} />
+      <rect
+        x={0}
+        y={100 - percentage}
+        width={100}
+        height={percentage}
+        rx={4}
+        className={indicatorClassName}
+      />
+    </svg>
+  );
+}
+
+export function MetricRing({
+  value,
+  label,
+  children,
+  className = "h-28 w-28",
+  trackClassName = "stroke-slate-200",
+  indicatorClassName = "stroke-cyan-600",
+}: {
+  value: number;
+  label: string;
+  children?: ReactNode;
+  className?: string;
+  trackClassName?: string;
+  indicatorClassName?: string;
+}) {
+  const percentage = clamp(value);
+  return (
+    <div
+      className={`relative shrink-0 ${className}`}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={percentage}
+    >
+      <svg viewBox="0 0 100 100" className="absolute inset-0 h-full w-full" aria-hidden>
+        <circle
+          cx={50}
+          cy={50}
+          r={42}
+          fill="none"
+          strokeWidth={8}
+          className={trackClassName}
+        />
+        <circle
+          cx={50}
+          cy={50}
+          r={42}
+          fill="none"
+          strokeWidth={8}
+          strokeLinecap="round"
+          pathLength={100}
+          strokeDasharray={100}
+          strokeDashoffset={100 - percentage}
+          transform="rotate(-90 50 50)"
+          className={indicatorClassName}
+        />
+      </svg>
+      <div className="absolute inset-3 flex items-center justify-center rounded-full bg-white shadow-inner">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/workspace/GuidedSetupWizard.tsx
+++ b/frontend/src/components/workspace/GuidedSetupWizard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
 import type { TenantSetupStatus } from "@/lib/api";
 import { CH_BTN_PRIMARY, CH_BTN_SECONDARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
 import { featureAiGovernancePlaybook } from "@/lib/config";
@@ -243,19 +244,13 @@ export function GuidedSetupWizard({ initialStatus, loadFailed = false }: GuidedS
           </span>
           <span className="tabular-nums text-[var(--sbs-text-secondary)]">{pct}%</span>
         </div>
-        <div
-          className="mt-2 h-2 w-full overflow-hidden rounded-full bg-slate-200"
-          role="progressbar"
-          aria-valuenow={doneCount}
-          aria-valuemin={0}
-          aria-valuemax={total}
-          aria-label="Guided-Setup-Fortschritt"
-        >
-          <div
-            className="h-full rounded-full bg-emerald-600 transition-[width] duration-300"
-            style={{ width: `${pct}%` }}
-          />
-        </div>
+        <HorizontalMetricBar
+          value={doneCount}
+          max={total}
+          label="Guided-Setup-Fortschritt"
+          className="mt-2 h-2 w-full"
+          indicatorClassName="fill-emerald-600"
+        />
       </div>
 
       <ol className="mt-6 space-y-3">

--- a/frontend/src/lib/advisorEvidenceHookStore.ts
+++ b/frontend/src/lib/advisorEvidenceHookStore.ts
@@ -1,13 +1,13 @@
 import "server-only";
 
-import { readFile } from "fs/promises";
 import { join } from "path";
 
 import type { EvidenceHookStoredRecord, EvidenceSourceSystemType } from "@/lib/advisorEvidenceHookTypes";
+import { absoluteRuntimeFilePath, readRuntimeTextFile } from "@/lib/runtimeFileIO";
 
 function hooksPath(): string {
   const fromEnv = process.env.ADVISOR_EVIDENCE_HOOKS_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) return join("/tmp", "compliancehub-advisor-evidence-hooks.json");
   return join(process.cwd(), "data", "advisor-evidence-hooks.json");
 }
@@ -53,7 +53,7 @@ export type AdvisorEvidenceHooksFile = { version?: string; hooks?: unknown };
 export async function readAdvisorEvidenceHooks(): Promise<EvidenceHookStoredRecord[]> {
   const path = hooksPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as AdvisorEvidenceHooksFile;
     if (!o || typeof o !== "object" || !Array.isArray(o.hooks)) return [];
     const out: EvidenceHookStoredRecord[] = [];

--- a/frontend/src/lib/advisorKpiHistoryStore.ts
+++ b/frontend/src/lib/advisorKpiHistoryStore.ts
@@ -1,10 +1,14 @@
 import "server-only";
 
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import type { AdvisorKpiPortfolioSnapshot } from "@/lib/advisorKpiTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 import {
   ADVISOR_KPI_HISTORY_FILE_VERSION,
   type AdvisorKpiHistoryPoint,
@@ -15,7 +19,7 @@ const MAX_SNAPSHOTS = 120;
 
 function historyPath(): string {
   const fromEnv = process.env.ADVISOR_KPI_HISTORY_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-advisor-kpi-history.json");
   }
@@ -29,7 +33,7 @@ function emptyState(): AdvisorKpiHistoryState {
 export async function readAdvisorKpiHistoryState(): Promise<AdvisorKpiHistoryState> {
   const path = historyPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as Record<string, unknown>;
     if (!o || typeof o !== "object") return emptyState();
     const snaps: AdvisorKpiHistoryPoint[] = [];
@@ -65,8 +69,7 @@ export async function readAdvisorKpiHistoryState(): Promise<AdvisorKpiHistorySta
 
 async function writeAdvisorKpiHistoryState(state: AdvisorKpiHistoryState): Promise<void> {
   const path = historyPath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify(state, null, 2)}\n`);
 }
 
 function utcDayKey(iso: string): string {

--- a/frontend/src/lib/advisorMandantHistoryStore.ts
+++ b/frontend/src/lib/advisorMandantHistoryStore.ts
@@ -1,7 +1,6 @@
 import "server-only";
 
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import type { AdvisorMandantHistoryApiDto } from "@/lib/kanzleiPortfolioTypes";
 import {
@@ -13,6 +12,11 @@ import {
   isNonEmptyUnparsableIso,
   maxIsoTimestamps,
 } from "@/lib/mandantHistoryMerge";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 /**
  * Persistente Kanzlei-Historie pro Mandant (Wave 40): Export-Zeitpunkte und Review-Markierung.
@@ -34,7 +38,7 @@ export type AdvisorMandantHistoryState = {
 
 function historyPath(): string {
   const fromEnv = process.env.ADVISOR_MANDANT_HISTORY_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-advisor-mandant-history.json");
   }
@@ -43,7 +47,7 @@ function historyPath(): string {
 
 function legacyTouchpointsPath(): string {
   const fromEnv = process.env.ADVISOR_PORTFOLIO_TOUCHPOINTS_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-advisor-portfolio-touchpoints.json");
   }
@@ -67,7 +71,7 @@ function emptyState(): AdvisorMandantHistoryState {
 async function readRawHistoryFile(): Promise<AdvisorMandantHistoryState> {
   const path = historyPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as { entries?: unknown };
     if (!o || typeof o !== "object") return emptyState();
     const entries: AdvisorMandantHistoryEntry[] = [];
@@ -112,7 +116,7 @@ type LegacyTouchRow = {
 async function readLegacyTouchpointsRows(): Promise<LegacyTouchRow[]> {
   const path = legacyTouchpointsPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as { entries?: unknown };
     if (!o || !Array.isArray(o.entries)) return [];
     const out: LegacyTouchRow[] = [];
@@ -176,8 +180,7 @@ export async function readAdvisorMandantHistoryEntry(
 
 async function writeHistoryState(state: AdvisorMandantHistoryState): Promise<void> {
   const path = historyPath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify({ entries: state.entries }, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify({ entries: state.entries }, null, 2)}\n`);
 }
 
 export async function recordMandantReadinessExport(tenantId: string, atIso?: string): Promise<void> {

--- a/frontend/src/lib/advisorMandantReminderStore.ts
+++ b/frontend/src/lib/advisorMandantReminderStore.ts
@@ -1,8 +1,7 @@
 import "server-only";
 
 import { randomUUID } from "crypto";
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import type { KanzleiAttentionQueueItem, KanzleiPortfolioRow } from "@/lib/kanzleiPortfolioTypes";
 import {
@@ -17,10 +16,15 @@ import type {
   MandantReminderStatus,
 } from "@/lib/advisorMandantReminderTypes";
 import { MANDANT_REMINDER_MANUAL_CATEGORIES } from "@/lib/advisorMandantReminderTypes";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 function remindersPath(): string {
   const fromEnv = process.env.ADVISOR_MANDANT_REMINDERS_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-advisor-mandant-reminders.json");
   }
@@ -34,7 +38,7 @@ function emptyState(): AdvisorMandantRemindersState {
 export async function readAdvisorMandantRemindersState(): Promise<AdvisorMandantRemindersState> {
   const path = remindersPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as { reminders?: unknown };
     if (!o || !Array.isArray(o.reminders)) return emptyState();
     const reminders: MandantReminderRecord[] = [];
@@ -66,8 +70,7 @@ export async function readAdvisorMandantRemindersState(): Promise<AdvisorMandant
 
 async function writeAdvisorMandantRemindersState(state: AdvisorMandantRemindersState): Promise<void> {
   const path = remindersPath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(state, null, 2), "utf8");
+  await writeRuntimeTextFile(path, JSON.stringify(state, null, 2));
 }
 
 function findOpenAuto(state: AdvisorMandantRemindersState, tenantId: string, category: MandantReminderCategory) {

--- a/frontend/src/lib/advisorSlaSignalStateStore.ts
+++ b/frontend/src/lib/advisorSlaSignalStateStore.ts
@@ -1,13 +1,18 @@
 import "server-only";
 
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
+
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 const FILE_VERSION = "wave47-v1";
 
 function statePath(): string {
   const fromEnv = process.env.ADVISOR_SLA_SIGNAL_STATE_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-advisor-sla-signal-state.json");
   }
@@ -24,7 +29,7 @@ export type AdvisorSlaSignalStateFile = {
 export async function readAdvisorSlaSignalState(): Promise<{ critical_rule_ids: string[] }> {
   const path = statePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as Record<string, unknown>;
     if (!o || typeof o !== "object") return { critical_rule_ids: [] };
     const ids: string[] = [];
@@ -46,6 +51,5 @@ export async function writeAdvisorSlaSignalState(criticalRuleIds: string[]): Pro
     updated_at: new Date().toISOString(),
     last_critical_rule_ids: [...new Set(criticalRuleIds)],
   };
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify(state, null, 2)}\n`);
 }

--- a/frontend/src/lib/boardReadinessBriefingSnapshotStore.ts
+++ b/frontend/src/lib/boardReadinessBriefingSnapshotStore.ts
@@ -1,13 +1,17 @@
 import "server-only";
 
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import type { BoardReadinessBriefingBaselineFile } from "@/lib/boardReadinessBriefingTypes";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 function resolvePath(): string {
   const fromEnv = process.env.BOARD_READINESS_BRIEFING_BASELINE_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-board-readiness-briefing-baseline.json");
   }
@@ -17,7 +21,7 @@ function resolvePath(): string {
 export async function readBoardReadinessBriefingBaseline(): Promise<BoardReadinessBriefingBaselineFile | null> {
   const path = resolvePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as BoardReadinessBriefingBaselineFile;
     if (!o || typeof o !== "object") return null;
     if (typeof o.saved_at !== "string" || typeof o.overall_status !== "string") return null;
@@ -32,6 +36,5 @@ export async function writeBoardReadinessBriefingBaseline(
   baseline: BoardReadinessBriefingBaselineFile,
 ): Promise<void> {
   const path = resolvePath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(baseline, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify(baseline, null, 2)}\n`);
 }

--- a/frontend/src/lib/contentSecurityPolicy.test.ts
+++ b/frontend/src/lib/contentSecurityPolicy.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildContentSecurityPolicy,
+  createCspNonce,
+} from "@/lib/contentSecurityPolicy";
+
+describe("content security policy", () => {
+  it("builds a strict production policy without inline or eval bypasses", () => {
+    const nonce = createCspNonce();
+    const policy = buildContentSecurityPolicy({
+      nonce,
+      development: false,
+      apiBaseUrl: "https://api.complywithai.de/v1",
+    });
+
+    expect(policy).toContain(`script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`);
+    expect(policy).toContain(`style-src 'self' 'nonce-${nonce}'`);
+    expect(policy).toContain("script-src-attr 'none'");
+    expect(policy).toContain("style-src-attr 'none'");
+    expect(policy).toContain("connect-src 'self' https://api.complywithai.de");
+    expect(policy).toContain("upgrade-insecure-requests");
+    expect(policy).not.toContain("unsafe-inline");
+    expect(policy).not.toContain("unsafe-eval");
+  });
+
+  it("allows only the development runtime exception and websocket transport", () => {
+    const policy = buildContentSecurityPolicy({
+      nonce: createCspNonce(),
+      development: true,
+    });
+
+    expect(policy).toContain("'unsafe-eval'");
+    expect(policy).toContain("connect-src 'self' ws:");
+    expect(policy).not.toContain("unsafe-inline");
+    expect(policy).not.toContain("upgrade-insecure-requests");
+  });
+
+  it("rejects malformed nonces and non-http API origins", () => {
+    expect(() =>
+      buildContentSecurityPolicy({ nonce: "attacker'; script-src *", development: false }),
+    ).toThrow("CSP nonce");
+
+    const policy = buildContentSecurityPolicy({
+      nonce: createCspNonce(),
+      development: false,
+      apiBaseUrl: "javascript:alert(1)",
+    });
+    expect(policy).toContain("connect-src 'self'");
+    expect(policy).not.toContain("javascript:");
+  });
+});

--- a/frontend/src/lib/contentSecurityPolicy.ts
+++ b/frontend/src/lib/contentSecurityPolicy.ts
@@ -1,0 +1,65 @@
+const CSP_NONCE_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
+
+function safeOrigin(value: string | undefined): string | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:"
+      ? url.origin
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export function createCspNonce(): string {
+  return Buffer.from(crypto.randomUUID()).toString("base64");
+}
+
+export function buildContentSecurityPolicy({
+  nonce,
+  development,
+  apiBaseUrl,
+}: {
+  nonce: string;
+  development: boolean;
+  apiBaseUrl?: string;
+}): string {
+  if (nonce.length < 24 || !CSP_NONCE_PATTERN.test(nonce)) {
+    throw new Error("CSP nonce must be an unpredictable base64 value");
+  }
+
+  const apiOrigin = safeOrigin(apiBaseUrl);
+  const connectSources = [
+    "'self'",
+    ...(apiOrigin ? [apiOrigin] : []),
+    ...(development ? ["ws:"] : []),
+  ].join(" ");
+  const scriptSources = [
+    "'self'",
+    `'nonce-${nonce}'`,
+    "'strict-dynamic'",
+    ...(development ? ["'unsafe-eval'"] : []),
+  ].join(" ");
+  const styleSources = ["'self'", `'nonce-${nonce}'`].join(" ");
+
+  return [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+    "form-action 'self'",
+    "object-src 'none'",
+    `script-src ${scriptSources}`,
+    "script-src-attr 'none'",
+    `style-src ${styleSources}`,
+    "style-src-attr 'none'",
+    "img-src 'self' data: blob:",
+    "font-src 'self' data:",
+    `connect-src ${connectSources}`,
+    "media-src 'self'",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    ...(development ? [] : ["upgrade-insecure-requests"]),
+  ].join("; ");
+}

--- a/frontend/src/lib/gtmProductAccountMapStore.ts
+++ b/frontend/src/lib/gtmProductAccountMapStore.ts
@@ -1,8 +1,12 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import { extractEmailDomain } from "@/lib/leadIdentity";
 import type { LeadInboxItem } from "@/lib/leadInboxTypes";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 export type GtmProductMapEntry = {
   tenant_id: string;
@@ -22,7 +26,7 @@ export type GtmProductAccountMapState = {
 
 function resolvePath(): string {
   const fromEnv = process.env.GTM_PRODUCT_ACCOUNT_MAP_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-gtm-product-account-map.json");
   }
@@ -40,7 +44,7 @@ function emptyState(): GtmProductAccountMapState {
 export async function readGtmProductAccountMap(): Promise<GtmProductAccountMapState> {
   const path = resolvePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as { entries?: unknown };
     if (!o || typeof o !== "object") return emptyState();
     const entries: GtmProductMapEntry[] = [];
@@ -92,6 +96,5 @@ export function findGtmProductMapEntry(
 
 export async function writeGtmProductAccountMap(state: GtmProductAccountMapState): Promise<void> {
   const path = resolvePath();
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify({ entries: state.entries }, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify({ entries: state.entries }, null, 2)}\n`);
 }

--- a/frontend/src/lib/gtmWeeklyReviewStore.ts
+++ b/frontend/src/lib/gtmWeeklyReviewStore.ts
@@ -1,9 +1,13 @@
-import { mkdir, readFile, writeFile } from "fs/promises";
-import { dirname, join } from "path";
 import { randomUUID } from "crypto";
+import { join } from "path";
 
 import type { GtmWeeklyReviewNote, GtmWeeklyReviewState } from "@/lib/gtmDashboardTypes";
 import { utcWeekStartMondayFromMs } from "@/lib/gtmDashboardTime";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 const MAX_NOTES = 40;
 const NOTE_MAX_LEN = 2000;
@@ -15,7 +19,7 @@ type FileShape = {
 
 function resolvePath(): string {
   const fromEnv = process.env.GTM_WEEKLY_REVIEW_STORE_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-gtm-weekly-review.json");
   }
@@ -29,7 +33,7 @@ function emptyState(): GtmWeeklyReviewState {
 export async function readGtmWeeklyReviewState(): Promise<GtmWeeklyReviewState> {
   const path = resolvePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as FileShape;
     if (!o || typeof o !== "object") return emptyState();
     const notes = Array.isArray(o.notes)
@@ -95,7 +99,6 @@ export async function updateGtmWeeklyReviewState(input: {
     notes: next.notes,
   };
 
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  await writeRuntimeTextFile(path, `${JSON.stringify(payload, null, 2)}\n`);
   return next;
 }

--- a/frontend/src/lib/kanzleiMonthlyReportBaseline.ts
+++ b/frontend/src/lib/kanzleiMonthlyReportBaseline.ts
@@ -1,12 +1,11 @@
 import "server-only";
 
-import { mkdir, readFile, writeFile } from "fs/promises";
-
 import type { BoardReadinessPillarKey, BoardReadinessTraffic } from "@/lib/boardReadinessTypes";
 import type { GtmReadinessClass } from "@/lib/gtmAccountReadiness";
 import { rowToBaselineTenant } from "@/lib/kanzleiMonthlyReportBuild";
 import type { KanzleiMonthlyBaselineTenant, KanzleiMonthlyReportBaselineState } from "@/lib/kanzleiMonthlyReportTypes";
 import type { KanzleiPortfolioPayload } from "@/lib/kanzleiPortfolioTypes";
+import { readRuntimeTextFile, writeRuntimeTextFile } from "@/lib/runtimeFileIO";
 
 const BASELINE_PATH = "/tmp/compliancehub-kanzlei-monthly-report-baseline.json";
 
@@ -45,7 +44,7 @@ function parseBand(x: unknown): KanzleiMonthlyBaselineTenant["attention_band"] {
 export async function readKanzleiMonthlyReportBaseline(): Promise<KanzleiMonthlyReportBaselineState | null> {
   const path = BASELINE_PATH;
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const o = JSON.parse(raw) as Record<string, unknown>;
     if (!o || typeof o.saved_at !== "string") return null;
     const tenants: KanzleiMonthlyReportBaselineState["tenants"] = {};
@@ -87,7 +86,6 @@ export async function writeKanzleiMonthlyReportBaseline(
   periodLabel: string | null,
 ): Promise<void> {
   const path = BASELINE_PATH;
-  await mkdir("/tmp", { recursive: true });
   const tenants: KanzleiMonthlyReportBaselineState["tenants"] = {};
   for (const row of payload.rows) {
     tenants[row.tenant_id] = rowToBaselineTenant(row);
@@ -98,5 +96,5 @@ export async function writeKanzleiMonthlyReportBaseline(
     portfolio_generated_at: payload.generated_at,
     tenants,
   };
-  await writeFile(path, JSON.stringify(state, null, 2), "utf8");
+  await writeRuntimeTextFile(path, JSON.stringify(state, null, 2));
 }

--- a/frontend/src/lib/leadOpsState.ts
+++ b/frontend/src/lib/leadOpsState.ts
@@ -1,5 +1,4 @@
-import { mkdir, readFile, rename, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import "server-only";
 
@@ -10,6 +9,12 @@ import type {
   LeadOpsFile,
 } from "@/lib/leadOpsTypes";
 import { coerceOpsEntry } from "@/lib/leadOpsSelectors";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  replaceRuntimeFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 import type { LeadTriageStatus } from "@/lib/leadTriage";
 
 const MAX_ACTIVITIES_PER_LEAD = 120;
@@ -21,7 +26,7 @@ export { getOpsEntryForLead } from "@/lib/leadOpsSelectors";
 
 function resolveOpsPath(): string {
   const fromEnv = process.env.LEAD_INQUIRY_OPS_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-lead-ops-state.json");
   }
@@ -31,7 +36,7 @@ function resolveOpsPath(): string {
 export async function readLeadOpsState(): Promise<LeadOpsFile> {
   const path = resolveOpsPath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const parsed = JSON.parse(raw) as LeadOpsFile;
     if (parsed?.version !== OPS_VERSION || typeof parsed.entries !== "object" || !parsed.entries) {
       return { version: OPS_VERSION, entries: {} };
@@ -66,7 +71,6 @@ export async function mutateLeadOps(
   },
 ): Promise<{ entry: LeadOpsEntry; path: string; changed: boolean }> {
   const path = resolveOpsPath();
-  await mkdir(dirname(path), { recursive: true });
 
   const state = await readLeadOpsState();
   const prev = coerceOpsEntry(state.entries[leadId]);
@@ -138,8 +142,8 @@ export async function mutateLeadOps(
   state.entries[leadId] = entry;
 
   const tmp = `${path}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(state, null, 0)}\n`, "utf8");
-  await rename(tmp, path);
+  await writeRuntimeTextFile(tmp, `${JSON.stringify(state, null, 0)}\n`);
+  await replaceRuntimeFile(tmp, path);
   return { entry, path, changed: true };
 }
 
@@ -149,12 +153,11 @@ export async function appendLeadOpsActivity(
   detail?: string,
 ): Promise<void> {
   const path = resolveOpsPath();
-  await mkdir(dirname(path), { recursive: true });
   const state = await readLeadOpsState();
   const prev = coerceOpsEntry(state.entries[leadId]);
   pushActivity(prev, action, detail);
   state.entries[leadId] = prev;
   const tmp = `${path}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(state, null, 0)}\n`, "utf8");
-  await rename(tmp, path);
+  await writeRuntimeTextFile(tmp, `${JSON.stringify(state, null, 0)}\n`);
+  await replaceRuntimeFile(tmp, path);
 }

--- a/frontend/src/lib/leadPersistence.ts
+++ b/frontend/src/lib/leadPersistence.ts
@@ -1,5 +1,4 @@
-import { appendFile, mkdir, readFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import {
   deriveLeadAccountKeyFromStoredRecord,
@@ -7,6 +6,11 @@ import {
 } from "@/lib/leadIdentity";
 import type { LeadDuplicateHint } from "@/lib/leadIdentity";
 import type { LeadOutboundPayloadV1 } from "@/lib/leadOutbound";
+import {
+  absoluteRuntimeFilePath,
+  appendRuntimeTextFile,
+  readRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 export type LeadStoreStatus = "received" | "forwarded" | "failed" | "reviewed";
 
@@ -39,7 +43,7 @@ export type LeadWebhookResultLine = {
 
 function resolveStorePath(): string {
   const fromEnv = process.env.LEAD_INQUIRY_STORE_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-lead-inquiries.jsonl");
   }
@@ -48,14 +52,13 @@ function resolveStorePath(): string {
 
 export async function persistLeadReceived(record: LeadStoreRecord): Promise<{ path: string }> {
   const path = resolveStorePath();
-  await mkdir(dirname(path), { recursive: true });
-  await appendFile(path, `${JSON.stringify(record)}\n`, "utf8");
+  await appendRuntimeTextFile(path, `${JSON.stringify(record)}\n`);
   return { path };
 }
 
 export async function appendLeadWebhookResult(line: LeadWebhookResultLine): Promise<void> {
   const path = resolveStorePath();
-  await appendFile(path, `${JSON.stringify(line)}\n`, "utf8");
+  await appendRuntimeTextFile(path, `${JSON.stringify(line)}\n`);
 }
 
 export type LeadAdminRow = LeadStoreRecord & {
@@ -66,7 +69,7 @@ export type LeadAdminRow = LeadStoreRecord & {
 
 async function mergeAllLeadAdminRowsFromPath(path: string): Promise<LeadAdminRow[]> {
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const lines = raw.trim().split("\n").filter(Boolean);
     const byId = new Map<string, LeadAdminRow>();
     for (const line of lines) {
@@ -139,7 +142,7 @@ export function countOtherContactKeysOnAccount(
 export async function findLeadInquiryRecord(leadId: string): Promise<LeadStoreRecord | null> {
   const path = resolveStorePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const lines = raw.trim().split("\n").filter(Boolean);
     let found: LeadStoreRecord | null = null;
     for (const line of lines) {
@@ -165,7 +168,7 @@ export async function getMergedLeadAdminRow(leadId: string): Promise<LeadAdminRo
   const row: LeadAdminRow = { ...base };
   const path = resolveStorePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const lines = raw.trim().split("\n").filter(Boolean);
     for (const line of lines) {
       try {

--- a/frontend/src/lib/leadSyncStore.ts
+++ b/frontend/src/lib/leadSyncStore.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "crypto";
-import { mkdir, readFile, rename, writeFile } from "fs/promises";
-import { dirname, join } from "path";
+import { join } from "path";
 
 import "server-only";
 
 import type { LeadSyncJob, LeadSyncPayloadV1, LeadSyncTarget } from "@/lib/leadSyncTypes";
+import {
+  absoluteRuntimeFilePath,
+  readRuntimeTextFile,
+  replaceRuntimeFile,
+  writeRuntimeTextFile,
+} from "@/lib/runtimeFileIO";
 
 const STORE_VERSION = 1;
 
@@ -17,7 +22,7 @@ type JobsStoreFile = {
 
 function resolveSyncStorePath(): string {
   const fromEnv = process.env.LEAD_SYNC_JOBS_STORE_PATH?.trim();
-  if (fromEnv) return fromEnv;
+  if (fromEnv) return absoluteRuntimeFilePath(fromEnv);
   if (process.env.VERCEL) {
     return join("/tmp", "compliancehub-lead-sync-jobs.json");
   }
@@ -31,7 +36,7 @@ function emptyStore(): JobsStoreFile {
 export async function readLeadSyncStore(): Promise<JobsStoreFile> {
   const path = resolveSyncStorePath();
   try {
-    const raw = await readFile(path, "utf8");
+    const raw = await readRuntimeTextFile(path);
     const p = JSON.parse(raw) as JobsStoreFile;
     if (p?.version !== STORE_VERSION || typeof p.jobs !== "object" || !p.jobs) {
       return emptyStore();
@@ -47,10 +52,9 @@ export async function readLeadSyncStore(): Promise<JobsStoreFile> {
 
 export async function writeLeadSyncStore(store: JobsStoreFile): Promise<void> {
   const path = resolveSyncStorePath();
-  await mkdir(dirname(path), { recursive: true });
   const tmp = `${path}.tmp`;
-  await writeFile(tmp, `${JSON.stringify(store)}\n`, "utf8");
-  await rename(tmp, path);
+  await writeRuntimeTextFile(tmp, `${JSON.stringify(store)}\n`);
+  await replaceRuntimeFile(tmp, path);
 }
 
 export async function getLeadSyncJobById(jobId: string): Promise<LeadSyncJob | null> {

--- a/frontend/src/lib/runtimeFileIO.ts
+++ b/frontend/src/lib/runtimeFileIO.ts
@@ -1,0 +1,42 @@
+import "server-only";
+
+import { appendFile, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute } from "node:path";
+
+export function absoluteRuntimeFilePath(path: string): string {
+  if (!isAbsolute(path)) {
+    throw new Error("Runtime file paths must be absolute");
+  }
+  return path;
+}
+
+async function ensureParentDirectory(path: string): Promise<void> {
+  const absolutePath = absoluteRuntimeFilePath(path);
+  await mkdir(/* turbopackIgnore: true */ dirname(absolutePath), { recursive: true });
+}
+
+export function readRuntimeTextFile(path: string): Promise<string> {
+  const absolutePath = absoluteRuntimeFilePath(path);
+  return readFile(/* turbopackIgnore: true */ absolutePath, "utf8");
+}
+
+export async function writeRuntimeTextFile(path: string, content: string): Promise<void> {
+  const absolutePath = absoluteRuntimeFilePath(path);
+  await ensureParentDirectory(absolutePath);
+  await writeFile(/* turbopackIgnore: true */ absolutePath, content, "utf8");
+}
+
+export async function appendRuntimeTextFile(path: string, content: string): Promise<void> {
+  const absolutePath = absoluteRuntimeFilePath(path);
+  await ensureParentDirectory(absolutePath);
+  await appendFile(/* turbopackIgnore: true */ absolutePath, content, "utf8");
+}
+
+export function replaceRuntimeFile(source: string, destination: string): Promise<void> {
+  const absoluteSource = absoluteRuntimeFilePath(source);
+  const absoluteDestination = absoluteRuntimeFilePath(destination);
+  return rename(
+    /* turbopackIgnore: true */ absoluteSource,
+    /* turbopackIgnore: true */ absoluteDestination,
+  );
+}

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -1,0 +1,42 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { proxy } from "@/proxy";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function nonceFrom(policy: string): string {
+  const match = policy.match(/'nonce-([^']+)'/);
+  if (!match) throw new Error("CSP nonce missing");
+  return match[1];
+}
+
+describe("proxy CSP boundary", () => {
+  it("generates a unique nonce and non-cacheable policy per request", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const first = proxy(new NextRequest("https://complywithai.de/"));
+    const second = proxy(new NextRequest("https://complywithai.de/"));
+    const firstPolicy = first.headers.get("content-security-policy") ?? "";
+    const secondPolicy = second.headers.get("content-security-policy") ?? "";
+
+    expect(firstPolicy).not.toContain("unsafe-inline");
+    expect(firstPolicy).not.toContain("unsafe-eval");
+    expect(nonceFrom(firstPolicy)).not.toBe(nonceFrom(secondPolicy));
+    expect(first.headers.get("cache-control")).toBe("private, no-store");
+  });
+
+  it("retains the strict policy on authentication redirects", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const response = proxy(
+      new NextRequest("https://complywithai.de/tenant/governance/overview"),
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toContain("/auth/login");
+    expect(response.headers.get("content-security-policy")).toContain(
+      "style-src-attr 'none'",
+    );
+  });
+});

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -9,8 +9,21 @@ import {
   DEMO_MODE_SESSION_COOKIE,
   WORKSPACE_TENANT_COOKIE,
 } from "@/lib/workspaceTenantConstants";
+import {
+  buildContentSecurityPolicy,
+  createCspNonce,
+} from "@/lib/contentSecurityPolicy";
 
 const WORKSPACE_COOKIE_MAX_AGE_SEC = 90 * 24 * 60 * 60;
+
+function applyRequestSecurityPolicy(
+  response: NextResponse,
+  contentSecurityPolicy: string,
+): NextResponse {
+  response.headers.set("Content-Security-Policy", contentSecurityPolicy);
+  response.headers.set("Cache-Control", "private, no-store");
+  return response;
+}
 
 function safeDecodeWorkspaceCookie(raw: string): string {
   const value = raw.trim();
@@ -58,9 +71,20 @@ function applyTenantsWorkspaceCookiePolicy(
 }
 
 export function proxy(request: NextRequest) {
-  const response = NextResponse.next();
+  const nonce = createCspNonce();
+  const contentSecurityPolicy = buildContentSecurityPolicy({
+    nonce,
+    development: process.env.NODE_ENV !== "production",
+    apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+  });
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  requestHeaders.set("Content-Security-Policy", contentSecurityPolicy);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
   const tenantsRedirect = applyTenantsWorkspaceCookiePolicy(request, response);
-  if (tenantsRedirect) return tenantsRedirect;
+  if (tenantsRedirect) {
+    return applyRequestSecurityPolicy(tenantsRedirect, contentSecurityPolicy);
+  }
 
   const publicDemoEnabled = process.env.COMPLIANCEHUB_PUBLIC_DEMO_ENABLED === "true";
   const requestedDemo =
@@ -100,10 +124,13 @@ export function proxy(request: NextRequest) {
     destination.pathname = "/auth/login";
     destination.search = "";
     destination.searchParams.set("next", returnTo);
-    return NextResponse.redirect(destination);
+    return applyRequestSecurityPolicy(
+      NextResponse.redirect(destination),
+      contentSecurityPolicy,
+    );
   }
 
-  return response;
+  return applyRequestSecurityPolicy(response, contentSecurityPolicy);
 }
 
 export const config = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "httpx2>=2.5.0,<3",
   "pytest>=8.0.0",
   "ruff>=0.15.0",
 ]
@@ -63,6 +64,9 @@ pythonpath = [
   "tests",
 ]
 addopts = "-q"
+filterwarnings = [
+  "error::starlette.exceptions.StarletteDeprecationWarning",
+]
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## What changed

- replace the static `unsafe-inline` CSP with a fresh request nonce, `strict-dynamic`, explicit script/style attribute blocking and non-cacheable responses
- preserve the strict policy on authentication and tenant redirects and validate API origins before adding them to `connect-src`
- replace all 21 application React inline-style sites with static CSS or accessible SVG geometry
- add a prebuild regression gate for inline styles, `dangerouslySetInnerHTML`, `unsafe-inline` and static CSP configuration
- centralize twelve mutable server-side file stores behind an absolute, server-only runtime-I/O boundary so Turbopack does not trace the whole project
- migrate Starlette `TestClient` to explicit `httpx2`, replace all deprecated 422 constants and promote future Starlette deprecations to test failures
- document implementation evidence and remaining deployment/assurance gates

## Why

The previous static CSP allowed arbitrary inline script and style execution for Next.js compatibility. The two backend warnings also represented active upstream migrations rather than harmless test noise. This change removes both root causes and adds durable regression gates.

## Validation

- frontend lint and strict CSP source gate passed
- 270 frontend unit tests passed
- Next.js 16.2.10 production build passed without TypeScript, Turbopack or NFT warnings
- 1,538 backend tests passed with `StarletteDeprecationWarning` treated as an error
- Bandit: zero findings
- `pip-audit`: no known vulnerabilities in resolvable third-party packages
- `npm audit --audit-level=high`: zero vulnerabilities
- production-mode browser: meaningful render, tab interaction, no overlay/console/page errors
- two consecutive responses carried different nonces; all 26 framework scripts were nonced and the header nonce matched rendered HTML
- inline-style injection was blocked and protected navigation retained CSP through the login redirect

## Review topology and remaining gate

This draft is intentionally stacked on #270 (`codex/sast-parser-hardening`) and should be retargeted after the lower stack merges. The runtime-I/O boundary fixes path and tracing behavior but does not make `/tmp` durable; approved Azure/Postgres/Blob persistence, a privacy-reviewed CSP reporting pipeline and independent production-equivalent review remain release blockers.
