### PR TITLE
Allow verified Vercel build metadata

### DIFF
--- a/docs/public-site-release-runbook.md
+++ b/docs/public-site-release-runbook.md
@@ -44,10 +44,13 @@ automation without the named owner and review evidence in the change record.
 
 ## Prohibited production configuration
 
-The build fails if the public profile inherits any `NEXT_PUBLIC_*`, `POSTGRES_*`,
-`SUPABASE_*`, `AZURE_*`, `DATABASE_URL`, `PGPASSWORD`, or unapproved
-`COMPLIANCEHUB_*` value. Remove integration-created variables from the Vercel
-production environment before deployment; do not replace them with dummy values.
+The build fails if the public profile inherits any application-defined
+`NEXT_PUBLIC_*`, `POSTGRES_*`, `SUPABASE_*`, `AZURE_*`, `DATABASE_URL`,
+`PGPASSWORD`, or unapproved `COMPLIANCEHUB_*` value. Vercel-generated
+`NEXT_PUBLIC_VERCEL_*` deployment metadata is permitted because Vercel injects it
+into builds and it contains no application credential. Remove integration-created
+variables from the Vercel production environment before deployment; do not replace
+them with dummy values.
 
 The following capabilities must be unset or `false`:
 

--- a/frontend/scripts/verify-enterprise-readiness.mjs
+++ b/frontend/scripts/verify-enterprise-readiness.mjs
@@ -155,7 +155,6 @@ if (releaseProfile === "public_site") {
     "COMPLIANCEHUB_LLM_PII_MODE",
   ]);
   const forbiddenPublicPrefixes = [
-    "NEXT_PUBLIC_",
     "POSTGRES_",
     "SUPABASE_",
     "AZURE_",
@@ -166,10 +165,16 @@ if (releaseProfile === "public_site") {
     if (!rawValue?.trim()) continue;
     const unapprovedComplianceHubKey =
       key.startsWith("COMPLIANCEHUB_") && !allowedComplianceHubKeys.has(key);
+    const unapprovedBrowserKey =
+      key.startsWith("NEXT_PUBLIC_") && !key.startsWith("NEXT_PUBLIC_VERCEL_");
     const forbiddenInfrastructureKey =
       forbiddenPublicExact.has(key) ||
       forbiddenPublicPrefixes.some((prefix) => key.startsWith(prefix));
-    if (unapprovedComplianceHubKey || forbiddenInfrastructureKey) {
+    if (
+      unapprovedComplianceHubKey ||
+      unapprovedBrowserKey ||
+      forbiddenInfrastructureKey
+    ) {
       errors.push(`${key} is forbidden in the stateless public_site release`);
     }
   }

--- a/frontend/src/lib/enterpriseReleaseGate.test.ts
+++ b/frontend/src/lib/enterpriseReleaseGate.test.ts
@@ -70,6 +70,23 @@ describe("enterprise release gate profiles", () => {
     );
   });
 
+  it("accepts Vercel system metadata but rejects application browser variables", () => {
+    const platformResult = runGate({
+      ...publicSiteEnvironment(),
+      NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA: "abc123",
+    });
+    const applicationResult = runGate({
+      ...publicSiteEnvironment(),
+      NEXT_PUBLIC_APPLICATION_FLAG: "true",
+    });
+
+    expect(platformResult.status, platformResult.stderr).toBe(0);
+    expect(applicationResult.status).toBe(1);
+    expect(applicationResult.stderr).toContain(
+      "NEXT_PUBLIC_APPLICATION_FLAG is forbidden in the stateless public_site release",
+    );
+  });
+
   it("requires explicit legal approval for the public-site release", () => {
     const environment = publicSiteEnvironment();
     delete environment.COMPLIANCEHUB_LEGAL_PUBLISH_READY;


### PR DESCRIPTION
## What changed
- permits only Vercel-generated `NEXT_PUBLIC_VERCEL_*` system metadata in the stateless public release
- keeps every application-defined `NEXT_PUBLIC_*` variable forbidden
- adds positive and negative release-gate regression coverage
- documents the narrow platform exception

## Root cause
Vercel injects public deployment metadata into production builds. The public release gate correctly removed application and integration variables but was too broad and rejected Vercel system metadata that cannot be removed from the build environment.

## Validation
- targeted release-gate tests: 5 passed
- `npm run lint`
- production-profile `npm run build` with representative Vercel system variables
- strict CSP and runtime-storage gates passed