### PR TITLE
Ship fail-closed public production release

### DIFF
--- a/docs/public-site-release-runbook.md
+++ b/docs/public-site-release-runbook.md
@@ -1,0 +1,77 @@
+# Public-site production release
+
+## Purpose
+
+The `public_site` release profile publishes only the reviewed marketing, contact,
+trust and legal pages on `https://complywithai.de`. It is deliberately isolated
+from the authenticated application and from all stateful APIs.
+
+This profile is not an enterprise-runtime waiver. The `enterprise` profile keeps
+the complete Entra, Azure Blob, Azure PostgreSQL, CSP reporting and operational
+evidence gates.
+
+## Allowed runtime scope
+
+- Public pages: `/`, `/kontakt`, `/trust-center`, `/impressum`, `/datenschutz`
+- Public metadata: `/robots.txt`, `/sitemap.xml`, `/manifest.webmanifest`
+- Responsible disclosure: `/.well-known/security.txt`
+- No authentication, demo session, lead form, marketing telemetry or CSP-report
+  ingestion
+- No customer, tenant or application data
+
+All other application and API paths return `404` at the proxy boundary before a
+route handler executes.
+
+## Required production configuration
+
+Set only the following non-empty `COMPLIANCEHUB_*` variables for the public-site
+profile. Optional phone and DPO contact values may be added after review.
+
+```text
+COMPLIANCEHUB_RELEASE_PROFILE=public_site
+COMPLIANCEHUB_APP_ORIGIN=https://complywithai.de
+COMPLIANCEHUB_TRUSTED_HOSTS=complywithai.de
+COMPLIANCEHUB_PUBLIC_SITE_READY=true
+COMPLIANCEHUB_LEGAL_PUBLISH_READY=true
+COMPLIANCEHUB_LEGAL_*=<reviewed public legal data>
+COMPLIANCEHUB_PRIVACY_*=<reviewed notice metadata and retention periods>
+COMPLIANCEHUB_SECURITY_CONTACT=<reviewed https: or mailto: contact>
+```
+
+`COMPLIANCEHUB_PUBLIC_SITE_READY` and
+`COMPLIANCEHUB_LEGAL_PUBLISH_READY` are attestations. They must never be set by
+automation without the named owner and review evidence in the change record.
+
+## Prohibited production configuration
+
+The build fails if the public profile inherits any `NEXT_PUBLIC_*`, `POSTGRES_*`,
+`SUPABASE_*`, `AZURE_*`, `DATABASE_URL`, `PGPASSWORD`, or unapproved
+`COMPLIANCEHUB_*` value. Remove integration-created variables from the Vercel
+production environment before deployment; do not replace them with dummy values.
+
+The following capabilities must be unset or `false`:
+
+- public demo
+- public lead capture
+- Entra authentication
+- CSP report collection
+
+## Release procedure
+
+1. Record legal owner approval for the exact imprint and privacy notice values.
+2. Confirm the Vercel data-processing agreement, subprocessor disclosure,
+   technically necessary log retention and international-transfer assessment.
+3. Remove prohibited production variables and add only the approved public-site
+   configuration.
+4. Run `npm run lint`, `npm run test:unit` and a production `npm run build` with
+   the exact release profile.
+5. Deploy the reviewed commit through the protected `main` branch.
+6. Verify the five public pages, `security.txt`, response headers and the expected
+   `404` response for one app route and one stateful API route.
+7. Record deployment ID, commit SHA, approver, test evidence and rollback target.
+
+## Rollback
+
+Promote the last reviewed production deployment in Vercel. Do not relax the
+release gate to recover service. If the legal content is in doubt, rollback or
+withdraw the affected page and keep stateful capabilities disabled.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,11 @@
+## Production builds require one explicit profile: public_site or enterprise.
+## public_site is a stateless marketing/legal surface; enterprise additionally
+## requires all identity, storage and database evidence below.
+COMPLIANCEHUB_RELEASE_PROFILE=
+COMPLIANCEHUB_RELEASE_CHANNEL=
+COMPLIANCEHUB_PUBLIC_SITE_READY=false
+COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED=false
+
 COMPLIANCEHUB_API_BASE_URL=http://localhost:8000
 COMPLIANCEHUB_API_KEY=
 COMPLIANCEHUB_TENANT_ID=tenant-overview-001

--- a/frontend/scripts/verify-csp.mjs
+++ b/frontend/scripts/verify-csp.mjs
@@ -35,6 +35,19 @@ if (nextConfig.includes("Content-Security-Policy")) {
   errors.push("next.config.ts: CSP must be generated per request in proxy.ts, not statically");
 }
 
+const rootLayout = readFileSync(resolve("src/app/layout.tsx"), "utf8");
+if (!rootLayout.includes('import { connection } from "next/server";')) {
+  errors.push("src/app/layout.tsx: nonce CSP requires Next.js request connection import");
+}
+if (!rootLayout.includes("await connection();")) {
+  errors.push("src/app/layout.tsx: nonce CSP requires dynamic request rendering");
+}
+
+const proxy = readFileSync(resolve("src/proxy.ts"), "utf8");
+if (!proxy.includes('requestHeaders.set("x-nonce", nonce);')) {
+  errors.push("src/proxy.ts: the CSP nonce must be forwarded to Next.js rendering");
+}
+
 if (errors.length) {
   process.stderr.write(`Strict CSP verification failed:\n- ${errors.join("\n- ")}\n`);
   process.exit(1);

--- a/frontend/scripts/verify-enterprise-readiness.mjs
+++ b/frontend/scripts/verify-enterprise-readiness.mjs
@@ -11,14 +11,14 @@ if (!production) {
 }
 
 const errors = [];
+const releaseProfile = process.env.COMPLIANCEHUB_RELEASE_PROFILE?.trim() || "";
+const supportedReleaseProfiles = new Set(["public_site", "enterprise"]);
 const guidPattern =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const nilGuid = "00000000-0000-0000-0000-000000000000";
-const required = [
-  "COMPLIANCEHUB_API_BASE_URL",
-  "COMPLIANCEHUB_API_KEY",
+
+const legalRequired = [
   "COMPLIANCEHUB_APP_ORIGIN",
-  "COMPLIANCEHUB_BFF_SHARED_SECRET",
   "COMPLIANCEHUB_TRUSTED_HOSTS",
   "COMPLIANCEHUB_LEGAL_ENTITY_NAME",
   "COMPLIANCEHUB_LEGAL_REPRESENTATIVE",
@@ -36,175 +36,80 @@ const required = [
   "COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS",
   "COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS",
   "COMPLIANCEHUB_SECURITY_CONTACT",
-  "COMPLIANCEHUB_AUDIT_PSEUDONYMIZATION_KEY",
-  "COMPLIANCEHUB_ENTRA_TENANT_ID",
-  "COMPLIANCEHUB_ENTRA_CLIENT_ID",
-  "COMPLIANCEHUB_ENTRA_CLIENT_SECRET",
-  "COMPLIANCEHUB_ENTRA_PROVIDER_ID",
-  "COMPLIANCEHUB_AUTH_TRANSACTION_SECRET",
-  "COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND",
-  "COMPLIANCEHUB_RUNTIME_STORAGE_AUTH",
-  "AZURE_STORAGE_ACCOUNT_NAME",
-  "AZURE_STORAGE_CONTAINER_NAME",
-  "COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND",
-  "AZURE_POSTGRES_HOST",
-  "AZURE_POSTGRES_DATABASE",
-  "AZURE_POSTGRES_USER",
-  "COMPLIANCEHUB_ADVISOR_RUNTIME_RETENTION_DAYS",
 ];
 
-for (const key of required) {
-  if (!process.env[key]?.trim()) errors.push(`${key} is required`);
-}
-
-for (const key of [
-  "COMPLIANCEHUB_ENTRA_TENANT_ID",
-  "COMPLIANCEHUB_ENTRA_CLIENT_ID",
-  "COMPLIANCEHUB_ENTRA_PROVIDER_ID",
-]) {
-  const value = process.env[key]?.trim().toLowerCase() || "";
-  if (value && (!guidPattern.test(value) || value === nilGuid)) {
-    errors.push(`${key} must be a non-placeholder GUID`);
+function requireKeys(keys) {
+  for (const key of keys) {
+    if (!process.env[key]?.trim()) errors.push(`${key} is required`);
   }
 }
+
+function validateRetentionDays(key, minimum, maximum) {
+  const value = Number(process.env[key]);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    errors.push(`${key} must be an approved value between ${minimum} and ${maximum}`);
+  }
+}
+
+if (!supportedReleaseProfiles.has(releaseProfile)) {
+  errors.push(
+    "COMPLIANCEHUB_RELEASE_PROFILE must be public_site or enterprise in production",
+  );
+}
+
+requireKeys(legalRequired);
 
 if (process.env.COMPLIANCEHUB_LEGAL_PUBLISH_READY !== "true") {
   errors.push(
-    "COMPLIANCEHUB_LEGAL_PUBLISH_READY must be true after legal review",
+    "COMPLIANCEHUB_LEGAL_PUBLISH_READY must be true after documented legal review",
   );
 }
-if (process.env.COMPLIANCEHUB_ENTERPRISE_AUTH_READY !== "true") {
-  errors.push(
-    "COMPLIANCEHUB_ENTERPRISE_AUTH_READY must attest the reviewed auth boundary",
-  );
+
+let appOrigin;
+try {
+  appOrigin = new URL(process.env.COMPLIANCEHUB_APP_ORIGIN || "");
+  if (
+    appOrigin.protocol !== "https:" ||
+    appOrigin.username ||
+    appOrigin.password ||
+    appOrigin.pathname !== "/" ||
+    appOrigin.search ||
+    appOrigin.hash
+  ) {
+    errors.push("COMPLIANCEHUB_APP_ORIGIN must be a bare HTTPS origin");
+  }
+} catch {
+  errors.push("COMPLIANCEHUB_APP_ORIGIN must be a valid HTTPS origin");
 }
-if (process.env.COMPLIANCEHUB_ENTRA_ENABLED !== "true") {
-  errors.push(
-    "COMPLIANCEHUB_ENTRA_ENABLED must be true for production identity",
-  );
-}
-if (process.env.COMPLIANCEHUB_ENTRA_CONDITIONAL_ACCESS_READY !== "true") {
-  errors.push("Entra MFA and Conditional Access evidence must be approved");
-}
-if (process.env.COMPLIANCEHUB_ENTRA_PROVISIONING_READY !== "true") {
-  errors.push(
-    "Entra identity provisioning and access recertification must be approved",
-  );
-}
-if (process.env.COMPLIANCEHUB_RUNTIME_STORAGE_READY !== "true") {
-  errors.push(
-    "Azure runtime storage region, RBAC, network, diagnostics and restore evidence must be approved",
-  );
-}
-if (process.env.COMPLIANCEHUB_CSP_REPORTING_READY !== "true") {
-  errors.push(
-    "CSP reporting privacy, SIEM retention, alerting and abuse controls must be approved",
-  );
-}
-if (process.env.COMPLIANCEHUB_RELATIONAL_RUNTIME_READY !== "true") {
-  errors.push(
-    "Azure PostgreSQL region, Entra role membership, TLS, schema and connection evidence must be approved",
-  );
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_RLS_READY !== "true") {
-  errors.push("PostgreSQL FORCE RLS and cross-tenant denial evidence must be approved");
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_NETWORK_READY !== "true") {
-  errors.push("Azure PostgreSQL private network and firewall evidence must be approved");
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_BACKUP_RESTORE_READY !== "true") {
-  errors.push("Azure PostgreSQL PITR and restore-test evidence must be approved");
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_RETENTION_READY !== "true") {
-  errors.push("PostgreSQL retention, legal-hold and deletion-audit evidence must be approved");
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_DATA_MIGRATION_READY !== "true") {
-  errors.push(
-    "PostgreSQL source-to-target counts, checksums and cutover rollback evidence must be approved",
-  );
-}
-if (process.env.COMPLIANCEHUB_POSTGRES_SUPPLY_CHAIN_READY !== "true") {
-  errors.push(
-    "PostgreSQL client dependency inventory and upstream supply-chain review must be approved",
-  );
-}
-const advisorRetentionDays = Number(
-  process.env.COMPLIANCEHUB_ADVISOR_RUNTIME_RETENTION_DAYS,
+
+const trustedHosts = new Set(
+  (process.env.COMPLIANCEHUB_TRUSTED_HOSTS || "")
+    .split(",")
+    .map((host) => host.trim().toLowerCase())
+    .filter(Boolean),
 );
-if (
-  !Number.isSafeInteger(advisorRetentionDays) ||
-  advisorRetentionDays < 30 ||
-  advisorRetentionDays > 3_650
-) {
-  errors.push(
-    "COMPLIANCEHUB_ADVISOR_RUNTIME_RETENTION_DAYS must be an approved value between 30 and 3650",
-  );
+if (appOrigin && !trustedHosts.has(appOrigin.host.toLowerCase())) {
+  errors.push("COMPLIANCEHUB_TRUSTED_HOSTS must include the application host");
 }
-if (process.env.COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND !== "azure_blob") {
-  errors.push("COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND must be azure_blob in production");
+
+const reviewedAt = process.env.COMPLIANCEHUB_PRIVACY_REVIEWED_AT || "";
+const reviewedDate = /^\d{4}-\d{2}-\d{2}$/.test(reviewedAt)
+  ? new Date(`${reviewedAt}T00:00:00.000Z`)
+  : new Date(Number.NaN);
+const legalReviewMaximumAgeMs = 366 * 24 * 60 * 60 * 1_000;
+if (Number.isNaN(reviewedDate.getTime())) {
+  errors.push("COMPLIANCEHUB_PRIVACY_REVIEWED_AT must use YYYY-MM-DD");
+} else if (reviewedDate.getTime() > Date.now()) {
+  errors.push("COMPLIANCEHUB_PRIVACY_REVIEWED_AT cannot be in the future");
+} else if (Date.now() - reviewedDate.getTime() > legalReviewMaximumAgeMs) {
+  errors.push("The privacy notice review must be renewed at least annually");
 }
-if (process.env.COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND !== "azure_postgres") {
-  errors.push(
-    "COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND must be azure_postgres in production",
-  );
-}
-const postgresHost = process.env.AZURE_POSTGRES_HOST?.trim().toLowerCase() || "";
-if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.postgres\.database\.azure\.com$/.test(postgresHost)) {
-  errors.push("AZURE_POSTGRES_HOST must be an Azure PostgreSQL hostname");
-}
-if (
-  ["postgres", "azure_pg_admin", "azuresu"].includes(
-    process.env.AZURE_POSTGRES_USER?.trim().toLowerCase() || "",
-  )
-) {
-  errors.push("Azure PostgreSQL administrator identities are forbidden for application runtime");
-}
-for (const forbiddenCredential of [
-  "AZURE_POSTGRES_PASSWORD",
-  "PGPASSWORD",
-  "POSTGRES_URL",
-  "DATABASE_URL",
-]) {
-  if (process.env[forbiddenCredential]?.trim()) {
-    errors.push(`${forbiddenCredential} is forbidden; use short-lived Microsoft Entra tokens`);
-  }
-}
-const runtimeStorageAuth = process.env.COMPLIANCEHUB_RUNTIME_STORAGE_AUTH;
-if (runtimeStorageAuth !== "managed_identity" && runtimeStorageAuth !== "vercel_oidc") {
-  errors.push("Runtime storage must use managed_identity or vercel_oidc authentication");
-}
-if (process.env.VERCEL && runtimeStorageAuth !== "vercel_oidc") {
-  errors.push("Vercel production runtime storage must use OIDC federation");
-}
-if (runtimeStorageAuth === "vercel_oidc") {
-  for (const key of ["AZURE_TENANT_ID", "AZURE_CLIENT_ID"]) {
-    if (!process.env[key]?.trim()) errors.push(`${key} is required for Vercel OIDC federation`);
-  }
-}
-if ((process.env.COMPLIANCEHUB_AUDIT_PSEUDONYMIZATION_KEY || "").length < 32) {
-  errors.push(
-    "COMPLIANCEHUB_AUDIT_PSEUDONYMIZATION_KEY must contain at least 32 characters",
-  );
-}
-if ((process.env.COMPLIANCEHUB_BFF_SHARED_SECRET || "").length < 32) {
-  errors.push(
-    "COMPLIANCEHUB_BFF_SHARED_SECRET must contain at least 32 characters",
-  );
-}
-if ((process.env.COMPLIANCEHUB_ENTRA_CLIENT_SECRET || "").length < 32) {
-  errors.push(
-    "COMPLIANCEHUB_ENTRA_CLIENT_SECRET must contain at least 32 characters",
-  );
-}
-if ((process.env.COMPLIANCEHUB_AUTH_TRANSACTION_SECRET || "").length < 32) {
-  errors.push(
-    "COMPLIANCEHUB_AUTH_TRANSACTION_SECRET must contain at least 32 characters",
-  );
-}
+
+validateRetentionDays("COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS", 1, 365);
+validateRetentionDays("COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS", 1, 3_650);
+
 if (process.env.NEXT_PUBLIC_API_KEY) {
-  errors.push(
-    "NEXT_PUBLIC_API_KEY is forbidden because it exposes a bearer credential",
-  );
+  errors.push("NEXT_PUBLIC_API_KEY is forbidden because it exposes a bearer credential");
 }
 if (process.env.COMPLIANCEHUB_ALLOW_GLOBAL_API_KEYS === "true") {
   errors.push("Global cross-tenant API keys are forbidden in production");
@@ -212,18 +117,205 @@ if (process.env.COMPLIANCEHUB_ALLOW_GLOBAL_API_KEYS === "true") {
 if ((process.env.COMPLIANCEHUB_LLM_PII_MODE || "block") !== "block") {
   errors.push("COMPLIANCEHUB_LLM_PII_MODE must be block in production");
 }
-if (process.env.COMPLIANCEHUB_LLM_PREFER_AZURE === "true") {
-  for (const key of ["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT"]) {
-    if (!process.env[key]?.trim())
-      errors.push(`${key} is required for Azure OpenAI`);
-  }
-  if (process.env.AZURE_OPENAI_AUTH !== "managed_identity") {
-    errors.push("AZURE_OPENAI_AUTH must be managed_identity in production");
-  }
-  if (process.env.COMPLIANCEHUB_LLM_ASSUME_AZURE_EU !== "true") {
+
+if (releaseProfile === "public_site") {
+  if (appOrigin?.origin !== "https://complywithai.de") {
     errors.push(
-      "Azure EU regional/Data Zone processing must be reviewed and attested",
+      "The public_site application origin must be https://complywithai.de",
     );
+  }
+  if (process.env.COMPLIANCEHUB_PUBLIC_SITE_READY !== "true") {
+    errors.push(
+      "COMPLIANCEHUB_PUBLIC_SITE_READY must attest the reviewed stateless public release",
+    );
+  }
+  for (const key of [
+    "COMPLIANCEHUB_PUBLIC_DEMO_ENABLED",
+    "COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED",
+    "COMPLIANCEHUB_ENTRA_ENABLED",
+    "COMPLIANCEHUB_CSP_REPORTING_READY",
+  ]) {
+    if (process.env[key] === "true") {
+      errors.push(`${key} must remain disabled in the public_site release`);
+    }
+  }
+
+  const allowedComplianceHubKeys = new Set([
+    ...legalRequired,
+    "COMPLIANCEHUB_RELEASE_CHANNEL",
+    "COMPLIANCEHUB_RELEASE_PROFILE",
+    "COMPLIANCEHUB_PUBLIC_SITE_READY",
+    "COMPLIANCEHUB_PUBLIC_DEMO_ENABLED",
+    "COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED",
+    "COMPLIANCEHUB_ENTRA_ENABLED",
+    "COMPLIANCEHUB_CSP_REPORTING_READY",
+    "COMPLIANCEHUB_LEGAL_PHONE",
+    "COMPLIANCEHUB_LEGAL_PUBLISH_READY",
+    "COMPLIANCEHUB_PRIVACY_DPO_CONTACT",
+    "COMPLIANCEHUB_LLM_PII_MODE",
+  ]);
+  const forbiddenPublicPrefixes = [
+    "NEXT_PUBLIC_",
+    "POSTGRES_",
+    "SUPABASE_",
+    "AZURE_",
+  ];
+  const forbiddenPublicExact = new Set(["DATABASE_URL", "PGPASSWORD"]);
+
+  for (const [key, rawValue] of Object.entries(process.env)) {
+    if (!rawValue?.trim()) continue;
+    const unapprovedComplianceHubKey =
+      key.startsWith("COMPLIANCEHUB_") && !allowedComplianceHubKeys.has(key);
+    const forbiddenInfrastructureKey =
+      forbiddenPublicExact.has(key) ||
+      forbiddenPublicPrefixes.some((prefix) => key.startsWith(prefix));
+    if (unapprovedComplianceHubKey || forbiddenInfrastructureKey) {
+      errors.push(`${key} is forbidden in the stateless public_site release`);
+    }
+  }
+}
+
+if (releaseProfile === "enterprise") {
+  const enterpriseRequired = [
+    "COMPLIANCEHUB_API_BASE_URL",
+    "COMPLIANCEHUB_API_KEY",
+    "COMPLIANCEHUB_BFF_SHARED_SECRET",
+    "COMPLIANCEHUB_AUDIT_PSEUDONYMIZATION_KEY",
+    "COMPLIANCEHUB_ENTRA_TENANT_ID",
+    "COMPLIANCEHUB_ENTRA_CLIENT_ID",
+    "COMPLIANCEHUB_ENTRA_CLIENT_SECRET",
+    "COMPLIANCEHUB_ENTRA_PROVIDER_ID",
+    "COMPLIANCEHUB_AUTH_TRANSACTION_SECRET",
+    "COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND",
+    "COMPLIANCEHUB_RUNTIME_STORAGE_AUTH",
+    "AZURE_STORAGE_ACCOUNT_NAME",
+    "AZURE_STORAGE_CONTAINER_NAME",
+    "COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND",
+    "AZURE_POSTGRES_HOST",
+    "AZURE_POSTGRES_DATABASE",
+    "AZURE_POSTGRES_USER",
+    "COMPLIANCEHUB_ADVISOR_RUNTIME_RETENTION_DAYS",
+  ];
+  requireKeys(enterpriseRequired);
+
+  for (const key of [
+    "COMPLIANCEHUB_ENTRA_TENANT_ID",
+    "COMPLIANCEHUB_ENTRA_CLIENT_ID",
+    "COMPLIANCEHUB_ENTRA_PROVIDER_ID",
+  ]) {
+    const value = process.env[key]?.trim().toLowerCase() || "";
+    if (value && (!guidPattern.test(value) || value === nilGuid)) {
+      errors.push(`${key} must be a non-placeholder GUID`);
+    }
+  }
+
+  const requiredAttestations = {
+    COMPLIANCEHUB_ENTERPRISE_AUTH_READY:
+      "the reviewed authentication boundary",
+    COMPLIANCEHUB_ENTRA_CONDITIONAL_ACCESS_READY:
+      "Entra MFA and Conditional Access evidence",
+    COMPLIANCEHUB_ENTRA_PROVISIONING_READY:
+      "Entra provisioning and access recertification evidence",
+    COMPLIANCEHUB_RUNTIME_STORAGE_READY:
+      "Azure storage region, RBAC, network, diagnostics and restore evidence",
+    COMPLIANCEHUB_CSP_REPORTING_READY:
+      "CSP reporting privacy, SIEM retention, alerting and abuse controls",
+    COMPLIANCEHUB_RELATIONAL_RUNTIME_READY:
+      "Azure PostgreSQL region, Entra role, TLS, schema and connection evidence",
+    COMPLIANCEHUB_POSTGRES_RLS_READY:
+      "PostgreSQL FORCE RLS and cross-tenant denial evidence",
+    COMPLIANCEHUB_POSTGRES_NETWORK_READY:
+      "Azure PostgreSQL private network and firewall evidence",
+    COMPLIANCEHUB_POSTGRES_BACKUP_RESTORE_READY:
+      "Azure PostgreSQL PITR and restore-test evidence",
+    COMPLIANCEHUB_POSTGRES_RETENTION_READY:
+      "PostgreSQL retention, legal-hold and deletion-audit evidence",
+    COMPLIANCEHUB_POSTGRES_DATA_MIGRATION_READY:
+      "PostgreSQL migration counts, checksums and rollback evidence",
+    COMPLIANCEHUB_POSTGRES_SUPPLY_CHAIN_READY:
+      "PostgreSQL client dependency and supply-chain evidence",
+  };
+  for (const [key, evidence] of Object.entries(requiredAttestations)) {
+    if (process.env[key] !== "true") {
+      errors.push(`${key} must attest ${evidence}`);
+    }
+  }
+
+  if (process.env.COMPLIANCEHUB_ENTRA_ENABLED !== "true") {
+    errors.push("COMPLIANCEHUB_ENTRA_ENABLED must be true for production identity");
+  }
+  if (process.env.COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND !== "azure_blob") {
+    errors.push("COMPLIANCEHUB_RUNTIME_STORAGE_BACKEND must be azure_blob in production");
+  }
+  if (process.env.COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND !== "azure_postgres") {
+    errors.push(
+      "COMPLIANCEHUB_RELATIONAL_RUNTIME_BACKEND must be azure_postgres in production",
+    );
+  }
+
+  validateRetentionDays("COMPLIANCEHUB_ADVISOR_RUNTIME_RETENTION_DAYS", 30, 3_650);
+
+  const postgresHost = process.env.AZURE_POSTGRES_HOST?.trim().toLowerCase() || "";
+  if (
+    !/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.postgres\.database\.azure\.com$/.test(
+      postgresHost,
+    )
+  ) {
+    errors.push("AZURE_POSTGRES_HOST must be an Azure PostgreSQL hostname");
+  }
+  if (
+    ["postgres", "azure_pg_admin", "azuresu"].includes(
+      process.env.AZURE_POSTGRES_USER?.trim().toLowerCase() || "",
+    )
+  ) {
+    errors.push(
+      "Azure PostgreSQL administrator identities are forbidden for application runtime",
+    );
+  }
+
+  for (const forbiddenCredential of [
+    "AZURE_POSTGRES_PASSWORD",
+    "PGPASSWORD",
+    "POSTGRES_URL",
+    "DATABASE_URL",
+  ]) {
+    if (process.env[forbiddenCredential]?.trim()) {
+      errors.push(
+        `${forbiddenCredential} is forbidden; use short-lived Microsoft Entra tokens`,
+      );
+    }
+  }
+
+  const runtimeStorageAuth = process.env.COMPLIANCEHUB_RUNTIME_STORAGE_AUTH;
+  if (runtimeStorageAuth !== "managed_identity" && runtimeStorageAuth !== "vercel_oidc") {
+    errors.push("Runtime storage must use managed_identity or vercel_oidc authentication");
+  }
+  if (process.env.VERCEL && runtimeStorageAuth !== "vercel_oidc") {
+    errors.push("Vercel production runtime storage must use OIDC federation");
+  }
+  if (runtimeStorageAuth === "vercel_oidc") {
+    requireKeys(["AZURE_TENANT_ID", "AZURE_CLIENT_ID"]);
+  }
+
+  for (const [key, minimumLength] of [
+    ["COMPLIANCEHUB_AUDIT_PSEUDONYMIZATION_KEY", 32],
+    ["COMPLIANCEHUB_BFF_SHARED_SECRET", 32],
+    ["COMPLIANCEHUB_ENTRA_CLIENT_SECRET", 32],
+    ["COMPLIANCEHUB_AUTH_TRANSACTION_SECRET", 32],
+  ]) {
+    if ((process.env[key] || "").length < minimumLength) {
+      errors.push(`${key} must contain at least ${minimumLength} characters`);
+    }
+  }
+
+  if (process.env.COMPLIANCEHUB_LLM_PREFER_AZURE === "true") {
+    requireKeys(["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_DEPLOYMENT"]);
+    if (process.env.AZURE_OPENAI_AUTH !== "managed_identity") {
+      errors.push("AZURE_OPENAI_AUTH must be managed_identity in production");
+    }
+    if (process.env.COMPLIANCEHUB_LLM_ASSUME_AZURE_EU !== "true") {
+      errors.push("Azure EU regional/Data Zone processing must be reviewed and attested");
+    }
   }
 }
 
@@ -240,9 +332,7 @@ function scanPublicCredentials(directory) {
     } else if (sourceExtensions.has(extname(path))) {
       const content = readFileSync(path, "utf8");
       if (publicCredentialPattern.test(content)) {
-        errors.push(
-          `${path}: public credential environment variables are forbidden`,
-        );
+        errors.push(`${path}: public credential environment variables are forbidden`);
       }
     }
   }
@@ -252,9 +342,9 @@ scanPublicCredentials(sourceRoot);
 
 if (errors.length) {
   process.stderr.write(
-    `Enterprise release gate failed:\n- ${errors.join("\n- ")}\n`,
+    `Enterprise release gate failed (${releaseProfile || "missing profile"}):\n- ${errors.join("\n- ")}\n`,
   );
   process.exit(1);
 }
 
-process.stdout.write("Enterprise release gate passed\n");
+process.stdout.write(`Enterprise release gate passed (${releaseProfile})\n`);

--- a/frontend/src/app/.well-known/security.txt/route.test.ts
+++ b/frontend/src/app/.well-known/security.txt/route.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GET } from "@/app/.well-known/security.txt/route";
+
+describe("security.txt", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("publishes a current RFC 9116 contact document", async () => {
+    vi.stubEnv("COMPLIANCEHUB_SECURITY_CONTACT", "mailto:security@complywithai.de");
+
+    const response = GET();
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/plain");
+    expect(body).toContain("Contact: mailto:security@complywithai.de");
+    expect(body).toContain(
+      "Canonical: https://complywithai.de/.well-known/security.txt",
+    );
+    expect(new Date(body.match(/Expires: (.+)/)?.[1] ?? 0).getTime()).toBeGreaterThan(
+      Date.now(),
+    );
+  });
+});

--- a/frontend/src/app/.well-known/security.txt/route.ts
+++ b/frontend/src/app/.well-known/security.txt/route.ts
@@ -1,15 +1,27 @@
-const SECURITY_TXT = `Contact: https://complywithai.de/kontakt
-Expires: 2027-07-01T00:00:00.000Z
-Preferred-Languages: de, en
-Canonical: https://complywithai.de/.well-known/security.txt
-Policy: https://complywithai.de/trust-center
-`;
+const SIX_MONTHS_MS = 183 * 24 * 60 * 60 * 1_000;
+
+export const dynamic = "force-dynamic";
 
 export function GET(): Response {
-  return new Response(SECURITY_TXT, {
+  const contact =
+    process.env.COMPLIANCEHUB_SECURITY_CONTACT?.trim() ||
+    "https://complywithai.de/kontakt";
+  const expires = new Date(Date.now() + SIX_MONTHS_MS).toISOString();
+  const body = [
+    `Contact: ${contact}`,
+    `Expires: ${expires}`,
+    "Preferred-Languages: de, en",
+    "Canonical: https://complywithai.de/.well-known/security.txt",
+    "Policy: https://complywithai.de/trust-center#disclosure",
+    "",
+  ].join("\n");
+
+  return new Response(body, {
+    status: 200,
     headers: {
+      "Cache-Control": "public, max-age=86400",
       "Content-Type": "text/plain; charset=utf-8",
-      "Cache-Control": "public, max-age=3600",
+      "X-Content-Type-Options": "nosniff",
     },
   });
 }

--- a/frontend/src/app/kontakt/page.tsx
+++ b/frontend/src/app/kontakt/page.tsx
@@ -3,6 +3,8 @@ import { Suspense } from "react";
 
 import { ContactLeadForm } from "@/components/contact/ContactLeadForm";
 import { CH_PAGE_SUB, CH_PAGE_TITLE, CH_SHELL } from "@/lib/boardLayout";
+import { PUBLIC_CONTACT_EMAIL, PUBLIC_CONTACT_MAILTO } from "@/lib/publicContact";
+import { isPublicSiteRelease } from "@/lib/releaseProfile";
 
 export const metadata: Metadata = {
   title: "Kontakt & Demo · Compliance Hub",
@@ -19,6 +21,8 @@ function FormFallback() {
 }
 
 export default function KontaktPage() {
+  const publicSite = isPublicSiteRelease();
+
   return (
     <div className={CH_SHELL}>
       <div className="max-w-2xl">
@@ -29,9 +33,34 @@ export default function KontaktPage() {
           nächsten Schritten.
         </p>
       </div>
-      <Suspense fallback={<FormFallback />}>
-        <ContactLeadForm />
-      </Suspense>
+      {publicSite ? (
+        <section className="max-w-2xl rounded-[1.75rem] border border-slate-200/80 bg-white p-6 shadow-xl shadow-slate-200/40 sm:p-8">
+          <p className="text-xs font-semibold uppercase tracking-[0.14em] text-cyan-700">
+            Direkter Kontakt
+          </p>
+          <h2 className="mt-3 text-xl font-semibold tracking-tight text-slate-950">
+            Ihr Anliegen bleibt unter Ihrer Kontrolle.
+          </h2>
+          <p className="mt-3 text-sm leading-7 text-slate-600">
+            Der öffentliche Release speichert keine Formulardaten. Schreiben Sie uns direkt;
+            Sie entscheiden selbst, welche Informationen Sie übermitteln.
+          </p>
+          <a
+            href={PUBLIC_CONTACT_MAILTO}
+            className="mt-6 inline-flex min-h-12 items-center justify-center rounded-full bg-[#07111f] px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-950/15 transition hover:-translate-y-0.5 hover:bg-slate-800"
+          >
+            {PUBLIC_CONTACT_EMAIL}
+          </a>
+          <p className="mt-5 text-xs leading-5 text-slate-500">
+            Bitte senden Sie keine besonderen Kategorien personenbezogener Daten oder
+            vertrauliche Mandantendaten per E-Mail.
+          </p>
+        </section>
+      ) : (
+        <Suspense fallback={<FormFallback />}>
+          <ContactLeadForm />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { connection } from "next/server";
 import React, { Suspense } from "react";
 
 import { DemoContextualHint } from "@/components/demo/DemoContextualHint";
@@ -8,6 +9,7 @@ import { SessionAttributionCapture } from "@/components/marketing/SessionAttribu
 import { CookieBanner } from "@/components/sbs/CookieBanner";
 import { SbsFooter } from "@/components/sbs/SbsFooter";
 import { SbsHeader } from "@/components/sbs/SbsHeader";
+import { isPublicSiteRelease } from "@/lib/releaseProfile";
 import { isDemoUiDesiredForTenant } from "@/lib/workspaceDemoServer";
 import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
 
@@ -42,8 +44,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const workspaceTenantId = await getWorkspaceTenantIdServer();
-  const showDemoUi = await isDemoUiDesiredForTenant(workspaceTenantId);
+  await connection();
+  const publicSite = isPublicSiteRelease();
+  const workspaceTenantId = publicSite ? "" : await getWorkspaceTenantIdServer();
+  const showDemoUi = publicSite
+    ? false
+    : await isDemoUiDesiredForTenant(workspaceTenantId);
 
   return (
     <html
@@ -52,10 +58,12 @@ export default async function RootLayout({
       data-scroll-behavior="smooth"
     >
       <body className="sbs-body flex min-h-screen flex-col bg-[#f5f7fb] antialiased">
-        <Suspense fallback={null}>
-          <SessionAttributionCapture />
-        </Suspense>
-        <SbsHeader />
+        {!publicSite ? (
+          <Suspense fallback={null}>
+            <SessionAttributionCapture />
+          </Suspense>
+        ) : null}
+        <SbsHeader publicSite={publicSite} />
         <DemoEnvironmentBanner visible={showDemoUi} />
         <main
           id="app-main"
@@ -64,11 +72,15 @@ export default async function RootLayout({
           <DemoContextualHint enabled={showDemoUi} />
           {children}
         </main>
-        <DemoGuide tenantId={workspaceTenantId} enabled={showDemoUi} />
-        <SbsFooter />
-        <Suspense fallback={null}>
-          <CookieBanner />
-        </Suspense>
+        {!publicSite ? (
+          <DemoGuide tenantId={workspaceTenantId} enabled={showDemoUi} />
+        ) : null}
+        <SbsFooter publicSite={publicSite} />
+        {!publicSite ? (
+          <Suspense fallback={null}>
+            <CookieBanner />
+          </Suspense>
+        ) : null}
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,6 +5,7 @@ import { TrackedContactLink } from "@/components/contact/TrackedContactLink";
 import { HomeProductPreview } from "@/components/home/HomeProductPreview";
 import { CH_BTN_PRIMARY } from "@/lib/boardLayout";
 import { contactPageHref } from "@/lib/publicContact";
+import { isPublicSiteRelease } from "@/lib/releaseProfile";
 
 function SectionTitle({
   title,
@@ -31,6 +32,8 @@ function SectionTitle({
 }
 
 export default function HomePage() {
+  const publicSite = isPublicSiteRelease();
+
   return (
     <div className="relative min-w-0">
       <div
@@ -67,6 +70,7 @@ export default function HomePage() {
                 })}
                 ctaId="home-hero-demo"
                 quelle="home-hero"
+                trackingEnabled={!publicSite}
                 className="inline-flex min-h-12 items-center justify-center rounded-full bg-[#07111f] px-6 py-3 text-sm font-semibold text-white shadow-xl shadow-slate-950/15 transition hover:-translate-y-0.5 hover:bg-slate-800"
               >
                 Demo anfragen
@@ -77,12 +81,14 @@ export default function HomePage() {
               >
                 Trust Center
               </Link>
-              <Link
-                href="/board/kpis"
-                className="inline-flex min-h-12 items-center justify-center rounded-full px-5 py-3 text-sm font-semibold text-slate-600 transition hover:text-slate-950"
-              >
-                Board öffnen
-              </Link>
+              {!publicSite ? (
+                <Link
+                  href="/board/kpis"
+                  className="inline-flex min-h-12 items-center justify-center rounded-full px-5 py-3 text-sm font-semibold text-slate-600 transition hover:text-slate-950"
+                >
+                  Board öffnen
+                </Link>
+              ) : null}
             </div>
             <p className="mt-8 text-[0.65rem] font-semibold uppercase tracking-[0.16em] text-slate-500 sm:text-xs">
               EU AI Act · NIS2 · ISO 27001/27701 · ISO 42001 · DSGVO
@@ -254,6 +260,7 @@ export default function HomePage() {
               })}
               ctaId="home-integrations-kontakt"
               quelle="home-integrations"
+              trackingEnabled={!publicSite}
               className="font-medium text-cyan-700 underline-offset-2 hover:underline"
             >
               Kontakt aufnehmen
@@ -286,16 +293,21 @@ export default function HomePage() {
               })}
               ctaId="home-mid-cta-demo"
               quelle="home-mid-cta"
+              trackingEnabled={!publicSite}
               className="inline-flex items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-950 shadow-md transition hover:-translate-y-0.5"
             >
               Demo anfragen
             </TrackedContactLink>
-            <Link href="/auth/login" className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/15">
-              Anmelden
-            </Link>
-            <Link href="/board/kpis" className="inline-flex items-center justify-center rounded-full px-5 py-3 text-sm font-semibold text-slate-300 transition hover:text-white">
-              Board-Ansicht
-            </Link>
+            {!publicSite ? (
+              <>
+                <Link href="/auth/login" className="inline-flex items-center justify-center rounded-full border border-white/20 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/15">
+                  Anmelden
+                </Link>
+                <Link href="/board/kpis" className="inline-flex items-center justify-center rounded-full px-5 py-3 text-sm font-semibold text-slate-300 transition hover:text-white">
+                  Board-Ansicht
+                </Link>
+              </>
+            ) : null}
           </div>
         </div>
       </section>
@@ -355,8 +367,11 @@ export default function HomePage() {
                 </div>
               ))}
             </div>
-            <Link href="/settings" className={`${CH_BTN_PRIMARY} mt-5 w-full sm:w-auto`}>
-              Zu Mandant &amp; Einstellungen
+            <Link
+              href={publicSite ? "/trust-center" : "/settings"}
+              className={`${CH_BTN_PRIMARY} mt-5 w-full sm:w-auto`}
+            >
+              {publicSite ? "Zum Trust Center" : "Zu Mandant & Einstellungen"}
             </Link>
           </div>
         </div>

--- a/frontend/src/app/trust-center/page.tsx
+++ b/frontend/src/app/trust-center/page.tsx
@@ -9,31 +9,37 @@ export const metadata: Metadata = {
 };
 
 const frameworks = [
-  { key: "EU_AI_ACT", label: "EU AI Act", icon: "🤖", status: "Aktiv" },
-  { key: "ISO_42001", label: "ISO 42001", icon: "📋", status: "Aktiv" },
-  { key: "ISO_27001", label: "ISO 27001", icon: "🔒", status: "Aktiv" },
-  { key: "NIS2", label: "NIS2", icon: "🛡️", status: "Aktiv" },
-  { key: "DSGVO", label: "DSGVO", icon: "🇪🇺", status: "Aktiv" },
-  { key: "GoBD", label: "GoBD", icon: "📊", status: "Aktiv" },
+  { key: "EU_AI_ACT", label: "EU AI Act", icon: "AI", status: "Im Kontrollmodell" },
+  { key: "ISO_42001", label: "ISO 42001", icon: "42", status: "Im Kontrollmodell" },
+  { key: "ISO_27001", label: "ISO 27001", icon: "27", status: "Im Kontrollmodell" },
+  { key: "NIS2", label: "NIS2", icon: "N2", status: "Im Kontrollmodell" },
+  { key: "DSGVO", label: "DSGVO", icon: "EU", status: "Im Kontrollmodell" },
+  { key: "GoBD", label: "GoBD", icon: "GB", status: "Im Kontrollmodell" },
 ];
 
 const securityCommitments = [
-  "Verschlüsselung in Transit (TLS 1.3) und at Rest (AES-256)",
-  "Rollenbasierte Zugriffskontrolle (RBAC) mit Enterprise-Rollen",
-  "Immutable Audit-Log für alle Änderungen und Zugriffe",
-  "Multi-Faktor-Authentifizierung (MFA) für alle Konten",
-  "Separation of Duties (SoD) Policies",
-  "Tenant-Isolation auf Daten- und Anwendungsebene",
+  "Nonce-basierte Content Security Policy ohne pauschale Skript- oder Stilfreigaben",
+  "Öffentlicher Release ohne Anmeldung, Mandantendaten oder Zustands-APIs",
+  "Kein Formular-Tracking, keine Drittanbieter-Analytics und keine Marketing-Cookies",
+  "Rechtliche Pflichtangaben und Datenschutzprüfung als technisches Build-Gate",
+  "Nicht freigegebene App-, Auth- und API-Routen werden vor der Anwendung abgewiesen",
+  "Enterprise-Datenebene bleibt bis zur separaten Evidenzfreigabe deaktiviert",
 ];
 
 const dataResidencyFeatures = [
-  "Primärer Betrieb in EU-Regionen (Frankfurt / DACH)",
-  "Mandanten-Region-Pinning verfügbar",
-  "Keine Datenverarbeitung außerhalb der EU",
-  "Transparente Subprocessor-Liste",
+  "Der Public-Site-Release verarbeitet keine Mandanten- oder Plattformdaten",
+  "Kontakt erfolgt ohne lokale Lead-Speicherung direkt über den E-Mail-Client des Nutzers",
+  "Web-Auslieferung und technisch erforderliche Protokolldaten sind in der Datenschutzerklärung beschrieben",
+  "Datenregionen der Enterprise-Plattform werden erst vertraglich und evidenzbasiert freigegeben",
 ];
 
 export default function TrustCenterPublicPage() {
+  const securityContact =
+    process.env.COMPLIANCEHUB_SECURITY_CONTACT?.trim() || "/kontakt";
+  const securityContactLabel = securityContact.startsWith("mailto:")
+    ? securityContact.slice("mailto:".length)
+    : "Security-Kontakt öffnen";
+
   return (
     <div className="min-w-0 space-y-12 md:space-y-16">
       {/* Hero */}
@@ -45,10 +51,9 @@ export default function TrustCenterPublicPage() {
           Vertrauen auf Enterprise-Niveau.
         </h1>
         <p className="mt-3 max-w-2xl text-base leading-relaxed text-slate-600">
-          DACH-fokussierte Sicherheits-, Datenschutz- und Governance-Architektur –
-          dokumentiert, auditierbar und auf Enterprise-Gruppen skalierbar.
-          Hier finden Sie einen strukturierten Überblick über unsere Sicherheitsmaßnahmen,
-          Compliance-Frameworks und Datenschutzpraktiken.
+          Hier dokumentieren wir den tatsächlich freigegebenen Produktionsumfang,
+          Sicherheitsgrenzen und den Evidenzstatus. Der öffentliche Release ist bewusst
+          von der Enterprise-Datenebene getrennt.
         </p>
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
@@ -56,12 +61,6 @@ export default function TrustCenterPublicPage() {
             className="inline-flex items-center justify-center rounded-xl bg-cyan-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-cyan-700"
           >
             Security Review anfragen
-          </Link>
-          <Link
-            href="/tenant/trust-center"
-            className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-2.5 text-sm font-semibold text-slate-800 shadow-sm transition hover:border-slate-300 hover:bg-slate-50"
-          >
-            Assurance Portal (Login)
           </Link>
         </div>
       </header>
@@ -75,8 +74,9 @@ export default function TrustCenterPublicPage() {
           Sicherheitsarchitektur
         </h2>
         <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-          Enterprise-grade Sicherheitsarchitektur mit Verschlüsselung, RBAC,
-          Audit-Trails und Tenant-Isolation.
+          Verifizierbare Kontrollen des stateless Public-Site-Profils. Aussagen zur
+          Enterprise-Plattform sind keine Produktzertifizierung und werden erst nach
+          dokumentierter Betriebsfreigabe erweitert.
         </p>
         <ul className="mt-5 grid gap-3 sm:grid-cols-2">
           {securityCommitments.map((c) => (
@@ -104,8 +104,9 @@ export default function TrustCenterPublicPage() {
           Unterstützte Frameworks & Standards
         </h2>
         <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-          ComplianceHub unterstützt die zentralen regulatorischen Frameworks für den DACH-Markt.
-          Ein gemeinsames Kontrollmodell ermöglicht &bdquo;Map once, comply many&ldquo;.
+          Die Produktlogik bildet Anforderungen dieser Frameworks in einem gemeinsamen
+          Kontrollmodell ab. Das ist weder eine Zertifizierung noch eine automatische
+          Feststellung der Rechtskonformität eines Kunden.
         </p>
         <div className="mt-5 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {frameworks.map((fw) => (
@@ -114,7 +115,7 @@ export default function TrustCenterPublicPage() {
               className="rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-200/40"
             >
               <div className="flex items-center gap-3">
-                <span className="text-2xl" aria-hidden>{fw.icon}</span>
+                <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-slate-950 font-mono text-xs font-semibold text-white" aria-hidden>{fw.icon}</span>
                 <div>
                   <p className="text-sm font-semibold text-slate-900">{fw.label}</p>
                   <p className="text-xs text-emerald-600 font-medium">{fw.status}</p>
@@ -131,15 +132,16 @@ export default function TrustCenterPublicPage() {
           id="data-residency"
           className="text-xl font-semibold tracking-tight text-slate-900"
         >
-          Datenresidenz & EU Hosting
+          Datenumfang des Public Release
         </h2>
         <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-          Primärer Betrieb in EU-Regionen mit klaren Residency-Policies für DACH-Kunden.
+          Der öffentliche Webauftritt ist technisch und organisatorisch von der späteren
+          Enterprise-Datenebene getrennt.
         </p>
         <div className="mt-5 rounded-2xl border border-slate-200/80 bg-white p-5 shadow-sm shadow-slate-200/40">
           <div className="flex items-center gap-2 text-sm font-medium text-slate-900">
-            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-cyan-100 text-cyan-700 text-xs">🇪🇺</span>
-            Hosting-Region: EU (Frankfurt / DACH)
+            <span className="flex h-6 w-6 items-center justify-center rounded-full bg-cyan-100 text-cyan-700 text-xs">01</span>
+            Freigegebener Umfang: öffentliche Produktinformation
           </div>
           <ul className="mt-4 space-y-2">
             {dataResidencyFeatures.map((f) => (
@@ -161,11 +163,12 @@ export default function TrustCenterPublicPage() {
           Subprocessor-Transparenz
         </h2>
         <p className="mt-2 max-w-2xl text-sm leading-relaxed text-slate-600">
-          Vollständige Transparenz über eingesetzte Unterauftragsverarbeiter. Die
-          aktuelle Liste ist auf Anfrage oder im eingeloggten Assurance Portal verfügbar.
+          Für die öffentliche Website wird Vercel zur Web-Auslieferung eingesetzt. Weitere
+          Unterauftragsverarbeiter und Datenregionen werden für Enterprise-Leistungen
+          vertrags- und instanzbezogen offengelegt, bevor Kundendaten verarbeitet werden.
         </p>
         <p className="mt-3 text-xs text-slate-500">
-          Letzte Aktualisierung: 01.04.2026
+          Letzte Aktualisierung: 15.07.2026
         </p>
       </section>
 
@@ -184,10 +187,10 @@ export default function TrustCenterPublicPage() {
           <p className="text-sm text-slate-700">
             <span className="font-medium">Security-Kontakt:</span>{" "}
             <a
-              href="mailto:security@compliancehub.de"
+              href={securityContact}
               className="text-cyan-700 underline decoration-cyan-600/25 underline-offset-4 transition hover:text-cyan-900"
             >
-              security@compliancehub.de
+              {securityContactLabel}
             </a>
           </p>
           <p className="mt-2 text-sm text-slate-700">

--- a/frontend/src/components/contact/TrackedContactLink.tsx
+++ b/frontend/src/components/contact/TrackedContactLink.tsx
@@ -10,16 +10,26 @@ type Props = {
   quelle: string;
   className: string;
   children: React.ReactNode;
+  trackingEnabled?: boolean;
 };
 
-export function TrackedContactLink({ href, ctaId, quelle, className, children }: Props) {
+export function TrackedContactLink({
+  href,
+  ctaId,
+  quelle,
+  className,
+  children,
+  trackingEnabled = true,
+}: Props) {
   return (
     <Link
       href={href}
       className={className}
       prefetch={false}
-      onClick={() =>
-        sendMarketingEvent({ event: "cta_click", cta_id: ctaId, quelle })
+      onClick={
+        trackingEnabled
+          ? () => sendMarketingEvent({ event: "cta_click", cta_id: ctaId, quelle })
+          : undefined
       }
     >
       {children}

--- a/frontend/src/components/sbs/GlobalAppNav.test.tsx
+++ b/frontend/src/components/sbs/GlobalAppNav.test.tsx
@@ -137,4 +137,15 @@ describe("GlobalAppNav", () => {
     render(<GlobalAppNav />);
     expect(screen.getByRole("button", { name: /Menü öffnen/i })).toBeTruthy();
   });
+
+  it("exposes only public destinations in the public-site profile", () => {
+    setupDefaults();
+    render(<GlobalAppNav publicSite />);
+
+    expect(screen.getByRole("link", { name: /^Start$/i })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Trust Center/i })).toBeTruthy();
+    expect(screen.getByRole("link", { name: /Kontakt/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Board/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Konto/i })).toBeNull();
+  });
 });

--- a/frontend/src/components/sbs/GlobalAppNav.tsx
+++ b/frontend/src/components/sbs/GlobalAppNav.tsx
@@ -356,7 +356,34 @@ function MobileNavContent({
 
 /* ── Main nav export ───────────────────────────────────────────────── */
 
-export function GlobalAppNav() {
+function PublicSiteNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex items-center justify-end gap-1" aria-label="Hauptnavigation">
+      <Link
+        href="/"
+        className={`${navLinkClass(pathname === "/")} hidden sm:inline-flex`}
+      >
+        Start
+      </Link>
+      <Link
+        href="/trust-center"
+        className={navLinkClass(pathname === "/trust-center")}
+      >
+        Trust Center
+      </Link>
+      <Link
+        href="/kontakt"
+        className="inline-flex min-h-9 items-center justify-center rounded-lg bg-[#07111f] px-3 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800"
+      >
+        Kontakt
+      </Link>
+    </nav>
+  );
+}
+
+function EnterpriseAppNav() {
   const pathname = usePathname();
 
   // RBAC visibility
@@ -536,3 +563,10 @@ export function GlobalAppNav() {
   );
 }
 
+type GlobalAppNavProps = {
+  publicSite?: boolean;
+};
+
+export function GlobalAppNav({ publicSite = false }: GlobalAppNavProps) {
+  return publicSite ? <PublicSiteNav /> : <EnterpriseAppNav />;
+}

--- a/frontend/src/components/sbs/SbsFooter.tsx
+++ b/frontend/src/components/sbs/SbsFooter.tsx
@@ -3,8 +3,50 @@ import React from "react";
 
 import { contactPageHref } from "@/lib/publicContact";
 
-export function SbsFooter() {
+type SbsFooterProps = {
+  publicSite?: boolean;
+};
+
+export function SbsFooter({ publicSite = false }: SbsFooterProps) {
   const y = new Date().getFullYear();
+  if (publicSite) {
+    return (
+      <footer className="sbs-premium-footer mt-auto border-t border-white/10 bg-[#07111f] py-12 text-white">
+        <div className="mx-auto grid min-w-0 max-w-[90rem] gap-10 px-4 md:grid-cols-[1.4fr_1fr_1fr] md:px-8">
+          <div className="max-w-md">
+            <p className="text-base font-semibold tracking-[-0.02em]">Compliance Hub</p>
+            <p className="mt-3 text-sm leading-6 text-slate-400">
+              Enterprise AI Governance für nachvollziehbare Controls, Evidence und
+              verantwortliche Entscheidungen.
+            </p>
+          </div>
+          <nav aria-label="Unternehmen">
+            <h2 className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500">
+              Unternehmen
+            </h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              <li><Link href="/" className="text-slate-300 hover:text-white">Start</Link></li>
+              <li><Link href="/trust-center" className="text-slate-300 hover:text-white">Trust Center</Link></li>
+              <li><Link href="/kontakt" className="text-slate-300 hover:text-white">Kontakt</Link></li>
+            </ul>
+          </nav>
+          <nav aria-label="Rechtliches">
+            <h2 className="text-[0.65rem] font-bold uppercase tracking-wider text-slate-500">
+              Rechtliches
+            </h2>
+            <ul className="mt-3 space-y-2 text-sm">
+              <li><Link href="/impressum" className="text-slate-300 hover:text-white">Impressum</Link></li>
+              <li><Link href="/datenschutz" className="text-slate-300 hover:text-white">Datenschutz</Link></li>
+            </ul>
+          </nav>
+          <p className="border-t border-white/10 pt-6 text-xs text-slate-500 md:col-span-3">
+            © {y} Compliance Hub · Öffentliche Produktinformation · Keine Rechtsberatung
+          </p>
+        </div>
+      </footer>
+    );
+  }
+
   return (
     <footer className="sbs-premium-footer mt-auto border-t border-slate-200/70 bg-[#07111f] py-12 text-white">
       <div className="mx-auto min-w-0 max-w-[90rem] px-4 md:px-8">

--- a/frontend/src/components/sbs/SbsHeader.tsx
+++ b/frontend/src/components/sbs/SbsHeader.tsx
@@ -6,7 +6,11 @@ import { BRAND_TAGLINE } from "@/lib/appNavConfig";
 import { AppSecondaryNav } from "./AppSecondaryNav";
 import { GlobalAppNav } from "./GlobalAppNav";
 
-export function SbsHeader() {
+type SbsHeaderProps = {
+  publicSite?: boolean;
+};
+
+export function SbsHeader({ publicSite = false }: SbsHeaderProps) {
   return (
     <header className="sticky top-0 z-50 border-b border-white/70 bg-white/80 shadow-[0_1px_0_rgba(7,17,31,0.06)] backdrop-blur-2xl backdrop-saturate-150">
       <div className="mx-auto flex min-h-16 max-w-[90rem] items-center justify-between gap-4 px-4 py-2 md:px-8 md:py-2.5">
@@ -26,9 +30,9 @@ export function SbsHeader() {
             </span>
           </span>
         </Link>
-        <GlobalAppNav />
+        <GlobalAppNav publicSite={publicSite} />
       </div>
-      <AppSecondaryNav />
+      {!publicSite ? <AppSecondaryNav /> : null}
     </header>
   );
 }

--- a/frontend/src/lib/contentSecurityPolicy.test.ts
+++ b/frontend/src/lib/contentSecurityPolicy.test.ts
@@ -53,4 +53,17 @@ describe("content security policy", () => {
     expect(policy).toContain("connect-src 'self'");
     expect(policy).not.toContain("javascript:");
   });
+
+  it("keeps enforcement active when production reporting is not approved", () => {
+    const policy = buildContentSecurityPolicy({
+      nonce: createCspNonce(),
+      development: false,
+      reportingEnabled: false,
+    });
+
+    expect(policy).toContain("frame-ancestors 'none'");
+    expect(policy).toContain("upgrade-insecure-requests");
+    expect(policy).not.toContain("report-uri");
+    expect(policy).not.toContain("report-to");
+  });
 });

--- a/frontend/src/lib/contentSecurityPolicy.ts
+++ b/frontend/src/lib/contentSecurityPolicy.ts
@@ -23,10 +23,12 @@ export function buildContentSecurityPolicy({
   nonce,
   development,
   apiBaseUrl,
+  reportingEnabled = !development,
 }: {
   nonce: string;
   development: boolean;
   apiBaseUrl?: string;
+  reportingEnabled?: boolean;
 }): string {
   if (nonce.length < 24 || !CSP_NONCE_PATTERN.test(nonce)) {
     throw new Error("CSP nonce must be an unpredictable base64 value");
@@ -64,7 +66,7 @@ export function buildContentSecurityPolicy({
     "worker-src 'self' blob:",
     "manifest-src 'self'",
     ...(development ? [] : ["upgrade-insecure-requests"]),
-    ...(development
+    ...(development || !reportingEnabled
       ? []
       : [
           `report-uri ${CSP_REPORT_ENDPOINT}`,

--- a/frontend/src/lib/enterpriseReleaseGate.test.ts
+++ b/frontend/src/lib/enterpriseReleaseGate.test.ts
@@ -1,0 +1,92 @@
+import { spawnSync } from "node:child_process";
+
+import { describe, expect, it } from "vitest";
+
+const sensitiveEnvironmentPattern =
+  /^(?:COMPLIANCEHUB_|NEXT_PUBLIC_|POSTGRES_|SUPABASE_|AZURE_|DATABASE_URL$|PGPASSWORD$|VERCEL)/;
+
+function reviewedDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function publicSiteEnvironment(): NodeJS.ProcessEnv {
+  const cleanEnvironment = Object.fromEntries(
+    Object.entries(process.env).filter(
+      ([key]) => !sensitiveEnvironmentPattern.test(key),
+    ),
+  );
+  return {
+    ...cleanEnvironment,
+    VERCEL_ENV: "production",
+    COMPLIANCEHUB_RELEASE_PROFILE: "public_site",
+    COMPLIANCEHUB_APP_ORIGIN: "https://complywithai.de",
+    COMPLIANCEHUB_TRUSTED_HOSTS: "complywithai.de",
+    COMPLIANCEHUB_LEGAL_ENTITY_NAME: "Example GmbH",
+    COMPLIANCEHUB_LEGAL_REPRESENTATIVE: "Erika Beispiel",
+    COMPLIANCEHUB_LEGAL_STREET: "Beispielweg 1",
+    COMPLIANCEHUB_LEGAL_POSTAL_CODE: "10115",
+    COMPLIANCEHUB_LEGAL_CITY: "Berlin",
+    COMPLIANCEHUB_LEGAL_COUNTRY: "Deutschland",
+    COMPLIANCEHUB_LEGAL_EMAIL: "legal@example.invalid",
+    COMPLIANCEHUB_LEGAL_REGISTER_COURT: "Amtsgericht Berlin",
+    COMPLIANCEHUB_LEGAL_REGISTER_NUMBER: "HRB 12345",
+    COMPLIANCEHUB_LEGAL_VAT_ID: "DE123456789",
+    COMPLIANCEHUB_PRIVACY_EMAIL: "privacy@example.invalid",
+    COMPLIANCEHUB_PRIVACY_NOTICE_VERSION: "test-1",
+    COMPLIANCEHUB_PRIVACY_REVIEWED_AT: reviewedDate(),
+    COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS: "14",
+    COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS: "180",
+    COMPLIANCEHUB_SECURITY_CONTACT: "mailto:security@example.invalid",
+    COMPLIANCEHUB_LEGAL_PUBLISH_READY: "true",
+    COMPLIANCEHUB_PUBLIC_SITE_READY: "true",
+  };
+}
+
+function runGate(environment: NodeJS.ProcessEnv) {
+  return spawnSync(process.execPath, ["scripts/verify-enterprise-readiness.mjs"], {
+    cwd: process.cwd(),
+    env: environment,
+    encoding: "utf8",
+  });
+}
+
+describe("enterprise release gate profiles", () => {
+  it("accepts a reviewed stateless public-site release", () => {
+    const result = runGate(publicSiteEnvironment());
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("passed (public_site)");
+  });
+
+  it("rejects inherited database credentials in the public-site release", () => {
+    const result = runGate({
+      ...publicSiteEnvironment(),
+      POSTGRES_URL: "postgres://forbidden.invalid/database",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain(
+      "POSTGRES_URL is forbidden in the stateless public_site release",
+    );
+  });
+
+  it("requires explicit legal approval for the public-site release", () => {
+    const environment = publicSiteEnvironment();
+    delete environment.COMPLIANCEHUB_LEGAL_PUBLISH_READY;
+    const result = runGate(environment);
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("documented legal review");
+  });
+
+  it("does not weaken the enterprise profile requirements", () => {
+    const result = runGate({
+      ...publicSiteEnvironment(),
+      COMPLIANCEHUB_RELEASE_PROFILE: "enterprise",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("COMPLIANCEHUB_API_BASE_URL is required");
+    expect(result.stderr).toContain("COMPLIANCEHUB_ENTRA_ENABLED must be true");
+  });
+});

--- a/frontend/src/lib/releaseProfile.ts
+++ b/frontend/src/lib/releaseProfile.ts
@@ -1,0 +1,18 @@
+export const PUBLIC_SITE_RELEASE_PROFILE = "public_site" as const;
+export const ENTERPRISE_RELEASE_PROFILE = "enterprise" as const;
+
+export type ReleaseProfile =
+  | typeof PUBLIC_SITE_RELEASE_PROFILE
+  | typeof ENTERPRISE_RELEASE_PROFILE
+  | "development";
+
+export function getReleaseProfile(): ReleaseProfile {
+  const profile = process.env.COMPLIANCEHUB_RELEASE_PROFILE?.trim();
+  if (profile === PUBLIC_SITE_RELEASE_PROFILE) return profile;
+  if (profile === ENTERPRISE_RELEASE_PROFILE) return profile;
+  return "development";
+}
+
+export function isPublicSiteRelease(): boolean {
+  return getReleaseProfile() === PUBLIC_SITE_RELEASE_PROFILE;
+}

--- a/frontend/src/proxy.test.ts
+++ b/frontend/src/proxy.test.ts
@@ -16,6 +16,7 @@ function nonceFrom(policy: string): string {
 describe("proxy CSP boundary", () => {
   it("generates a unique nonce and non-cacheable policy per request", () => {
     vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("COMPLIANCEHUB_CSP_REPORTING_READY", "true");
     const first = proxy(new NextRequest("https://complywithai.de/"));
     const second = proxy(new NextRequest("https://complywithai.de/"));
     const firstPolicy = first.headers.get("content-security-policy") ?? "";
@@ -32,6 +33,7 @@ describe("proxy CSP boundary", () => {
 
   it("retains the strict policy on authentication redirects", () => {
     vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("COMPLIANCEHUB_CSP_REPORTING_READY", "true");
     const response = proxy(
       new NextRequest("https://complywithai.de/tenant/governance/overview"),
     );
@@ -52,5 +54,26 @@ describe("proxy CSP boundary", () => {
 
     expect(response.headers.get("content-security-policy")).not.toContain("report-to");
     expect(response.headers.has("reporting-endpoints")).toBe(false);
+  });
+
+  it("allows only approved public pages in the stateless public release", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("COMPLIANCEHUB_RELEASE_PROFILE", "public_site");
+
+    const publicPage = proxy(new NextRequest("https://complywithai.de/trust-center"));
+    const applicationPage = proxy(
+      new NextRequest("https://complywithai.de/board/kpis"),
+    );
+    const leadApi = proxy(
+      new NextRequest("https://complywithai.de/api/lead-inquiry", {
+        method: "POST",
+      }),
+    );
+
+    expect(publicPage.status).toBe(200);
+    expect(applicationPage.status).toBe(404);
+    expect(leadApi.status).toBe(404);
+    expect(leadApi.headers.get("cache-control")).toBe("private, no-store");
+    expect(publicPage.headers.has("reporting-endpoints")).toBe(false);
   });
 });

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -15,8 +15,20 @@ import {
   CSP_REPORTING_GROUP,
   createCspNonce,
 } from "@/lib/contentSecurityPolicy";
+import { isPublicSiteRelease } from "@/lib/releaseProfile";
 
 const WORKSPACE_COOKIE_MAX_AGE_SEC = 90 * 24 * 60 * 60;
+const PUBLIC_SITE_PATHS = new Set([
+  "/",
+  "/kontakt",
+  "/trust-center",
+  "/impressum",
+  "/datenschutz",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/manifest.webmanifest",
+  "/.well-known/security.txt",
+]);
 
 function applyRequestSecurityPolicy(
   response: NextResponse,
@@ -79,16 +91,31 @@ function applyTenantsWorkspaceCookiePolicy(
 }
 
 export function proxy(request: NextRequest) {
+  const publicSiteRelease = isPublicSiteRelease();
   const nonce = createCspNonce();
   const contentSecurityPolicy = buildContentSecurityPolicy({
     nonce,
     development: process.env.NODE_ENV !== "production",
     apiBaseUrl: process.env.NEXT_PUBLIC_API_BASE_URL,
+    reportingEnabled:
+      !publicSiteRelease &&
+      process.env.COMPLIANCEHUB_CSP_REPORTING_READY === "true",
   });
   const requestHeaders = new Headers(request.headers);
   requestHeaders.set("x-nonce", nonce);
   requestHeaders.set("Content-Security-Policy", contentSecurityPolicy);
   const response = NextResponse.next({ request: { headers: requestHeaders } });
+
+  if (publicSiteRelease && !PUBLIC_SITE_PATHS.has(request.nextUrl.pathname)) {
+    return applyRequestSecurityPolicy(
+      new NextResponse("Not Found", {
+        status: 404,
+        headers: { "Content-Type": "text/plain; charset=utf-8" },
+      }),
+      contentSecurityPolicy,
+    );
+  }
+
   const tenantsRedirect = applyTenantsWorkspaceCookiePolicy(request, response);
   if (tenantsRedirect) {
     return applyRequestSecurityPolicy(tenantsRedirect, contentSecurityPolicy);


### PR DESCRIPTION
## What changed
- adds explicit `public_site` and `enterprise` release profiles
- restricts the public production surface to reviewed marketing, trust, contact and legal routes
- disables login, stateful APIs, lead storage, demo cookies, telemetry and CSP reporting in the public profile
- adds public-only navigation, direct-email contact, honest Trust Center copy and dynamic `security.txt`
- forces request rendering so every Next.js script receives the CSP nonce
- adds release-gate, CSP, proxy, navigation and security.txt regression tests plus an operating runbook

## Root cause
The merged production deployment failed because the full enterprise readiness gate correctly required Azure/Entra/legal evidence that is not configured in Vercel. The domain therefore remained on the prior April deployment. A separate stateless public release profile was required; bypassing the enterprise gate would have exposed unapproved runtime paths.

## Validation
- `npm run lint`
- `npm run test:unit` — 84 files / 302 tests
- production-profile `npm run build`
- browser verification at 1440px and 390px
- 23/23 Next.js scripts carry the request nonce; no console errors
- public routes return 200; Board, Auth and lead API return 404

## Deployment note
Production remains gated until the exact legal representative, privacy notice review and Vercel production environment cleanup are explicitly approved.