### PR TITLE
Avoid duplicate public navigation prefetches

### DIFF
--- a/frontend/src/components/sbs/GlobalAppNav.tsx
+++ b/frontend/src/components/sbs/GlobalAppNav.tsx
@@ -363,18 +363,21 @@ function PublicSiteNav() {
     <nav className="flex items-center justify-end gap-1" aria-label="Hauptnavigation">
       <Link
         href="/"
+        prefetch={false}
         className={`${navLinkClass(pathname === "/")} hidden sm:inline-flex`}
       >
         Start
       </Link>
       <Link
         href="/trust-center"
+        prefetch={false}
         className={navLinkClass(pathname === "/trust-center")}
       >
         Trust Center
       </Link>
       <Link
         href="/kontakt"
+        prefetch={false}
         className="inline-flex min-h-9 items-center justify-center rounded-lg bg-[#07111f] px-3 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-800"
       >
         Kontakt

--- a/frontend/src/components/sbs/SbsFooter.tsx
+++ b/frontend/src/components/sbs/SbsFooter.tsx
@@ -25,9 +25,9 @@ export function SbsFooter({ publicSite = false }: SbsFooterProps) {
               Unternehmen
             </h2>
             <ul className="mt-3 space-y-2 text-sm">
-              <li><Link href="/" className="text-slate-300 hover:text-white">Start</Link></li>
-              <li><Link href="/trust-center" className="text-slate-300 hover:text-white">Trust Center</Link></li>
-              <li><Link href="/kontakt" className="text-slate-300 hover:text-white">Kontakt</Link></li>
+              <li><Link href="/" prefetch={false} className="text-slate-300 hover:text-white">Start</Link></li>
+              <li><Link href="/trust-center" prefetch={false} className="text-slate-300 hover:text-white">Trust Center</Link></li>
+              <li><Link href="/kontakt" prefetch={false} className="text-slate-300 hover:text-white">Kontakt</Link></li>
             </ul>
           </nav>
           <nav aria-label="Rechtliches">
@@ -35,8 +35,8 @@ export function SbsFooter({ publicSite = false }: SbsFooterProps) {
               Rechtliches
             </h2>
             <ul className="mt-3 space-y-2 text-sm">
-              <li><Link href="/impressum" className="text-slate-300 hover:text-white">Impressum</Link></li>
-              <li><Link href="/datenschutz" className="text-slate-300 hover:text-white">Datenschutz</Link></li>
+              <li><Link href="/impressum" prefetch={false} className="text-slate-300 hover:text-white">Impressum</Link></li>
+              <li><Link href="/datenschutz" prefetch={false} className="text-slate-300 hover:text-white">Datenschutz</Link></li>
             </ul>
           </nav>
           <p className="border-t border-white/10 pt-6 text-xs text-slate-500 md:col-span-3">

--- a/frontend/src/components/sbs/SbsHeader.tsx
+++ b/frontend/src/components/sbs/SbsHeader.tsx
@@ -14,7 +14,11 @@ export function SbsHeader({ publicSite = false }: SbsHeaderProps) {
   return (
     <header className="sticky top-0 z-50 border-b border-white/70 bg-white/80 shadow-[0_1px_0_rgba(7,17,31,0.06)] backdrop-blur-2xl backdrop-saturate-150">
       <div className="mx-auto flex min-h-16 max-w-[90rem] items-center justify-between gap-4 px-4 py-2 md:px-8 md:py-2.5">
-        <Link href="/" className="group flex min-w-0 flex-1 items-center gap-3 no-underline">
+        <Link
+          href="/"
+          prefetch={publicSite ? false : null}
+          className="group flex min-w-0 flex-1 items-center gap-3 no-underline"
+        >
           <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[0.7rem] bg-[#07111f] text-white shadow-lg shadow-slate-950/15" aria-hidden>
             <svg viewBox="0 0 24 24" className="h-5 w-5" fill="none">
               <path d="M12 3.5a8.5 8.5 0 1 0 0 17" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" />


### PR DESCRIPTION
## What changed

Disables automatic route prefetching for the compact public header and footer navigation while preserving the default behavior for the authenticated enterprise shell.

## Why

The public header exposes both a home logo and a visible Start link. Next.js tried to prefetch the same current route twice and canceled one duplicate RSC request. The stateless public site is small enough to navigate on demand without speculative traffic.

## Impact

Public navigation remains fully functional while avoiding duplicate or unnecessary background route requests.

## Validation

- GlobalAppNav: 13 tests passed
- ESLint passed with zero warnings
- strict CSP verification passed
- diff whitespace check passed