### PR TITLE
Add Article 50 transparency assurance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Bestehende SQLite-/Postgres-Datenbanken: additive Schema-Updates (z. B. neue O
 - `docs/security-csp-hardening-20260715.md` (Nonce-CSP, Browser-Evidenz, Runtime-I/O-Grenze)
 - `docs/azure-runtime-storage-csp-reporting-20260715.md` (Azure-Blob-Persistenz, OIDC/Managed Identity, CSP-Reporting)
 - `docs/azure-postgresql-rls-runtime-state-20260715.md` (Azure PostgreSQL, Entra-Token, FORCE RLS, Retention/PITR-Gates)
+- `docs/enterprise/wave60-article50-transparency-assurance.md` (Art. 50/DSGVO Kontrollregister, Evidenz, Review und Tenant-Grenzen)
 - `docs/architecture.md`
 - `docs/db-migrations.md` (additive Schema-Updates neben `create_all`)
 - `docs/product-strategy.md`

--- a/app/ai_transparency_assurance_models.py
+++ b/app/ai_transparency_assurance_models.py
@@ -1,0 +1,264 @@
+"""Typed evidence model for EU AI Act Article 50 and GDPR transparency assurance."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+
+class AIValueChainRole(StrEnum):
+    unknown = "unknown"
+    provider = "provider"
+    deployer = "deployer"
+    both = "both"
+
+
+class TransparencyControlStatus(StrEnum):
+    not_assessed = "not_assessed"
+    not_applicable = "not_applicable"
+    planned = "planned"
+    implemented = "implemented"
+    verified = "verified"
+
+
+class TransparencyControlKey(StrEnum):
+    ai_interaction_disclosure = "ai_interaction_disclosure"
+    synthetic_content_marking = "synthetic_content_marking"
+    emotion_biometric_notice = "emotion_biometric_notice"
+    deepfake_disclosure = "deepfake_disclosure"
+    public_interest_text_review_or_disclosure = "public_interest_text_review_or_disclosure"
+    gdpr_transparency_notice = "gdpr_transparency_notice"
+
+
+CONTROL_DEFINITIONS: dict[TransparencyControlKey, dict[str, str]] = {
+    TransparencyControlKey.ai_interaction_disclosure: {
+        "title_de": "KI-Interaktion offenlegen",
+        "description_de": (
+            "Betroffene Personen werden spätestens bei der ersten Interaktion klar und "
+            "barrierearm darüber informiert, dass sie mit einem KI-System interagieren."
+        ),
+        "legal_basis": "EU AI Act Art. 50(1)",
+        "accountable_role": "Provider",
+    },
+    TransparencyControlKey.synthetic_content_marking: {
+        "title_de": "Synthetische Inhalte maschinenlesbar kennzeichnen",
+        "description_de": (
+            "KI-generierte oder manipulierte Ausgaben werden in einem maschinenlesbaren "
+            "Format markiert und als künstlich erzeugt oder verändert erkennbar gemacht."
+        ),
+        "legal_basis": "EU AI Act Art. 50(2)",
+        "accountable_role": "Provider",
+    },
+    TransparencyControlKey.emotion_biometric_notice: {
+        "title_de": "Emotionserkennung und biometrische Kategorisierung anzeigen",
+        "description_de": (
+            "Betroffene Personen werden über den Betrieb eines Systems zur Emotionserkennung "
+            "oder biometrischen Kategorisierung informiert."
+        ),
+        "legal_basis": "EU AI Act Art. 50(3)",
+        "accountable_role": "Deployer",
+    },
+    TransparencyControlKey.deepfake_disclosure: {
+        "title_de": "Deepfakes offenlegen",
+        "description_de": (
+            "Künstlich erzeugte oder manipulierte Bild-, Audio- oder Videoinhalte werden "
+            "klar als solche offengelegt."
+        ),
+        "legal_basis": "EU AI Act Art. 50(4)",
+        "accountable_role": "Deployer",
+    },
+    TransparencyControlKey.public_interest_text_review_or_disclosure: {
+        "title_de": "Public-Interest-Texte prüfen oder offenlegen",
+        "description_de": (
+            "Bei KI-generiertem Text zu Angelegenheiten von öffentlichem Interesse wird die "
+            "Offenlegung oder eine nachweislich substanzielle menschliche Prüfung mit "
+            "redaktioneller Verantwortung dokumentiert."
+        ),
+        "legal_basis": "EU AI Act Art. 50(4)",
+        "accountable_role": "Deployer",
+    },
+    TransparencyControlKey.gdpr_transparency_notice: {
+        "title_de": "DSGVO-Transparenzinformation verknüpfen",
+        "description_de": (
+            "Die einschlägige Datenschutzinformation, Zwecke, Rechtsgrundlagen, Empfänger, "
+            "Speicherdauer und Betroffenenrechte sind referenziert und geprüft."
+        ),
+        "legal_basis": "DSGVO Art. 12–14; ggf. Art. 22",
+        "accountable_role": "Verantwortlicher",
+    },
+}
+
+
+class TransparencyControlInput(BaseModel):
+    control_key: TransparencyControlKey
+    status: TransparencyControlStatus = TransparencyControlStatus.not_assessed
+    evidence_reference: str | None = Field(default=None, max_length=1024)
+    rationale: str | None = Field(default=None, max_length=4000)
+
+    @field_validator("evidence_reference", "rationale", mode="before")
+    @classmethod
+    def normalize_optional_text(cls, value: object) -> object:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+
+class TransparencyControlRead(TransparencyControlInput):
+    title_de: str
+    description_de: str
+    legal_basis: str
+    accountable_role: str
+    updated_at_utc: datetime | None = None
+
+
+class AITransparencyAssessmentUpsert(BaseModel):
+    expected_version: int = Field(default=0, ge=0)
+    role_scope: AIValueChainRole = AIValueChainRole.unknown
+    control_owner: str | None = Field(default=None, max_length=255)
+    reviewer: str | None = Field(default=None, max_length=255)
+    reviewed_at_utc: datetime | None = None
+    review_due_at_utc: datetime | None = None
+    controls: list[TransparencyControlInput] = Field(min_length=6, max_length=6)
+
+    @field_validator("control_owner", "reviewer", mode="before")
+    @classmethod
+    def normalize_optional_identity(cls, value: object) -> object:
+        if value is None:
+            return None
+        normalized = str(value).strip()
+        return normalized or None
+
+    @field_validator("reviewed_at_utc", "review_due_at_utc")
+    @classmethod
+    def require_timezone(cls, value: datetime | None) -> datetime | None:
+        if value is not None and (value.tzinfo is None or value.utcoffset() is None):
+            raise ValueError("review timestamps must include a UTC offset")
+        return value
+
+    @model_validator(mode="after")
+    def validate_assurance_evidence(self) -> AITransparencyAssessmentUpsert:
+        expected_keys = set(TransparencyControlKey)
+        actual_keys = [control.control_key for control in self.controls]
+        if set(actual_keys) != expected_keys or len(set(actual_keys)) != len(actual_keys):
+            raise ValueError("controls must contain every transparency control exactly once")
+
+        verified = [
+            control
+            for control in self.controls
+            if control.status == TransparencyControlStatus.verified
+        ]
+        missing_evidence = [
+            control.control_key.value for control in verified if not control.evidence_reference
+        ]
+        if missing_evidence:
+            raise ValueError(
+                "verified controls require an evidence_reference: " + ", ".join(missing_evidence)
+            )
+        missing_rationale = [
+            control.control_key.value
+            for control in self.controls
+            if control.status == TransparencyControlStatus.not_applicable and not control.rationale
+        ]
+        if missing_rationale:
+            raise ValueError(
+                "not_applicable controls require a rationale: " + ", ".join(missing_rationale)
+            )
+        if verified and (
+            not self.control_owner
+            or not self.reviewer
+            or self.reviewed_at_utc is None
+            or self.review_due_at_utc is None
+        ):
+            raise ValueError(
+                "verified controls require control_owner, reviewer, reviewed_at_utc and "
+                "review_due_at_utc"
+            )
+        if verified and self.role_scope == AIValueChainRole.unknown:
+            raise ValueError("role_scope must be resolved before controls can be verified")
+        if (
+            self.control_owner
+            and self.reviewer
+            and self.control_owner.casefold() == self.reviewer.casefold()
+        ):
+            raise ValueError("reviewer must differ from control_owner (four-eyes principle)")
+        if (
+            self.reviewed_at_utc is not None
+            and self.review_due_at_utc is not None
+            and self.review_due_at_utc < self.reviewed_at_utc
+        ):
+            raise ValueError("review_due_at_utc cannot be before reviewed_at_utc")
+        return self
+
+
+class AITransparencyAssessmentRead(BaseModel):
+    id: str | None = None
+    tenant_id: str
+    ai_system_id: str
+    role_scope: AIValueChainRole
+    control_owner: str | None = None
+    reviewer: str | None = None
+    reviewed_at_utc: datetime | None = None
+    review_due_at_utc: datetime | None = None
+    version: int = 0
+    controls: list[TransparencyControlRead]
+    created_at_utc: datetime | None = None
+    updated_at_utc: datetime | None = None
+    updated_by: str | None = None
+
+
+class AITransparencySystemRow(BaseModel):
+    ai_system_id: str
+    ai_system_name: str
+    business_unit: str
+    risk_level: str
+    ai_act_category: str
+    assessment: AITransparencyAssessmentRead
+    readiness_score_pct: int = Field(ge=0, le=100)
+    posture: str
+    applicable_controls: int = Field(ge=0)
+    verified_controls: int = Field(ge=0)
+    review_overdue: bool = False
+
+
+class AITransparencyAssuranceSummary(BaseModel):
+    total_systems: int = Field(ge=0)
+    assessed_systems: int = Field(ge=0)
+    requires_scope_count: int = Field(ge=0)
+    verified_systems: int = Field(ge=0)
+    overdue_review_count: int = Field(ge=0)
+    applicable_controls: int = Field(ge=0)
+    verified_controls: int = Field(ge=0)
+
+
+class AITransparencyAssuranceResponse(BaseModel):
+    tenant_id: str
+    generated_at_utc: datetime
+    article_50_application_at_utc: datetime
+    days_until_application: int
+    readiness_score_pct: int = Field(ge=0, le=100)
+    posture: str
+    framework_version: str = "ec-article-50-guidelines-2026-07-20"
+    source_url: str = (
+        "https://digital-strategy.ec.europa.eu/en/faqs/"
+        "transparency-obligations-under-article-50-ai-act"
+    )
+    legal_disclaimer_de: str = (
+        "Operative Kontroll- und Evidenzunterstützung; keine Rechtsberatung und keine "
+        "automatische Konformitätsfeststellung."
+    )
+    summary: AITransparencyAssuranceSummary
+    systems: list[AITransparencySystemRow]
+
+
+def default_transparency_controls() -> list[TransparencyControlRead]:
+    return [
+        TransparencyControlRead(
+            control_key=key,
+            status=TransparencyControlStatus.not_assessed,
+            **definition,
+        )
+        for key, definition in CONTROL_DEFINITIONS.items()
+    ]

--- a/app/ai_transparency_assurance_routes.py
+++ b/app/ai_transparency_assurance_routes.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.ai_transparency_assurance_models import (
+    AITransparencyAssessmentRead,
+    AITransparencyAssessmentUpsert,
+    AITransparencyAssuranceResponse,
+)
+from app.auth_dependencies import get_auth_context
+from app.db import get_session
+from app.rbac.dependencies import require_permission
+from app.rbac.permissions import Permission
+from app.rbac.roles import EnterpriseRole
+from app.repositories.ai_systems import AISystemRepository
+from app.repositories.ai_transparency_assessments import (
+    AITransparencyAssessmentRepository,
+    TransparencyAssessmentVersionConflict,
+)
+from app.repositories.audit import AuditRepository
+from app.repositories.audit_logs import AuditLogRepository
+from app.security import AuthContext
+from app.services.ai_transparency_assurance import build_ai_transparency_assurance
+
+router = APIRouter(prefix="/api/v1", tags=["transparency-assurance"])
+
+
+def _audit_snapshot(assessment: AITransparencyAssessmentRead) -> str:
+    """Minimized change record: no evidence paths or reviewer identifiers in the hash log."""
+    return json.dumps(
+        {
+            "version": assessment.version,
+            "role_scope": assessment.role_scope.value,
+            "controls": {
+                control.control_key.value: {
+                    "status": control.status.value,
+                    "evidence_attached": bool(control.evidence_reference),
+                    "rationale_attached": bool(control.rationale),
+                }
+                for control in assessment.controls
+            },
+            "reviewed": assessment.reviewed_at_utc is not None,
+            "review_due": assessment.review_due_at_utc.isoformat()
+            if assessment.review_due_at_utc
+            else None,
+        },
+        sort_keys=True,
+    )
+
+
+def _require_ai_system(
+    session: Session,
+    tenant_id: str,
+    ai_system_id: str,
+) -> None:
+    if AISystemRepository(session).get_by_id(tenant_id, ai_system_id) is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="AI system not found",
+        )
+
+
+@router.get(
+    "/transparency-assurance",
+    response_model=AITransparencyAssuranceResponse,
+)
+def get_transparency_assurance(
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    _role: Annotated[
+        EnterpriseRole,
+        Depends(require_permission(Permission.VIEW_TRANSPARENCY_ASSURANCE)),
+    ],
+) -> AITransparencyAssuranceResponse:
+    return build_ai_transparency_assurance(
+        auth_context.tenant_id,
+        AISystemRepository(session).list_for_tenant(auth_context.tenant_id),
+        AITransparencyAssessmentRepository(session),
+    )
+
+
+@router.get(
+    "/ai-systems/{ai_system_id}/transparency-assurance",
+    response_model=AITransparencyAssessmentRead,
+)
+def get_ai_system_transparency_assurance(
+    ai_system_id: str,
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    _role: Annotated[
+        EnterpriseRole,
+        Depends(require_permission(Permission.VIEW_TRANSPARENCY_ASSURANCE)),
+    ],
+) -> AITransparencyAssessmentRead:
+    _require_ai_system(session, auth_context.tenant_id, ai_system_id)
+    repository = AITransparencyAssessmentRepository(session)
+    return repository.get(
+        auth_context.tenant_id,
+        ai_system_id,
+    ) or repository.default_for_system(auth_context.tenant_id, ai_system_id)
+
+
+@router.put(
+    "/ai-systems/{ai_system_id}/transparency-assurance",
+    response_model=AITransparencyAssessmentRead,
+)
+def put_ai_system_transparency_assurance(
+    ai_system_id: str,
+    body: AITransparencyAssessmentUpsert,
+    auth_context: Annotated[AuthContext, Depends(get_auth_context)],
+    session: Annotated[Session, Depends(get_session)],
+    role: Annotated[
+        EnterpriseRole,
+        Depends(require_permission(Permission.MANAGE_TRANSPARENCY_ASSURANCE)),
+    ],
+) -> AITransparencyAssessmentRead:
+    tenant_id = auth_context.tenant_id
+    _require_ai_system(session, tenant_id, ai_system_id)
+    repository = AITransparencyAssessmentRepository(session)
+    before = repository.get(tenant_id, ai_system_id) or repository.default_for_system(
+        tenant_id,
+        ai_system_id,
+    )
+    try:
+        updated = repository.upsert(
+            tenant_id,
+            ai_system_id,
+            body,
+            actor=auth_context.actor_id,
+            commit=False,
+        )
+    except TransparencyAssessmentVersionConflict as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "transparency_assessment_version_conflict",
+                "message": str(exc),
+            },
+        ) from exc
+
+    AuditRepository(session).log_event(
+        tenant_id=tenant_id,
+        actor_type=auth_context.credential_kind,
+        actor_id=auth_context.actor_id,
+        entity_type="ai_transparency_assessment",
+        entity_id=ai_system_id,
+        action="upserted",
+        metadata={
+            "version": updated.version,
+            "role_scope": updated.role_scope.value,
+        },
+        commit=False,
+    )
+    # record_event commits assessment, normalized event and hash-chain entry atomically.
+    AuditLogRepository(session).record_event(
+        tenant_id=tenant_id,
+        actor=auth_context.actor_id,
+        actor_role=role.value,
+        action="update_transparency_assurance",
+        entity_type="AITransparencyAssessment",
+        entity_id=ai_system_id,
+        before=_audit_snapshot(before),
+        after=_audit_snapshot(updated),
+        outcome="success",
+        metadata_json=json.dumps(
+            {
+                "framework": "EU AI Act Art. 50 / GDPR Art. 12-14",
+                "version": updated.version,
+            },
+            sort_keys=True,
+        ),
+    )
+    return updated

--- a/app/db_migrations/migrations/m20260502_ai_transparency_assurance.py
+++ b/app/db_migrations/migrations/m20260502_ai_transparency_assurance.py
@@ -1,0 +1,102 @@
+"""Add normalized Article 50 and GDPR transparency assurance records."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    MetaData,
+    String,
+    Table,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.engine import Engine
+
+from app.db_migrations.util import table_exists
+
+logger = logging.getLogger(__name__)
+
+MIGRATION_ID = "20260502_ai_transparency_assurance"
+DISPLAY_NAME = "ai_transparency_assurance"
+
+
+def satisfied(engine: Engine) -> bool:
+    return table_exists(engine, "ai_transparency_assessments") and table_exists(
+        engine, "ai_transparency_controls"
+    )
+
+
+def apply(engine: Engine) -> bool:
+    if satisfied(engine):
+        return False
+    metadata = MetaData()
+    Table("ai_systems", metadata, Column("id", String(255), primary_key=True))
+    assessments = Table(
+        "ai_transparency_assessments",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column("tenant_id", String(255), nullable=False),
+        Column(
+            "ai_system_id",
+            String(255),
+            ForeignKey("ai_systems.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        Column("role_scope", String(32), nullable=False, server_default="unknown"),
+        Column("control_owner", String(255)),
+        Column("reviewer", String(255)),
+        Column("reviewed_at_utc", DateTime(timezone=True)),
+        Column("review_due_at_utc", DateTime(timezone=True)),
+        Column("version", Integer, nullable=False, server_default="1"),
+        Column("created_at_utc", DateTime(timezone=True), nullable=False),
+        Column("updated_at_utc", DateTime(timezone=True), nullable=False),
+        Column("updated_by", String(255), nullable=False),
+        UniqueConstraint(
+            "tenant_id",
+            "ai_system_id",
+            name="uq_ai_transparency_assessment_tenant_system",
+        ),
+    )
+    Index(
+        "ix_ai_transparency_assessments_tenant_review_due",
+        assessments.c.tenant_id,
+        assessments.c.review_due_at_utc,
+    )
+    controls = Table(
+        "ai_transparency_controls",
+        metadata,
+        Column("id", String(36), primary_key=True),
+        Column(
+            "assessment_id",
+            String(36),
+            ForeignKey("ai_transparency_assessments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        Column("tenant_id", String(255), nullable=False),
+        Column("control_key", String(64), nullable=False),
+        Column("status", String(32), nullable=False, server_default="not_assessed"),
+        Column("evidence_reference", String(1024)),
+        Column("rationale", Text),
+        Column("updated_at_utc", DateTime(timezone=True), nullable=False),
+        UniqueConstraint(
+            "assessment_id",
+            "control_key",
+            name="uq_ai_transparency_control_assessment_key",
+        ),
+    )
+    Index(
+        "ix_ai_transparency_controls_tenant_status",
+        controls.c.tenant_id,
+        controls.c.status,
+    )
+    with engine.begin() as conn:
+        assessments.create(conn, checkfirst=True)
+        controls.create(conn, checkfirst=True)
+    logger.info("db_migration applied: %s", MIGRATION_ID)
+    return True

--- a/app/main.py
+++ b/app/main.py
@@ -125,6 +125,7 @@ from app.ai_system_models import (
     AISystemStatus,
     AISystemUpdate,
 )
+from app.ai_transparency_assurance_routes import router as ai_transparency_assurance_router
 from app.audit_models import AuditEvent, AuditLog
 from app.auth_dependencies import (
     get_api_key_and_tenant,
@@ -640,6 +641,7 @@ app.include_router(compliance_compass_router)
 app.include_router(board_reporting_router)
 app.include_router(remediation_automation_router)
 app.include_router(remediation_actions_router)
+app.include_router(ai_transparency_assurance_router)
 
 logger = logging.getLogger(__name__)
 

--- a/app/models_db.py
+++ b/app/models_db.py
@@ -380,6 +380,80 @@ class AISystemInventoryProfileDB(Base):
     updated_by: Mapped[str] = mapped_column(String(320), nullable=False, default="api_client")
 
 
+class AITransparencyAssessmentTable(Base):
+    """Versioned assurance header for Article 50 and GDPR transparency controls."""
+
+    __tablename__ = "ai_transparency_assessments"
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id",
+            "ai_system_id",
+            name="uq_ai_transparency_assessment_tenant_system",
+        ),
+        Index(
+            "ix_ai_transparency_assessments_tenant_review_due",
+            "tenant_id",
+            "review_due_at_utc",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    ai_system_id: Mapped[str] = mapped_column(
+        String(255),
+        ForeignKey("ai_systems.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    role_scope: Mapped[str] = mapped_column(String(32), nullable=False, default="unknown")
+    control_owner: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    reviewer: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    reviewed_at_utc: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    review_due_at_utc: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    created_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+    updated_by: Mapped[str] = mapped_column(String(255), nullable=False)
+
+
+class AITransparencyControlTable(Base):
+    """Per-control evidence record; evidence never gets inferred from a global checkbox."""
+
+    __tablename__ = "ai_transparency_controls"
+    __table_args__ = (
+        UniqueConstraint(
+            "assessment_id",
+            "control_key",
+            name="uq_ai_transparency_control_assessment_key",
+        ),
+        Index(
+            "ix_ai_transparency_controls_tenant_status",
+            "tenant_id",
+            "status",
+        ),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    assessment_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("ai_transparency_assessments.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    tenant_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    control_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False, default="not_assessed")
+    evidence_reference: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    updated_at_utc: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, nullable=False
+    )
+
+
 class AIRegisterEntryDB(Base):
     __tablename__ = "ai_register_entries"
     __table_args__ = (

--- a/app/rbac/permissions.py
+++ b/app/rbac/permissions.py
@@ -46,6 +46,8 @@ class Permission(StrEnum):
     MANAGE_BILLING = "manage_billing"
     VIEW_TRUST_CENTER = "view_trust_center"
     MANAGE_TRUST_CENTER = "manage_trust_center"
+    VIEW_TRANSPARENCY_ASSURANCE = "view_transparency_assurance"
+    MANAGE_TRANSPARENCY_ASSURANCE = "manage_transparency_assurance"
     ACCESS_EVIDENCE_BUNDLES = "access_evidence_bundles"
     DOWNLOAD_ASSURANCE_DOCS = "download_assurance_docs"
     VIEW_ANALYTICS = "view_analytics"
@@ -68,6 +70,7 @@ _CONTRIBUTOR_PERMS = _VIEWER_PERMS | frozenset(
         Permission.VIEW_INCIDENTS,
         Permission.VIEW_AUDIT_LOG,
         Permission.DOWNLOAD_ASSURANCE_DOCS,
+        Permission.VIEW_TRANSPARENCY_ASSURANCE,
     }
 )
 
@@ -96,6 +99,7 @@ _COMPLIANCE_OFFICER_PERMS = _EDITOR_PERMS | frozenset(
         Permission.GENERATE_BOARD_REPORTS,
         Permission.MANAGE_COMPLIANCE_CALENDAR,
         Permission.MANAGE_ONBOARDING_READINESS,
+        Permission.MANAGE_TRANSPARENCY_ASSURANCE,
     }
 )
 
@@ -119,6 +123,7 @@ _BOARD_MEMBER_PERMS = frozenset(
         Permission.VIEW_EXECUTIVE_DASHBOARD,
         Permission.VIEW_GAP_REPORTS,
         Permission.GENERATE_PDF_REPORT,
+        Permission.VIEW_TRANSPARENCY_ASSURANCE,
     }
 )
 

--- a/app/repositories/ai_transparency_assessments.py
+++ b/app/repositories/ai_transparency_assessments.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.ai_transparency_assurance_models import (
+    CONTROL_DEFINITIONS,
+    AITransparencyAssessmentRead,
+    AITransparencyAssessmentUpsert,
+    TransparencyControlKey,
+    TransparencyControlRead,
+    default_transparency_controls,
+)
+from app.models_db import AITransparencyAssessmentTable, AITransparencyControlTable
+
+
+class TransparencyAssessmentVersionConflict(RuntimeError):
+    """Raised when a stale browser attempts to overwrite a newer assessment."""
+
+
+class AITransparencyAssessmentRepository:
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def _controls_for_assessment(
+        self,
+        tenant_id: str,
+        assessment_id: str,
+    ) -> list[AITransparencyControlTable]:
+        stmt = select(AITransparencyControlTable).where(
+            AITransparencyControlTable.tenant_id == tenant_id,
+            AITransparencyControlTable.assessment_id == assessment_id,
+        )
+        return list(self._session.scalars(stmt).all())
+
+    @staticmethod
+    def _to_domain(
+        row: AITransparencyAssessmentTable,
+        control_rows: list[AITransparencyControlTable],
+    ) -> AITransparencyAssessmentRead:
+        by_key = {control.control_key: control for control in control_rows}
+        controls: list[TransparencyControlRead] = []
+        for key, definition in CONTROL_DEFINITIONS.items():
+            stored = by_key.get(key.value)
+            if stored is None:
+                controls.append(
+                    TransparencyControlRead(
+                        control_key=key,
+                        status="not_assessed",
+                        **definition,
+                    )
+                )
+                continue
+            controls.append(
+                TransparencyControlRead(
+                    control_key=TransparencyControlKey(stored.control_key),
+                    status=stored.status,
+                    evidence_reference=stored.evidence_reference,
+                    rationale=stored.rationale,
+                    updated_at_utc=stored.updated_at_utc,
+                    **definition,
+                )
+            )
+        return AITransparencyAssessmentRead(
+            id=row.id,
+            tenant_id=row.tenant_id,
+            ai_system_id=row.ai_system_id,
+            role_scope=row.role_scope,
+            control_owner=row.control_owner,
+            reviewer=row.reviewer,
+            reviewed_at_utc=row.reviewed_at_utc,
+            review_due_at_utc=row.review_due_at_utc,
+            version=row.version,
+            controls=controls,
+            created_at_utc=row.created_at_utc,
+            updated_at_utc=row.updated_at_utc,
+            updated_by=row.updated_by,
+        )
+
+    def get(
+        self,
+        tenant_id: str,
+        ai_system_id: str,
+    ) -> AITransparencyAssessmentRead | None:
+        stmt = select(AITransparencyAssessmentTable).where(
+            AITransparencyAssessmentTable.tenant_id == tenant_id,
+            AITransparencyAssessmentTable.ai_system_id == ai_system_id,
+        )
+        row = self._session.scalar(stmt)
+        if row is None:
+            return None
+        return self._to_domain(row, self._controls_for_assessment(tenant_id, row.id))
+
+    def default_for_system(
+        self,
+        tenant_id: str,
+        ai_system_id: str,
+    ) -> AITransparencyAssessmentRead:
+        return AITransparencyAssessmentRead(
+            tenant_id=tenant_id,
+            ai_system_id=ai_system_id,
+            role_scope="unknown",
+            controls=default_transparency_controls(),
+        )
+
+    def list_for_tenant(self, tenant_id: str) -> dict[str, AITransparencyAssessmentRead]:
+        rows = list(
+            self._session.scalars(
+                select(AITransparencyAssessmentTable).where(
+                    AITransparencyAssessmentTable.tenant_id == tenant_id
+                )
+            ).all()
+        )
+        if not rows:
+            return {}
+        assessment_ids = [row.id for row in rows]
+        controls = list(
+            self._session.scalars(
+                select(AITransparencyControlTable).where(
+                    AITransparencyControlTable.tenant_id == tenant_id,
+                    AITransparencyControlTable.assessment_id.in_(assessment_ids),
+                )
+            ).all()
+        )
+        controls_by_assessment: dict[str, list[AITransparencyControlTable]] = {}
+        for control in controls:
+            controls_by_assessment.setdefault(control.assessment_id, []).append(control)
+        return {
+            row.ai_system_id: self._to_domain(row, controls_by_assessment.get(row.id, []))
+            for row in rows
+        }
+
+    def upsert(
+        self,
+        tenant_id: str,
+        ai_system_id: str,
+        payload: AITransparencyAssessmentUpsert,
+        *,
+        actor: str,
+        commit: bool = True,
+    ) -> AITransparencyAssessmentRead:
+        now = datetime.now(UTC)
+        stmt = (
+            select(AITransparencyAssessmentTable)
+            .where(
+                AITransparencyAssessmentTable.tenant_id == tenant_id,
+                AITransparencyAssessmentTable.ai_system_id == ai_system_id,
+            )
+            .with_for_update()
+        )
+        row = self._session.scalar(stmt)
+        current_version = row.version if row is not None else 0
+        if payload.expected_version != current_version:
+            raise TransparencyAssessmentVersionConflict(
+                f"expected version {payload.expected_version}, current version {current_version}"
+            )
+
+        try:
+            if row is None:
+                row = AITransparencyAssessmentTable(
+                    id=str(uuid4()),
+                    tenant_id=tenant_id,
+                    ai_system_id=ai_system_id,
+                    version=1,
+                    created_at_utc=now,
+                    updated_at_utc=now,
+                    updated_by=actor,
+                )
+                self._session.add(row)
+                self._session.flush()
+            else:
+                row.version += 1
+                row.updated_at_utc = now
+                row.updated_by = actor
+
+            row.role_scope = payload.role_scope.value
+            row.control_owner = payload.control_owner
+            row.reviewer = payload.reviewer
+            row.reviewed_at_utc = payload.reviewed_at_utc
+            row.review_due_at_utc = payload.review_due_at_utc
+
+            existing_controls = {
+                control.control_key: control
+                for control in self._controls_for_assessment(tenant_id, row.id)
+            }
+            for control in payload.controls:
+                control_row = existing_controls.get(control.control_key.value)
+                if control_row is None:
+                    control_row = AITransparencyControlTable(
+                        id=str(uuid4()),
+                        assessment_id=row.id,
+                        tenant_id=tenant_id,
+                        control_key=control.control_key.value,
+                    )
+                    self._session.add(control_row)
+                control_row.status = control.status.value
+                control_row.evidence_reference = control.evidence_reference
+                control_row.rationale = control.rationale
+                control_row.updated_at_utc = now
+
+            if commit:
+                self._session.commit()
+            else:
+                self._session.flush()
+        except IntegrityError as exc:
+            self._session.rollback()
+            raise TransparencyAssessmentVersionConflict(
+                "assessment was created or updated by another transaction"
+            ) from exc
+
+        self._session.refresh(row)
+        return self._to_domain(row, self._controls_for_assessment(tenant_id, row.id))

--- a/app/repositories/audit.py
+++ b/app/repositories/audit.py
@@ -52,6 +52,8 @@ class AuditRepository:
         action: str,
         actor_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        *,
+        commit: bool = True,
     ) -> AuditEvent:
         row = AuditEventTable(
             id=str(uuid.uuid4()),
@@ -65,7 +67,10 @@ class AuditRepository:
             metadata_json=metadata,
         )
         self._session.add(row)
-        self._session.commit()
+        if commit:
+            self._session.commit()
+        else:
+            self._session.flush()
         self._session.refresh(row)
         return self._to_domain(row)
 

--- a/app/services/ai_transparency_assurance.py
+++ b/app/services/ai_transparency_assurance.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from app.ai_system_models import AISystem
+from app.ai_transparency_assurance_models import (
+    AITransparencyAssessmentRead,
+    AITransparencyAssuranceResponse,
+    AITransparencyAssuranceSummary,
+    AITransparencySystemRow,
+    AIValueChainRole,
+    TransparencyControlStatus,
+)
+from app.repositories.ai_transparency_assessments import AITransparencyAssessmentRepository
+
+ARTICLE_50_APPLICATION_AT_UTC = datetime(2026, 8, 2, tzinfo=UTC)
+
+_STATUS_SCORE = {
+    TransparencyControlStatus.not_assessed: 0,
+    TransparencyControlStatus.planned: 25,
+    TransparencyControlStatus.implemented: 75,
+    TransparencyControlStatus.verified: 100,
+}
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _system_metrics(
+    assessment: AITransparencyAssessmentRead,
+    now: datetime,
+) -> tuple[int, str, int, int, bool]:
+    applicable = [
+        control
+        for control in assessment.controls
+        if control.status != TransparencyControlStatus.not_applicable
+    ]
+    verified = [
+        control for control in applicable if control.status == TransparencyControlStatus.verified
+    ]
+    score = (
+        round(sum(_STATUS_SCORE[control.status] for control in applicable) / len(applicable))
+        if applicable
+        else 0
+    )
+    review_overdue = bool(
+        assessment.review_due_at_utc and _as_utc(assessment.review_due_at_utc) < now
+    )
+    requires_scope = (
+        assessment.version == 0
+        or assessment.role_scope == AIValueChainRole.unknown
+        or not applicable
+    )
+    if review_overdue:
+        posture = "review_overdue"
+    elif requires_scope:
+        posture = "requires_scope"
+    elif len(verified) == len(applicable):
+        posture = "verified"
+    elif score >= 75:
+        posture = "implementation_pending_verification"
+    elif score > 0:
+        posture = "remediation_active"
+    else:
+        posture = "action_required"
+    return score, posture, len(applicable), len(verified), review_overdue
+
+
+def build_ai_transparency_assurance(
+    tenant_id: str,
+    ai_systems: list[AISystem],
+    repository: AITransparencyAssessmentRepository,
+    *,
+    now: datetime | None = None,
+) -> AITransparencyAssuranceResponse:
+    generated_at = _as_utc(now or datetime.now(UTC))
+    stored = repository.list_for_tenant(tenant_id)
+    rows: list[AITransparencySystemRow] = []
+
+    for system in sorted(ai_systems, key=lambda item: (item.name.casefold(), item.id)):
+        assessment = stored.get(system.id) or repository.default_for_system(tenant_id, system.id)
+        score, posture, applicable, verified, overdue = _system_metrics(
+            assessment,
+            generated_at,
+        )
+        rows.append(
+            AITransparencySystemRow(
+                ai_system_id=system.id,
+                ai_system_name=system.name,
+                business_unit=system.business_unit,
+                risk_level=system.risk_level,
+                ai_act_category=system.ai_act_category,
+                assessment=assessment,
+                readiness_score_pct=score,
+                posture=posture,
+                applicable_controls=applicable,
+                verified_controls=verified,
+                review_overdue=overdue,
+            )
+        )
+
+    total_systems = len(rows)
+    assessed_systems = sum(row.assessment.version > 0 for row in rows)
+    requires_scope_count = sum(row.posture == "requires_scope" for row in rows)
+    verified_systems = sum(row.posture == "verified" for row in rows)
+    overdue_review_count = sum(row.review_overdue for row in rows)
+    applicable_controls = sum(row.applicable_controls for row in rows)
+    verified_controls = sum(row.verified_controls for row in rows)
+    readiness_score = (
+        round(sum(row.readiness_score_pct for row in rows) / total_systems) if total_systems else 0
+    )
+    if total_systems == 0:
+        posture = "no_ai_systems"
+    elif overdue_review_count:
+        posture = "review_overdue"
+    elif requires_scope_count:
+        posture = "scope_incomplete"
+    elif verified_systems == total_systems:
+        posture = "verified"
+    elif readiness_score >= 75:
+        posture = "implementation_pending_verification"
+    else:
+        posture = "action_required"
+
+    return AITransparencyAssuranceResponse(
+        tenant_id=tenant_id,
+        generated_at_utc=generated_at,
+        article_50_application_at_utc=ARTICLE_50_APPLICATION_AT_UTC,
+        days_until_application=(ARTICLE_50_APPLICATION_AT_UTC.date() - generated_at.date()).days,
+        readiness_score_pct=readiness_score,
+        posture=posture,
+        summary=AITransparencyAssuranceSummary(
+            total_systems=total_systems,
+            assessed_systems=assessed_systems,
+            requires_scope_count=requires_scope_count,
+            verified_systems=verified_systems,
+            overdue_review_count=overdue_review_count,
+            applicable_controls=applicable_controls,
+            verified_controls=verified_controls,
+        ),
+        systems=rows,
+    )

--- a/docs/enterprise-readiness-20260714.md
+++ b/docs/enterprise-readiness-20260714.md
@@ -199,6 +199,20 @@ The previously documented Bandit findings were remediated without suppressions:
 The full application Bandit scan now reports zero findings. This is implementation evidence, not a
 replacement for independent review, penetration testing or continuous scanning of future changes.
 
+## Article 50 transparency assurance — 21 July 2026
+
+The AI-system inventory now has a normalized, tenant-scoped Article 50 and GDPR transparency
+assurance register. Six controls retain independent status, rationale and evidence references;
+verification requires resolved value-chain role, a control owner, a distinct reviewer, a dated review
+and a next review boundary. Optimistic version checks prevent silent overwrite, and audit snapshots deliberately
+retain only status/presence signals rather than evidence paths or reviewer labels. Unassessed systems
+remain visible and score as unresolved rather than disappearing from the denominator.
+
+This closes the missing operational register, not the legal or production-compliance gate. Evidence
+authenticity, technical marking effectiveness, exception applicability, core-domain PostgreSQL RLS,
+retention and independent legal/privacy review remain mandatory. See
+`docs/enterprise/wave60-article50-transparency-assurance.md`.
+
 ## Azure deployment checklist
 
 The application expects:

--- a/docs/enterprise/wave60-article50-transparency-assurance.md
+++ b/docs/enterprise/wave60-article50-transparency-assurance.md
@@ -1,0 +1,114 @@
+# Wave 60 – Article 50 & GDPR Transparency Assurance
+
+## Ziel und Kontrollgrenze
+
+Wave 60 ergänzt das KI-System-Register um ein persistentes, mandantenfähiges Nachweisregister für
+Transparenzkontrollen. Es bewertet keine Rechtskonformität automatisch. Die Anwendung zeigt offen,
+welche Scoping-, Implementierungs-, Evidenz- oder Review-Schritte noch fehlen.
+
+Die Kontrollbibliothek bildet sechs getrennte Sachverhalte ab:
+
+| Kontrollschlüssel | Operativer Gegenstand | Rechtsbezug |
+| --- | --- | --- |
+| `ai_interaction_disclosure` | Offenlegung der KI-Interaktion ab der ersten Interaktion | EU AI Act Art. 50(1) |
+| `synthetic_content_marking` | Maschinenlesbare Kennzeichnung künstlicher/manipulierter Inhalte | EU AI Act Art. 50(2) |
+| `emotion_biometric_notice` | Information bei Emotionserkennung/biometrischer Kategorisierung | EU AI Act Art. 50(3) |
+| `deepfake_disclosure` | Offenlegung künstlich erzeugter/manipulierter Bild-, Audio- und Videoinhalte | EU AI Act Art. 50(4) |
+| `public_interest_text_review_or_disclosure` | Offenlegung oder substanzielle menschliche Prüfung unter redaktioneller Verantwortung | EU AI Act Art. 50(4) |
+| `gdpr_transparency_notice` | Referenz auf die einschlägige Datenschutzinformation | DSGVO Art. 12–14, ggf. Art. 22 |
+
+Die EU-Kommission beschreibt den 2. August 2026 als Beginn der Anwendbarkeit der
+Art.-50-Transparenzpflichten. Die UI zeigt diesen Termin und die verbleibenden beziehungsweise
+verstrichenen Tage, ohne daraus eine rechtliche Einzelfallentscheidung abzuleiten.
+
+## Evidenz- und Freigaberegeln
+
+- Status je Kontrolle: `not_assessed`, `not_applicable`, `planned`, `implemented`, `verified`.
+- `verified` erfordert eine Evidenzreferenz, geklärte Provider-/Deployer-Rolle, Control Owner,
+  unabhängigen Reviewer, Prüfdatum und nächsten Review-Termin.
+- `not_applicable` erfordert immer eine konkrete Begründung.
+- Control Owner und Reviewer müssen verschieden sein (Vier-Augen-Prinzip).
+- Alle sechs Kontrollschlüssel müssen bei jedem Speichern genau einmal enthalten sein.
+- `expected_version` verhindert das unbemerkte Überschreiben eines zwischenzeitlich geänderten
+  Assessments; veraltete Writes enden mit HTTP 409.
+- Das Readiness-Scoring ist ein operativer Reifeindikator, keine Konformitätsfeststellung:
+  `planned=25`, `implemented=75`, `verified=100`; begründet nicht anwendbare Kontrollen werden aus
+  dem Nenner genommen. Ein vollständig leerer oder ungeklärter Scope bleibt `requires_scope`.
+
+## Persistenz und Tenant-Isolation
+
+Die Migration `20260502_ai_transparency_assurance` legt zwei normalisierte Tabellen an:
+
+- `ai_transparency_assessments`: Scope, Owner/Reviewer, Review-Kadenz, Version und Änderungsmetadaten;
+- `ai_transparency_controls`: genau eine status- und evidenzfähige Zeile je Kontrollschlüssel.
+
+Jede Repository-Abfrage filtert explizit nach `tenant_id`; Child-Zeilen tragen den Tenant ebenfalls.
+Negative API-Tests belegen, dass ein anderer Mandant weder Assessment noch Systemreferenz erhält.
+Das ist Anwendungsschicht-Evidenz. Der weiterhin geltende Enterprise-Exit-Gate verlangt zusätzlich
+Tests gegen eine produktionsäquivalente PostgreSQL-Konfiguration und eine freigegebene RLS-Strategie
+für diese Core-Domäne.
+
+## APIs und Berechtigungen
+
+| Methode | Route | Permission |
+| --- | --- | --- |
+| GET | `/api/v1/transparency-assurance` | `view_transparency_assurance` |
+| GET | `/api/v1/ai-systems/{id}/transparency-assurance` | `view_transparency_assurance` |
+| PUT | `/api/v1/ai-systems/{id}/transparency-assurance` | `manage_transparency_assurance` |
+
+Contributor, Auditor und höhere operative Rollen können lesen; Board Member erhalten die
+Portfolioansicht. Nur Compliance Officer und die davon erbenden Rollen dürfen attestieren. Viewer
+und Editor können keine Evidenz freigeben.
+
+Jede Änderung erzeugt:
+
+1. einen hashverketteten GoBD-orientierten Audit-Eintrag mit Status- und Presence-Signalen; und
+2. ein normalisiertes Audit Event für operative Auswertungen.
+
+Assessment, normalisiertes Audit Event und hashverketteter Audit-Eintrag werden in derselben
+Datenbanktransaktion geschrieben. Schlägt ein Teil fehl, wird die gesamte Änderung zurückgerollt.
+
+Aus Datenschutzgründen enthält der hashverkettete Before/After-Snapshot weder Evidenzpfade noch
+Reviewer- oder Owner-Bezeichnungen. Im Assessment selbst sollen Funktionsrollen und kontrollierte
+Dokument-IDs statt unnötiger personenbezogener Daten, Secrets oder frei zugänglicher URLs verwendet
+werden.
+
+## UI
+
+`/tenant/transparency-assurance` liefert:
+
+- Regulatory Clock und Portfolio-Readiness;
+- alle KI-Systeme einschließlich vollständig unbewerteter Systeme;
+- explizite Scope-/Overdue-/Verification-Posture;
+- sechs barrierearm beschriftete Kontroll-Editoren;
+- client- und serverseitige Evidenzvalidierung;
+- Link auf die zugrunde liegende EU-Kommissionsquelle und einen sichtbaren Legal Boundary.
+
+Die Seite ist eine Enterprise-Route und bleibt im `public_site`-Releaseprofil nicht veröffentlicht.
+
+## Verifikationsumfang
+
+- Pydantic-Negativtests für fehlende Evidenz, fehlende Ausnahmebegründung, naive Zeitstempel,
+  fehlende Wiedervorlage und verletzte Funktionstrennung;
+- API-Tests für Default-Lücken, Scoring, RBAC, Cross-Tenant-Isolation, 409-Konflikte und
+  Audit-Datenminimierung;
+- React-Tests für Kontrollvollständigkeit, lokale Evidenzvalidierung und versioniertes Speichern;
+- Ruff, vollständige Backend-Tests, Frontend-Lint/Unit/Build, CSP-/Runtime-Storage-Gates und
+  Browser-Verifikation vor Merge.
+
+## Bewusst offene Grenzen
+
+- Eine Evidenzreferenz beweist nicht selbst die Echtheit oder inhaltliche Eignung des Artefakts.
+- Das Register testet nicht automatisch, ob ein konkretes Wasserzeichen oder maschinenlesbares
+  Kennzeichnungsformat technisch wirksam ist.
+- Die Anwendbarkeit von Ausnahmen, DSGVO-Rechtsgrundlagen sowie Art. 22 und die Qualität einer
+  „substanziellen“ redaktionellen Prüfung bleiben fachlich und rechtlich zu prüfen.
+- Retention, Legal Hold, DSAR, DPIA/FRIA, Löschung und produktionsäquivalente RLS-Evidenz bleiben
+  separate, weiterhin verbindliche Enterprise-Gates.
+
+## Primärquellen
+
+- [EU-Kommission – FAQ zu Art. 50 Transparenzpflichten](https://digital-strategy.ec.europa.eu/en/faqs/transparency-obligations-under-article-50-ai-act)
+- [EU-Kommission – Veröffentlichung der Art.-50-Leitlinien, 20. Juli 2026](https://digital-strategy.ec.europa.eu/en/news/commission-publishes-guidelines-transparency-obligations-providers-and-deployers-certain-ai-systems)
+- [Verordnung (EU) 2024/1689 – EU AI Act](https://eur-lex.europa.eu/eli/reg/2024/1689/oj)
+- [Verordnung (EU) 2016/679 – DSGVO](https://eur-lex.europa.eu/eli/reg/2016/679/oj)

--- a/frontend/src/app/tenant/transparency-assurance/page.tsx
+++ b/frontend/src/app/tenant/transparency-assurance/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+
+import { EnterprisePageHeader } from "@/components/sbs/EnterprisePageHeader";
+import { TransparencyAssuranceWorkspace } from "@/components/tenant/TransparencyAssuranceWorkspace";
+import { fetchAITransparencyAssurance } from "@/lib/api";
+import { CH_BTN_SECONDARY, CH_PAGE_NAV_LINK, CH_SHELL } from "@/lib/boardLayout";
+import { getWorkspaceTenantIdServer } from "@/lib/workspaceTenantServer";
+
+export default async function TransparencyAssurancePage() {
+  const tenantId = await getWorkspaceTenantIdServer();
+  const data = await fetchAITransparencyAssurance(tenantId);
+
+  return (
+    <div className={CH_SHELL}>
+      <EnterprisePageHeader
+        eyebrow="EU AI Act · DSGVO"
+        title="Transparency Assurance"
+        description="Prüfbares Kontrollregister für die Transparenzpflichten je KI-System – mit Provider-/Deployer-Scope, Evidenz, Vier-Augen-Review und Wiedervorlage."
+        breadcrumbs={[
+          { label: "Workspace", href: "/tenant/compliance-overview" },
+          { label: "EU AI Act", href: "/tenant/eu-ai-act" },
+          { label: "Transparency Assurance" },
+        ]}
+        actions={
+          <Link href="/tenant/ai-systems" className={CH_BTN_SECONDARY}>
+            Zum KI-System-Register
+          </Link>
+        }
+        below={
+          <>
+            <Link href="/tenant/eu-ai-act" className={CH_PAGE_NAV_LINK}>
+              EU AI Act Cockpit
+            </Link>
+            <Link href="/tenant/audit-log" className={CH_PAGE_NAV_LINK}>
+              Audit-Log prüfen
+            </Link>
+          </>
+        }
+      />
+
+      <TransparencyAssuranceWorkspace tenantId={tenantId} initialData={data} />
+    </div>
+  );
+}

--- a/frontend/src/components/tenant/TransparencyAssessmentEditor.tsx
+++ b/frontend/src/components/tenant/TransparencyAssessmentEditor.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import { useState } from "react";
+
+import {
+  type AITransparencyAssessmentUpsertDto,
+  type AITransparencySystemRowDto,
+  type AIValueChainRoleDto,
+  type TransparencyControlKeyDto,
+  type TransparencyControlStatusDto,
+  updateAITransparencyAssessment,
+} from "@/lib/api";
+import { CH_BTN_PRIMARY, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+type TransparencyAssessmentEditorProps = {
+  tenantId: string;
+  system: AITransparencySystemRowDto;
+  onSaved: () => Promise<void>;
+};
+
+type EditableControl = AITransparencyAssessmentUpsertDto["controls"][number] & {
+  title_de: string;
+  description_de: string;
+  legal_basis: string;
+  accountable_role: string;
+};
+
+const STATUS_OPTIONS: { value: TransparencyControlStatusDto; label: string }[] = [
+  { value: "not_assessed", label: "Nicht bewertet" },
+  { value: "not_applicable", label: "Nicht anwendbar" },
+  { value: "planned", label: "Geplant" },
+  { value: "implemented", label: "Implementiert" },
+  { value: "verified", label: "Evidenzgeprüft" },
+];
+
+const ROLE_OPTIONS: { value: AIValueChainRoleDto; label: string }[] = [
+  { value: "unknown", label: "Rolle noch offen" },
+  { value: "provider", label: "Provider" },
+  { value: "deployer", label: "Deployer" },
+  { value: "both", label: "Provider und Deployer" },
+];
+
+function dateValue(timestamp: string | null): string {
+  return timestamp ? timestamp.slice(0, 10) : "";
+}
+
+function utcDate(date: string): string | null {
+  return date ? `${date}T12:00:00.000Z` : null;
+}
+
+function validateDraft(
+  roleScope: AIValueChainRoleDto,
+  owner: string,
+  reviewer: string,
+  reviewedDate: string,
+  reviewDueDate: string,
+  controls: EditableControl[],
+): string | null {
+  const verified = controls.filter((control) => control.status === "verified");
+  const missingEvidence = verified.find((control) => !control.evidence_reference?.trim());
+  if (missingEvidence) {
+    return `„${missingEvidence.title_de}“ benötigt vor Verifizierung einen konkreten Nachweis.`;
+  }
+  const missingRationale = controls.find(
+    (control) => control.status === "not_applicable" && !control.rationale?.trim(),
+  );
+  if (missingRationale) {
+    return `„${missingRationale.title_de}“ benötigt eine begründete Nichtanwendbarkeit.`;
+  }
+  if (verified.length > 0 && roleScope === "unknown") {
+    return "Vor einer Verifizierung muss die Provider-/Deployer-Rolle geklärt sein.";
+  }
+  if (
+    verified.length > 0 &&
+    (!owner.trim() || !reviewer.trim() || !reviewedDate || !reviewDueDate)
+  ) {
+    return "Verifizierte Kontrollen benötigen Control Owner, Reviewer, Prüfdatum und nächsten Review-Termin.";
+  }
+  if (owner.trim() && reviewer.trim() && owner.trim().toLocaleLowerCase() === reviewer.trim().toLocaleLowerCase()) {
+    return "Control Owner und Reviewer müssen nach dem Vier-Augen-Prinzip verschieden sein.";
+  }
+  if (reviewedDate && reviewDueDate && reviewDueDate < reviewedDate) {
+    return "Der nächste Review-Termin darf nicht vor dem Prüfdatum liegen.";
+  }
+  return null;
+}
+
+export function TransparencyAssessmentEditor({
+  tenantId,
+  system,
+  onSaved,
+}: TransparencyAssessmentEditorProps) {
+  const assessment = system.assessment;
+  const [roleScope, setRoleScope] = useState<AIValueChainRoleDto>(assessment.role_scope);
+  const [controlOwner, setControlOwner] = useState(assessment.control_owner ?? "");
+  const [reviewer, setReviewer] = useState(assessment.reviewer ?? "");
+  const [reviewedDate, setReviewedDate] = useState(dateValue(assessment.reviewed_at_utc));
+  const [reviewDueDate, setReviewDueDate] = useState(dateValue(assessment.review_due_at_utc));
+  const [controls, setControls] = useState<EditableControl[]>(() =>
+    assessment.controls.map((control) => ({
+      control_key: control.control_key,
+      status: control.status,
+      evidence_reference: control.evidence_reference,
+      rationale: control.rationale,
+      title_de: control.title_de,
+      description_de: control.description_de,
+      legal_basis: control.legal_basis,
+      accountable_role: control.accountable_role,
+    })),
+  );
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const updateControl = (
+    key: TransparencyControlKeyDto,
+    update: Partial<Pick<EditableControl, "status" | "evidence_reference" | "rationale">>,
+  ) => {
+    setControls((current) =>
+      current.map((control) =>
+        control.control_key === key ? { ...control, ...update } : control,
+      ),
+    );
+    setMessage(null);
+    setError(null);
+  };
+
+  const save = async () => {
+    setMessage(null);
+    setError(null);
+    const validationError = validateDraft(
+      roleScope,
+      controlOwner,
+      reviewer,
+      reviewedDate,
+      reviewDueDate,
+      controls,
+    );
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setSaving(true);
+    const body: AITransparencyAssessmentUpsertDto = {
+      expected_version: assessment.version,
+      role_scope: roleScope,
+      control_owner: controlOwner.trim() || null,
+      reviewer: reviewer.trim() || null,
+      reviewed_at_utc: utcDate(reviewedDate),
+      review_due_at_utc: utcDate(reviewDueDate),
+      controls: controls.map((control) => ({
+        control_key: control.control_key,
+        status: control.status,
+        evidence_reference: control.evidence_reference?.trim() || null,
+        rationale: control.rationale?.trim() || null,
+      })),
+    };
+    try {
+      await updateAITransparencyAssessment(tenantId, system.ai_system_id, body);
+      setMessage("Assessment revisionssicher gespeichert. Readiness wird neu berechnet.");
+      try {
+        await onSaved();
+      } catch {
+        setMessage(
+          "Assessment wurde gespeichert; die aktualisierte Portfolioansicht konnte noch nicht geladen werden.",
+        );
+      }
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error
+          ? saveError.message
+          : "Assessment konnte nicht gespeichert werden.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className={CH_CARD} aria-labelledby="transparency-assessment-editor-title">
+      <div className="border-b border-slate-200 pb-5">
+        <p className={CH_SECTION_LABEL}>Control attestation</p>
+        <h3 id="transparency-assessment-editor-title" className="mt-1 text-xl font-semibold text-slate-950">
+          Transparenzkontrollen und Nachweise
+        </h3>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+          Ein Status „Evidenzgeprüft“ wird nur mit Beleg, unabhängiger Review-Rolle und
+          Wiedervorlage akzeptiert. Funktionsrollen statt privater Namen reduzieren unnötige
+          personenbezogene Daten.
+        </p>
+      </div>
+
+      <fieldset className="mt-6 grid gap-4 md:grid-cols-2">
+        <legend className="sr-only">Verantwortung und Review</legend>
+        <label className="text-xs font-semibold text-slate-700" htmlFor="transparency-role-scope">
+          Rolle in der AI-Wertschöpfungskette
+          <select
+            id="transparency-role-scope"
+            className="mt-1 block w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-normal text-slate-950"
+            value={roleScope}
+            onChange={(event) => setRoleScope(event.target.value as AIValueChainRoleDto)}
+          >
+            {ROLE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label className="text-xs font-semibold text-slate-700" htmlFor="transparency-owner">
+          Control Owner (Funktionsrolle)
+          <input
+            id="transparency-owner"
+            className="mt-1 block w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm font-normal text-slate-950"
+            value={controlOwner}
+            maxLength={255}
+            onChange={(event) => setControlOwner(event.target.value)}
+            placeholder="z. B. AI Product Control"
+          />
+        </label>
+        <label className="text-xs font-semibold text-slate-700" htmlFor="transparency-reviewer">
+          Unabhängiger Reviewer (Funktionsrolle)
+          <input
+            id="transparency-reviewer"
+            className="mt-1 block w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm font-normal text-slate-950"
+            value={reviewer}
+            maxLength={255}
+            onChange={(event) => setReviewer(event.target.value)}
+            placeholder="z. B. Data Protection Review"
+          />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="text-xs font-semibold text-slate-700" htmlFor="transparency-reviewed-date">
+            Geprüft am
+            <input
+              id="transparency-reviewed-date"
+              type="date"
+              className="mt-1 block w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm font-normal text-slate-950"
+              value={reviewedDate}
+              onChange={(event) => setReviewedDate(event.target.value)}
+            />
+          </label>
+          <label className="text-xs font-semibold text-slate-700" htmlFor="transparency-review-due-date">
+            Nächster Review
+            <input
+              id="transparency-review-due-date"
+              type="date"
+              className="mt-1 block w-full rounded-xl border border-slate-300 px-3 py-2.5 text-sm font-normal text-slate-950"
+              value={reviewDueDate}
+              onChange={(event) => setReviewDueDate(event.target.value)}
+            />
+          </label>
+        </div>
+      </fieldset>
+
+      <div className="mt-7 space-y-4">
+        {controls.map((control, index) => {
+          const baseId = `transparency-${control.control_key}`;
+          return (
+            <fieldset key={control.control_key} className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <legend className="sr-only">{control.title_de}</legend>
+              <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_15rem]">
+                <div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-mono text-[0.65rem] font-semibold text-slate-400">
+                      {String(index + 1).padStart(2, "0")}
+                    </span>
+                    <h4 className="text-sm font-semibold text-slate-950">{control.title_de}</h4>
+                  </div>
+                  <p className="mt-2 text-xs leading-5 text-slate-600">{control.description_de}</p>
+                  <p className="mt-2 text-[0.7rem] font-semibold text-slate-500">
+                    {control.legal_basis} · accountable: {control.accountable_role}
+                  </p>
+                </div>
+                <label className="text-xs font-semibold text-slate-700" htmlFor={`${baseId}-status`}>
+                  Kontrollstatus
+                  <select
+                    id={`${baseId}-status`}
+                    className="mt-1 block w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-normal text-slate-950"
+                    value={control.status}
+                    onChange={(event) =>
+                      updateControl(control.control_key, {
+                        status: event.target.value as TransparencyControlStatusDto,
+                      })
+                    }
+                  >
+                    {STATUS_OPTIONS.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+              <div className="mt-4 grid gap-4 lg:grid-cols-2">
+                <label className="text-xs font-semibold text-slate-700" htmlFor={`${baseId}-evidence`}>
+                  Evidenzreferenz
+                  <input
+                    id={`${baseId}-evidence`}
+                    className="mt-1 block w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-normal text-slate-950"
+                    value={control.evidence_reference ?? ""}
+                    maxLength={1024}
+                    onChange={(event) =>
+                      updateControl(control.control_key, {
+                        evidence_reference: event.target.value,
+                      })
+                    }
+                    placeholder="Dokument-ID, kontrollierte URL oder Evidence-Bundle-Referenz"
+                  />
+                </label>
+                <label className="text-xs font-semibold text-slate-700" htmlFor={`${baseId}-rationale`}>
+                  Begründung / Scope-Entscheidung
+                  <textarea
+                    id={`${baseId}-rationale`}
+                    className="mt-1 block min-h-20 w-full rounded-xl border border-slate-300 bg-white px-3 py-2.5 text-sm font-normal leading-5 text-slate-950"
+                    value={control.rationale ?? ""}
+                    maxLength={4000}
+                    onChange={(event) =>
+                      updateControl(control.control_key, { rationale: event.target.value })
+                    }
+                    placeholder="Nachvollziehbare Begründung, Prüfmethode oder Ausnahme dokumentieren"
+                  />
+                </label>
+              </div>
+            </fieldset>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-5">
+        <p className="text-xs text-slate-500">
+          Aktuelle Version: v{assessment.version} · konfliktgeschütztes Speichern
+        </p>
+        <button
+          type="button"
+          className={CH_BTN_PRIMARY}
+          disabled={saving}
+          onClick={() => void save()}
+        >
+          {saving ? "Wird revisionssicher gespeichert…" : "Assessment speichern"}
+        </button>
+      </div>
+      {error ? (
+        <p role="alert" className="mt-4 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+          {error}
+        </p>
+      ) : null}
+      {message ? (
+        <p role="status" className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-900">
+          {message}
+        </p>
+      ) : null}
+    </section>
+  );
+}

--- a/frontend/src/components/tenant/TransparencyAssuranceWorkspace.test.tsx
+++ b/frontend/src/components/tenant/TransparencyAssuranceWorkspace.test.tsx
@@ -1,0 +1,162 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AITransparencyAssuranceResponseDto,
+  TransparencyControlKeyDto,
+} from "@/lib/api";
+
+import { TransparencyAssuranceWorkspace } from "./TransparencyAssuranceWorkspace";
+
+const mockFetch = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    fetchAITransparencyAssurance: (...args: unknown[]) => mockFetch(...args),
+    updateAITransparencyAssessment: (...args: unknown[]) => mockUpdate(...args),
+  };
+});
+
+const keys: TransparencyControlKeyDto[] = [
+  "ai_interaction_disclosure",
+  "synthetic_content_marking",
+  "emotion_biometric_notice",
+  "deepfake_disclosure",
+  "public_interest_text_review_or_disclosure",
+  "gdpr_transparency_notice",
+];
+
+function fixture(version = 0): AITransparencyAssuranceResponseDto {
+  return {
+    tenant_id: "tenant-1",
+    generated_at_utc: "2026-07-21T10:00:00Z",
+    article_50_application_at_utc: "2026-08-02T00:00:00Z",
+    days_until_application: 12,
+    readiness_score_pct: 0,
+    posture: "scope_incomplete",
+    framework_version: "ec-article-50-guidelines-2026-07-20",
+    source_url: "https://digital-strategy.ec.europa.eu/example",
+    legal_disclaimer_de: "Keine automatische Konformitätsfeststellung.",
+    summary: {
+      total_systems: 1,
+      assessed_systems: version > 0 ? 1 : 0,
+      requires_scope_count: 1,
+      verified_systems: 0,
+      overdue_review_count: 0,
+      applicable_controls: 6,
+      verified_controls: 0,
+    },
+    systems: [
+      {
+        ai_system_id: "sys-1",
+        ai_system_name: "Customer Service Assistant",
+        business_unit: "Service",
+        risk_level: "limited",
+        ai_act_category: "limited_risk",
+        readiness_score_pct: 0,
+        posture: "requires_scope",
+        applicable_controls: 6,
+        verified_controls: 0,
+        review_overdue: false,
+        assessment: {
+          id: version > 0 ? "assessment-1" : null,
+          tenant_id: "tenant-1",
+          ai_system_id: "sys-1",
+          role_scope: "unknown",
+          control_owner: null,
+          reviewer: null,
+          reviewed_at_utc: null,
+          review_due_at_utc: null,
+          version,
+          created_at_utc: null,
+          updated_at_utc: null,
+          updated_by: null,
+          controls: keys.map((controlKey) => ({
+            control_key: controlKey,
+            status: "not_assessed",
+            evidence_reference: null,
+            rationale: null,
+            title_de: `Kontrolle ${controlKey}`,
+            description_de: "Prüfbare Beschreibung",
+            legal_basis: controlKey === "gdpr_transparency_notice" ? "DSGVO Art. 12–14" : "EU AI Act Art. 50",
+            accountable_role: "Provider",
+            updated_at_utc: null,
+          })),
+        },
+      },
+    ],
+  };
+}
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("TransparencyAssuranceWorkspace", () => {
+  it("renders the deadline, system evidence controls and legal boundary", () => {
+    render(<TransparencyAssuranceWorkspace tenantId="tenant-1" initialData={fixture()} />);
+
+    expect(screen.getByRole("heading", { name: /Art\. 50 Transparenzpflichten/i })).toBeTruthy();
+    expect(screen.getByText(/in 12 Tagen anwendbar/i)).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Customer Service Assistant" })).toBeTruthy();
+    expect(screen.getAllByLabelText("Kontrollstatus")).toHaveLength(6);
+    expect(screen.getByText("Keine automatische Konformitätsfeststellung.")).toBeTruthy();
+  });
+
+  it("blocks a verified status without evidence before calling the API", async () => {
+    render(<TransparencyAssuranceWorkspace tenantId="tenant-1" initialData={fixture()} />);
+
+    fireEvent.change(screen.getAllByLabelText("Kontrollstatus")[0], {
+      target: { value: "verified" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Assessment speichern" }));
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(/konkreten Nachweis/i);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("requires both control owner and reviewer before verification", async () => {
+    render(<TransparencyAssuranceWorkspace tenantId="tenant-1" initialData={fixture()} />);
+
+    fireEvent.change(screen.getAllByLabelText("Kontrollstatus")[0], {
+      target: { value: "verified" },
+    });
+    fireEvent.change(screen.getAllByLabelText("Evidenzreferenz")[0], {
+      target: { value: "evidence://interaction-notice/v1" },
+    });
+    fireEvent.change(screen.getByLabelText("Rolle in der AI-Wertschöpfungskette"), {
+      target: { value: "provider" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Assessment speichern" }));
+
+    expect((await screen.findByRole("alert")).textContent).toMatch(/Control Owner, Reviewer/i);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("persists all six controls with optimistic version and refreshes the summary", async () => {
+    mockUpdate.mockResolvedValue(fixture(1).systems[0].assessment);
+    mockFetch.mockResolvedValue(fixture(1));
+    render(<TransparencyAssuranceWorkspace tenantId="tenant-1" initialData={fixture()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Assessment speichern" }));
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledTimes(1));
+    expect(mockUpdate).toHaveBeenCalledWith(
+      "tenant-1",
+      "sys-1",
+      expect.objectContaining({
+        expected_version: 0,
+        controls: expect.arrayContaining([
+          expect.objectContaining({ control_key: "gdpr_transparency_notice" }),
+        ]),
+      }),
+    );
+    const body = mockUpdate.mock.calls[0][2];
+    expect(body.controls).toHaveLength(6);
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledWith("tenant-1"));
+  });
+});

--- a/frontend/src/components/tenant/TransparencyAssuranceWorkspace.tsx
+++ b/frontend/src/components/tenant/TransparencyAssuranceWorkspace.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { TransparencyAssessmentEditor } from "@/components/tenant/TransparencyAssessmentEditor";
+import {
+  fetchAITransparencyAssurance,
+  type AITransparencyAssuranceResponseDto,
+  type AITransparencySystemRowDto,
+} from "@/lib/api";
+import { CH_BADGE, CH_CARD, CH_SECTION_LABEL } from "@/lib/boardLayout";
+
+type TransparencyAssuranceWorkspaceProps = {
+  tenantId: string;
+  initialData: AITransparencyAssuranceResponseDto;
+};
+
+const POSTURE_LABELS: Record<string, string> = {
+  no_ai_systems: "Kein System im Register",
+  scope_incomplete: "Scope offen",
+  requires_scope: "Scope offen",
+  action_required: "Handlungsbedarf",
+  remediation_active: "Umsetzung läuft",
+  implementation_pending_verification: "Prüfung ausstehend",
+  verified: "Evidenzgeprüft",
+  review_overdue: "Review überfällig",
+};
+
+function postureClasses(posture: string): string {
+  if (posture === "verified") return "bg-emerald-50 text-emerald-800 ring-emerald-200";
+  if (posture === "review_overdue" || posture === "action_required") {
+    return "bg-rose-50 text-rose-800 ring-rose-200";
+  }
+  if (posture === "scope_incomplete" || posture === "requires_scope") {
+    return "bg-amber-50 text-amber-900 ring-amber-200";
+  }
+  return "bg-cyan-50 text-cyan-900 ring-cyan-200";
+}
+
+function deadlineLabel(days: number): string {
+  if (days < 0) return `seit ${Math.abs(days)} Tagen anwendbar`;
+  if (days === 0) return "ab heute anwendbar";
+  return `in ${days} Tagen anwendbar`;
+}
+
+export function TransparencyAssuranceWorkspace({
+  tenantId,
+  initialData,
+}: TransparencyAssuranceWorkspaceProps) {
+  const [data, setData] = useState(initialData);
+  const [selectedSystemId, setSelectedSystemId] = useState(
+    initialData.systems[0]?.ai_system_id ?? "",
+  );
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setRefreshError(null);
+    try {
+      setData(await fetchAITransparencyAssurance(tenantId));
+    } catch (error) {
+      setRefreshError(
+        error instanceof Error ? error.message : "Assurance-Übersicht konnte nicht aktualisiert werden.",
+      );
+      throw error;
+    }
+  }, [tenantId]);
+
+  const selected =
+    data.systems.find((system) => system.ai_system_id === selectedSystemId) ??
+    data.systems[0] ??
+    null;
+
+  return (
+    <div className="space-y-8">
+      <section
+        className={`overflow-hidden ${CH_CARD}`}
+        aria-labelledby="article-50-deadline-title"
+      >
+        <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
+          <div>
+            <p className={CH_SECTION_LABEL}>Regulatory clock</p>
+            <h2 id="article-50-deadline-title" className="mt-2 text-xl font-semibold text-slate-950">
+              Art. 50 Transparenzpflichten: 2. August 2026
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
+              {deadlineLabel(data.days_until_application)}. Die Ansicht trennt Provider- und
+              Deployer-Pflichten, dokumentiert jede Nichtanwendbarkeit und wertet nur belegte,
+              unabhängig geprüfte Kontrollen als verifiziert.
+            </p>
+          </div>
+          <div className="min-w-40 rounded-2xl bg-slate-950 px-5 py-4 text-white">
+            <p className="text-xs font-semibold uppercase tracking-[0.12em] text-slate-400">
+              Readiness
+            </p>
+            <p className="mt-1 text-4xl font-semibold tabular-nums">
+              {data.readiness_score_pct}%
+            </p>
+            <p className="mt-1 text-xs text-slate-300">
+              {POSTURE_LABELS[data.posture] ?? data.posture}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5" aria-label="Assurance-Kennzahlen">
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>KI-Systeme</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-950">
+            {data.summary.total_systems}
+          </p>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Assessed</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-slate-950">
+            {data.summary.assessed_systems}
+          </p>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Scope offen</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-amber-700">
+            {data.summary.requires_scope_count}
+          </p>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Verifiziert</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-emerald-700">
+            {data.summary.verified_systems}
+          </p>
+        </article>
+        <article className={CH_CARD}>
+          <p className={CH_SECTION_LABEL}>Review überfällig</p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums text-rose-700">
+            {data.summary.overdue_review_count}
+          </p>
+        </article>
+      </section>
+
+      {data.systems.length === 0 ? (
+        <section className={CH_CARD}>
+          <h2 className="text-lg font-semibold text-slate-950">Noch keine KI-Systeme vorhanden</h2>
+          <p className="mt-2 text-sm text-slate-600">
+            Legen Sie zuerst ein System im KI-System-Register an. Unregistrierte Systeme werden
+            bewusst nicht als konform oder nicht anwendbar bewertet.
+          </p>
+        </section>
+      ) : (
+        <section className="grid gap-5 xl:grid-cols-[20rem_minmax(0,1fr)]" aria-label="System-Assessments">
+          <aside className={`${CH_CARD} h-fit xl:sticky xl:top-28`}>
+            <p className={CH_SECTION_LABEL}>Systemportfolio</p>
+            <label className="mt-4 block text-xs font-semibold text-slate-700 xl:hidden" htmlFor="assurance-system-select">
+              KI-System auswählen
+            </label>
+            <select
+              id="assurance-system-select"
+              className="mt-1 w-full rounded-xl border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 xl:hidden"
+              value={selected?.ai_system_id ?? ""}
+              onChange={(event) => setSelectedSystemId(event.target.value)}
+            >
+              {data.systems.map((system) => (
+                <option key={system.ai_system_id} value={system.ai_system_id}>
+                  {system.ai_system_name}
+                </option>
+              ))}
+            </select>
+            <ul className="mt-4 hidden space-y-2 xl:block">
+              {data.systems.map((system: AITransparencySystemRowDto) => {
+                const active = system.ai_system_id === selected?.ai_system_id;
+                return (
+                  <li key={system.ai_system_id}>
+                    <button
+                      type="button"
+                      className={`w-full rounded-xl border px-3 py-3 text-left transition ${
+                        active
+                          ? "border-slate-900 bg-slate-950 text-white"
+                          : "border-slate-200 bg-white text-slate-800 hover:border-slate-300 hover:bg-slate-50"
+                      }`}
+                      onClick={() => setSelectedSystemId(system.ai_system_id)}
+                      aria-pressed={active}
+                    >
+                      <span className="block truncate text-sm font-semibold">
+                        {system.ai_system_name}
+                      </span>
+                      <span className={`mt-1 block text-xs ${active ? "text-slate-300" : "text-slate-500"}`}>
+                        {system.readiness_score_pct}% · {POSTURE_LABELS[system.posture] ?? system.posture}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          </aside>
+
+          {selected ? (
+            <div className="min-w-0 space-y-4">
+              <div className={CH_CARD}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className={CH_SECTION_LABEL}>{selected.business_unit}</p>
+                    <h2 className="mt-1 text-2xl font-semibold tracking-tight text-slate-950">
+                      {selected.ai_system_name}
+                    </h2>
+                    <p className="mt-1 text-xs text-slate-500">
+                      {selected.ai_system_id} · {selected.ai_act_category} · {selected.risk_level}
+                    </p>
+                  </div>
+                  <span className={`${CH_BADGE} ${postureClasses(selected.posture)}`}>
+                    {POSTURE_LABELS[selected.posture] ?? selected.posture}
+                  </span>
+                </div>
+                <div className="mt-5 grid gap-4 sm:grid-cols-[1fr_auto] sm:items-center">
+                  <div>
+                    <label htmlFor="system-readiness-progress" className="text-xs font-semibold text-slate-700">
+                      Kontrollreife {selected.readiness_score_pct}%
+                    </label>
+                    <progress
+                      id="system-readiness-progress"
+                      className="mt-2 h-2 w-full overflow-hidden rounded-full accent-emerald-600"
+                      value={selected.readiness_score_pct}
+                      max={100}
+                    >
+                      {selected.readiness_score_pct}%
+                    </progress>
+                  </div>
+                  <p className="text-xs text-slate-500">
+                    {selected.verified_controls}/{selected.applicable_controls} Kontrollen verifiziert
+                  </p>
+                </div>
+              </div>
+
+              <TransparencyAssessmentEditor
+                key={selected.ai_system_id}
+                tenantId={tenantId}
+                system={selected}
+                onSaved={refresh}
+              />
+            </div>
+          ) : null}
+        </section>
+      )}
+
+      {refreshError ? (
+        <p role="alert" className="rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900">
+          {refreshError}
+        </p>
+      ) : null}
+
+      <section className="rounded-2xl border border-slate-200 bg-slate-50 px-5 py-4 text-xs leading-5 text-slate-600">
+        <p>{data.legal_disclaimer_de}</p>
+        <a
+          className="mt-2 inline-flex font-semibold text-[var(--sbs-text-accent)] underline underline-offset-4"
+          href={data.source_url}
+          target="_blank"
+          rel="noreferrer"
+        >
+          Primärquelle: EU-Kommission, Art.-50-Leitlinien und FAQ
+        </a>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useUserRole.ts
+++ b/frontend/src/hooks/useUserRole.ts
@@ -59,10 +59,11 @@ const VALID_ROLES: ReadonlySet<string> = new Set<UserRole>([
 ]);
 
 function resolveRole(): UserRole | null {
-  const raw =
-    typeof window !== "undefined"
-      ? process.env.NEXT_PUBLIC_OPA_USER_ROLE?.trim().toLowerCase() ?? null
-      : null;
+  // NEXT_PUBLIC_* values are embedded into the client bundle by Next.js and
+  // are also available while rendering Client Components on the server. Read
+  // the same value in both environments so the initial navigation markup is
+  // hydration-stable. API/session authorization remains authoritative.
+  const raw = process.env.NEXT_PUBLIC_OPA_USER_ROLE?.trim().toLowerCase() ?? null;
   if (!raw || !VALID_ROLES.has(raw)) return null;
   return raw as UserRole;
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3199,3 +3199,124 @@ export async function sendN8nWebhook(
     },
   ) as Promise<N8nWebhookResponse>;
 }
+
+// ─── Article 50 / GDPR Transparency Assurance ───────────────────────────
+
+export type AIValueChainRoleDto = "unknown" | "provider" | "deployer" | "both";
+export type TransparencyControlStatusDto =
+  | "not_assessed"
+  | "not_applicable"
+  | "planned"
+  | "implemented"
+  | "verified";
+export type TransparencyControlKeyDto =
+  | "ai_interaction_disclosure"
+  | "synthetic_content_marking"
+  | "emotion_biometric_notice"
+  | "deepfake_disclosure"
+  | "public_interest_text_review_or_disclosure"
+  | "gdpr_transparency_notice";
+
+export interface TransparencyControlDto {
+  control_key: TransparencyControlKeyDto;
+  status: TransparencyControlStatusDto;
+  evidence_reference: string | null;
+  rationale: string | null;
+  title_de: string;
+  description_de: string;
+  legal_basis: string;
+  accountable_role: string;
+  updated_at_utc: string | null;
+}
+
+export interface AITransparencyAssessmentDto {
+  id: string | null;
+  tenant_id: string;
+  ai_system_id: string;
+  role_scope: AIValueChainRoleDto;
+  control_owner: string | null;
+  reviewer: string | null;
+  reviewed_at_utc: string | null;
+  review_due_at_utc: string | null;
+  version: number;
+  controls: TransparencyControlDto[];
+  created_at_utc: string | null;
+  updated_at_utc: string | null;
+  updated_by: string | null;
+}
+
+export interface AITransparencySystemRowDto {
+  ai_system_id: string;
+  ai_system_name: string;
+  business_unit: string;
+  risk_level: string;
+  ai_act_category: string;
+  assessment: AITransparencyAssessmentDto;
+  readiness_score_pct: number;
+  posture: string;
+  applicable_controls: number;
+  verified_controls: number;
+  review_overdue: boolean;
+}
+
+export interface AITransparencyAssuranceResponseDto {
+  tenant_id: string;
+  generated_at_utc: string;
+  article_50_application_at_utc: string;
+  days_until_application: number;
+  readiness_score_pct: number;
+  posture: string;
+  framework_version: string;
+  source_url: string;
+  legal_disclaimer_de: string;
+  summary: {
+    total_systems: number;
+    assessed_systems: number;
+    requires_scope_count: number;
+    verified_systems: number;
+    overdue_review_count: number;
+    applicable_controls: number;
+    verified_controls: number;
+  };
+  systems: AITransparencySystemRowDto[];
+}
+
+export interface AITransparencyAssessmentUpsertDto {
+  expected_version: number;
+  role_scope: AIValueChainRoleDto;
+  control_owner: string | null;
+  reviewer: string | null;
+  reviewed_at_utc: string | null;
+  review_due_at_utc: string | null;
+  controls: {
+    control_key: TransparencyControlKeyDto;
+    status: TransparencyControlStatusDto;
+    evidence_reference: string | null;
+    rationale: string | null;
+  }[];
+}
+
+export async function fetchAITransparencyAssurance(
+  tenantId: string,
+): Promise<AITransparencyAssuranceResponseDto> {
+  return tenantApiFetch(
+    "/api/v1/transparency-assurance",
+    tenantId,
+  ) as Promise<AITransparencyAssuranceResponseDto>;
+}
+
+export async function updateAITransparencyAssessment(
+  tenantId: string,
+  aiSystemId: string,
+  body: AITransparencyAssessmentUpsertDto,
+): Promise<AITransparencyAssessmentDto> {
+  const sid = encodeURIComponent(aiSystemId);
+  return tenantApiFetch(
+    `/api/v1/ai-systems/${sid}/transparency-assurance`,
+    tenantId,
+    {
+      method: "PUT",
+      body: JSON.stringify(body),
+    },
+  ) as Promise<AITransparencyAssessmentDto>;
+}

--- a/frontend/src/lib/appNavConfig.ts
+++ b/frontend/src/lib/appNavConfig.ts
@@ -14,6 +14,7 @@ export const WORKSPACE_NAV_ITEMS = [
   { href: "/tenant/compliance-overview", label: "Übersicht" },
   { href: "/tenant/ai-systems", label: "KI-Systeme" },
   { href: "/tenant/eu-ai-act", label: "EU AI Act" },
+  { href: "/tenant/transparency-assurance", label: "Transparency" },
   { href: "/tenant/blueprints", label: "Blueprints" },
   { href: "/tenant/policies", label: "Policies" },
   { href: "/tenant/audit-log", label: "Audit-Log" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "pyyaml>=6.0",
   "langgraph>=1.0.0",
   "temporalio>=1.8.0",
-  "haystack-ai>=2.8.0",
+  "haystack-ai>=2.8.0,<3",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_ai_transparency_assurance.py
+++ b/tests/test_ai_transparency_assurance.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+from sqlalchemy import create_engine, inspect, select
+
+from app.ai_transparency_assurance_models import AITransparencyAssessmentUpsert
+from app.db import SessionLocal
+from app.db_migrations.migrations import m20260502_ai_transparency_assurance as migration
+from app.main import app
+from app.models_db import AISystemTable, AITransparencyAssessmentTable, AuditLogTable
+from app.repositories.audit import AuditEventTable
+
+
+def _headers(tenant_id: str, role: str = "compliance_officer") -> dict[str, str]:
+    return {
+        "x-api-key": "test-api-key",
+        "x-tenant-id": tenant_id,
+        "x-opa-user-role": role,
+    }
+
+
+def _create_system(client: TestClient, tenant_id: str, system_id: str) -> None:
+    response = client.post(
+        "/api/v1/ai-systems",
+        headers=_headers(tenant_id, "tenant_admin"),
+        json={
+            "id": system_id,
+            "name": f"Article 50 System {system_id}",
+            "description": "Assurance integration test",
+            "business_unit": "Digital Products",
+            "risk_level": "high",
+            "ai_act_category": "limited_risk",
+            "gdpr_dpia_required": True,
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def _control_payloads() -> list[dict[str, str | None]]:
+    return [
+        {
+            "control_key": "ai_interaction_disclosure",
+            "status": "verified",
+            "evidence_reference": "evidence://notice-release-42",
+            "rationale": "Notice shown on first interaction and accessibility tested.",
+        },
+        {
+            "control_key": "synthetic_content_marking",
+            "status": "implemented",
+            "evidence_reference": "evidence://c2pa-test-17",
+            "rationale": "Release implemented; independent verification is scheduled.",
+        },
+        {
+            "control_key": "emotion_biometric_notice",
+            "status": "not_applicable",
+            "evidence_reference": None,
+            "rationale": (
+                "System performs neither emotion recognition nor biometric categorisation."
+            ),
+        },
+        {
+            "control_key": "deepfake_disclosure",
+            "status": "not_applicable",
+            "evidence_reference": None,
+            "rationale": "System does not generate or manipulate image, audio or video content.",
+        },
+        {
+            "control_key": "public_interest_text_review_or_disclosure",
+            "status": "not_applicable",
+            "evidence_reference": None,
+            "rationale": "No public-interest publication is within the approved use case.",
+        },
+        {
+            "control_key": "gdpr_transparency_notice",
+            "status": "not_applicable",
+            "evidence_reference": None,
+            "rationale": "No personal data processing occurs in the approved deployment scope.",
+        },
+    ]
+
+
+def _assessment_payload(expected_version: int = 0) -> dict[str, object]:
+    return {
+        "expected_version": expected_version,
+        "role_scope": "provider",
+        "control_owner": "AI Product Control",
+        "reviewer": "Data Protection Review",
+        "reviewed_at_utc": "2026-07-20T10:00:00+00:00",
+        "review_due_at_utc": "2026-10-20T10:00:00+00:00",
+        "controls": _control_payloads(),
+    }
+
+
+def test_model_rejects_unsubstantiated_verification_and_na_rationale_gap() -> None:
+    body = _assessment_payload()
+    controls = body["controls"]
+    assert isinstance(controls, list)
+    controls[0]["evidence_reference"] = None
+    controls[2]["rationale"] = None
+    with pytest.raises(ValidationError) as exc_info:
+        AITransparencyAssessmentUpsert.model_validate(body)
+    assert "evidence_reference" in str(exc_info.value)
+
+
+def test_model_enforces_four_eyes_and_timezone_aware_review() -> None:
+    body = _assessment_payload()
+    body["reviewer"] = body["control_owner"]
+    with pytest.raises(ValidationError, match="four-eyes"):
+        AITransparencyAssessmentUpsert.model_validate(body)
+
+    body = _assessment_payload()
+    body["reviewed_at_utc"] = "2026-07-20T10:00:00"
+    with pytest.raises(ValidationError, match="UTC offset"):
+        AITransparencyAssessmentUpsert.model_validate(body)
+
+
+def test_assurance_register_defaults_upsert_summary_and_audit_minimization() -> None:
+    tenant_id = f"transparency-{uuid4().hex[:10]}"
+    system_id = f"article50-{uuid4().hex[:10]}"
+    with TestClient(app) as client:
+        _create_system(client, tenant_id, system_id)
+
+        initial = client.get(
+            "/api/v1/transparency-assurance",
+            headers=_headers(tenant_id, "auditor"),
+        )
+        assert initial.status_code == 200, initial.text
+        initial_body = initial.json()
+        row = next(item for item in initial_body["systems"] if item["ai_system_id"] == system_id)
+        assert row["posture"] == "requires_scope"
+        assert row["assessment"]["version"] == 0
+        assert len(row["assessment"]["controls"]) == 6
+        assert initial_body["summary"]["requires_scope_count"] >= 1
+
+        saved = client.put(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_id),
+            json=_assessment_payload(),
+        )
+        assert saved.status_code == 200, saved.text
+        assert saved.json()["version"] == 1
+        assert saved.json()["role_scope"] == "provider"
+
+        summary = client.get(
+            "/api/v1/transparency-assurance",
+            headers=_headers(tenant_id, "board_member"),
+        )
+        assert summary.status_code == 200, summary.text
+        saved_row = next(
+            item for item in summary.json()["systems"] if item["ai_system_id"] == system_id
+        )
+        assert saved_row["readiness_score_pct"] == 88
+        assert saved_row["applicable_controls"] == 2
+        assert saved_row["verified_controls"] == 1
+        assert saved_row["posture"] == "implementation_pending_verification"
+
+    with SessionLocal() as session:
+        log = session.scalar(
+            select(AuditLogTable)
+            .where(
+                AuditLogTable.tenant_id == tenant_id,
+                AuditLogTable.action == "update_transparency_assurance",
+            )
+            .order_by(AuditLogTable.id.desc())
+        )
+        assert log is not None
+        assert log.entry_hash
+        assert "evidence://notice-release-42" not in (log.after or "")
+        assert "Data Protection Review" not in (log.after or "")
+        assert '"evidence_attached": true' in (log.after or "")
+
+
+def test_stale_update_is_rejected_without_overwrite() -> None:
+    tenant_id = f"transparency-version-{uuid4().hex[:8]}"
+    system_id = f"article50-version-{uuid4().hex[:8]}"
+    with TestClient(app) as client:
+        _create_system(client, tenant_id, system_id)
+        first = client.put(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_id),
+            json=_assessment_payload(),
+        )
+        assert first.status_code == 200
+
+        stale = client.put(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_id),
+            json=_assessment_payload(expected_version=0),
+        )
+        assert stale.status_code == 409
+        assert stale.json()["detail"]["code"] == "transparency_assessment_version_conflict"
+
+        current = client.get(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_id, "auditor"),
+        )
+        assert current.status_code == 200
+        assert current.json()["version"] == 1
+
+
+def test_assessment_and_both_audit_records_share_one_commit_boundary() -> None:
+    tenant_id = f"transparency-atomic-{uuid4().hex[:8]}"
+    system_id = f"article50-atomic-{uuid4().hex[:8]}"
+    with TestClient(app, raise_server_exceptions=False) as client:
+        _create_system(client, tenant_id, system_id)
+        with patch(
+            "app.ai_transparency_assurance_routes.AuditLogRepository.record_event",
+            side_effect=RuntimeError("forced hash-audit failure"),
+        ):
+            response = client.put(
+                f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+                headers=_headers(tenant_id),
+                json=_assessment_payload(),
+            )
+        assert response.status_code == 500
+
+    with SessionLocal() as session:
+        assessment = session.scalar(
+            select(AITransparencyAssessmentTable).where(
+                AITransparencyAssessmentTable.tenant_id == tenant_id,
+                AITransparencyAssessmentTable.ai_system_id == system_id,
+            )
+        )
+        normalized_event = session.scalar(
+            select(AuditEventTable).where(
+                AuditEventTable.tenant_id == tenant_id,
+                AuditEventTable.entity_type == "ai_transparency_assessment",
+                AuditEventTable.entity_id == system_id,
+            )
+        )
+        assert assessment is None
+        assert normalized_event is None
+
+
+def test_tenant_isolation_and_least_privilege_are_enforced() -> None:
+    tenant_a = f"transparency-a-{uuid4().hex[:8]}"
+    tenant_b = f"transparency-b-{uuid4().hex[:8]}"
+    system_id = f"article50-isolation-{uuid4().hex[:8]}"
+    with TestClient(app) as client:
+        _create_system(client, tenant_a, system_id)
+        saved = client.put(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_a),
+            json=_assessment_payload(),
+        )
+        assert saved.status_code == 200
+
+        cross_tenant = client.get(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_b, "auditor"),
+        )
+        assert cross_tenant.status_code == 404
+        tenant_b_summary = client.get(
+            "/api/v1/transparency-assurance",
+            headers=_headers(tenant_b, "auditor"),
+        )
+        assert tenant_b_summary.status_code == 200
+        assert tenant_b_summary.json()["systems"] == []
+
+        viewer_read = client.get(
+            "/api/v1/transparency-assurance",
+            headers=_headers(tenant_a, "viewer"),
+        )
+        assert viewer_read.status_code == 403
+        editor_write = client.put(
+            f"/api/v1/ai-systems/{system_id}/transparency-assurance",
+            headers=_headers(tenant_a, "editor"),
+            json=_assessment_payload(expected_version=1),
+        )
+        assert editor_write.status_code == 403
+
+
+def test_verified_review_requires_a_future_review_boundary() -> None:
+    body = _assessment_payload()
+    body["control_owner"] = None
+    with pytest.raises(ValidationError, match="control_owner"):
+        AITransparencyAssessmentUpsert.model_validate(body)
+
+    body = _assessment_payload()
+    body["review_due_at_utc"] = None
+    with pytest.raises(ValidationError, match="review_due_at_utc"):
+        AITransparencyAssessmentUpsert.model_validate(body)
+
+    body = _assessment_payload()
+    body["review_due_at_utc"] = datetime(2026, 7, 19, tzinfo=UTC).isoformat()
+    with pytest.raises(ValidationError, match="cannot be before"):
+        AITransparencyAssessmentUpsert.model_validate(body)
+
+
+def test_transparency_migration_creates_normalized_tables_and_is_idempotent() -> None:
+    migration_engine = create_engine("sqlite+pysqlite:///:memory:")
+    AISystemTable.__table__.create(migration_engine)
+
+    assert migration.apply(migration_engine) is True
+    assert migration.apply(migration_engine) is False
+    table_names = set(inspect(migration_engine).get_table_names())
+    assert "ai_transparency_assessments" in table_names
+    assert "ai_transparency_controls" in table_names

--- a/tests/test_db_migrations_ledger_optional.py
+++ b/tests/test_db_migrations_ledger_optional.py
@@ -116,7 +116,8 @@ def test_run_all_ledgerless_reports_unsatisfied_without_ddl(tmp_path) -> None:
     assert "20260429_remediation_automation_layer" in ids
     assert "20260430_governance_workflow_orchestration" in ids
     assert "20260501_enterprise_user_sessions" in ids
-    assert len(ids) == 30
+    assert "20260502_ai_transparency_assurance" in ids
+    assert len(ids) == 31
     cols = {c["name"] for c in inspect(engine).get_columns("tenants")}
     assert "kritis_sector" not in cols
     engine.dispose()

--- a/tests/test_rbac_permissions.py
+++ b/tests/test_rbac_permissions.py
@@ -25,6 +25,10 @@ def test_viewer_cannot_edit() -> None:
     assert not has_permission(EnterpriseRole.VIEWER, Permission.EDIT_RISK_REGISTER)
     assert not has_permission(EnterpriseRole.VIEWER, Permission.MANAGE_INCIDENTS)
     assert not has_permission(EnterpriseRole.VIEWER, Permission.MANAGE_POLICIES)
+    assert not has_permission(
+        EnterpriseRole.VIEWER,
+        Permission.VIEW_TRANSPARENCY_ASSURANCE,
+    )
 
 
 def test_compliance_officer_can_manage_incidents() -> None:
@@ -32,6 +36,10 @@ def test_compliance_officer_can_manage_incidents() -> None:
     assert has_permission(EnterpriseRole.COMPLIANCE_OFFICER, Permission.MANAGE_POLICIES)
     assert has_permission(EnterpriseRole.COMPLIANCE_OFFICER, Permission.GENERATE_BOARD_REPORTS)
     assert has_permission(EnterpriseRole.COMPLIANCE_OFFICER, Permission.MANAGE_COMPLIANCE_CALENDAR)
+    assert has_permission(
+        EnterpriseRole.COMPLIANCE_OFFICER,
+        Permission.MANAGE_TRANSPARENCY_ASSURANCE,
+    )
     # Also inherits editor/contributor perms
     assert has_permission(EnterpriseRole.COMPLIANCE_OFFICER, Permission.EDIT_AI_SYSTEMS)
     assert has_permission(EnterpriseRole.COMPLIANCE_OFFICER, Permission.VIEW_DASHBOARD)
@@ -75,6 +83,7 @@ def test_board_member_has_restricted_view() -> None:
             Permission.VIEW_EXECUTIVE_DASHBOARD,
             Permission.VIEW_GAP_REPORTS,
             Permission.GENERATE_PDF_REPORT,
+            Permission.VIEW_TRANSPARENCY_ASSURANCE,
         }
     )
 
@@ -83,6 +92,10 @@ def test_auditor_has_export_audit_log() -> None:
     assert has_permission(EnterpriseRole.AUDITOR, Permission.EXPORT_AUDIT_LOG)
     assert has_permission(EnterpriseRole.AUDITOR, Permission.VIEW_AUDIT_LOG)
     assert not has_permission(EnterpriseRole.AUDITOR, Permission.EDIT_AI_SYSTEMS)
+    assert has_permission(
+        EnterpriseRole.AUDITOR,
+        Permission.VIEW_TRANSPARENCY_ASSURANCE,
+    )
 
 
 # ── Unit tests: role resolution ────────────────────────────────────────


### PR DESCRIPTION
## What changed

- add a normalized, tenant-scoped Article 50 and GDPR transparency assurance register for every AI system
- enforce six explicit controls, evidence-backed verification, provider/deployer scoping, control-owner/reviewer separation, review cadence, and optimistic locking
- add least-privilege RBAC, minimized dual audit records, and one atomic commit boundary for assessment plus audits
- add an enterprise workspace with portfolio readiness, regulatory clock, accessible control editing, and explicit legal boundary
- fix hydration-stable role-based global navigation discovered during real-browser verification
- document implementation evidence and residual production/legal gates

## Why

Article 50 transparency obligations apply from 2 August 2026. The product needed an operational evidence register that keeps unresolved systems visible and does not infer or claim legal conformity from incomplete data.

## Validation

- full backend pytest suite
- Ruff check and format check across the repository
- 90 frontend test files / 314 tests
- ESLint with zero warnings
- Strict CSP, runtime storage, and enterprise release gates
- Next.js production build including `/tenant/transparency-assurance`
- Bandit high-severity scan, pip-audit, and npm audit
- headed Playwright flow: verified account login, tenant/RBAC access, evidence validation, CSRF-protected PUT, version increment, and readiness refresh

## Explicit residual gates

This change provides implementation and process evidence; it does not certify legal compliance. Evidence authenticity, technical marking effectiveness, exception applicability, retention/legal hold, independent legal/privacy review, and production-equivalent PostgreSQL RLS evidence remain release gates for the enterprise deployment.
