### PR TITLE
Add CFO investment portfolio

### DIFF
--- a/app/enterprise_investment_portfolio_models.py
+++ b/app/enterprise_investment_portfolio_models.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field
+
+from app.enterprise_integration_blueprint_models import SourceSystemType
+
+
+class InvestmentDecision(StrEnum):
+    fund_now = "fund_now"
+    sequence = "sequence"
+    validate = "validate"
+    hold = "hold"
+
+
+class InvestmentEnvelopeBand(StrEnum):
+    small = "small"
+    medium = "medium"
+    large = "large"
+
+
+class TimeToValueBand(StrEnum):
+    near_term = "near_term"
+    mid_term = "mid_term"
+    long_term = "long_term"
+
+
+class InvestmentPortfolioWeights(BaseModel):
+    strategic_value_weight: int = 30
+    risk_reduction_weight: int = 30
+    execution_confidence_weight: int = 25
+    capital_efficiency_weight: int = 15
+
+
+class EnterpriseInvestmentInitiative(BaseModel):
+    initiative_id: str = Field(..., min_length=1, max_length=160)
+    tenant_id: str = Field(..., min_length=1, max_length=255)
+    connector_type: SourceSystemType
+    initiative_name_de: str = Field(..., min_length=1, max_length=255)
+    baseline_rank: int = Field(ge=1)
+    recommended_decision: InvestmentDecision
+    investment_envelope_band: InvestmentEnvelopeBand
+    time_to_value_band: TimeToValueBand
+    strategic_value_score: int = Field(ge=0, le=100)
+    risk_reduction_score: int = Field(ge=0, le=100)
+    execution_confidence_score: int = Field(ge=0, le=100)
+    capital_efficiency_score: int = Field(ge=0, le=100)
+    blocker_score: int = Field(ge=0, le=100)
+    portfolio_score: int = Field(ge=0, le=100)
+    decision_rationale_de: str = Field(..., min_length=1, max_length=1000)
+    funding_preconditions_de: list[str] = Field(default_factory=list)
+    source_refs: list[str] = Field(default_factory=list)
+    requires_finance_input: bool = True
+    is_financial_estimate: bool = False
+
+
+class InvestmentPortfolioSummary(BaseModel):
+    total_initiatives: int = 0
+    fund_now_count: int = 0
+    sequence_count: int = 0
+    validate_count: int = 0
+    hold_count: int = 0
+    large_envelope_count: int = 0
+    missing_finance_inputs: int = 0
+    top_recommendation_de: str | None = None
+
+
+class EnterpriseInvestmentPortfolioResponse(BaseModel):
+    tenant_id: str
+    generated_at_utc: datetime
+    baseline_weights: InvestmentPortfolioWeights
+    summary: InvestmentPortfolioSummary
+    initiatives: list[EnterpriseInvestmentInitiative]
+    assumptions_de: list[str] = Field(default_factory=list)
+    markdown_de: str | None = None

--- a/app/main.py
+++ b/app/main.py
@@ -199,6 +199,7 @@ from app.enterprise_integration_blueprint_models import (
     EnterpriseIntegrationBlueprintResponse,
     EnterpriseIntegrationBlueprintUpsert,
 )
+from app.enterprise_investment_portfolio_models import EnterpriseInvestmentPortfolioResponse
 from app.enterprise_onboarding_models import (
     EnterpriseOnboardingReadinessResponse,
     EnterpriseOnboardingReadinessUpsert,
@@ -443,6 +444,9 @@ from app.services.enterprise_connector_runtime import (
 from app.services.enterprise_control_center import build_enterprise_control_center
 from app.services.enterprise_integration_blueprint import (
     build_enterprise_integration_blueprint_response,
+)
+from app.services.enterprise_investment_portfolio import (
+    build_enterprise_investment_portfolio,
 )
 from app.services.eu_ai_act_readiness import compute_eu_ai_act_readiness_overview
 from app.services.eu_ai_act_wizard_decision import evaluate_wizard_decision
@@ -5963,6 +5967,60 @@ def get_enterprise_connector_candidates(
         incident_repo=incident_repo,
         deadline_repo=deadline_repo,
         ai_repo=ai_repo,
+        include_markdown=include_markdown,
+    )
+
+
+@app.get(
+    "/api/internal/enterprise/investment-portfolio",
+    response_model=EnterpriseInvestmentPortfolioResponse,
+    tags=["internal", "enterprise"],
+)
+def get_enterprise_investment_portfolio(
+    auth: Annotated[AuthContext, Depends(get_auth_context)],
+    _: Annotated[
+        EnterpriseRole,
+        Depends(require_permission(Permission.VIEW_EXECUTIVE_DASHBOARD)),
+    ],
+    session: Annotated[Session, Depends(get_session)],
+    onboarding_repo: Annotated[
+        EnterpriseOnboardingRepository,
+        Depends(get_enterprise_onboarding_repository),
+    ],
+    blueprint_repo: Annotated[
+        EnterpriseIntegrationBlueprintRepository,
+        Depends(get_enterprise_integration_blueprint_repository),
+    ],
+    audit_repo: Annotated[AuditLogRepository, Depends(get_audit_log_repository)],
+    incident_repo: Annotated[NIS2IncidentRepository, Depends(get_nis2_incident_repository)],
+    deadline_repo: Annotated[
+        ComplianceDeadlineRepository,
+        Depends(get_compliance_deadline_repository),
+    ],
+    ai_repo: Annotated[AISystemRepository, Depends(get_ai_system_repository)],
+    include_markdown: bool = Query(False),
+) -> EnterpriseInvestmentPortfolioResponse:
+    onboarding = onboarding_repo.get(auth.tenant_id)
+    blueprints = build_enterprise_integration_blueprint_response(
+        tenant_id=auth.tenant_id,
+        blueprint_rows=blueprint_repo.list_for_tenant(auth.tenant_id),
+        onboarding=onboarding,
+        include_markdown=False,
+    ).blueprint_rows
+    candidates = build_connector_candidates_response(
+        tenant_id=auth.tenant_id,
+        session=session,
+        onboarding=onboarding,
+        blueprints=blueprints,
+        audit_repo=audit_repo,
+        incident_repo=incident_repo,
+        deadline_repo=deadline_repo,
+        ai_repo=ai_repo,
+        include_markdown=False,
+    )
+    return build_enterprise_investment_portfolio(
+        tenant_id=auth.tenant_id,
+        candidates=candidates,
         include_markdown=include_markdown,
     )
 

--- a/app/services/enterprise_investment_portfolio.py
+++ b/app/services/enterprise_investment_portfolio.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.enterprise_connector_candidate_models import (
+    ConnectorCandidatePriority,
+    EnterpriseConnectorCandidateRow,
+    EnterpriseConnectorCandidatesResponse,
+)
+from app.enterprise_integration_blueprint_models import SourceSystemType
+from app.enterprise_investment_portfolio_models import (
+    EnterpriseInvestmentInitiative,
+    EnterpriseInvestmentPortfolioResponse,
+    InvestmentDecision,
+    InvestmentEnvelopeBand,
+    InvestmentPortfolioSummary,
+    InvestmentPortfolioWeights,
+    TimeToValueBand,
+)
+
+BASELINE_WEIGHTS = InvestmentPortfolioWeights()
+
+_INITIATIVE_NAMES: dict[SourceSystemType, str] = {
+    SourceSystemType.sap_s4hana: "SAP S/4HANA Evidence Integration",
+    SourceSystemType.sap_btp: "SAP BTP Governance Integration",
+    SourceSystemType.datev: "DATEV Evidence & Export Integration",
+    SourceSystemType.ms_dynamics: "Microsoft Dynamics Governance Integration",
+    SourceSystemType.generic_api: "Generic API Evidence Integration",
+}
+
+ASSUMPTIONS_DE = [
+    "Die Bewertung verwendet keine Umsatz-, Vertrags-, Personal- oder Budgetdaten.",
+    "Investment-Bänder sind relative Größenklassen und keine Euro-Schätzung.",
+    "Ein Szenario ersetzt weder Business Case noch Finance-, Legal- oder Architekturfreigabe.",
+    (
+        "Scores werden ausschließlich aus strukturierten Readiness-, Blocker- "
+        "und Compliance-Signalen abgeleitet."
+    ),
+]
+
+
+def build_enterprise_investment_portfolio(
+    *,
+    tenant_id: str,
+    candidates: EnterpriseConnectorCandidatesResponse,
+    include_markdown: bool,
+    generated_at_utc: datetime | None = None,
+) -> EnterpriseInvestmentPortfolioResponse:
+    generated_at = generated_at_utc or datetime.now(UTC)
+    initiatives = [_build_initiative(tenant_id, row) for row in candidates.candidate_rows]
+    initiatives.sort(
+        key=lambda item: (
+            -item.portfolio_score,
+            item.blocker_score,
+            item.initiative_id,
+        )
+    )
+    initiatives = [
+        item.model_copy(update={"baseline_rank": index})
+        for index, item in enumerate(initiatives, 1)
+    ]
+
+    summary = InvestmentPortfolioSummary(
+        total_initiatives=len(initiatives),
+        fund_now_count=sum(
+            i.recommended_decision == InvestmentDecision.fund_now for i in initiatives
+        ),
+        sequence_count=sum(
+            i.recommended_decision == InvestmentDecision.sequence for i in initiatives
+        ),
+        validate_count=sum(
+            i.recommended_decision == InvestmentDecision.validate for i in initiatives
+        ),
+        hold_count=sum(i.recommended_decision == InvestmentDecision.hold for i in initiatives),
+        large_envelope_count=sum(
+            i.investment_envelope_band == InvestmentEnvelopeBand.large for i in initiatives
+        ),
+        missing_finance_inputs=sum(i.requires_finance_input for i in initiatives),
+        top_recommendation_de=(
+            f"{initiatives[0].initiative_name_de}: "
+            f"{initiatives[0].recommended_decision.value} ({initiatives[0].portfolio_score}/100)"
+            if initiatives
+            else None
+        ),
+    )
+    markdown = _build_markdown(tenant_id, initiatives, summary) if include_markdown else None
+    return EnterpriseInvestmentPortfolioResponse(
+        tenant_id=tenant_id,
+        generated_at_utc=generated_at,
+        baseline_weights=BASELINE_WEIGHTS,
+        summary=summary,
+        initiatives=initiatives,
+        assumptions_de=ASSUMPTIONS_DE,
+        markdown_de=markdown,
+    )
+
+
+def _build_initiative(
+    tenant_id: str,
+    row: EnterpriseConnectorCandidateRow,
+) -> EnterpriseInvestmentInitiative:
+    execution_confidence = _clamp(
+        round(row.readiness_score * 0.6 + (100 - row.blocker_score) * 0.4)
+    )
+    capital_efficiency = _clamp(100 - row.estimated_implementation_complexity)
+    portfolio_score = _clamp(
+        round(
+            (
+                row.strategic_value_score * BASELINE_WEIGHTS.strategic_value_weight
+                + row.compliance_impact_score * BASELINE_WEIGHTS.risk_reduction_weight
+                + execution_confidence * BASELINE_WEIGHTS.execution_confidence_weight
+                + capital_efficiency * BASELINE_WEIGHTS.capital_efficiency_weight
+            )
+            / 100
+        )
+    )
+    envelope = _envelope_band(row.estimated_implementation_complexity)
+    decision = _decision(
+        candidate_priority=row.recommended_priority,
+        portfolio_score=portfolio_score,
+        execution_confidence=execution_confidence,
+        blocker_score=row.blocker_score,
+        envelope=envelope,
+    )
+    preconditions = _funding_preconditions(
+        readiness_score=row.readiness_score,
+        blocker_score=row.blocker_score,
+        envelope=envelope,
+    )
+    return EnterpriseInvestmentInitiative(
+        initiative_id=f"connector:{row.connector_type.value}",
+        tenant_id=tenant_id,
+        connector_type=row.connector_type,
+        initiative_name_de=_INITIATIVE_NAMES[row.connector_type],
+        baseline_rank=1,
+        recommended_decision=decision,
+        investment_envelope_band=envelope,
+        time_to_value_band=_time_to_value_band(envelope, row.readiness_score),
+        strategic_value_score=row.strategic_value_score,
+        risk_reduction_score=row.compliance_impact_score,
+        execution_confidence_score=execution_confidence,
+        capital_efficiency_score=capital_efficiency,
+        blocker_score=row.blocker_score,
+        portfolio_score=portfolio_score,
+        decision_rationale_de=(
+            f"{_INITIATIVE_NAMES[row.connector_type]} erreicht {portfolio_score}/100. "
+            f"Strategischer Wert {row.strategic_value_score}, Risikowirkung "
+            f"{row.compliance_impact_score}, Ausführungssicherheit {execution_confidence} "
+            f"und Kapitaleffizienz {capital_efficiency}."
+        ),
+        funding_preconditions_de=preconditions,
+        source_refs=[
+            f"connector_candidate:{row.connector_type.value}",
+            "enterprise_onboarding_readiness",
+            "enterprise_control_center",
+        ],
+    )
+
+
+def _decision(
+    *,
+    candidate_priority: ConnectorCandidatePriority,
+    portfolio_score: int,
+    execution_confidence: int,
+    blocker_score: int,
+    envelope: InvestmentEnvelopeBand,
+) -> InvestmentDecision:
+    if candidate_priority == ConnectorCandidatePriority.not_now or blocker_score >= 70:
+        return InvestmentDecision.hold
+    if execution_confidence < 55:
+        return InvestmentDecision.validate
+    if portfolio_score >= 72 and blocker_score <= 35 and envelope != InvestmentEnvelopeBand.large:
+        return InvestmentDecision.fund_now
+    if portfolio_score >= 60:
+        return InvestmentDecision.sequence
+    return InvestmentDecision.validate
+
+
+def _envelope_band(complexity: int) -> InvestmentEnvelopeBand:
+    if complexity >= 70:
+        return InvestmentEnvelopeBand.large
+    if complexity >= 45:
+        return InvestmentEnvelopeBand.medium
+    return InvestmentEnvelopeBand.small
+
+
+def _time_to_value_band(
+    envelope: InvestmentEnvelopeBand,
+    readiness_score: int,
+) -> TimeToValueBand:
+    if envelope == InvestmentEnvelopeBand.small and readiness_score >= 60:
+        return TimeToValueBand.near_term
+    if envelope == InvestmentEnvelopeBand.large:
+        return TimeToValueBand.long_term
+    return TimeToValueBand.mid_term
+
+
+def _funding_preconditions(
+    *,
+    readiness_score: int,
+    blocker_score: int,
+    envelope: InvestmentEnvelopeBand,
+) -> list[str]:
+    conditions = [
+        "Finance Owner, Euro-Korridor und Capex-/Opex-Behandlung bestätigen.",
+        "Messbare Value-Hypothese und Abbruchkriterium dokumentieren.",
+    ]
+    if readiness_score < 65:
+        conditions.append("Readiness auf mindestens 65/100 evidenzbasiert bestätigen.")
+    if blocker_score > 35:
+        conditions.append("Blocker-Belastung vor Finanzierung auf höchstens 35/100 reduzieren.")
+    if envelope == InvestmentEnvelopeBand.large:
+        conditions.append(
+            "Architektur-, Delivery- und Beschaffungsfreigabe vor Commit abschließen."
+        )
+    return conditions
+
+
+def _build_markdown(
+    tenant_id: str,
+    initiatives: list[EnterpriseInvestmentInitiative],
+    summary: InvestmentPortfolioSummary,
+) -> str:
+    lines = [
+        "# CFO Investment Portfolio (Wave 59)",
+        "",
+        f"- Mandant: {tenant_id}",
+        f"- Initiativen: {summary.total_initiatives}",
+        f"- Jetzt finanzieren: {summary.fund_now_count}",
+        f"- Sequenzieren: {summary.sequence_count}",
+        f"- Validieren: {summary.validate_count}",
+        f"- Halten: {summary.hold_count}",
+        "- Hinweis: Relative Entscheidungshilfe, keine Budgetfreigabe oder Finanzprognose.",
+        "",
+        "## Priorisierte Initiativen",
+    ]
+    for item in initiatives:
+        lines.append(
+            f"{item.baseline_rank}. {item.initiative_name_de}: "
+            f"{item.recommended_decision.value} ({item.portfolio_score}/100, "
+            f"Envelope {item.investment_envelope_band.value})."
+        )
+    lines.extend(["", "## Verbindliche Annahmen"])
+    lines.extend(f"- {assumption}" for assumption in ASSUMPTIONS_DE)
+    return "\n".join(lines).strip() + "\n"
+
+
+def _clamp(value: int) -> int:
+    return max(0, min(100, value))

--- a/docs/enterprise/wave59-cfo-investment-portfolio.md
+++ b/docs/enterprise/wave59-cfo-investment-portfolio.md
@@ -1,0 +1,51 @@
+# Wave 59 – CFO Investment Portfolio
+
+## Zweck
+
+Das CFO Investment Portfolio verdichtet vorhandene Enterprise-Signale zu einer
+nachvollziehbaren Reihenfolge für Governance- und Connector-Investitionen:
+
+- Welche Initiative ist entscheidungsreif?
+- Welche Initiative muss zuerst validiert oder sequenziert werden?
+- Wo verhindern Blocker oder fehlende Finance-Inputs eine belastbare Freigabe?
+
+Die Funktion ist eine Entscheidungshilfe. Sie erteilt keine Budgetfreigabe und erzeugt
+keine Finanzprognose.
+
+## Deterministisches Modell
+
+Jede Initiative verwendet vier sichtbare Faktoren:
+
+| Faktor | Baseline-Gewicht |
+| --- | ---: |
+| Strategischer Wert | 30 % |
+| Risikowirkung | 30 % |
+| Ausführungssicherheit | 25 % |
+| Kapitaleffizienz | 15 % |
+
+Die Faktoren werden aus dem bestehenden Connector-Candidate-Scoring abgeleitet. Es gibt
+keine Blackbox und keinen LLM-Aufruf.
+
+## Entscheidungsklassen
+
+- `fund_now`: hoher Portfolio-Score, belastbare Ausführungssicherheit, begrenzte Blocker
+- `sequence`: attraktiv, aber in eine belastbare Delivery-Reihenfolge einzuordnen
+- `validate`: Value-Hypothese, Readiness oder Finance-Input zuerst bestätigen
+- `hold`: aktuell zu hohe Blocker oder bestehende `not_now`-Einordnung
+
+## Finanzielle Grenzen
+
+- Investment-Envelopes (`small|medium|large`) sind relative Komplexitätsbänder.
+- Es werden keine Euro-Werte, Einsparungen oder vermiedenen Schäden erfunden.
+- Jede Initiative bleibt `requires_finance_input=true` und `is_financial_estimate=false`.
+- Finance Owner, Euro-Korridor und Capex-/Opex-Behandlung sind verbindliche Funding Gates.
+
+## API und UI
+
+- `GET /api/internal/enterprise/investment-portfolio`
+- optional `include_markdown=true`
+- tenant-scharf und nach Least Privilege über `view_executive_dashboard` geschützt
+- Board-UI: `/board/investment-portfolio`
+
+Die UI bietet kontrollierte Szenario-Linsen. Diese gewichten dieselben vier Faktoren neu,
+speichern nichts und ändern keine Baseline- oder Freigabeentscheidung.

--- a/frontend/src/app/board/investment-portfolio/page.tsx
+++ b/frontend/src/app/board/investment-portfolio/page.tsx
@@ -1,0 +1,253 @@
+import Link from "next/link";
+
+import { CfoInvestmentScenarioExplorer } from "@/components/board/CfoInvestmentScenarioExplorer";
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import {
+  fetchEnterpriseInvestmentPortfolio,
+  type InvestmentDecisionDto,
+  type InvestmentEnvelopeBandDto,
+  type TimeToValueBandDto,
+} from "@/lib/api";
+import {
+  CH_BTN_SECONDARY,
+  CH_CARD,
+  CH_CARD_MUTED,
+  CH_PAGE_NAV_LINK,
+  CH_SECTION_LABEL,
+  CH_SHELL,
+} from "@/lib/boardLayout";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+const DECISION_LABELS: Record<InvestmentDecisionDto, string> = {
+  fund_now: "Jetzt finanzieren",
+  sequence: "Sequenzieren",
+  validate: "Validieren",
+  hold: "Halten",
+};
+
+const ENVELOPE_LABELS: Record<InvestmentEnvelopeBandDto, string> = {
+  small: "Klein",
+  medium: "Mittel",
+  large: "Groß",
+};
+
+const TIME_TO_VALUE_LABELS: Record<TimeToValueBandDto, string> = {
+  near_term: "Kurzfristig",
+  mid_term: "Mittelfristig",
+  long_term: "Langfristig",
+};
+
+export const metadata = {
+  title: "CFO Investment Portfolio | ComplianceHub",
+};
+
+export default async function InvestmentPortfolioPage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  const portfolio = await fetchEnterpriseInvestmentPortfolio(tenantId, false);
+
+  return (
+    <div className={CH_SHELL}>
+      <EnterprisePageHeader
+        eyebrow="Board · Finance Governance"
+        title="CFO Investment Portfolio"
+        description="Nachvollziehbare Kapitalallokation für Compliance- und Integrationsvorhaben – mit sichtbaren Annahmen, Finance-Gates und reproduzierbaren Szenarien."
+        breadcrumbs={[
+          { label: "Board", href: "/board/executive-dashboard" },
+          { label: "Investment Portfolio" },
+        ]}
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <Link href="/tenant/control-center" className={CH_BTN_SECONDARY}>
+              Control Center
+            </Link>
+            <Link href="/tenant/onboarding-readiness" className={CH_BTN_SECONDARY}>
+              Readiness prüfen
+            </Link>
+          </div>
+        }
+        below={
+          <>
+            <Link href="/board/executive-dashboard" className={CH_PAGE_NAV_LINK}>
+              Executive Dashboard
+            </Link>
+            <Link href="/board/analytics" className={CH_PAGE_NAV_LINK}>
+              Compliance Analytics
+            </Link>
+            <span className="text-sm text-slate-500">
+              Stand {new Date(portfolio.generated_at_utc).toLocaleString("de-DE")}
+            </span>
+          </>
+        }
+      />
+
+      <section aria-label="Portfolio-Zusammenfassung" className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <SummaryCard
+          label="Bewertete Initiativen"
+          value={portfolio.summary.total_initiatives}
+          detail="Tenant-isolierte Governance-Signale"
+        />
+        <SummaryCard
+          label="Jetzt finanzieren"
+          value={portfolio.summary.fund_now_count}
+          detail="Nur nach Erfüllung aller Finance-Gates"
+          accent="text-emerald-700"
+        />
+        <SummaryCard
+          label="Sequenzieren"
+          value={portfolio.summary.sequence_count}
+          detail="Abhängigkeiten und Delivery-Reihenfolge klären"
+          accent="text-cyan-800"
+        />
+        <SummaryCard
+          label="Finance Inputs offen"
+          value={portfolio.summary.missing_finance_inputs}
+          detail="Euro-Korridor, Owner und Capex/Opex fehlen bewusst"
+          accent="text-amber-800"
+        />
+      </section>
+
+      <CfoInvestmentScenarioExplorer initiatives={portfolio.initiatives} />
+
+      <section aria-labelledby="investment-boundaries-title" className="grid gap-5 lg:grid-cols-2">
+        <article className={CH_CARD_MUTED}>
+          <p className={CH_SECTION_LABEL}>Decision Integrity</p>
+          <h2 id="investment-boundaries-title" className="mt-2 text-xl font-semibold text-slate-950">
+            Kontrollierte Annahmen
+          </h2>
+          <ul className="mt-4 space-y-3 text-sm leading-6 text-slate-700">
+            {portfolio.assumptions_de.map((assumption) => (
+              <li key={assumption} className="flex gap-3">
+                <span
+                  aria-hidden
+                  className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--sbs-navy-mid)]"
+                />
+                <span>{assumption}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Baseline-Logik</p>
+          <h2 className="mt-2 text-xl font-semibold text-slate-950">
+            100 % sichtbare Gewichtung
+          </h2>
+          <dl className="mt-5 grid grid-cols-2 gap-4 text-sm">
+            <Weight label="Strategischer Wert" value={portfolio.baseline_weights.strategic_value_weight} />
+            <Weight label="Risikoreduktion" value={portfolio.baseline_weights.risk_reduction_weight} />
+            <Weight
+              label="Ausführungssicherheit"
+              value={portfolio.baseline_weights.execution_confidence_weight}
+            />
+            <Weight
+              label="Kapitaleffizienz"
+              value={portfolio.baseline_weights.capital_efficiency_weight}
+            />
+          </dl>
+          <div className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm leading-6 text-amber-950">
+            Diese Ansicht ist eine relative Entscheidungshilfe. Sie ist weder Finanzprognose noch
+            Budgetfreigabe und ersetzt keinen genehmigten Business Case.
+          </div>
+        </article>
+      </section>
+
+      <section aria-labelledby="baseline-register-title" className={CH_CARD}>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className={CH_SECTION_LABEL}>Board Decision Register</p>
+            <h2 id="baseline-register-title" className="mt-2 text-xl font-semibold text-slate-950">
+              Baseline und verbindliche Funding-Gates
+            </h2>
+          </div>
+          <p className="max-w-xl text-sm text-slate-600">
+            Die Rangfolge bleibt serverseitig deterministisch; Szenarien oben sind nicht persistent.
+          </p>
+        </div>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full border-separate border-spacing-0 text-left text-sm">
+            <thead>
+              <tr className="text-xs uppercase tracking-[0.1em] text-slate-500">
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Rang</th>
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Initiative</th>
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Entscheidung</th>
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Envelope</th>
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Time-to-value</th>
+                <th scope="col" className="border-b border-slate-200 px-3 py-3 font-semibold">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {portfolio.initiatives.map((initiative) => (
+                <tr key={initiative.initiative_id} className="align-top text-slate-700">
+                  <td className="border-b border-slate-100 px-3 py-4 font-semibold text-slate-950">
+                    {String(initiative.baseline_rank).padStart(2, "0")}
+                  </td>
+                  <td className="min-w-72 border-b border-slate-100 px-3 py-4">
+                    <p className="font-semibold text-slate-950">{initiative.initiative_name_de}</p>
+                    <p className="mt-1 text-xs leading-5 text-slate-500">
+                      {initiative.decision_rationale_de}
+                    </p>
+                    <details className="mt-3">
+                      <summary className="cursor-pointer text-xs font-semibold text-[var(--sbs-text-accent)]">
+                        Funding-Gates und Quellen
+                      </summary>
+                      <ul className="mt-2 space-y-1 text-xs leading-5 text-slate-600">
+                        {initiative.funding_preconditions_de.map((precondition) => (
+                          <li key={precondition}>• {precondition}</li>
+                        ))}
+                      </ul>
+                      <p className="mt-2 text-xs text-slate-500">
+                        Quellen: {initiative.source_refs.join(" · ")}
+                      </p>
+                    </details>
+                  </td>
+                  <td className="whitespace-nowrap border-b border-slate-100 px-3 py-4 font-medium text-slate-950">
+                    {DECISION_LABELS[initiative.recommended_decision]}
+                  </td>
+                  <td className="whitespace-nowrap border-b border-slate-100 px-3 py-4">
+                    {ENVELOPE_LABELS[initiative.investment_envelope_band]}
+                  </td>
+                  <td className="whitespace-nowrap border-b border-slate-100 px-3 py-4">
+                    {TIME_TO_VALUE_LABELS[initiative.time_to_value_band]}
+                  </td>
+                  <td className="border-b border-slate-100 px-3 py-4 font-semibold text-slate-950">
+                    {initiative.portfolio_score}/100
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  detail,
+  accent = "text-slate-950",
+}: {
+  label: string;
+  value: number;
+  detail: string;
+  accent?: string;
+}) {
+  return (
+    <article className={CH_CARD}>
+      <p className={CH_SECTION_LABEL}>{label}</p>
+      <p className={`mt-3 text-4xl font-semibold tracking-tight ${accent}`}>{value}</p>
+      <p className="mt-2 text-xs leading-5 text-slate-500">{detail}</p>
+    </article>
+  );
+}
+
+function Weight({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <dt className="text-xs font-medium text-slate-600">{label}</dt>
+      <dd className="mt-2 text-2xl font-semibold text-slate-950">{value}%</dd>
+    </div>
+  );
+}

--- a/frontend/src/components/board/CfoInvestmentScenarioExplorer.test.tsx
+++ b/frontend/src/components/board/CfoInvestmentScenarioExplorer.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import type { EnterpriseInvestmentInitiativeDto } from "@/lib/api";
+
+import { CfoInvestmentScenarioExplorer } from "./CfoInvestmentScenarioExplorer";
+
+afterEach(() => {
+  cleanup();
+});
+
+function initiative(
+  id: string,
+  name: string,
+  strategic: number,
+  risk: number,
+): EnterpriseInvestmentInitiativeDto {
+  return {
+    initiative_id: id,
+    tenant_id: "tenant-cfo",
+    connector_type: "generic_api",
+    initiative_name_de: name,
+    baseline_rank: 1,
+    recommended_decision: "sequence",
+    investment_envelope_band: "medium",
+    time_to_value_band: "mid_term",
+    strategic_value_score: strategic,
+    risk_reduction_score: risk,
+    execution_confidence_score: 75,
+    capital_efficiency_score: 50,
+    blocker_score: 20,
+    portfolio_score: 70,
+    decision_rationale_de: "Kontrollierte Testannahme.",
+    funding_preconditions_de: ["Finance Owner bestätigen."],
+    source_refs: ["test"],
+    requires_finance_input: true,
+    is_financial_estimate: false,
+  };
+}
+
+describe("CfoInvestmentScenarioExplorer", () => {
+  it("switches the visible decision lens without mutating the baseline", () => {
+    render(
+      <CfoInvestmentScenarioExplorer
+        initiatives={[
+          initiative("strategic", "Strategischer Hebel", 98, 35),
+          initiative("risk", "Risikohebel", 45, 98),
+        ]}
+      />,
+    );
+
+    const riskButton = screen.getByRole("button", { name: "Risikobegrenzung" });
+    expect(riskButton.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(riskButton);
+
+    expect(riskButton.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("heading", { name: "Risikohebel", level: 3 })).toBeTruthy();
+    expect(screen.getByText(/Priorisiert die stärkste Compliance/)).toBeTruthy();
+  });
+});

--- a/frontend/src/components/board/CfoInvestmentScenarioExplorer.tsx
+++ b/frontend/src/components/board/CfoInvestmentScenarioExplorer.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState } from "react";
+
+import { HorizontalMetricBar } from "@/components/visualization/StrictCspMetrics";
+import type {
+  EnterpriseInvestmentInitiativeDto,
+  InvestmentDecisionDto,
+} from "@/lib/api";
+import {
+  CFO_SCENARIOS,
+  getCfoScenario,
+  rankInvestmentInitiatives,
+  type CfoScenarioId,
+} from "@/lib/cfoInvestmentScenario";
+
+const DECISION_LABELS: Record<InvestmentDecisionDto, string> = {
+  fund_now: "Jetzt finanzieren",
+  sequence: "Sequenzieren",
+  validate: "Validieren",
+  hold: "Halten",
+};
+
+const DECISION_CLASSES: Record<InvestmentDecisionDto, string> = {
+  fund_now: "border-emerald-300 bg-emerald-50 text-emerald-900",
+  sequence: "border-cyan-300 bg-cyan-50 text-cyan-950",
+  validate: "border-amber-300 bg-amber-50 text-amber-950",
+  hold: "border-slate-300 bg-slate-100 text-slate-700",
+};
+
+type CfoInvestmentScenarioExplorerProps = {
+  initiatives: EnterpriseInvestmentInitiativeDto[];
+};
+
+export function CfoInvestmentScenarioExplorer({
+  initiatives,
+}: CfoInvestmentScenarioExplorerProps) {
+  const [scenarioId, setScenarioId] = useState<CfoScenarioId>("balanced");
+  const scenario = getCfoScenario(scenarioId);
+  const ranked = rankInvestmentInitiatives(initiatives, scenarioId);
+  const lead = ranked[0];
+
+  return (
+    <section
+      aria-labelledby="cfo-decision-lab-title"
+      className="overflow-hidden rounded-[2rem] border border-slate-800 bg-slate-950 text-white shadow-xl shadow-slate-300/30"
+    >
+      <div className="border-b border-white/10 px-5 py-6 sm:px-7 lg:px-9 lg:py-8">
+        <div className="flex flex-col gap-5 xl:flex-row xl:items-end xl:justify-between">
+          <div className="max-w-2xl">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-cyan-300">
+              CFO Decision Lab
+            </p>
+            <h2 id="cfo-decision-lab-title" className="mt-2 text-2xl font-semibold tracking-tight">
+              Investitionsreihenfolge unter kontrollierten Annahmen
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-slate-300">
+              Szenarien gewichten vorhandene Governance-Signale neu. Sie verändern keine
+              Quelldaten und lösen keine Budgetfreigabe aus.
+            </p>
+          </div>
+          <div
+            role="group"
+            aria-label="Investitionsszenario auswählen"
+            className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4"
+          >
+            {CFO_SCENARIOS.map((item) => {
+              const selected = item.id === scenarioId;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setScenarioId(item.id)}
+                  className={`rounded-xl border px-3 py-2 text-left text-xs font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300 ${
+                    selected
+                      ? "border-cyan-300 bg-cyan-300 text-slate-950"
+                      : "border-white/15 bg-white/5 text-slate-200 hover:border-white/30 hover:bg-white/10"
+                  }`}
+                >
+                  {item.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {lead ? (
+        <div className="grid lg:grid-cols-[minmax(0,1.2fr)_minmax(20rem,0.8fr)]">
+          <div className="border-b border-white/10 p-5 sm:p-7 lg:border-b-0 lg:border-r lg:p-9">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-[0.16em] text-slate-400">
+                  Szenario · {scenario.label}
+                </p>
+                <p className="mt-1 max-w-xl text-sm text-slate-300">{scenario.description}</p>
+              </div>
+              <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs text-slate-300">
+                Relative Bewertung · keine Euro-Prognose
+              </span>
+            </div>
+
+            <div className="mt-8 flex flex-col gap-5 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-sm text-slate-400">Priorität 01</p>
+                <h3 className="mt-1 max-w-xl text-2xl font-semibold tracking-tight sm:text-3xl">
+                  {lead.initiative_name_de}
+                </h3>
+                <span
+                  className={`mt-4 inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${DECISION_CLASSES[lead.scenario_decision]}`}
+                >
+                  {DECISION_LABELS[lead.scenario_decision]}
+                </span>
+              </div>
+              <div className="shrink-0 text-left sm:text-right">
+                <p className="text-5xl font-semibold tracking-tight text-white">
+                  {lead.scenario_score}
+                </p>
+                <p className="text-xs uppercase tracking-[0.16em] text-slate-400">von 100</p>
+              </div>
+            </div>
+
+            <dl className="mt-8 grid gap-5 sm:grid-cols-2">
+              <FactorMetric
+                label="Strategischer Wert"
+                value={lead.strategic_value_score}
+                weight={scenario.weights.strategicValue}
+              />
+              <FactorMetric
+                label="Risikoreduktion"
+                value={lead.risk_reduction_score}
+                weight={scenario.weights.riskReduction}
+              />
+              <FactorMetric
+                label="Ausführungssicherheit"
+                value={lead.execution_confidence_score}
+                weight={scenario.weights.executionConfidence}
+              />
+              <FactorMetric
+                label="Kapitaleffizienz"
+                value={lead.capital_efficiency_score}
+                weight={scenario.weights.capitalEfficiency}
+              />
+            </dl>
+          </div>
+
+          <div className="bg-white/[0.03] p-5 sm:p-7 lg:p-9">
+            <div className="flex items-center justify-between gap-3">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.14em] text-slate-300">
+                Szenario-Rangfolge
+              </h3>
+              <span className="text-xs text-slate-500">{ranked.length} Initiativen</span>
+            </div>
+            <ol className="mt-5 space-y-3">
+              {ranked.map((initiative) => (
+                <li
+                  key={initiative.initiative_id}
+                  className="rounded-2xl border border-white/10 bg-white/5 p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-white/10 text-xs font-semibold text-cyan-200">
+                      {String(initiative.scenario_rank).padStart(2, "0")}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="text-sm font-semibold text-white">
+                        {initiative.initiative_name_de}
+                      </p>
+                      <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-slate-400">
+                        <span>{initiative.scenario_score}/100</span>
+                        <span aria-hidden>·</span>
+                        <span>{DECISION_LABELS[initiative.scenario_decision]}</span>
+                        <span aria-hidden>·</span>
+                        <span>Envelope {initiative.investment_envelope_band}</span>
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      ) : (
+        <p role="status" className="px-7 py-10 text-sm text-slate-300">
+          Noch keine investitionsfähigen Initiativen vorhanden.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function FactorMetric({ label, value, weight }: { label: string; value: number; weight: number }) {
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-3 text-xs">
+        <dt className="font-medium text-slate-300">{label}</dt>
+        <dd className="text-slate-400">
+          {value}/100 · Gewicht {weight}%
+        </dd>
+      </div>
+      <HorizontalMetricBar
+        value={value}
+        label={`${label}: ${value} von 100`}
+        className="mt-2 h-2 w-full"
+        trackClassName="fill-slate-700"
+        indicatorClassName="fill-cyan-300"
+      />
+    </div>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2826,6 +2826,67 @@ export async function fetchEnterpriseConnectorCandidates(
   ) as Promise<EnterpriseConnectorCandidatesResponseDto>;
 }
 
+export type InvestmentDecisionDto = "fund_now" | "sequence" | "validate" | "hold";
+export type InvestmentEnvelopeBandDto = "small" | "medium" | "large";
+export type TimeToValueBandDto = "near_term" | "mid_term" | "long_term";
+
+export interface EnterpriseInvestmentInitiativeDto {
+  initiative_id: string;
+  tenant_id: string;
+  connector_type: IntegrationBlueprintSourceSystemTypeDto;
+  initiative_name_de: string;
+  baseline_rank: number;
+  recommended_decision: InvestmentDecisionDto;
+  investment_envelope_band: InvestmentEnvelopeBandDto;
+  time_to_value_band: TimeToValueBandDto;
+  strategic_value_score: number;
+  risk_reduction_score: number;
+  execution_confidence_score: number;
+  capital_efficiency_score: number;
+  blocker_score: number;
+  portfolio_score: number;
+  decision_rationale_de: string;
+  funding_preconditions_de: string[];
+  source_refs: string[];
+  requires_finance_input: boolean;
+  is_financial_estimate: boolean;
+}
+
+export interface EnterpriseInvestmentPortfolioResponseDto {
+  tenant_id: string;
+  generated_at_utc: string;
+  baseline_weights: {
+    strategic_value_weight: number;
+    risk_reduction_weight: number;
+    execution_confidence_weight: number;
+    capital_efficiency_weight: number;
+  };
+  summary: {
+    total_initiatives: number;
+    fund_now_count: number;
+    sequence_count: number;
+    validate_count: number;
+    hold_count: number;
+    large_envelope_count: number;
+    missing_finance_inputs: number;
+    top_recommendation_de: string | null;
+  };
+  initiatives: EnterpriseInvestmentInitiativeDto[];
+  assumptions_de: string[];
+  markdown_de?: string | null;
+}
+
+export async function fetchEnterpriseInvestmentPortfolio(
+  tenantId: string,
+  includeMarkdown = false,
+): Promise<EnterpriseInvestmentPortfolioResponseDto> {
+  const qs = includeMarkdown ? "?include_markdown=true" : "";
+  return tenantApiFetch(
+    `/api/internal/enterprise/investment-portfolio${qs}`,
+    tenantId,
+  ) as Promise<EnterpriseInvestmentPortfolioResponseDto>;
+}
+
 export type ConnectorConnectionStatusDto = "not_configured" | "connected" | "degraded";
 
 export type SyncRunLifecycleDto =

--- a/frontend/src/lib/appNavConfig.test.ts
+++ b/frontend/src/lib/appNavConfig.test.ts
@@ -30,6 +30,7 @@ describe("appNavConfig", () => {
     expect(REPORTING_NAV_ITEMS.length).toBeGreaterThanOrEqual(5);
     const hrefs = REPORTING_NAV_ITEMS.map((i) => i.href);
     expect(hrefs).toContain("/board/executive-dashboard");
+    expect(hrefs).toContain("/board/investment-portfolio");
     expect(hrefs).toContain("/board/gap-analysis");
     expect(hrefs).toContain("/board/datev-export");
   });

--- a/frontend/src/lib/appNavConfig.ts
+++ b/frontend/src/lib/appNavConfig.ts
@@ -23,6 +23,7 @@ export const WORKSPACE_NAV_ITEMS = [
 /** Enterprise Reporting & Export module pages. */
 export const REPORTING_NAV_ITEMS = [
   { href: "/board/executive-dashboard", label: "Executive Dashboard" },
+  { href: "/board/investment-portfolio", label: "Investment Portfolio" },
   { href: "/board/analytics", label: "Compliance Analytics" },
   { href: "/board/gap-analysis", label: "Gap Analysis" },
   { href: "/board/ai-compliance-report", label: "AI Compliance Report" },

--- a/frontend/src/lib/cfoInvestmentScenario.test.ts
+++ b/frontend/src/lib/cfoInvestmentScenario.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { EnterpriseInvestmentInitiativeDto } from "@/lib/api";
+
+import { CFO_SCENARIOS, rankInvestmentInitiatives } from "./cfoInvestmentScenario";
+
+function initiative(
+  id: string,
+  scores: Pick<
+    EnterpriseInvestmentInitiativeDto,
+    | "strategic_value_score"
+    | "risk_reduction_score"
+    | "execution_confidence_score"
+    | "capital_efficiency_score"
+  >,
+): EnterpriseInvestmentInitiativeDto {
+  return {
+    initiative_id: id,
+    tenant_id: "tenant-cfo",
+    connector_type: "generic_api",
+    initiative_name_de: id,
+    baseline_rank: 1,
+    recommended_decision: "sequence",
+    investment_envelope_band: "medium",
+    time_to_value_band: "mid_term",
+    blocker_score: 20,
+    portfolio_score: 70,
+    decision_rationale_de: "Kontrollierte Testannahme.",
+    funding_preconditions_de: ["Finance Owner bestätigen."],
+    source_refs: ["test"],
+    requires_finance_input: true,
+    is_financial_estimate: false,
+    ...scores,
+  };
+}
+
+describe("CFO investment scenarios", () => {
+  it("uses explicit weights that each sum to 100", () => {
+    for (const scenario of CFO_SCENARIOS) {
+      expect(Object.values(scenario.weights).reduce((sum, value) => sum + value, 0)).toBe(100);
+    }
+  });
+
+  it("re-ranks deterministically without changing source initiatives", () => {
+    const strategic = initiative("Strategischer Hebel", {
+      strategic_value_score: 95,
+      risk_reduction_score: 40,
+      execution_confidence_score: 75,
+      capital_efficiency_score: 40,
+    });
+    const risk = initiative("Risikohebel", {
+      strategic_value_score: 55,
+      risk_reduction_score: 95,
+      execution_confidence_score: 80,
+      capital_efficiency_score: 80,
+    });
+    const source = [strategic, risk];
+
+    expect(rankInvestmentInitiatives(source, "risk_containment")[0].initiative_id).toBe(
+      "Risikohebel",
+    );
+    expect(rankInvestmentInitiatives(source, "acceleration")[0].initiative_id).toBe(
+      "Strategischer Hebel",
+    );
+    expect(source[0]).toBe(strategic);
+    expect(source[0]).not.toHaveProperty("scenario_score");
+  });
+});

--- a/frontend/src/lib/cfoInvestmentScenario.ts
+++ b/frontend/src/lib/cfoInvestmentScenario.ts
@@ -1,0 +1,142 @@
+import type {
+  EnterpriseInvestmentInitiativeDto,
+  InvestmentDecisionDto,
+} from "@/lib/api";
+
+export type CfoScenarioId =
+  | "balanced"
+  | "capital_discipline"
+  | "risk_containment"
+  | "acceleration";
+
+export type CfoScenario = {
+  id: CfoScenarioId;
+  label: string;
+  description: string;
+  weights: {
+    strategicValue: number;
+    riskReduction: number;
+    executionConfidence: number;
+    capitalEfficiency: number;
+  };
+};
+
+export type ScenarioRankedInitiative = EnterpriseInvestmentInitiativeDto & {
+  scenario_rank: number;
+  scenario_score: number;
+  scenario_decision: InvestmentDecisionDto;
+};
+
+export const CFO_SCENARIOS: readonly CfoScenario[] = [
+  {
+    id: "balanced",
+    label: "Ausgewogen",
+    description: "Baseline für Wert, Risiko, Ausführung und Kapitaleffizienz.",
+    weights: {
+      strategicValue: 30,
+      riskReduction: 30,
+      executionConfidence: 25,
+      capitalEfficiency: 15,
+    },
+  },
+  {
+    id: "capital_discipline",
+    label: "Kapitaldisziplin",
+    description: "Bevorzugt fokussierte Vorhaben mit hoher relativer Kapitaleffizienz.",
+    weights: {
+      strategicValue: 20,
+      riskReduction: 20,
+      executionConfidence: 20,
+      capitalEfficiency: 40,
+    },
+  },
+  {
+    id: "risk_containment",
+    label: "Risikobegrenzung",
+    description: "Priorisiert die stärkste Compliance- und Risikowirkung.",
+    weights: {
+      strategicValue: 20,
+      riskReduction: 45,
+      executionConfidence: 20,
+      capitalEfficiency: 15,
+    },
+  },
+  {
+    id: "acceleration",
+    label: "Beschleunigung",
+    description: "Gewichtet strategischen Wert und sichere Lieferfähigkeit höher.",
+    weights: {
+      strategicValue: 45,
+      riskReduction: 20,
+      executionConfidence: 25,
+      capitalEfficiency: 10,
+    },
+  },
+] as const;
+
+export function getCfoScenario(scenarioId: CfoScenarioId): CfoScenario {
+  return CFO_SCENARIOS.find((scenario) => scenario.id === scenarioId) ?? CFO_SCENARIOS[0];
+}
+
+export function rankInvestmentInitiatives(
+  initiatives: EnterpriseInvestmentInitiativeDto[],
+  scenarioId: CfoScenarioId,
+): ScenarioRankedInitiative[] {
+  const scenario = getCfoScenario(scenarioId);
+  const ranked = initiatives.map((initiative) => {
+    const scenarioScore = clamp(
+      Math.round(
+        (initiative.strategic_value_score * scenario.weights.strategicValue +
+          initiative.risk_reduction_score * scenario.weights.riskReduction +
+          initiative.execution_confidence_score * scenario.weights.executionConfidence +
+          initiative.capital_efficiency_score * scenario.weights.capitalEfficiency) /
+          100,
+      ),
+    );
+    return {
+      ...initiative,
+      scenario_rank: 1,
+      scenario_score: scenarioScore,
+      scenario_decision: scenarioDecision(initiative, scenarioScore),
+    };
+  });
+
+  ranked.sort(
+    (left, right) =>
+      right.scenario_score - left.scenario_score ||
+      left.blocker_score - right.blocker_score ||
+      left.initiative_id.localeCompare(right.initiative_id),
+  );
+
+  return ranked.map((initiative, index) => ({
+    ...initiative,
+    scenario_rank: index + 1,
+  }));
+}
+
+function scenarioDecision(
+  initiative: EnterpriseInvestmentInitiativeDto,
+  scenarioScore: number,
+): InvestmentDecisionDto {
+  if (initiative.recommended_decision === "hold" || initiative.blocker_score >= 70) {
+    return "hold";
+  }
+  if (initiative.execution_confidence_score < 55) {
+    return "validate";
+  }
+  if (
+    scenarioScore >= 72 &&
+    initiative.blocker_score <= 35 &&
+    initiative.investment_envelope_band !== "large"
+  ) {
+    return "fund_now";
+  }
+  if (scenarioScore >= 60) {
+    return "sequence";
+  }
+  return "validate";
+}
+
+function clamp(value: number): number {
+  return Math.max(0, Math.min(100, value));
+}

--- a/tests/test_enterprise_investment_portfolio.py
+++ b/tests/test_enterprise_investment_portfolio.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+
+from app.enterprise_connector_candidate_models import (
+    ConnectorCandidatePriority,
+    ConnectorScoringWeights,
+    EnterpriseConnectorCandidateRow,
+    EnterpriseConnectorCandidatesResponse,
+    ImplementationComplexityBand,
+)
+from app.enterprise_integration_blueprint_models import SourceSystemType
+from app.main import app
+from app.services.enterprise_investment_portfolio import (
+    build_enterprise_investment_portfolio,
+)
+
+client = TestClient(app)
+
+
+def _candidate(
+    connector_type: SourceSystemType,
+    *,
+    readiness: int,
+    blocker: int,
+    strategic: int,
+    compliance: int,
+    complexity: int,
+    priority: ConnectorCandidatePriority,
+) -> EnterpriseConnectorCandidateRow:
+    return EnterpriseConnectorCandidateRow(
+        tenant_id="cfo-test",
+        connector_type=connector_type,
+        readiness_score=readiness,
+        blocker_score=blocker,
+        strategic_value_score=strategic,
+        compliance_impact_score=compliance,
+        estimated_implementation_complexity=complexity,
+        complexity_band=(
+            ImplementationComplexityBand.high
+            if complexity >= 70
+            else ImplementationComplexityBand.medium
+            if complexity >= 45
+            else ImplementationComplexityBand.low
+        ),
+        recommended_priority=priority,
+        rationale_summary_de="Testkandidat",
+        rationale_factors_de=[],
+        score_total=70,
+    )
+
+
+def test_portfolio_is_deterministic_and_never_claims_financial_estimates() -> None:
+    generated_at = datetime(2026, 7, 19, 12, tzinfo=UTC)
+    rows = [
+        _candidate(
+            SourceSystemType.datev,
+            readiness=82,
+            blocker=18,
+            strategic=82,
+            compliance=88,
+            complexity=38,
+            priority=ConnectorCandidatePriority.high,
+        ),
+        _candidate(
+            SourceSystemType.sap_s4hana,
+            readiness=58,
+            blocker=42,
+            strategic=94,
+            compliance=76,
+            complexity=82,
+            priority=ConnectorCandidatePriority.medium,
+        ),
+    ]
+    candidates = EnterpriseConnectorCandidatesResponse(
+        tenant_id="cfo-test",
+        generated_at_utc=generated_at,
+        scoring_weights=ConnectorScoringWeights(),
+        candidate_rows=rows,
+        top_priorities=rows,
+        grouped_priorities_by_connector_type={},
+    )
+
+    result = build_enterprise_investment_portfolio(
+        tenant_id="cfo-test",
+        candidates=candidates,
+        include_markdown=True,
+        generated_at_utc=generated_at,
+    )
+
+    assert result.generated_at_utc == generated_at
+    assert sum(result.baseline_weights.model_dump().values()) == 100
+    assert result.initiatives[0].connector_type == SourceSystemType.datev
+    assert result.initiatives[0].recommended_decision == "fund_now"
+    assert result.initiatives[1].investment_envelope_band == "large"
+    assert all(item.requires_finance_input for item in result.initiatives)
+    assert all(not item.is_financial_estimate for item in result.initiatives)
+    assert "keine Budgetfreigabe" in (result.markdown_de or "")
+
+
+def test_investment_portfolio_api_is_tenant_scoped_and_explainable() -> None:
+    tenant = "investment-portfolio-tenant"
+    response = client.get(
+        "/api/internal/enterprise/investment-portfolio?include_markdown=true",
+        headers={
+            "x-api-key": "test-key",
+            "x-tenant-id": tenant,
+            "x-opa-user-role": "tenant_admin",
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["tenant_id"] == tenant
+    assert body["initiatives"]
+    assert body["summary"]["missing_finance_inputs"] == len(body["initiatives"])
+    assert body["markdown_de"]
+    assert all(item["tenant_id"] == tenant for item in body["initiatives"])
+
+
+def test_investment_portfolio_requires_executive_dashboard_permission() -> None:
+    response = client.get(
+        "/api/internal/enterprise/investment-portfolio",
+        headers={
+            "x-api-key": "test-key",
+            "x-tenant-id": "investment-portfolio-viewer",
+            "x-opa-user-role": "viewer",
+        },
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Was sich ändert

- führt ein tenant-isoliertes CFO Investment Portfolio mit deterministischer Priorisierung ein
- ergänzt vier transparente Szenario-Linsen für Strategie, Risiko, Ausführung und Kapitaleffizienz
- liefert ein interaktives Board Decision Lab mit Baseline-Register und Funding-Gates
- schützt die interne API nach Least Privilege über `view_executive_dashboard`
- dokumentiert finanzielle Grenzen: keine erfundenen Euro-Werte, keine automatische Budgetfreigabe, keine LLM-Blackbox

## Wirkung

Boards und Finance-Verantwortliche erhalten eine nachvollziehbare Reihenfolge für Connector- und Governance-Investitionen. Szenarien bleiben lokal und nicht persistent; serverseitige Baseline und Quelldaten werden nicht verändert. Die stateless Public-Site bleibt fail-closed und liefert für die neue Board-Route weiterhin 404.

## Verifikation

- Ruff: grün
- vollständige Backend-Test-Suite: grün
- Frontend: 89 Testdateien / 310 Tests grün
- ESLint: grün
- Strict CSP, Runtime Storage und Enterprise Release Gate: grün
- Next.js Produktionsbuild: grün
- Browser: Public Site ohne Overlay/Console-Fehler; interne Enterprise-Ansicht und Szenariowechsel verifiziert
