### PR TITLE
Harden sovereign pre-production release controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Lint and format check
         run: |
-          ruff check app/ tests/
-          ruff format --check app/ tests/
+          ruff check app/ scripts/hetzner_release.py scripts/verify_release_evidence.py scripts/sovereign_release_build.py scripts/sovereign_restore_drill.py tests/
+          ruff format --check app/ scripts/hetzner_release.py scripts/verify_release_evidence.py scripts/sovereign_release_build.py scripts/sovereign_restore_drill.py tests/
 
       - name: Dependency vulnerability audit
         run: pip-audit --skip-editable --desc
@@ -49,7 +49,9 @@ jobs:
         run: pip-audit -r requirements.lock --format cyclonedx-json --output backend-sbom.cdx.json
 
       - name: Static security analysis
-        run: bandit -q -r app -x app/db_migrations -lll
+        run: |
+          bandit -q -r app -x app/db_migrations -lll
+          bandit -q scripts/hetzner_release.py scripts/verify_release_evidence.py scripts/sovereign_release_build.py scripts/sovereign_restore_drill.py
 
       - name: Test
         run: python -m pytest tests/ -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: python -m pytest tests/ -q
 
       - name: Upload backend SBOM
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-cyclonedx-sbom
           path: backend-sbom.cdx.json
@@ -99,7 +99,7 @@ jobs:
         run: npm run build
 
       - name: Upload frontend SBOM
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-cyclonedx-sbom
           path: frontend/frontend-sbom.cdx.json
@@ -125,10 +125,10 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build production image for security verification
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload container scan evidence
         if: always()
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: trivy-${{ matrix.component }}-${{ github.sha }}
           path: trivy-${{ matrix.component }}.json

--- a/.github/workflows/preproduction-build.yml
+++ b/.github/workflows/preproduction-build.yml
@@ -1,0 +1,40 @@
+name: Pre-production sovereign build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: preproduction-sovereign-build
+  cancel-in-progress: false
+
+jobs:
+  build-sign-attest:
+    name: Build, scan, sign and attest on Hetzner
+    if: github.ref == 'refs/heads/main' && github.repository == 'Luyzz22/Compliance-Hub'
+    runs-on: [self-hosted, linux, x64, compliancehub-hetzner-release]
+    environment: preproduction
+    timeout-minutes: 60
+    steps:
+      - name: Checkout immutable main commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Build, scan, sign and attest in the sovereign zone
+        env:
+          COMPLIANCEHUB_RELEASE_BUILDER_CONFIG: /etc/compliancehub/release-builder.json
+          COMPLIANCEHUB_RELEASE_COMMIT: ${{ github.sha }}
+          COMPLIANCEHUB_RELEASE_INVOCATION: github-run-${{ github.run_id }}-${{ github.run_attempt }}
+        run: python3 scripts/sovereign_release_build.py
+
+      - name: Record non-secret evidence location
+        run: |
+          printf '%s\n' \
+            'Build evidence was retained on the Hetzner release runner.' \
+            'No image, SBOM, scan report, registry credential or OpenBao token was uploaded to GitHub.' \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile.hetzner
+++ b/Dockerfile.hetzner
@@ -1,4 +1,7 @@
-FROM python:3.11-alpine3.23@sha256:f73754c398b259dfbbe482361dca8b464dea57da74efe5214966ca2ee767ee12 AS builder
+ARG PYTHON_BASE_IMAGE=python:3.11-alpine3.23@sha256:f73754c398b259dfbbe482361dca8b464dea57da74efe5214966ca2ee767ee12
+ARG PYTHON_INDEX_URL=https://pypi.org/simple
+FROM ${PYTHON_BASE_IMAGE} AS builder
+ARG PYTHON_INDEX_URL
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1 \
     PYTHONDONTWRITEBYTECODE=1
@@ -7,11 +10,11 @@ RUN python -m venv /opt/venv
 ENV PATH=/opt/venv/bin:$PATH
 COPY pyproject.toml requirements.lock README.md ./
 COPY app ./app
-RUN pip install --require-hashes --no-deps -r requirements.lock \
+RUN pip install --index-url "${PYTHON_INDEX_URL}" --require-hashes --no-deps -r requirements.lock \
     && pip install --no-deps --no-build-isolation . \
     && pip uninstall --yes pip setuptools wheel
 
-FROM python:3.11-alpine3.23@sha256:f73754c398b259dfbbe482361dca8b464dea57da74efe5214966ca2ee767ee12 AS runtime
+FROM ${PYTHON_BASE_IMAGE} AS runtime
 ENV PATH=/opt/venv/bin:$PATH \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -40,6 +40,7 @@ secrets/s3-secret-access-key
 secrets/azure-openai-client-certificate.pem
 secrets/bff-shared-secret
 secrets/audit-pseudonymization-key
+secrets/credential-pepper
 secrets/internal-health-api-key
 secrets/entra-client-secret
 secrets/auth-transaction-secret
@@ -52,8 +53,22 @@ Dateibasierte Compose-Secrets sind Bind-Mounts; Docker Compose setzt deren dekla
 UID/GID/Moduswerte nicht um. Deshalb enthält `compose.yml` einen separaten
 `x-secret-host-contract`. Der Release-Controller prüft vor jedem mutierenden Schritt,
 dass jede Quelldatei regulär, kein Symlink, Eigentum der vorgesehenen numerischen
-Container-UID und exakt `0400` ist. Die YAML-Langsyntax selbst wird nicht als
-Berechtigungsnachweis behandelt.
+Container-UID und exakt `0400` ist. Zusätzlich bindet der Vertrag Mindestlänge,
+Inhaltstyp, die einzigen zulässigen Verbraucher und eine Rotationsklasse. Der Preflight
+gleicht die Verbraucher gegen die tatsächlichen Compose-Mounts ab, prüft einzeilige
+opaque Werte, vollständige PostgreSQL-DSNs und PEM-Marker und gibt dabei niemals
+Secret-Inhalte aus. Die YAML-Langsyntax selbst wird nicht als Berechtigungsnachweis
+behandelt.
+
+Die Rotationsklassen sind verbindliche Betriebsverfahren, keine Behauptung bereits
+erfolgter Rotation:
+
+- `standard_90d`: spätestens alle 90 Tage oder unmittelbar nach Expositionsverdacht;
+  neuer Wert, abhängige Sitzung/Verbindung, Funktionsprüfung, danach Widerruf des alten.
+- `certificate_lifecycle`: Erneuerung vor dem 30-Tage-Ablaufgate, Ketten-/Key-Pair-Prüfung
+  und anschließender Widerruf des Vorgängers.
+- `coordinated_change_window`: Vier-Augen-Change mit gemeinsamem Neustart abhängiger
+  Dienste; bei `credential-pepper` inklusive geplanter API-Key-/Session-Neuausstellung.
 
 API-Keys, Passwörter oder private Schlüssel dürfen weder in `.env.production`, Compose,
 Container-Image, CI-Variablen-Ausgabe noch Logs gelangen. BFF-Vertrauensanker,

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -147,6 +147,26 @@ getrennten Signer-/HSM-Grenzen und dürfen nicht auf dem Deployment-Host liegen.
 jeweilige `subject` muss zusätzlich mit `built_by` beziehungsweise `approved_by`
 übereinstimmen; damit kann eine gültige Signatur nicht unter fremder Identität erscheinen.
 
+Der vorgelagerte Build läuft ausschließlich über den manuell freizugebenden Workflow
+`preproduction-build.yml` auf einem isolierten Runner mit den Labels `self-hosted`,
+`linux`, `x64` und `compliancehub-hetzner-release`. Der Runner liest die root-owned
+Konfiguration `/etc/compliancehub/release-builder.json`, verwendet eine vorab
+authentifizierte private Registry und lädt während des Builds keine Werkzeuge nach.
+Cosign 3.0.6 signiert die Digest-Referenzen über einen OpenBao-Transit-Key; der private
+Schlüssel wird nie exportiert. Signaturen, CycloneDX-Attestierungen und SLSA-v1-
+Provenance liegen als OCI-Artefakte in derselben privaten Registry. SBOM, Trivy-JSON,
+Provenance und Build-Manifest verbleiben mit Modus `0700`/`0600` unter
+`/var/lib/compliancehub/release-evidence`. GitHub erhält davon weder Artefakte noch
+Registry-Credentials oder OpenBao-Tokens.
+
+Vor Aktivierung muss ein Administrator `release-builder.example.json` außerhalb des
+Repositories als root-owned Konfiguration provisionieren. Der OpenBao-Agent erzeugt
+für jeden Lauf ein kurzlebiges, auf `transit/keys`, `transit/hmac`, `transit/sign`
+und `transit/verify` des einen Release-Keys begrenztes Token. Der Runner darf keine
+OpenBao-Key-Erzeugungs-, Export-, Secret-Lese- oder Administrationsrechte besitzen.
+Die Cosign-Aufrufe deaktivieren sowohl den öffentlichen Transparency-Log-Upload als
+auch die TUF-basierte öffentliche Signing-Konfiguration ausdrücklich.
+
 Auf dem Deployment-Host wird der Verifier in einer dedizierten root-owned Python-3.11-
 Umgebung betrieben. `cryptography` und seine Transitivabhängigkeiten werden während der
 Host-Provisionierung aus dem geprüften `requirements.lock` mit `--require-hashes`

--- a/deploy/hetzner/README.md
+++ b/deploy/hetzner/README.md
@@ -206,6 +206,7 @@ vor `docker compose pull` und `up` muss dann der vollständige Gate-Befehl erfol
   --approver-public-key /etc/compliancehub/release-trust/approver-ed25519.pem \
   --backend-sbom artifacts/backend.cdx.json \
   --frontend-sbom artifacts/frontend.cdx.json \
+  --restore-evidence artifacts/restore-drill.json \
   --deployment-dir .
 ```
 
@@ -215,6 +216,50 @@ Signaturen sowie die exakt von Compose gelesenen Release-ID-, Commit-, Evidence-
 Image-Werte. Fehlende Argumente,
 falsche Schlüssel, ein nachträglich geändertes JSON oder eine abweichende Env-Datei führen
 zu einem Fehlerstatus. Das Beispiel bleibt absichtlich nicht freigabefähig.
+
+### Isolierter Restore-Drill
+
+Ein frei formulierter Restore-Verweis reicht nicht als Produktionsnachweis. Der
+root-owned Vertrag `restore-drill.example.json` bindet einen konkreten PostgreSQL-
+Custom-Dump, dessen SHA-256 und Erstellzeit sowie einen versionierten S3-Backup-Präfix.
+Der Drill läuft mit `sovereign_restore_drill.py` auf einem getrennten Hetzner-
+Operationshost. Er darf weder Produktionsdatenbank noch produktives Objekt-Bucket als
+Ziel verwenden:
+
+- PostgreSQL-Zielhost muss einen expliziten `restore`-Hostnamen besitzen; der neue,
+  vorab nicht existierende Datenbankname beginnt mit `compliancehub_restore_`.
+- S3-Quelle und -Ziel verwenden getrennte Buckets; das Ziel-Bucket enthält `restore`
+  und der Zielpräfix lautet exakt `restore-drills/<Drill-ID>`.
+- `pg_restore --exit-on-error` stellt ohne Owner/ACLs wieder her. Danach werden Anzahl
+  und verpflichtende Tabellen logisch geprüft und nur die eindeutig selbst erstellte
+  Drill-Datenbank gelöscht.
+- `rclone check --download` vergleicht jedes restaurierte Objekt byteweise. Anschließend
+  wird nur der dedizierte Drill-Präfix bereinigt und dessen Leerstand erneut geprüft.
+
+Der Restore-Operator erhält nur `CREATE DATABASE`/`CONNECT` für den isolierten Cluster
+und Schreib-/Löschrechte ausschließlich im Restore-Bucket; er besitzt keine Schreib-
+oder Löschrechte auf Backup- oder Produktions-Buckets. Backup-Ersteller und unabhängiger
+Freigeber sind getrennte Rollen. PostgreSQL-Passwort und S3-Schlüssel liegen nur in
+OpenBao-materialisierten Dateien mit `0400`; sie erscheinen weder im Nachweis noch in
+Kommandozeilen oder Logs. Der Aufruf lautet:
+
+```bash
+COMPLIANCEHUB_RESTORE_DRILL_CONFIG=/etc/compliancehub/restore/restore-drill.json \
+  /opt/compliancehub-release-venv/bin/python ../../scripts/sovereign_restore_drill.py
+```
+
+Das Ergebnis unter `/var/lib/compliancehub/restore-evidence/<Drill-ID>.json` enthält nur
+Messwerte, Werkzeugversionen, Hashes und pseudonyme Host-/Backup-Kennungen. Es muss vor
+der Release-Evidence entstanden und höchstens 31 Tage alt sein. Seine Drill-ID und sein
+SHA-256 werden in `database.restore_drill_id` und `database.restore_evidence_sha256`
+übernommen und damit durch Builder und unabhängigen Approver signiert. Der Release-
+Controller verlangt zusätzlich die tatsächliche Datei mit Modus `0400`, `0440` oder
+`0600`; fehlende, manipulierte, zu alte, nicht bereinigte oder RPO/RTO-verfehlende
+Nachweise blockieren den Cutover.
+Die atomare Datei `.<Drill-ID>.lock` reserviert jeden Drill einmalig und bleibt auch
+nach Erfolg bestehen. Wiederholung oder Entfernung ist nur nach dokumentierter
+Operatorprüfung zulässig; ein fehlgeschlagener Lauf darf nicht still überschrieben
+werden.
 
 Der Anwendungscontainer führt in Produktion weder `create_all` noch Migrationen aus.
 Schemaänderungen werden zuvor mit einer separaten DDL-Rolle, eigenem Change Window und

--- a/deploy/hetzner/compose.yml
+++ b/deploy/hetzner/compose.yml
@@ -3,20 +3,34 @@ name: compliancehub
 # Docker Compose bind-mounts file-backed secrets and cannot remap uid/gid/mode.
 # The release controller validates this host-side contract before any pull or up.
 x-secret-host-contract:
-  tls_certificate: { uid: 65532, mode: "0400" }
-  tls_private_key: { uid: 65532, mode: "0400" }
-  backend_database_url: { uid: 10001, mode: "0400" }
-  postgres_password: { uid: 10001, mode: "0400" }
-  s3_access_key: { uid: 10001, mode: "0400" }
-  s3_secret_access_key: { uid: 10001, mode: "0400" }
-  azure_openai_client_certificate: { uid: 10001, mode: "0400" }
-  bff_shared_secret: { uid: 10001, mode: "0400" }
-  audit_pseudonymization_key: { uid: 10001, mode: "0400" }
-  credential_pepper: { uid: 10001, mode: "0400" }
-  internal_health_api_key: { uid: 10001, mode: "0400" }
-  entra_client_secret: { uid: 10001, mode: "0400" }
-  auth_transaction_secret: { uid: 10001, mode: "0400" }
-  lead_admin_secret: { uid: 10001, mode: "0400" }
+  tls_certificate:
+    { uid: 65532, mode: "0400", min_bytes: 256, content_kind: pem_certificate, consumers: [edge], rotation_policy: certificate_lifecycle }
+  tls_private_key:
+    { uid: 65532, mode: "0400", min_bytes: 256, content_kind: pem_private_key, consumers: [edge], rotation_policy: certificate_lifecycle }
+  backend_database_url:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: postgres_dsn, consumers: [backend], rotation_policy: standard_90d }
+  postgres_password:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
+  s3_access_key:
+    { uid: 10001, mode: "0400", min_bytes: 16, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
+  s3_secret_access_key:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
+  azure_openai_client_certificate:
+    { uid: 10001, mode: "0400", min_bytes: 512, content_kind: pem_certificate_private_key, consumers: [backend], rotation_policy: certificate_lifecycle }
+  bff_shared_secret:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend, backend], rotation_policy: coordinated_change_window }
+  audit_pseudonymization_key:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [backend], rotation_policy: coordinated_change_window }
+  credential_pepper:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [backend], rotation_policy: coordinated_change_window }
+  internal_health_api_key:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [backend], rotation_policy: standard_90d }
+  entra_client_secret:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
+  auth_transaction_secret:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
+  lead_admin_secret:
+    { uid: 10001, mode: "0400", min_bytes: 32, content_kind: opaque, consumers: [frontend], rotation_policy: standard_90d }
 
 services:
   edge:

--- a/deploy/hetzner/postgres-restore-connection.example.json
+++ b/deploy/hetzner/postgres-restore-connection.example.json
@@ -1,0 +1,7 @@
+{
+  "host": "postgres-restore.internal.example.de",
+  "port": 5432,
+  "username": "compliancehub_restore_operator",
+  "maintenance_database": "postgres",
+  "sslmode": "verify-full"
+}

--- a/deploy/hetzner/release-builder.example.json
+++ b/deploy/hetzner/release-builder.example.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": 1,
+  "registry_prefix": "registry.internal.example.de/compliancehub",
+  "allowed_registry_hosts": ["registry.internal.example.de"],
+  "base_images": {
+    "backend": "registry.internal.example.de/mirror/python@sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    "frontend": "registry.internal.example.de/mirror/node@sha256:0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "package_mirrors": {
+    "python": "https://packages.internal.example.de/pypi/simple",
+    "npm": "https://packages.internal.example.de/npm/"
+  },
+  "allowed_package_hosts": ["packages.internal.example.de"],
+  "trivy_cache_dir": "/var/lib/compliancehub/trivy-cache",
+  "trivy_db_max_age_hours": 24,
+  "evidence_root": "/var/lib/compliancehub/release-evidence",
+  "openbao_address": "https://openbao.internal.example.de:8200",
+  "openbao_transit_key": "compliancehub-release",
+  "openbao_token_file": "/run/compliancehub-release/openbao-token",
+  "cosign_public_key": "/etc/compliancehub/release-trust/cosign.pub",
+  "required_tools": {
+    "cosign": "v3.0.6",
+    "syft": "1.50.0",
+    "trivy": "0.73.0"
+  }
+}

--- a/deploy/hetzner/release-evidence.example.json
+++ b/deploy/hetzner/release-evidence.example.json
@@ -29,7 +29,8 @@
   },
   "database": {
     "migration_plan_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-    "backup_restore_evidence": "replace-with-immutable-evidence-reference",
+    "restore_drill_id": "DR-YYYYMMDD-CHANGEID",
+    "restore_evidence_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
     "change_class": "none",
     "migration_execution_status": "not_required",
     "schema_verification_status": "pending",

--- a/deploy/hetzner/restore-drill.example.json
+++ b/deploy/hetzner/restore-drill.example.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "drill_id": "DR-20260813-CHANGE1234",
+  "evidence_root": "/var/lib/compliancehub/restore-evidence",
+  "postgres_backup_file": "/var/lib/compliancehub/backups/postgres/approved.dump",
+  "postgres_backup_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
+  "postgres_backup_created_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "postgres_connection_file": "/etc/compliancehub/restore/postgres-connection.json",
+  "postgres_pgpass_file": "/run/compliancehub-restore/pgpass",
+  "allowed_postgres_hosts": ["postgres-restore.internal.example.de"],
+  "postgres_restore_database": "compliancehub_restore_20260813_change1234",
+  "postgres_required_tables": ["tenants", "ai_systems", "audit_logs", "evidence_files"],
+  "postgres_minimum_public_tables": 4,
+  "object_rclone_config_file": "/run/compliancehub-restore/rclone.conf",
+  "object_remote": "hetzner_restore",
+  "object_backup_bucket": "compliancehub-backups",
+  "object_restore_bucket": "compliancehub-restore-drills",
+  "object_backup_prefix": "approved/2026-08-13",
+  "object_backup_created_at": "YYYY-MM-DDTHH:MM:SSZ",
+  "object_restore_prefix": "restore-drills/DR-20260813-CHANGE1234",
+  "allowed_object_hosts": ["fsn1.your-objectstorage.com"],
+  "rpo_target_minutes": 1440,
+  "rto_target_minutes": 240,
+  "required_tools": {
+    "psql": "17.9",
+    "pg_restore": "17.9",
+    "createdb": "17.9",
+    "dropdb": "17.9",
+    "rclone": "v1.72.1"
+  }
+}

--- a/frontend/Dockerfile.hetzner
+++ b/frontend/Dockerfile.hetzner
@@ -1,9 +1,13 @@
-FROM node:22-alpine3.23@sha256:46825fbbd4e996a78b7a2cdc08d75e38a5a505bdab95dcda55605359bf124bc6 AS dependencies
+ARG NODE_BASE_IMAGE=node:22-alpine3.23@sha256:46825fbbd4e996a78b7a2cdc08d75e38a5a505bdab95dcda55605359bf124bc6
+ARG NPM_REGISTRY_URL=https://registry.npmjs.org/
+FROM ${NODE_BASE_IMAGE} AS dependencies
+ARG NPM_REGISTRY_URL
 WORKDIR /workspace/frontend
 COPY frontend/package.json frontend/package-lock.json ./
-RUN npm ci --ignore-scripts
+RUN npm ci --ignore-scripts --registry="${NPM_REGISTRY_URL}" --replace-registry-host=always \
+    --audit=false --fund=false --update-notifier=false
 
-FROM node:22-alpine3.23@sha256:46825fbbd4e996a78b7a2cdc08d75e38a5a505bdab95dcda55605359bf124bc6 AS builder
+FROM ${NODE_BASE_IMAGE} AS builder
 WORKDIR /workspace/frontend
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY --from=dependencies /workspace/frontend/node_modules ./node_modules
@@ -14,7 +18,7 @@ COPY db/postgres/migrations/20260715_advisor_runtime_state_rls.sql /workspace/db
 COPY tests/postgres/advisor_runtime_state_rls_test.sql /workspace/tests/postgres/advisor_runtime_state_rls_test.sql
 RUN npm run build
 
-FROM node:22-alpine3.23@sha256:46825fbbd4e996a78b7a2cdc08d75e38a5a505bdab95dcda55605359bf124bc6 AS runtime
+FROM ${NODE_BASE_IMAGE} AS runtime
 WORKDIR /app
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/scripts/hetzner_release.py
+++ b/scripts/hetzner_release.py
@@ -9,7 +9,9 @@ import hashlib
 import json
 import os
 import stat
-import subprocess
+
+# Fixed argv execution is required for the approved release tools.
+import subprocess  # nosec B404
 import sys
 import tempfile
 from collections.abc import Iterator, Sequence
@@ -84,6 +86,7 @@ class ReleasePaths:
     approver_public_key: Path
     backend_sbom: Path
     frontend_sbom: Path
+    restore_evidence: Path
     lock_file: Path
     audit_log: Path
 
@@ -378,7 +381,8 @@ def _run(
     environment: dict[str, str] | None = None,
 ) -> str:
     try:
-        result = subprocess.run(
+        # No shell is used; command construction is limited to release-controller controls.
+        result = subprocess.run(  # nosec B603
             list(command),
             cwd=cwd,
             env=environment,
@@ -434,6 +438,8 @@ def _verify_release_evidence(paths: ReleasePaths) -> None:
             str(paths.backend_sbom),
             "--frontend-sbom",
             str(paths.frontend_sbom),
+            "--restore-evidence",
+            str(paths.restore_evidence),
             "--deployment-dir",
             str(paths.deployment),
             "--json",
@@ -482,6 +488,7 @@ def preflight(paths: ReleasePaths) -> tuple[dict[str, object], bytes, dict[str, 
         (paths.approver_public_key, {0o400, 0o440, 0o444}, {0}),
         (paths.backend_sbom, {0o400, 0o440, 0o444}, {0, os.geteuid()}),
         (paths.frontend_sbom, {0o400, 0o440, 0o444}, {0, os.geteuid()}),
+        (paths.restore_evidence, {0o400, 0o440, 0o600}, {0, os.geteuid()}),
     ):
         _secure_read(control_path, allowed_modes=modes, allowed_uids=owners)
     compose_bytes = _secure_read(paths.compose, allowed_modes={0o444, 0o644})
@@ -811,6 +818,7 @@ def _resolve_paths(arguments: argparse.Namespace) -> ReleasePaths:
         approver_public_key=resolve(arguments.approver_public_key),
         backend_sbom=resolve(arguments.backend_sbom),
         frontend_sbom=resolve(arguments.frontend_sbom),
+        restore_evidence=resolve(arguments.restore_evidence),
         lock_file=Path(arguments.lock_file).resolve(),
         audit_log=Path(arguments.audit_log).resolve(),
     )
@@ -833,6 +841,7 @@ def main() -> int:
     )
     parser.add_argument("--backend-sbom", default="artifacts/backend.cdx.json")
     parser.add_argument("--frontend-sbom", default="artifacts/frontend.cdx.json")
+    parser.add_argument("--restore-evidence", default="artifacts/restore-drill.json")
     parser.add_argument("--lock-file", default="/var/lock/compliancehub/release.lock")
     parser.add_argument("--audit-log", default="/var/log/compliancehub/release-events.jsonl")
     parser.add_argument("--confirm-release-id")

--- a/scripts/hetzner_release.py
+++ b/scripts/hetzner_release.py
@@ -17,6 +17,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+from urllib.parse import urlsplit
 
 import yaml
 
@@ -44,6 +45,26 @@ RELEASE_LABELS = {
 SERVICE_IMAGES = {
     "backend": "COMPLIANCEHUB_BACKEND_IMAGE",
     "frontend": "COMPLIANCEHUB_FRONTEND_IMAGE",
+}
+SECRET_CONTRACT_FIELDS = {
+    "uid",
+    "mode",
+    "min_bytes",
+    "content_kind",
+    "consumers",
+    "rotation_policy",
+}
+SECRET_CONTENT_KINDS = {
+    "opaque",
+    "postgres_dsn",
+    "pem_certificate",
+    "pem_private_key",
+    "pem_certificate_private_key",
+}
+SECRET_ROTATION_POLICIES = {
+    "certificate_lifecycle",
+    "standard_90d",
+    "coordinated_change_window",
 }
 
 
@@ -161,10 +182,29 @@ def validate_secret_host_contract(deployment: Path, compose_payload: object) -> 
         raise ReleaseError("compose.yml must contain an object")
     contracts = compose_payload.get("x-secret-host-contract")
     definitions = compose_payload.get("secrets")
-    if not isinstance(contracts, dict) or not isinstance(definitions, dict):
-        raise ReleaseError("compose.yml must define secrets and x-secret-host-contract")
+    services = compose_payload.get("services")
+    if (
+        not isinstance(contracts, dict)
+        or not isinstance(definitions, dict)
+        or not isinstance(services, dict)
+    ):
+        raise ReleaseError("compose.yml must define services, secrets and x-secret-host-contract")
     if set(contracts) != set(definitions):
         raise ReleaseError("secret host contract must cover every Compose secret exactly")
+
+    actual_consumers: dict[str, set[str]] = {name: set() for name in definitions}
+    for service_name, service in services.items():
+        if not isinstance(service_name, str) or not isinstance(service, dict):
+            raise ReleaseError("Compose service definition is malformed")
+        for mounted in service.get("secrets", []):
+            if not isinstance(mounted, dict) or not isinstance(mounted.get("source"), str):
+                raise ReleaseError(f"Compose secret mount is malformed: {service_name}")
+            source_name = mounted["source"]
+            if source_name not in actual_consumers:
+                raise ReleaseError(
+                    f"Compose service references an undefined secret: {service_name}"
+                )
+            actual_consumers[source_name].add(service_name)
 
     deployment_root = deployment.resolve(strict=True)
     for name in sorted(definitions):
@@ -175,8 +215,28 @@ def validate_secret_host_contract(deployment: Path, compose_payload: object) -> 
         source = definition.get("file")
         uid = contract.get("uid")
         raw_mode = contract.get("mode")
-        if not isinstance(source, str) or type(uid) is not int or raw_mode != "0400":
+        minimum_bytes = contract.get("min_bytes")
+        content_kind = contract.get("content_kind")
+        consumers = contract.get("consumers")
+        rotation_policy = contract.get("rotation_policy")
+        if set(contract) != SECRET_CONTRACT_FIELDS:
+            raise ReleaseError(f"secret contract has unknown or missing fields: {name}")
+        if (
+            not isinstance(source, str)
+            or type(uid) is not int
+            or raw_mode != "0400"
+            or type(minimum_bytes) is not int
+            or not 16 <= minimum_bytes <= MAX_SECRET_BYTES
+            or content_kind not in SECRET_CONTENT_KINDS
+            or not isinstance(consumers, list)
+            or not consumers
+            or any(not isinstance(consumer, str) for consumer in consumers)
+            or len(consumers) != len(set(consumers))
+            or rotation_policy not in SECRET_ROTATION_POLICIES
+        ):
             raise ReleaseError(f"secret contract is incomplete: {name}")
+        if set(consumers) != actual_consumers[name]:
+            raise ReleaseError(f"secret consumer contract does not match Compose mounts: {name}")
         source_path = deployment_root / source
         for parent in source_path.parents:
             if parent == deployment_root:
@@ -192,8 +252,40 @@ def validate_secret_host_contract(deployment: Path, compose_payload: object) -> 
             allowed_uids={uid},
             maximum_bytes=MAX_SECRET_BYTES,
         )
-        if not content.strip():
+        normalized = content.strip()
+        if not normalized:
             raise ReleaseError(f"secret source must not be empty: {name}")
+        if len(normalized) < minimum_bytes:
+            raise ReleaseError(f"secret source does not meet its minimum length: {name}")
+        if b"\x00" in normalized:
+            raise ReleaseError(f"secret source contains forbidden binary data: {name}")
+        if content_kind == "opaque" and (b"\n" in normalized or b"\r" in normalized):
+            raise ReleaseError(f"opaque secret source must contain exactly one line: {name}")
+        if content_kind == "postgres_dsn":
+            try:
+                parsed = urlsplit(normalized.decode("utf-8"))
+            except (UnicodeDecodeError, ValueError) as exc:
+                raise ReleaseError(f"PostgreSQL secret is not a valid DSN: {name}") from exc
+            if (
+                parsed.scheme not in {"postgres", "postgresql"}
+                or not parsed.hostname
+                or not parsed.username
+                or parsed.password is None
+                or not parsed.path.strip("/")
+            ):
+                raise ReleaseError(f"PostgreSQL secret is not a complete DSN: {name}")
+        pem_markers = {
+            "pem_certificate": (b"-----BEGIN CERTIFICATE-----",),
+            "pem_private_key": (b"-----BEGIN PRIVATE KEY-----",),
+            "pem_certificate_private_key": (
+                b"-----BEGIN CERTIFICATE-----",
+                b"-----BEGIN PRIVATE KEY-----",
+            ),
+        }
+        if content_kind in pem_markers and any(
+            marker not in normalized for marker in pem_markers[content_kind]
+        ):
+            raise ReleaseError(f"secret source does not match its declared PEM type: {name}")
 
 
 def _secret_source(deployment: Path, compose_payload: object, name: str) -> Path:

--- a/scripts/sovereign_release_build.py
+++ b/scripts/sovereign_release_build.py
@@ -1,0 +1,688 @@
+#!/usr/bin/env python3
+"""Build and attest release images entirely inside the Hetzner trust boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import stat
+
+# Fixed argv execution is required for the explicitly approved release tools.
+import subprocess  # nosec B404
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import urlsplit
+
+MAX_CONFIG_BYTES = 64 * 1024
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+INVOCATION_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+REGISTRY_PREFIX_PATTERN = re.compile(
+    r"(?P<host>[a-z0-9.-]+(?::[0-9]{2,5})?)/(?P<path>[a-z0-9._/-]+)"
+)
+FORBIDDEN_REGISTRY_HOSTS = {
+    "docker.io",
+    "ghcr.io",
+    "quay.io",
+    "gcr.io",
+    "registry.gitlab.com",
+}
+CONFIG_FIELDS = {
+    "schema_version",
+    "registry_prefix",
+    "allowed_registry_hosts",
+    "base_images",
+    "package_mirrors",
+    "allowed_package_hosts",
+    "trivy_cache_dir",
+    "trivy_db_max_age_hours",
+    "evidence_root",
+    "openbao_address",
+    "openbao_transit_key",
+    "openbao_token_file",
+    "cosign_public_key",
+    "required_tools",
+}
+BASE_IMAGE_PATTERN = re.compile(
+    r"(?P<host>[a-z0-9.-]+(?::[0-9]{2,5})?)/[a-z0-9._/-]+@sha256:[0-9a-f]{64}"
+)
+FORBIDDEN_PACKAGE_HOSTS = {
+    "files.pythonhosted.org",
+    "pypi.org",
+    "registry.npmjs.org",
+}
+
+
+class BuildError(RuntimeError):
+    """The sovereign build failed without disclosing secret material."""
+
+
+def _secure_read(
+    path: Path,
+    *,
+    allowed_modes: set[int],
+    allowed_uids: set[int],
+    maximum_bytes: int = MAX_CONFIG_BYTES,
+) -> bytes:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise BuildError(f"required control file cannot be inspected: {path.name}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or path.is_symlink()
+        or stat.S_IMODE(metadata.st_mode) not in allowed_modes
+        or metadata.st_uid not in allowed_uids
+        or metadata.st_size > maximum_bytes
+    ):
+        raise BuildError(f"required control file has an unsafe contract: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise BuildError(f"required control file cannot be opened: {path.name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if opened.st_dev != metadata.st_dev or opened.st_ino != metadata.st_ino:
+            raise BuildError(f"required control file changed during validation: {path.name}")
+        content = os.read(descriptor, maximum_bytes + 1)
+    finally:
+        os.close(descriptor)
+    if len(content) > maximum_bytes:
+        raise BuildError(f"required control file is too large: {path.name}")
+    return content
+
+
+def _secure_file_metadata(
+    path: Path,
+    *,
+    allowed_modes: set[int],
+    allowed_uids: set[int],
+    minimum_bytes: int,
+    maximum_bytes: int,
+) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise BuildError(f"required control file cannot be inspected: {path.name}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or path.is_symlink()
+        or stat.S_IMODE(metadata.st_mode) not in allowed_modes
+        or metadata.st_uid not in allowed_uids
+        or not minimum_bytes <= metadata.st_size <= maximum_bytes
+    ):
+        raise BuildError(f"required control file has an unsafe contract: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise BuildError(f"required control file cannot be opened: {path.name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+            or opened.st_size != metadata.st_size
+        ):
+            raise BuildError(f"required control file changed during validation: {path.name}")
+        return opened
+    finally:
+        os.close(descriptor)
+
+
+def load_builder_config(
+    path: Path,
+    *,
+    allowed_uids: set[int] | None = None,
+) -> dict[str, object]:
+    content = _secure_read(
+        path,
+        allowed_modes={0o400, 0o440},
+        allowed_uids=allowed_uids or {0},
+    )
+    try:
+        config = json.loads(content)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise BuildError("release builder configuration must be valid JSON") from exc
+    if not isinstance(config, dict) or set(config) != CONFIG_FIELDS:
+        raise BuildError("release builder configuration has unknown or missing fields")
+    if config.get("schema_version") != 1:
+        raise BuildError("release builder configuration schema must be 1")
+
+    prefix = config.get("registry_prefix")
+    allowed_hosts = config.get("allowed_registry_hosts")
+    match = REGISTRY_PREFIX_PATTERN.fullmatch(str(prefix or ""))
+    if (
+        not match
+        or not isinstance(allowed_hosts, list)
+        or not allowed_hosts
+        or any(not isinstance(host, str) for host in allowed_hosts)
+        or match.group("host") not in allowed_hosts
+        or match.group("host").split(":", 1)[0] in FORBIDDEN_REGISTRY_HOSTS
+        or any(host.split(":", 1)[0] in FORBIDDEN_REGISTRY_HOSTS for host in allowed_hosts)
+    ):
+        raise BuildError("release registry is not an explicitly allowed private registry")
+
+    base_images = config.get("base_images")
+    if not isinstance(base_images, dict) or set(base_images) != {"backend", "frontend"}:
+        raise BuildError("base_images must define backend and frontend")
+    for image in base_images.values():
+        image_match = BASE_IMAGE_PATTERN.fullmatch(str(image or ""))
+        if not image_match or image_match.group("host") not in allowed_hosts:
+            raise BuildError("every base image must use an allowed private digest reference")
+
+    package_mirrors = config.get("package_mirrors")
+    package_hosts = config.get("allowed_package_hosts")
+    if (
+        not isinstance(package_mirrors, dict)
+        or set(package_mirrors) != {"python", "npm"}
+        or not isinstance(package_hosts, list)
+        or not package_hosts
+        or any(not isinstance(host, str) or not host for host in package_hosts)
+        or any(host in FORBIDDEN_PACKAGE_HOSTS for host in package_hosts)
+    ):
+        raise BuildError("package mirror allowlist is invalid")
+    for mirror in package_mirrors.values():
+        parsed_mirror = urlsplit(str(mirror or ""))
+        if (
+            parsed_mirror.scheme != "https"
+            or not parsed_mirror.hostname
+            or parsed_mirror.hostname not in package_hosts
+            or parsed_mirror.hostname in FORBIDDEN_PACKAGE_HOSTS
+            or parsed_mirror.username
+            or parsed_mirror.password
+            or parsed_mirror.query
+            or parsed_mirror.fragment
+        ):
+            raise BuildError("every package mirror must use an allowed internal HTTPS host")
+
+    address = config.get("openbao_address")
+    parsed_address = urlsplit(str(address or ""))
+    if parsed_address.scheme != "https" or not parsed_address.hostname:
+        raise BuildError("OpenBao address must be an absolute HTTPS URL")
+    transit_key = str(config.get("openbao_transit_key") or "")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}", transit_key):
+        raise BuildError("OpenBao transit key name is invalid")
+    for field in (
+        "evidence_root",
+        "openbao_token_file",
+        "cosign_public_key",
+        "trivy_cache_dir",
+    ):
+        value = config.get(field)
+        if not isinstance(value, str) or not Path(value).is_absolute():
+            raise BuildError(f"{field} must be an absolute path")
+    maximum_db_age = config.get("trivy_db_max_age_hours")
+    if not isinstance(maximum_db_age, int) or not 1 <= maximum_db_age <= 72:
+        raise BuildError("trivy_db_max_age_hours must be between 1 and 72")
+    required_tools = config.get("required_tools")
+    if not isinstance(required_tools, dict) or set(required_tools) != {"cosign", "syft", "trivy"}:
+        raise BuildError("required_tools must pin cosign, syft and trivy")
+    if any(not isinstance(value, str) or not value for value in required_tools.values()):
+        raise BuildError("every release tool must have an exact required version")
+    return config
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str] | None = None,
+    capture: bool = False,
+) -> str:
+    try:
+        # No shell is used; every argv entry originates from fixed release controls.
+        result = subprocess.run(  # nosec B603
+            command,
+            cwd=cwd,
+            env=environment,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=3600,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise BuildError(f"release command could not complete: {command[0]}") from exc
+    if result.returncode:
+        raise BuildError(f"release command failed: {command[0]}")
+    return result.stdout.strip() if capture else ""
+
+
+def _ensure_evidence_directory(root: Path, commit: str, invocation: str) -> Path:
+    try:
+        metadata = root.lstat()
+    except OSError as exc:
+        raise BuildError("evidence root cannot be inspected") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or root.is_symlink()
+        or metadata.st_uid not in {0, os.geteuid()}
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise BuildError("evidence root must be an owner-only non-symlink directory")
+    output = root / f"{commit}-{invocation}"
+    output.mkdir(mode=0o700, exist_ok=False)
+    return output
+
+
+def _validate_trivy_cache(
+    cache: Path,
+    *,
+    maximum_age_hours: int,
+    allowed_uids: set[int] | None = None,
+    now: datetime | None = None,
+) -> None:
+    owners = allowed_uids or {0}
+    try:
+        metadata = cache.lstat()
+    except OSError as exc:
+        raise BuildError("Trivy cache cannot be inspected") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or cache.is_symlink()
+        or metadata.st_uid not in owners
+        or stat.S_IMODE(metadata.st_mode) not in {0o700, 0o750}
+    ):
+        raise BuildError("Trivy cache directory has an unsafe contract")
+    database = cache / "db" / "trivy.db"
+    metadata_path = cache / "db" / "metadata.json"
+    _secure_file_metadata(
+        database,
+        allowed_modes={0o400, 0o440, 0o444},
+        allowed_uids=owners,
+        minimum_bytes=1024,
+        maximum_bytes=1024 * 1024 * 1024,
+    )
+    try:
+        db_metadata = json.loads(
+            _secure_read(
+                metadata_path,
+                allowed_modes={0o400, 0o440, 0o444},
+                allowed_uids=owners,
+                maximum_bytes=16 * 1024,
+            )
+        )
+        updated_at = datetime.fromisoformat(str(db_metadata["UpdatedAt"]).replace("Z", "+00:00"))
+        next_update = datetime.fromisoformat(str(db_metadata["NextUpdate"]).replace("Z", "+00:00"))
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+        raise BuildError("Trivy vulnerability database metadata is invalid") from exc
+    current = now or datetime.now(UTC)
+    maximum_age_seconds = maximum_age_hours * 60 * 60
+    if (
+        updated_at.tzinfo is None
+        or next_update.tzinfo is None
+        or updated_at > current
+        or (current - updated_at).total_seconds() > maximum_age_seconds
+        or next_update < current
+    ):
+        raise BuildError("Trivy vulnerability database is stale")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        written = 0
+        while written < len(encoded):
+            count = os.write(descriptor, encoded[written:])
+            if count <= 0:
+                raise BuildError("evidence file write did not complete")
+            written += count
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _seal_evidence_file(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise BuildError(f"expected evidence file is unavailable: {path.name}") from exc
+    if not stat.S_ISREG(metadata.st_mode) or path.is_symlink() or metadata.st_uid != os.geteuid():
+        raise BuildError(f"evidence file has an unsafe type or owner: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise BuildError(f"evidence file cannot be opened safely: {path.name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+        ):
+            raise BuildError(f"evidence file changed during validation: {path.name}")
+        os.fchmod(descriptor, 0o600)
+    except OSError as exc:
+        raise BuildError(f"evidence file permissions cannot be sealed: {path.name}") from exc
+    finally:
+        os.close(descriptor)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _check_tool_versions(config: dict[str, object], repository: Path) -> dict[str, str]:
+    required = config["required_tools"]
+    if not isinstance(required, dict):
+        raise BuildError("required tool contract is unavailable")
+    commands = {
+        "cosign": ["cosign", "version"],
+        "syft": ["syft", "version"],
+        "trivy": ["trivy", "version"],
+    }
+    actual: dict[str, str] = {}
+    for tool, command in commands.items():
+        output = _run(command, cwd=repository, capture=True)
+        expected = str(required[tool])
+        if expected not in output:
+            raise BuildError(f"{tool} version does not match the approved builder contract")
+        actual[tool] = expected
+    return actual
+
+
+def _build_component(
+    *,
+    component: str,
+    dockerfile: str,
+    repository: Path,
+    evidence: Path,
+    registry_prefix: str,
+    commit: str,
+    invocation: str,
+    started_at: str,
+    tools: dict[str, str],
+    signing_environment: dict[str, str],
+    public_key: Path,
+    transit_key: str,
+    build_arguments: dict[str, str],
+    trivy_cache: Path,
+) -> dict[str, str]:
+    metadata_path = evidence / f"{component}-build-metadata.json"
+    sbom_path = evidence / f"{component}.cdx.json"
+    scan_path = evidence / f"{component}.trivy.json"
+    provenance_path = evidence / f"{component}.provenance.json"
+    tagged_image = f"{registry_prefix}/{component}:git-{commit}"
+    build_command = [
+        "docker",
+        "buildx",
+        "build",
+        "--platform",
+        "linux/amd64",
+        "--provenance=false",
+        "--sbom=false",
+        "--push",
+        "--metadata-file",
+        str(metadata_path),
+        "--tag",
+        tagged_image,
+        "--file",
+        dockerfile,
+    ]
+    for name, value in sorted(build_arguments.items()):
+        build_command.extend(["--build-arg", f"{name}={value}"])
+    build_command.append(".")
+    _run(build_command, cwd=repository)
+    _seal_evidence_file(metadata_path)
+    try:
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        digest = metadata["containerimage.digest"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise BuildError(f"{component} build did not produce an immutable digest") from exc
+    if not isinstance(digest, str) or not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+        raise BuildError(f"{component} build digest is invalid")
+    image = f"{registry_prefix}/{component}@{digest}"
+
+    _run(["syft", "scan", image, "-o", f"cyclonedx-json={sbom_path}"], cwd=repository)
+    _run(
+        [
+            "trivy",
+            "--cache-dir",
+            str(trivy_cache),
+            "image",
+            "--skip-db-update",
+            "--skip-java-db-update",
+            "--skip-check-update",
+            "--offline-scan",
+            "--format",
+            "json",
+            "--output",
+            str(scan_path),
+            "--exit-code",
+            "1",
+            "--ignore-unfixed=false",
+            "--vuln-type",
+            "os,library",
+            "--severity",
+            "HIGH,CRITICAL",
+            image,
+        ],
+        cwd=repository,
+    )
+    _seal_evidence_file(sbom_path)
+    _seal_evidence_file(scan_path)
+    finished_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    _write_json(
+        provenance_path,
+        {
+            "buildDefinition": {
+                "buildType": "https://complywithai.de/build-types/hetzner-buildx/v1",
+                "externalParameters": {
+                    "component": component,
+                    "dockerfile": dockerfile,
+                    "platform": "linux/amd64",
+                },
+                "internalParameters": {},
+                "resolvedDependencies": [
+                    {
+                        "uri": "git+https://github.com/Luyzz22/Compliance-Hub",
+                        "digest": {"gitCommit": commit},
+                    }
+                ],
+            },
+            "runDetails": {
+                "builder": {
+                    "id": "https://complywithai.de/builders/hetzner-sovereign-release/v1",
+                    "version": tools,
+                },
+                "metadata": {
+                    "invocationId": invocation,
+                    "startedOn": started_at,
+                    "finishedOn": finished_at,
+                },
+            },
+        },
+    )
+    kms_key = f"openbao://{transit_key}"
+    _run(
+        [
+            "cosign",
+            "sign",
+            "--yes",
+            "--tlog-upload=false",
+            "--use-signing-config=false",
+            "--key",
+            kms_key,
+            image,
+        ],
+        cwd=repository,
+        environment=signing_environment,
+    )
+    for predicate_type, predicate in (
+        ("slsaprovenance1", provenance_path),
+        ("cyclonedx", sbom_path),
+    ):
+        _run(
+            [
+                "cosign",
+                "attest",
+                "--yes",
+                "--tlog-upload=false",
+                "--use-signing-config=false",
+                "--type",
+                predicate_type,
+                "--predicate",
+                str(predicate),
+                "--key",
+                kms_key,
+                image,
+            ],
+            cwd=repository,
+            environment=signing_environment,
+        )
+    for command in (
+        ["cosign", "verify", "--private-infrastructure", "--key", str(public_key), image],
+        [
+            "cosign",
+            "verify-attestation",
+            "--private-infrastructure",
+            "--type",
+            "slsaprovenance1",
+            "--key",
+            str(public_key),
+            image,
+        ],
+        [
+            "cosign",
+            "verify-attestation",
+            "--private-infrastructure",
+            "--type",
+            "cyclonedx",
+            "--key",
+            str(public_key),
+            image,
+        ],
+    ):
+        _run(command, cwd=repository)
+    return {
+        "image": image,
+        "sbom_sha256": _sha256(sbom_path),
+        "scan_sha256": _sha256(scan_path),
+        "provenance_sha256": _sha256(provenance_path),
+    }
+
+
+def main() -> int:
+    os.umask(0o077)
+    repository = Path(__file__).resolve().parents[1]
+    config_path = Path(os.environ.get("COMPLIANCEHUB_RELEASE_BUILDER_CONFIG", ""))
+    commit = os.environ.get("COMPLIANCEHUB_RELEASE_COMMIT", "")
+    invocation = os.environ.get("COMPLIANCEHUB_RELEASE_INVOCATION", "")
+    if not config_path.is_absolute():
+        raise BuildError("COMPLIANCEHUB_RELEASE_BUILDER_CONFIG must be an absolute path")
+    if not SHA_PATTERN.fullmatch(commit):
+        raise BuildError("COMPLIANCEHUB_RELEASE_COMMIT must be a full lowercase Git SHA")
+    if not INVOCATION_PATTERN.fullmatch(invocation):
+        raise BuildError("COMPLIANCEHUB_RELEASE_INVOCATION is invalid")
+    head = _run(["git", "rev-parse", "HEAD"], cwd=repository, capture=True)
+    dirty = _run(
+        ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=repository,
+        capture=True,
+    )
+    if head != commit or dirty:
+        raise BuildError("release checkout must match the clean approved commit")
+
+    config = load_builder_config(config_path)
+    token_path = Path(str(config["openbao_token_file"]))
+    token = (
+        _secure_read(
+            token_path,
+            allowed_modes={0o400, 0o600},
+            allowed_uids={0, os.geteuid()},
+            maximum_bytes=8 * 1024,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    if len(token) < 20 or "\n" in token or "\r" in token:
+        raise BuildError("OpenBao token file does not contain one valid short-lived token")
+    public_key = Path(str(config["cosign_public_key"]))
+    _secure_read(
+        public_key,
+        allowed_modes={0o400, 0o440, 0o444},
+        allowed_uids={0},
+    )
+    tools = _check_tool_versions(config, repository)
+    trivy_cache = Path(str(config["trivy_cache_dir"]))
+    _validate_trivy_cache(
+        trivy_cache,
+        maximum_age_hours=int(config["trivy_db_max_age_hours"]),
+    )
+    evidence = _ensure_evidence_directory(Path(str(config["evidence_root"])), commit, invocation)
+    signing_environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/nonexistent"),
+        "BAO_ADDR": str(config["openbao_address"]),
+        "BAO_TOKEN": token,
+    }
+    started_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+    components: dict[str, dict[str, str]] = {}
+    base_images = config["base_images"]
+    package_mirrors = config["package_mirrors"]
+    if not isinstance(base_images, dict) or not isinstance(package_mirrors, dict):
+        raise BuildError("approved dependency mirrors are unavailable")
+    for component, dockerfile, build_arguments in (
+        (
+            "backend",
+            "Dockerfile.hetzner",
+            {
+                "PYTHON_BASE_IMAGE": str(base_images["backend"]),
+                "PYTHON_INDEX_URL": str(package_mirrors["python"]),
+            },
+        ),
+        (
+            "frontend",
+            "frontend/Dockerfile.hetzner",
+            {
+                "NODE_BASE_IMAGE": str(base_images["frontend"]),
+                "NPM_REGISTRY_URL": str(package_mirrors["npm"]),
+            },
+        ),
+    ):
+        components[component] = _build_component(
+            component=component,
+            dockerfile=dockerfile,
+            repository=repository,
+            evidence=evidence,
+            registry_prefix=str(config["registry_prefix"]),
+            commit=commit,
+            invocation=invocation,
+            started_at=started_at,
+            tools=tools,
+            signing_environment=signing_environment,
+            public_key=public_key,
+            transit_key=str(config["openbao_transit_key"]),
+            build_arguments=build_arguments,
+            trivy_cache=trivy_cache,
+        )
+    _write_json(
+        evidence / "build-manifest.json",
+        {
+            "schema_version": 1,
+            "commit_sha": commit,
+            "invocation_id": invocation,
+            "builder_id": "https://complywithai.de/builders/hetzner-sovereign-release/v1",
+            "tools": tools,
+            "components": components,
+        },
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BuildError as exc:
+        print(f"sovereign_release_build=failed: {exc}", file=os.sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/sovereign_restore_drill.py
+++ b/scripts/sovereign_restore_drill.py
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+"""Prove PostgreSQL and S3 restoreability without mutating production targets."""
+
+from __future__ import annotations
+
+import configparser
+import hashlib
+import json
+import os
+import re
+import stat
+
+# Fixed argv execution is required for the explicitly approved restore tools.
+import subprocess  # nosec B404
+from datetime import UTC, datetime
+from pathlib import Path
+from urllib.parse import urlsplit
+
+CONFIG_FIELDS = {
+    "schema_version",
+    "drill_id",
+    "evidence_root",
+    "postgres_backup_file",
+    "postgres_backup_sha256",
+    "postgres_backup_created_at",
+    "postgres_connection_file",
+    "postgres_pgpass_file",
+    "allowed_postgres_hosts",
+    "postgres_restore_database",
+    "postgres_required_tables",
+    "postgres_minimum_public_tables",
+    "object_rclone_config_file",
+    "object_remote",
+    "object_backup_bucket",
+    "object_restore_bucket",
+    "object_backup_prefix",
+    "object_backup_created_at",
+    "object_restore_prefix",
+    "allowed_object_hosts",
+    "rpo_target_minutes",
+    "rto_target_minutes",
+    "required_tools",
+}
+CONNECTION_FIELDS = {"host", "port", "username", "maintenance_database", "sslmode"}
+DRILL_ID_PATTERN = re.compile(r"DR-[0-9]{8}-[A-Z0-9]{4,16}")
+DATABASE_PATTERN = re.compile(r"compliancehub_restore_[a-z0-9_]{8,48}")
+NAME_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}")
+BUCKET_PATTERN = re.compile(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]")
+PREFIX_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]{0,511}")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+HOST_PATTERN = re.compile(
+    r"(?=.{1,253}\Z)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)*"
+    r"[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?"
+)
+FORBIDDEN_OBJECT_HOSTS = {
+    "s3.amazonaws.com",
+    "storage.googleapis.com",
+}
+
+
+class DrillError(RuntimeError):
+    """The restore drill failed without disclosing secret material."""
+
+
+def _secure_read(
+    path: Path,
+    *,
+    allowed_modes: set[int],
+    allowed_uids: set[int],
+    minimum_bytes: int = 1,
+    maximum_bytes: int = 64 * 1024,
+) -> bytes:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise DrillError(f"required drill file cannot be inspected: {path.name}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or path.is_symlink()
+        or stat.S_IMODE(metadata.st_mode) not in allowed_modes
+        or metadata.st_uid not in allowed_uids
+        or not minimum_bytes <= metadata.st_size <= maximum_bytes
+    ):
+        raise DrillError(f"required drill file has an unsafe contract: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise DrillError(f"required drill file cannot be opened: {path.name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if opened.st_dev != metadata.st_dev or opened.st_ino != metadata.st_ino:
+            raise DrillError(f"required drill file changed during validation: {path.name}")
+        content = os.read(descriptor, maximum_bytes + 1)
+    finally:
+        os.close(descriptor)
+    if len(content) > maximum_bytes:
+        raise DrillError(f"required drill file is too large: {path.name}")
+    return content
+
+
+def _secure_file_metadata(
+    path: Path,
+    *,
+    allowed_uids: set[int],
+    minimum_bytes: int,
+    maximum_bytes: int,
+) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+    except OSError as exc:
+        raise DrillError(f"backup cannot be inspected: {path.name}") from exc
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or path.is_symlink()
+        or metadata.st_uid not in allowed_uids
+        or stat.S_IMODE(metadata.st_mode) not in {0o400, 0o440}
+        or not minimum_bytes <= metadata.st_size <= maximum_bytes
+    ):
+        raise DrillError(f"backup has an unsafe contract: {path.name}")
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError as exc:
+        raise DrillError(f"backup cannot be opened: {path.name}") from exc
+    try:
+        opened = os.fstat(descriptor)
+        if (
+            opened.st_dev != metadata.st_dev
+            or opened.st_ino != metadata.st_ino
+            or opened.st_size != metadata.st_size
+        ):
+            raise DrillError(f"backup changed during validation: {path.name}")
+        return opened
+    finally:
+        os.close(descriptor)
+
+
+def _parse_utc(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise DrillError(f"{field} must be an RFC 3339 UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise DrillError(f"{field} must be an RFC 3339 UTC timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed):
+        raise DrillError(f"{field} must use UTC")
+    return parsed
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(path, flags)
+    try:
+        with os.fdopen(descriptor, "rb", closefd=False) as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    finally:
+        os.close(descriptor)
+    return digest.hexdigest()
+
+
+def load_drill_config(
+    path: Path,
+    *,
+    allowed_uids: set[int] | None = None,
+) -> dict[str, object]:
+    owners = allowed_uids or {0}
+    try:
+        payload = json.loads(_secure_read(path, allowed_modes={0o400, 0o440}, allowed_uids=owners))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DrillError("restore drill configuration must be valid JSON") from exc
+    if not isinstance(payload, dict) or set(payload) != CONFIG_FIELDS:
+        raise DrillError("restore drill configuration has unknown or missing fields")
+    if type(payload.get("schema_version")) is not int or payload.get("schema_version") != 1:
+        raise DrillError("restore drill configuration schema must be 1")
+    drill_id = payload.get("drill_id")
+    if not isinstance(drill_id, str) or not DRILL_ID_PATTERN.fullmatch(drill_id):
+        raise DrillError("drill_id is invalid")
+
+    for field in (
+        "evidence_root",
+        "postgres_backup_file",
+        "postgres_connection_file",
+        "postgres_pgpass_file",
+        "object_rclone_config_file",
+    ):
+        value = payload.get(field)
+        if not isinstance(value, str) or not Path(value).is_absolute():
+            raise DrillError(f"{field} must be an absolute path")
+    backup_digest = str(payload.get("postgres_backup_sha256") or "")
+    if not SHA256_PATTERN.fullmatch(backup_digest) or backup_digest == "0" * 64:
+        raise DrillError("postgres_backup_sha256 must be a lowercase SHA-256 digest")
+    _parse_utc(payload.get("postgres_backup_created_at"), "postgres_backup_created_at")
+    _parse_utc(payload.get("object_backup_created_at"), "object_backup_created_at")
+
+    allowed_db_hosts = payload.get("allowed_postgres_hosts")
+    allowed_object_hosts = payload.get("allowed_object_hosts")
+    for field, hosts in (
+        ("allowed_postgres_hosts", allowed_db_hosts),
+        ("allowed_object_hosts", allowed_object_hosts),
+    ):
+        if (
+            not isinstance(hosts, list)
+            or not hosts
+            or any(not isinstance(host, str) or not HOST_PATTERN.fullmatch(host) for host in hosts)
+        ):
+            raise DrillError(f"{field} must be a non-empty host allowlist")
+    if any(host in FORBIDDEN_OBJECT_HOSTS for host in allowed_object_hosts):
+        raise DrillError("object host allowlist contains a forbidden provider")
+
+    database = payload.get("postgres_restore_database")
+    if not isinstance(database, str) or not DATABASE_PATTERN.fullmatch(database):
+        raise DrillError("postgres restore database must use the isolated drill prefix")
+    required_tables = payload.get("postgres_required_tables")
+    if (
+        not isinstance(required_tables, list)
+        or not required_tables
+        or any(
+            not isinstance(name, str) or not NAME_PATTERN.fullmatch(name)
+            for name in required_tables
+        )
+    ):
+        raise DrillError("postgres_required_tables is invalid")
+    minimum_tables = payload.get("postgres_minimum_public_tables")
+    if not isinstance(minimum_tables, int) or not 1 <= minimum_tables <= 10_000:
+        raise DrillError("postgres_minimum_public_tables is invalid")
+
+    remote = payload.get("object_remote")
+    backup_bucket = payload.get("object_backup_bucket")
+    restore_bucket = payload.get("object_restore_bucket")
+    source_prefix = payload.get("object_backup_prefix")
+    target_prefix = payload.get("object_restore_prefix")
+    if not isinstance(remote, str) or not NAME_PATTERN.fullmatch(remote):
+        raise DrillError("object_remote is invalid")
+    for field, bucket in (
+        ("object_backup_bucket", backup_bucket),
+        ("object_restore_bucket", restore_bucket),
+    ):
+        if not isinstance(bucket, str) or not BUCKET_PATTERN.fullmatch(bucket):
+            raise DrillError(f"{field} is invalid")
+    if restore_bucket == backup_bucket or "restore" not in str(restore_bucket).split("-"):
+        raise DrillError("object restore bucket must be a dedicated restore bucket")
+    if (
+        not isinstance(source_prefix, str)
+        or not PREFIX_PATTERN.fullmatch(source_prefix)
+        or source_prefix.startswith("/")
+        or ".." in source_prefix.split("/")
+    ):
+        raise DrillError("object backup prefix is invalid")
+    expected_target = f"restore-drills/{drill_id}"
+    if target_prefix != expected_target or target_prefix == source_prefix:
+        raise DrillError("object restore prefix must be the dedicated drill target")
+
+    for field in ("rpo_target_minutes", "rto_target_minutes"):
+        value = payload.get(field)
+        if not isinstance(value, int) or not 1 <= value <= 10_080:
+            raise DrillError(f"{field} is invalid")
+    tools = payload.get("required_tools")
+    if (
+        not isinstance(tools, dict)
+        or set(tools) != {"psql", "pg_restore", "createdb", "dropdb", "rclone"}
+        or any(not isinstance(value, str) or not value for value in tools.values())
+    ):
+        raise DrillError("required restore tool versions are invalid")
+    postgres_versions = {str(tools[name]) for name in ("psql", "pg_restore", "createdb", "dropdb")}
+    if len(postgres_versions) != 1 or not re.fullmatch(r"[0-9]+\.[0-9]+", postgres_versions.pop()):
+        raise DrillError("PostgreSQL restore tools must use one exact approved version")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", str(tools["rclone"])):
+        raise DrillError("rclone must use an exact approved version")
+    return payload
+
+
+def _load_postgres_connection(
+    path: Path,
+    *,
+    allowed_hosts: set[str],
+    allowed_uids: set[int],
+) -> dict[str, object]:
+    try:
+        connection = json.loads(
+            _secure_read(path, allowed_modes={0o400, 0o440}, allowed_uids=allowed_uids)
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise DrillError("PostgreSQL connection contract must be valid JSON") from exc
+    if not isinstance(connection, dict) or set(connection) != CONNECTION_FIELDS:
+        raise DrillError("PostgreSQL connection contract has unknown or missing fields")
+    host = connection.get("host")
+    port = connection.get("port")
+    username = connection.get("username")
+    database = connection.get("maintenance_database")
+    if (
+        not isinstance(host, str)
+        or not HOST_PATTERN.fullmatch(host)
+        or host not in allowed_hosts
+        or not re.search(r"(?:^|[.-])restore(?:[.-]|$)", host)
+    ):
+        raise DrillError("PostgreSQL restore host is not allowed")
+    if not isinstance(port, int) or not 1 <= port <= 65535:
+        raise DrillError("PostgreSQL restore port is invalid")
+    if not isinstance(username, str) or not NAME_PATTERN.fullmatch(username):
+        raise DrillError("PostgreSQL restore username is invalid")
+    if database not in {"postgres", "template1"}:
+        raise DrillError("PostgreSQL maintenance database is invalid")
+    if connection.get("sslmode") not in {"verify-full", "verify-ca"}:
+        raise DrillError("PostgreSQL restore connection must verify TLS")
+    return connection
+
+
+def _validate_rclone_config(
+    path: Path,
+    *,
+    remote: str,
+    allowed_hosts: set[str],
+    allowed_uids: set[int],
+) -> str:
+    content = _secure_read(
+        path,
+        allowed_modes={0o400, 0o440},
+        allowed_uids=allowed_uids,
+        maximum_bytes=256 * 1024,
+    )
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        parser.read_string(content.decode("utf-8"))
+    except (UnicodeDecodeError, configparser.Error) as exc:
+        raise DrillError("rclone configuration is invalid") from exc
+    if (
+        parser.defaults()
+        or set(parser.sections()) != {remote}
+        or set(parser[remote])
+        != {"type", "provider", "endpoint", "access_key_id", "secret_access_key", "acl"}
+        or parser[remote].get("type") != "s3"
+    ):
+        raise DrillError("rclone remote must be an S3 configuration")
+    if parser[remote].get("provider") != "Other":
+        raise DrillError("rclone S3 provider must use the approved generic contract")
+    endpoint = urlsplit(parser[remote].get("endpoint", ""))
+    if (
+        endpoint.scheme != "https"
+        or not endpoint.hostname
+        or endpoint.hostname not in allowed_hosts
+        or endpoint.username
+        or endpoint.password
+        or endpoint.query
+        or endpoint.fragment
+    ):
+        raise DrillError("rclone S3 endpoint is not an allowed HTTPS host")
+    if (
+        len(parser[remote].get("access_key_id", "")) < 16
+        or len(parser[remote].get("secret_access_key", "")) < 32
+        or parser[remote].get("acl", "private") != "private"
+    ):
+        raise DrillError("rclone S3 credentials are unavailable")
+    return endpoint.hostname
+
+
+def _validate_pgpass(content: bytes, connection: dict[str, object]) -> None:
+    try:
+        value = content.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise DrillError("PostgreSQL password file must be UTF-8") from exc
+    if value.endswith("\n"):
+        value = value[:-1]
+    if "\n" in value or "\r" in value or "\\" in value:
+        raise DrillError("PostgreSQL password file must contain one literal entry")
+    fields = value.split(":", 4)
+    expected = [
+        str(connection["host"]),
+        str(connection["port"]),
+        "*",
+        str(connection["username"]),
+    ]
+    if len(fields) != 5 or fields[:4] != expected or len(fields[4]) < 20:
+        raise DrillError("PostgreSQL password file does not match the restore connection")
+
+
+def _run(
+    command: list[str],
+    *,
+    cwd: Path,
+    environment: dict[str, str],
+    capture: bool = False,
+    timeout: int = 14_400,
+) -> str:
+    try:
+        # No shell is used; argv entries are validated configuration or fixed controls.
+        result = subprocess.run(  # nosec B603
+            command,
+            cwd=cwd,
+            env=environment,
+            check=False,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise DrillError(f"restore command could not complete: {command[0]}") from exc
+    if result.returncode:
+        raise DrillError(f"restore command failed: {command[0]}")
+    return result.stdout.strip() if capture else ""
+
+
+def _check_tool_versions(config: dict[str, object], repository: Path) -> dict[str, str]:
+    expected = config["required_tools"]
+    if not isinstance(expected, dict):
+        raise DrillError("restore tool contract is unavailable")
+    versions: dict[str, str] = {}
+    environment = {"PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")}
+    for tool in ("psql", "pg_restore", "createdb", "dropdb", "rclone"):
+        output = _run([tool, "--version"], cwd=repository, environment=environment, capture=True)
+        version = str(expected[tool])
+        first_line = output.splitlines()[0] if output else ""
+        if not re.search(rf"(?:^|[ (]){re.escape(version)}(?:$|[ )])", first_line):
+            raise DrillError(f"{tool} version does not match the approved drill contract")
+        versions[tool] = version
+    return versions
+
+
+def _postgres_args(connection: dict[str, object], database: str) -> list[str]:
+    return [
+        "--host",
+        str(connection["host"]),
+        "--port",
+        str(connection["port"]),
+        "--username",
+        str(connection["username"]),
+        "--dbname",
+        database,
+    ]
+
+
+def _postgres_server_args(connection: dict[str, object]) -> list[str]:
+    return [
+        "--host",
+        str(connection["host"]),
+        "--port",
+        str(connection["port"]),
+        "--username",
+        str(connection["username"]),
+    ]
+
+
+def _run_postgres_restore(
+    *,
+    repository: Path,
+    connection: dict[str, object],
+    pgpass_file: Path,
+    backup: Path,
+    restore_database: str,
+    required_tables: set[str],
+    minimum_tables: int,
+) -> dict[str, object]:
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+        "PGPASSFILE": str(pgpass_file),
+        "PGCONNECT_TIMEOUT": "15",
+        "PGSSLMODE": str(connection["sslmode"]),
+    }
+    maintenance = str(connection["maintenance_database"])
+    _run(["pg_restore", "--list", str(backup)], cwd=repository, environment=environment)
+    database_exists = _run(
+        [
+            "psql",
+            *_postgres_args(connection, maintenance),
+            "--no-psqlrc",
+            "--tuples-only",
+            "--no-align",
+            "--set",
+            "ON_ERROR_STOP=1",
+            "--command",
+            "SELECT count(*) FROM pg_database WHERE datname = "
+            ":'restore_database' AND datallowconn;",
+            "--variable",
+            f"restore_database={restore_database}",
+        ],
+        cwd=repository,
+        environment=environment,
+        capture=True,
+    )
+    if database_exists != "0":
+        raise DrillError("PostgreSQL restore target must not exist")
+    started = datetime.now(UTC)
+    created = False
+    cleanup_status = "failed"
+    try:
+        _run(
+            [
+                "createdb",
+                *_postgres_server_args(connection),
+                "--maintenance-db",
+                maintenance,
+                restore_database,
+            ],
+            cwd=repository,
+            environment=environment,
+        )
+        created = True
+        _run(
+            [
+                "pg_restore",
+                *_postgres_args(connection, restore_database),
+                "--exit-on-error",
+                "--no-owner",
+                "--no-privileges",
+                str(backup),
+            ],
+            cwd=repository,
+            environment=environment,
+        )
+        query = (
+            "SELECT json_build_object("
+            "'database',current_database(),"
+            "'table_count',(SELECT count(*)::int FROM pg_catalog.pg_tables "
+            "WHERE schemaname='public'),"
+            "'tables',(SELECT coalesce(json_agg(tablename ORDER BY tablename),'[]'::json) "
+            "FROM pg_catalog.pg_tables WHERE schemaname='public'));"
+        )
+        output = _run(
+            [
+                "psql",
+                *_postgres_args(connection, restore_database),
+                "--no-psqlrc",
+                "--tuples-only",
+                "--no-align",
+                "--set",
+                "ON_ERROR_STOP=1",
+                "--command",
+                query,
+            ],
+            cwd=repository,
+            environment=environment,
+            capture=True,
+        )
+        try:
+            result = json.loads(output)
+            tables = result["tables"]
+            table_count = result["table_count"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise DrillError("PostgreSQL restore verification output is invalid") from exc
+        if (
+            result.get("database") != restore_database
+            or not isinstance(table_count, int)
+            or table_count < minimum_tables
+            or not isinstance(tables, list)
+            or not required_tables.issubset(set(tables))
+        ):
+            raise DrillError("PostgreSQL restored schema does not meet the approved contract")
+        result_payload = {
+            "status": "passed",
+            "public_table_count": table_count,
+            "required_tables": sorted(required_tables),
+            "restore_seconds": round((datetime.now(UTC) - started).total_seconds(), 3),
+        }
+    finally:
+        if created:
+            _run(
+                [
+                    "dropdb",
+                    *_postgres_server_args(connection),
+                    "--maintenance-db",
+                    maintenance,
+                    "--force",
+                    "--if-exists",
+                    restore_database,
+                ],
+                cwd=repository,
+                environment=environment,
+            )
+            cleanup_status = "passed"
+    if cleanup_status != "passed":
+        raise DrillError("PostgreSQL restore target cleanup did not complete")
+    result_payload["cleanup_status"] = cleanup_status
+    return result_payload
+
+
+def _rclone_size(
+    reference: str,
+    *,
+    repository: Path,
+    config_file: Path,
+    environment: dict[str, str],
+) -> tuple[int, int]:
+    output = _run(
+        ["rclone", "size", reference, "--json", "--config", str(config_file)],
+        cwd=repository,
+        environment=environment,
+        capture=True,
+    )
+    try:
+        payload = json.loads(output)
+        count = payload.get("count", payload.get("Count"))
+        total_bytes = payload.get("bytes", payload.get("Bytes"))
+    except (json.JSONDecodeError, TypeError) as exc:
+        raise DrillError("object restore size output is invalid") from exc
+    if not isinstance(count, int) or not isinstance(total_bytes, int):
+        raise DrillError("object restore size output is incomplete")
+    return count, total_bytes
+
+
+def _run_object_restore(
+    *,
+    repository: Path,
+    config_file: Path,
+    remote: str,
+    backup_bucket: str,
+    restore_bucket: str,
+    source_prefix: str,
+    target_prefix: str,
+) -> dict[str, object]:
+    environment = {
+        "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin"),
+    }
+    source = f"{remote}:{backup_bucket}/{source_prefix}"
+    target = f"{remote}:{restore_bucket}/{target_prefix}"
+    source_count, source_bytes = _rclone_size(
+        source,
+        repository=repository,
+        config_file=config_file,
+        environment=environment,
+    )
+    target_count, target_bytes = _rclone_size(
+        target,
+        repository=repository,
+        config_file=config_file,
+        environment=environment,
+    )
+    if source_count <= 0 or source_bytes <= 0:
+        raise DrillError("object backup is empty")
+    if target_count or target_bytes:
+        raise DrillError("object restore target must be empty")
+    started = datetime.now(UTC)
+    copy_attempted = False
+    cleanup_status = "failed"
+    try:
+        copy_attempted = True
+        _run(
+            [
+                "rclone",
+                "copy",
+                source,
+                target,
+                "--config",
+                str(config_file),
+                "--metadata",
+                "--immutable",
+            ],
+            cwd=repository,
+            environment=environment,
+        )
+        _run(
+            [
+                "rclone",
+                "check",
+                source,
+                target,
+                "--config",
+                str(config_file),
+                "--download",
+                "--one-way",
+            ],
+            cwd=repository,
+            environment=environment,
+        )
+        restored_count, restored_bytes = _rclone_size(
+            target,
+            repository=repository,
+            config_file=config_file,
+            environment=environment,
+        )
+        if (restored_count, restored_bytes) != (source_count, source_bytes):
+            raise DrillError("object restore counts or bytes do not match the backup")
+        result_payload = {
+            "status": "passed",
+            "object_count": restored_count,
+            "total_bytes": restored_bytes,
+            "verified_object_count": restored_count,
+            "restore_seconds": round((datetime.now(UTC) - started).total_seconds(), 3),
+        }
+    finally:
+        if copy_attempted:
+            _run(
+                ["rclone", "purge", target, "--config", str(config_file)],
+                cwd=repository,
+                environment=environment,
+            )
+            remaining_count, remaining_bytes = _rclone_size(
+                target,
+                repository=repository,
+                config_file=config_file,
+                environment=environment,
+            )
+            if remaining_count or remaining_bytes:
+                raise DrillError("object restore target cleanup is incomplete")
+            cleanup_status = "passed"
+    if cleanup_status != "passed":
+        raise DrillError("object restore target cleanup did not complete")
+    result_payload["cleanup_status"] = cleanup_status
+    return result_payload
+
+
+def _ensure_evidence_root(root: Path, *, allowed_uids: set[int]) -> None:
+    try:
+        metadata = root.lstat()
+    except OSError as exc:
+        raise DrillError("restore evidence root cannot be inspected") from exc
+    if (
+        not stat.S_ISDIR(metadata.st_mode)
+        or root.is_symlink()
+        or metadata.st_uid not in allowed_uids
+        or stat.S_IMODE(metadata.st_mode) != 0o700
+    ):
+        raise DrillError("restore evidence root must be an owner-only directory")
+
+
+def _reserve_drill(root: Path, drill_id: str) -> Path:
+    lock = root / f".{drill_id}.lock"
+    try:
+        descriptor = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise DrillError("restore drill id is already reserved and requires review") from exc
+    try:
+        content = f"drill_id={drill_id}\nreserved_at={datetime.now(UTC).isoformat()}\n".encode()
+        written = os.write(descriptor, content)
+        if written != len(content):
+            raise DrillError("restore drill reservation write did not complete")
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    return lock
+
+
+def _write_json(path: Path, payload: object) -> None:
+    encoded = (json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        written = 0
+        while written < len(encoded):
+            count = os.write(descriptor, encoded[written:])
+            if count <= 0:
+                raise DrillError("restore evidence write did not complete")
+            written += count
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def run_drill(
+    config: dict[str, object],
+    *,
+    repository: Path,
+    allowed_uids: set[int] | None = None,
+) -> Path:
+    runtime_uid = os.geteuid()
+    trusted_config_owners = allowed_uids or {0}
+    started = datetime.now(UTC)
+    backup_created = _parse_utc(config["postgres_backup_created_at"], "postgres backup")
+    object_created = _parse_utc(config["object_backup_created_at"], "object backup")
+    rpo_minutes = round(
+        max((started - backup_created).total_seconds(), (started - object_created).total_seconds())
+        / 60,
+        3,
+    )
+    rpo_target = int(config["rpo_target_minutes"])
+    if rpo_minutes < 0 or rpo_minutes > rpo_target:
+        raise DrillError("backup age exceeds the approved RPO")
+
+    evidence_root = Path(str(config["evidence_root"]))
+    _ensure_evidence_root(evidence_root, allowed_uids={runtime_uid})
+    evidence_path = evidence_root / f"{config['drill_id']}.json"
+    if evidence_path.exists() or evidence_path.is_symlink():
+        raise DrillError("restore evidence target already exists")
+
+    backup = Path(str(config["postgres_backup_file"]))
+    _secure_file_metadata(
+        backup,
+        allowed_uids={0},
+        minimum_bytes=1024,
+        maximum_bytes=1024 * 1024 * 1024 * 1024,
+    )
+    backup_digest = _sha256_file(backup)
+    if backup_digest != config["postgres_backup_sha256"]:
+        raise DrillError("PostgreSQL backup digest does not match the approved contract")
+
+    connection = _load_postgres_connection(
+        Path(str(config["postgres_connection_file"])),
+        allowed_hosts=set(config["allowed_postgres_hosts"]),
+        allowed_uids=trusted_config_owners,
+    )
+    pgpass = Path(str(config["postgres_pgpass_file"]))
+    pgpass_content = _secure_read(
+        pgpass,
+        allowed_modes={0o400},
+        allowed_uids={0, runtime_uid},
+        minimum_bytes=16,
+        maximum_bytes=16 * 1024,
+    )
+    _validate_pgpass(pgpass_content, connection)
+    object_host = _validate_rclone_config(
+        Path(str(config["object_rclone_config_file"])),
+        remote=str(config["object_remote"]),
+        allowed_hosts=set(config["allowed_object_hosts"]),
+        allowed_uids={0, runtime_uid},
+    )
+    tools = _check_tool_versions(config, repository)
+    _reserve_drill(evidence_root, str(config["drill_id"]))
+
+    postgres_result = _run_postgres_restore(
+        repository=repository,
+        connection=connection,
+        pgpass_file=pgpass,
+        backup=backup,
+        restore_database=str(config["postgres_restore_database"]),
+        required_tables=set(config["postgres_required_tables"]),
+        minimum_tables=int(config["postgres_minimum_public_tables"]),
+    )
+    object_result = _run_object_restore(
+        repository=repository,
+        config_file=Path(str(config["object_rclone_config_file"])),
+        remote=str(config["object_remote"]),
+        backup_bucket=str(config["object_backup_bucket"]),
+        restore_bucket=str(config["object_restore_bucket"]),
+        source_prefix=str(config["object_backup_prefix"]),
+        target_prefix=str(config["object_restore_prefix"]),
+    )
+    completed = datetime.now(UTC)
+    rto_seconds = round((completed - started).total_seconds(), 3)
+    rto_target_seconds = int(config["rto_target_minutes"]) * 60
+    recovery_status = "passed" if rto_seconds <= rto_target_seconds else "failed"
+    payload = {
+        "schema_version": 1,
+        "drill_id": config["drill_id"],
+        "started_at": started.isoformat().replace("+00:00", "Z"),
+        "completed_at": completed.isoformat().replace("+00:00", "Z"),
+        "tools": tools,
+        "postgres": {
+            **postgres_result,
+            "backup_sha256": backup_digest,
+            "backup_created_at": backup_created.isoformat().replace("+00:00", "Z"),
+            "restore_host_sha256": hashlib.sha256(
+                str(connection["host"]).encode("utf-8")
+            ).hexdigest(),
+        },
+        "object_storage": {
+            **object_result,
+            "backup_reference_sha256": hashlib.sha256(
+                (
+                    f"{config['object_remote']}:{config['object_backup_bucket']}/"
+                    f"{config['object_backup_prefix']}"
+                ).encode()
+            ).hexdigest(),
+            "backup_created_at": object_created.isoformat().replace("+00:00", "Z"),
+            "endpoint_host_sha256": hashlib.sha256(object_host.encode("utf-8")).hexdigest(),
+        },
+        "recovery": {
+            "status": recovery_status,
+            "rpo_minutes": rpo_minutes,
+            "rpo_target_minutes": rpo_target,
+            "rto_seconds": rto_seconds,
+            "rto_target_seconds": rto_target_seconds,
+        },
+    }
+    _write_json(evidence_path, payload)
+    if recovery_status != "passed":
+        raise DrillError("restore drill exceeded the approved RTO")
+    return evidence_path
+
+
+def main() -> int:
+    os.umask(0o077)
+    repository = Path(__file__).resolve().parents[1]
+    config_path = Path(os.environ.get("COMPLIANCEHUB_RESTORE_DRILL_CONFIG", ""))
+    if not config_path.is_absolute():
+        raise DrillError("COMPLIANCEHUB_RESTORE_DRILL_CONFIG must be an absolute path")
+    config = load_drill_config(config_path)
+    evidence = run_drill(config, repository=repository)
+    print(f"restore_drill=passed evidence={evidence.name}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except DrillError as exc:
+        print(f"restore_drill=failed: {exc}", file=os.sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/verify_release_evidence.py
+++ b/scripts/verify_release_evidence.py
@@ -9,7 +9,9 @@ import binascii
 import hashlib
 import json
 import re
-import subprocess
+
+# Fixed argv execution is required only to resolve the checked-out Git commit.
+import subprocess  # nosec B404
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -288,6 +290,219 @@ def validate_cyclonedx_sbom(path: Path, label: str) -> list[str]:
     return errors
 
 
+def validate_restore_drill_evidence(
+    path: Path,
+    *,
+    release_created_at: datetime | None = None,
+) -> list[str]:
+    """Validate the measured, cleaned-up PostgreSQL and object restore drill."""
+
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_json_object,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+        return ["restore drill evidence must be readable JSON without duplicate keys"]
+    errors: list[str] = []
+    root = _mapping(payload, "restore drill evidence", errors)
+    _reject_unknown_fields(
+        root,
+        {
+            "schema_version",
+            "drill_id",
+            "started_at",
+            "completed_at",
+            "tools",
+            "postgres",
+            "object_storage",
+            "recovery",
+        },
+        "restore drill evidence",
+        errors,
+    )
+    if type(root.get("schema_version")) is not int or root.get("schema_version") != 1:
+        errors.append("restore drill evidence.schema_version must be 1")
+    drill_id = root.get("drill_id")
+    if not isinstance(drill_id, str) or not re.fullmatch(r"DR-[0-9]{8}-[A-Z0-9]{4,16}", drill_id):
+        errors.append("restore drill evidence.drill_id is invalid")
+    started = _parse_timestamp(root.get("started_at"), "restore drill started_at", errors)
+    completed = _parse_timestamp(root.get("completed_at"), "restore drill completed_at", errors)
+    if started and completed and completed <= started:
+        errors.append("restore drill completed_at must be later than started_at")
+    if completed and release_created_at:
+        if completed > release_created_at:
+            errors.append("restore drill must complete before release evidence is created")
+        if release_created_at - completed > timedelta(days=31):
+            errors.append("restore drill evidence must be no older than 31 days")
+
+    tools = _mapping(root.get("tools"), "restore drill tools", errors)
+    _reject_unknown_fields(
+        tools,
+        {"psql", "pg_restore", "createdb", "dropdb", "rclone"},
+        "restore drill tools",
+        errors,
+    )
+    for tool in ("psql", "pg_restore", "createdb", "dropdb", "rclone"):
+        _require_reviewed_text(tools, tool, errors)
+
+    postgres = _mapping(root.get("postgres"), "restore drill postgres", errors)
+    _reject_unknown_fields(
+        postgres,
+        {
+            "status",
+            "public_table_count",
+            "required_tables",
+            "restore_seconds",
+            "cleanup_status",
+            "backup_sha256",
+            "backup_created_at",
+            "restore_host_sha256",
+        },
+        "restore drill postgres",
+        errors,
+    )
+    for field in ("status", "cleanup_status"):
+        if postgres.get(field) != "passed":
+            errors.append(f"restore drill postgres.{field} must be passed")
+    if (
+        type(postgres.get("public_table_count")) is not int
+        or postgres.get("public_table_count", 0) < 1
+    ):
+        errors.append("restore drill postgres.public_table_count must be positive")
+    required_tables = postgres.get("required_tables")
+    if (
+        not isinstance(required_tables, list)
+        or not required_tables
+        or any(not isinstance(value, str) or not value for value in required_tables)
+    ):
+        errors.append("restore drill postgres.required_tables must be non-empty")
+    for field in ("restore_seconds",):
+        value = postgres.get(field)
+        if type(value) not in {int, float} or value < 0:
+            errors.append(f"restore drill postgres.{field} must be non-negative")
+    for field in ("backup_sha256", "restore_host_sha256"):
+        _require_digest(postgres, field, errors, label=f"restore drill postgres.{field}")
+    postgres_backup_created = _parse_timestamp(
+        postgres.get("backup_created_at"),
+        "restore drill postgres.backup_created_at",
+        errors,
+    )
+
+    storage = _mapping(root.get("object_storage"), "restore drill object_storage", errors)
+    _reject_unknown_fields(
+        storage,
+        {
+            "status",
+            "object_count",
+            "total_bytes",
+            "verified_object_count",
+            "restore_seconds",
+            "cleanup_status",
+            "backup_reference_sha256",
+            "backup_created_at",
+            "endpoint_host_sha256",
+        },
+        "restore drill object_storage",
+        errors,
+    )
+    for field in ("status", "cleanup_status"):
+        if storage.get(field) != "passed":
+            errors.append(f"restore drill object_storage.{field} must be passed")
+    object_count = storage.get("object_count")
+    verified_count = storage.get("verified_object_count")
+    if type(object_count) is not int or object_count < 1:
+        errors.append("restore drill object_storage.object_count must be positive")
+    if type(verified_count) is not int or verified_count != object_count:
+        errors.append("restore drill object_storage.verified_object_count must match object_count")
+    if type(storage.get("total_bytes")) is not int or storage.get("total_bytes", 0) < 1:
+        errors.append("restore drill object_storage.total_bytes must be positive")
+    if (
+        type(storage.get("restore_seconds")) not in {int, float}
+        or storage.get("restore_seconds", -1) < 0
+    ):
+        errors.append("restore drill object_storage.restore_seconds must be non-negative")
+    for field in ("backup_reference_sha256", "endpoint_host_sha256"):
+        _require_digest(storage, field, errors, label=f"restore drill object_storage.{field}")
+    object_backup_created = _parse_timestamp(
+        storage.get("backup_created_at"),
+        "restore drill object_storage.backup_created_at",
+        errors,
+    )
+
+    recovery = _mapping(root.get("recovery"), "restore drill recovery", errors)
+    _reject_unknown_fields(
+        recovery,
+        {
+            "status",
+            "rpo_minutes",
+            "rpo_target_minutes",
+            "rto_seconds",
+            "rto_target_seconds",
+        },
+        "restore drill recovery",
+        errors,
+    )
+    if recovery.get("status") != "passed":
+        errors.append("restore drill recovery.status must be passed")
+    for actual, target in (
+        ("rpo_minutes", "rpo_target_minutes"),
+        ("rto_seconds", "rto_target_seconds"),
+    ):
+        actual_value = recovery.get(actual)
+        target_value = recovery.get(target)
+        if type(actual_value) not in {int, float} or actual_value < 0:
+            errors.append(f"restore drill recovery.{actual} must be non-negative")
+        if type(target_value) not in {int, float} or target_value <= 0:
+            errors.append(f"restore drill recovery.{target} must be positive")
+        if (
+            type(actual_value) in {int, float}
+            and type(target_value) in {int, float}
+            and actual_value > target_value
+        ):
+            errors.append(f"restore drill recovery.{actual} exceeds {target}")
+    if started and postgres_backup_created and postgres_backup_created > started:
+        errors.append("restore drill postgres.backup_created_at cannot be later than started_at")
+    if started and object_backup_created and object_backup_created > started:
+        errors.append(
+            "restore drill object_storage.backup_created_at cannot be later than started_at"
+        )
+    recorded_rpo = recovery.get("rpo_minutes")
+    if (
+        started
+        and postgres_backup_created
+        and object_backup_created
+        and type(recorded_rpo)
+        in {
+            int,
+            float,
+        }
+    ):
+        calculated_rpo = (
+            max(
+                (started - postgres_backup_created).total_seconds(),
+                (started - object_backup_created).total_seconds(),
+            )
+            / 60
+        )
+        if abs(float(recorded_rpo) - calculated_rpo) > 0.01:
+            errors.append("restore drill recovery.rpo_minutes does not match backup timestamps")
+    recorded_rto = recovery.get("rto_seconds")
+    if started and completed and type(recorded_rto) in {int, float}:
+        calculated_rto = (completed - started).total_seconds()
+        if abs(float(recorded_rto) - calculated_rto) > 0.01:
+            errors.append("restore drill recovery.rto_seconds does not match drill timestamps")
+    if (
+        isinstance(required_tables, list)
+        and type(postgres.get("public_table_count")) is int
+        and postgres["public_table_count"] < len(set(required_tables))
+    ):
+        errors.append(
+            "restore drill postgres.public_table_count cannot be smaller than required_tables"
+        )
+    return errors
+
+
 def read_environment(path: Path, errors: list[str]) -> dict[str, str]:
     environment: dict[str, str] = {}
     try:
@@ -525,7 +740,8 @@ def validate_release_evidence(
         database,
         {
             "migration_plan_sha256",
-            "backup_restore_evidence",
+            "restore_drill_id",
+            "restore_evidence_sha256",
             "change_class",
             "migration_execution_status",
             "schema_verification_status",
@@ -540,7 +756,15 @@ def validate_release_evidence(
         errors,
         label="database.migration_plan_sha256",
     )
-    _require_reviewed_text(database, "backup_restore_evidence", errors)
+    restore_drill_id = _require_reviewed_text(database, "restore_drill_id", errors)
+    if restore_drill_id and not re.fullmatch(r"DR-[0-9]{8}-[A-Z0-9]{4,16}", restore_drill_id):
+        errors.append("database.restore_drill_id is invalid")
+    _require_digest(
+        database,
+        "restore_evidence_sha256",
+        errors,
+        label="database.restore_evidence_sha256",
+    )
     change_class = database.get("change_class")
     if change_class not in {"none", "backward_compatible_expand"}:
         errors.append("database.change_class must be none or backward_compatible_expand")
@@ -624,7 +848,7 @@ def validate_release_evidence(
 
 
 def _current_commit() -> str:
-    result = subprocess.run(
+    result = subprocess.run(  # nosec B603, B607
         ["git", "rev-parse", "HEAD"],
         check=True,
         capture_output=True,
@@ -651,6 +875,7 @@ def main() -> int:
     parser.add_argument("--approver-public-key", type=Path)
     parser.add_argument("--backend-sbom", type=Path)
     parser.add_argument("--frontend-sbom", type=Path)
+    parser.add_argument("--restore-evidence", type=Path)
     parser.add_argument("--deployment-dir", type=Path)
     parser.add_argument("--print-signing-payload", action="store_true")
     parser.add_argument("--json", action="store_true")
@@ -722,6 +947,56 @@ def main() -> int:
                     frontend_sha256=frontend_sbom_sha256,
                 )
             )
+
+        release_created_at = None
+        if isinstance(payload, dict):
+            created_value = payload.get("created_at")
+            if isinstance(created_value, str):
+                try:
+                    parsed_created_at = datetime.fromisoformat(created_value.replace("Z", "+00:00"))
+                except ValueError:
+                    release_created_at = None
+                else:
+                    if (
+                        parsed_created_at.tzinfo is not None
+                        and parsed_created_at.utcoffset() == UTC.utcoffset(parsed_created_at)
+                    ):
+                        release_created_at = parsed_created_at
+        if arguments.restore_evidence is None:
+            errors.append("--restore-evidence is required for production verification")
+        else:
+            restore_sha256 = _sha256_file(
+                arguments.restore_evidence,
+                "restore drill evidence",
+                errors,
+            )
+            errors.extend(
+                validate_restore_drill_evidence(
+                    arguments.restore_evidence,
+                    release_created_at=release_created_at,
+                )
+            )
+            database = payload.get("database") if isinstance(payload, dict) else {}
+            if (
+                not isinstance(database, dict)
+                or database.get("restore_evidence_sha256") != restore_sha256
+            ):
+                errors.append(
+                    "restore drill evidence file does not match database.restore_evidence_sha256"
+                )
+            try:
+                restore_payload = json.loads(
+                    arguments.restore_evidence.read_text(encoding="utf-8"),
+                    object_pairs_hook=_reject_duplicate_json_object,
+                )
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                restore_payload = {}
+            if (
+                not isinstance(database, dict)
+                or not isinstance(restore_payload, dict)
+                or database.get("restore_drill_id") != restore_payload.get("drill_id")
+            ):
+                errors.append("restore drill evidence does not match database.restore_drill_id")
 
         if arguments.builder_public_key is None:
             errors.append("--builder-public-key is required for production verification")

--- a/tests/test_hetzner_deployment_contract.py
+++ b/tests/test_hetzner_deployment_contract.py
@@ -142,9 +142,18 @@ def test_file_secret_permissions_are_an_explicit_host_preflight_contract() -> No
 
     assert set(contracts) == set(compose["secrets"])
     assert all(contract["mode"] == "0400" for contract in contracts.values())
+    assert all(contract["min_bytes"] >= 16 for contract in contracts.values())
+    assert all(contract["consumers"] for contract in contracts.values())
+    assert all(contract["rotation_policy"] for contract in contracts.values())
+    actual_consumers = {name: set() for name in compose["secrets"]}
     for service in compose["services"].values():
         for secret in service.get("secrets", []):
             assert set(secret) == {"source", "target"}
+    for service_name, service in compose["services"].items():
+        for secret in service.get("secrets", []):
+            actual_consumers[secret["source"]].add(service_name)
+    for name, contract in contracts.items():
+        assert set(contract["consumers"]) == actual_consumers[name]
 
 
 def test_audit_key_is_mounted_only_into_the_backend() -> None:

--- a/tests/test_hetzner_deployment_contract.py
+++ b/tests/test_hetzner_deployment_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import yaml
@@ -44,7 +45,8 @@ def test_application_containers_are_rootless_read_only_and_drop_capabilities() -
         dockerfile = ROOT / dockerfile_name
         source = dockerfile.read_text(encoding="utf-8")
         assert "USER 10001:10001" in source
-        assert all("@sha256:" in line for line in source.splitlines() if line.startswith("FROM "))
+        assert re.search(r"^ARG [A-Z_]+_BASE_IMAGE=.+@sha256:[0-9a-f]{64}$", source, re.MULTILINE)
+        assert all("${" in line for line in source.splitlines() if line.startswith("FROM "))
 
     assert compose["services"]["edge"]["user"] == "65532:65532"
 
@@ -63,7 +65,7 @@ def test_runtime_dependencies_and_all_public_images_are_immutable() -> None:
     lock = lockfile.read_text(encoding="utf-8")
     assert "--hash=sha256:" in lock
     dockerfile = (ROOT / "Dockerfile.hetzner").read_text(encoding="utf-8")
-    assert "pip install --require-hashes --no-deps -r requirements.lock" in dockerfile
+    assert 'pip install --index-url "${PYTHON_INDEX_URL}" --require-hashes' in dockerfile
     assert "pip install --no-deps --no-build-isolation ." in dockerfile
 
 
@@ -72,7 +74,7 @@ def test_runtime_images_use_minimal_alpine_baselines_without_language_package_ma
     frontend = (ROOT / "frontend" / "Dockerfile.hetzner").read_text(encoding="utf-8")
 
     assert all(
-        line.startswith("FROM python:3.11-alpine3.23@sha256:")
+        line.startswith("FROM ${PYTHON_BASE_IMAGE}")
         for line in backend.splitlines()
         if line.startswith("FROM ")
     )
@@ -81,7 +83,7 @@ def test_runtime_images_use_minimal_alpine_baselines_without_language_package_ma
     assert "/usr/local/bin/pip" in backend
 
     assert all(
-        line.startswith("FROM node:22-alpine3.23@sha256:")
+        line.startswith("FROM ${NODE_BASE_IMAGE}")
         for line in frontend.splitlines()
         if line.startswith("FROM ")
     )
@@ -89,6 +91,7 @@ def test_runtime_images_use_minimal_alpine_baselines_without_language_package_ma
     assert "/usr/local/bin/npm" in frontend
     assert "/usr/local/bin/npx" in frontend
     assert "/usr/local/bin/corepack" in frontend
+    assert "--replace-registry-host=always" in frontend
 
 
 def test_frontend_container_build_preserves_cross_stack_prebuild_gates() -> None:

--- a/tests/test_hetzner_deployment_contract.py
+++ b/tests/test_hetzner_deployment_contract.py
@@ -222,7 +222,9 @@ def test_ci_builds_and_scans_both_production_images() -> None:
     assert "container-security:" in workflow
     assert "component: backend" in workflow
     assert "component: frontend" in workflow
-    assert "docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83" in workflow
+    assert "docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a" in workflow
+    assert "docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c" in workflow
+    assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
     assert "aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25" in workflow
     assert "severity: HIGH,CRITICAL" in workflow
     assert 'exit-code: "1"' in workflow

--- a/tests/test_hetzner_deployment_contract.py
+++ b/tests/test_hetzner_deployment_contract.py
@@ -241,6 +241,8 @@ def test_ci_builds_and_scans_both_production_images() -> None:
     assert "severity: HIGH,CRITICAL" in workflow
     assert 'exit-code: "1"' in workflow
     assert 'PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"' in workflow
+    assert "scripts/sovereign_release_build.py scripts/sovereign_restore_drill.py" in workflow
+    assert "bandit -q scripts/hetzner_release.py scripts/verify_release_evidence.py" in workflow
 
 
 def test_application_containers_expose_release_evidence_labels() -> None:

--- a/tests/test_hetzner_release.py
+++ b/tests/test_hetzner_release.py
@@ -62,10 +62,20 @@ def test_secret_contract_rejects_symlinks_wrong_modes_and_empty_files(
     secrets = deployment / "secrets"
     secrets.mkdir(parents=True)
     secret = secrets / "api-key"
-    _write(secret, b"secret", 0o400)
+    _write(secret, b"a" * 32, 0o400)
     payload = {
-        "x-secret-host-contract": {"api_key": {"uid": os.geteuid(), "mode": "0400"}},
+        "x-secret-host-contract": {
+            "api_key": {
+                "uid": os.geteuid(),
+                "mode": "0400",
+                "min_bytes": 32,
+                "content_kind": "opaque",
+                "consumers": ["api"],
+                "rotation_policy": "standard_90d",
+            }
+        },
         "secrets": {"api_key": {"file": "./secrets/api-key"}},
+        "services": {"api": {"secrets": [{"source": "api_key", "target": "api_key"}]}},
     }
 
     hetzner_release.validate_secret_host_contract(deployment, payload)
@@ -79,9 +89,46 @@ def test_secret_contract_rejects_symlinks_wrong_modes_and_empty_files(
         hetzner_release.validate_secret_host_contract(deployment, payload)
     secret.unlink()
     target = secrets / "real-key"
-    _write(target, b"secret", 0o400)
+    _write(target, b"a" * 32, 0o400)
     secret.symlink_to(target)
     with pytest.raises(hetzner_release.ReleaseError, match="non-symlink"):
+        hetzner_release.validate_secret_host_contract(deployment, payload)
+
+
+def test_secret_contract_rejects_weak_content_and_undeclared_consumers(
+    tmp_path: Path,
+) -> None:
+    deployment = tmp_path / "deploy"
+    secret = deployment / "secrets" / "database-url"
+    _write(secret, b"too-short", 0o400)
+    payload = {
+        "x-secret-host-contract": {
+            "database_url": {
+                "uid": os.geteuid(),
+                "mode": "0400",
+                "min_bytes": 32,
+                "content_kind": "postgres_dsn",
+                "consumers": ["backend"],
+                "rotation_policy": "standard_90d",
+            }
+        },
+        "secrets": {"database_url": {"file": "./secrets/database-url"}},
+        "services": {
+            "backend": {"secrets": [{"source": "database_url", "target": "database_url"}]}
+        },
+    }
+
+    with pytest.raises(hetzner_release.ReleaseError, match="minimum length"):
+        hetzner_release.validate_secret_host_contract(deployment, payload)
+
+    secret.chmod(0o600)
+    _write(secret, b"postgresql://runtime:long-secret-value@db.internal/app", 0o400)
+    hetzner_release.validate_secret_host_contract(deployment, payload)
+
+    payload["services"]["worker"] = {
+        "secrets": [{"source": "database_url", "target": "database_url"}]
+    }
+    with pytest.raises(hetzner_release.ReleaseError, match="consumer contract"):
         hetzner_release.validate_secret_host_contract(deployment, payload)
 
 

--- a/tests/test_hetzner_release.py
+++ b/tests/test_hetzner_release.py
@@ -26,6 +26,7 @@ def _paths(tmp_path: Path) -> hetzner_release.ReleasePaths:
         approver_public_key=deployment / "approver.pem",
         backend_sbom=deployment / "backend.cdx.json",
         frontend_sbom=deployment / "frontend.cdx.json",
+        restore_evidence=deployment / "restore-drill.json",
         lock_file=tmp_path / "lock" / "release.lock",
         audit_log=tmp_path / "log" / "release.jsonl",
     )

--- a/tests/test_release_evidence.py
+++ b/tests/test_release_evidence.py
@@ -21,6 +21,7 @@ from scripts.verify_release_evidence import (
     validate_cyclonedx_sbom,
     validate_deployment_binding,
     validate_release_evidence,
+    validate_restore_drill_evidence,
     validate_rollback_binding,
     validate_sbom_binding,
     verify_release_signatures,
@@ -65,7 +66,8 @@ def _valid_evidence() -> dict:
         },
         "database": {
             "migration_plan_sha256": DIGEST_A,
-            "backup_restore_evidence": "evidence://restore/2026-08-11/approved",
+            "restore_drill_id": "DR-20260811-CHANGE4815",
+            "restore_evidence_sha256": DIGEST_B,
             "change_class": "none",
             "migration_execution_status": "not_required",
             "schema_verification_status": "passed",
@@ -104,6 +106,50 @@ def _valid_evidence() -> dict:
                 "signature": base64.b64encode(b"b" * 64).decode("ascii"),
             },
         ],
+    }
+
+
+def _valid_restore_evidence() -> dict:
+    return {
+        "schema_version": 1,
+        "drill_id": "DR-20260811-CHANGE4815",
+        "started_at": "2026-08-11T08:00:00Z",
+        "completed_at": "2026-08-11T09:00:00Z",
+        "tools": {
+            "psql": "17.9",
+            "pg_restore": "17.9",
+            "createdb": "17.9",
+            "dropdb": "17.9",
+            "rclone": "v1.72.1",
+        },
+        "postgres": {
+            "status": "passed",
+            "public_table_count": 64,
+            "required_tables": ["tenants", "ai_systems", "audit_logs", "evidence_files"],
+            "restore_seconds": 120.5,
+            "cleanup_status": "passed",
+            "backup_sha256": DIGEST_A,
+            "backup_created_at": "2026-08-11T07:45:00Z",
+            "restore_host_sha256": DIGEST_B,
+        },
+        "object_storage": {
+            "status": "passed",
+            "object_count": 18,
+            "total_bytes": 4096,
+            "verified_object_count": 18,
+            "restore_seconds": 90.25,
+            "cleanup_status": "passed",
+            "backup_reference_sha256": DIGEST_C,
+            "backup_created_at": "2026-08-11T07:45:00Z",
+            "endpoint_host_sha256": DIGEST_D,
+        },
+        "recovery": {
+            "status": "passed",
+            "rpo_minutes": 15.0,
+            "rpo_target_minutes": 1440,
+            "rto_seconds": 3600.0,
+            "rto_target_seconds": 14400,
+        },
     }
 
 
@@ -316,6 +362,31 @@ def test_sbom_files_are_bound_to_recorded_digests() -> None:
     ) == ["backend SBOM file does not match sboms.backend_sha256"]
 
 
+def test_restore_drill_evidence_requires_measured_restore_and_cleanup(tmp_path) -> None:
+    path = tmp_path / "restore-drill.json"
+    path.write_text(json.dumps(_valid_restore_evidence()), encoding="utf-8")
+    assert validate_restore_drill_evidence(path, release_created_at=NOW) == []
+
+    payload = _valid_restore_evidence()
+    payload["object_storage"]["verified_object_count"] = 17
+    payload["postgres"]["cleanup_status"] = "failed"
+    payload["recovery"]["rto_seconds"] = 20_000
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    errors = validate_restore_drill_evidence(path, release_created_at=NOW)
+    assert "restore drill postgres.cleanup_status must be passed" in errors
+    assert "restore drill object_storage.verified_object_count must match object_count" in errors
+    assert "restore drill recovery.rto_seconds exceeds rto_target_seconds" in errors
+    assert "restore drill recovery.rto_seconds does not match drill timestamps" in errors
+
+
+def test_restore_drill_validation_handles_invalid_release_timestamp_without_crashing(
+    tmp_path,
+) -> None:
+    path = tmp_path / "restore-drill.json"
+    path.write_text(json.dumps(_valid_restore_evidence()), encoding="utf-8")
+    assert validate_restore_drill_evidence(path, release_created_at=None) == []
+
+
 def test_cyclonedx_sbom_requires_a_supported_non_empty_document(tmp_path) -> None:
     valid = tmp_path / "valid.cdx.json"
     valid.write_text(
@@ -371,6 +442,11 @@ def test_production_cli_verifies_keys_sboms_environment_and_evidence_hash(tmp_pa
         "backend_sha256": hashlib.sha256(backend_sbom.read_bytes()).hexdigest(),
         "frontend_sha256": hashlib.sha256(frontend_sbom.read_bytes()).hexdigest(),
     }
+    restore_evidence = tmp_path / "restore-drill.json"
+    restore_evidence.write_text(json.dumps(_valid_restore_evidence()), encoding="utf-8")
+    evidence["database"]["restore_evidence_sha256"] = hashlib.sha256(
+        restore_evidence.read_bytes()
+    ).hexdigest()
     deployment_dir = tmp_path / "deploy" / "hetzner"
     deployment_dir.mkdir(parents=True)
     (deployment_dir / "compose.yml").write_text("services: {}\n", encoding="utf-8")
@@ -438,6 +514,8 @@ def test_production_cli_verifies_keys_sboms_environment_and_evidence_hash(tmp_pa
             str(backend_sbom),
             "--frontend-sbom",
             str(frontend_sbom),
+            "--restore-evidence",
+            str(restore_evidence),
             "--deployment-dir",
             str(deployment_dir),
             "--json",

--- a/tests/test_sovereign_release_build.py
+++ b/tests/test_sovereign_release_build.py
@@ -1,0 +1,177 @@
+"""Contracts for the Hetzner-only signed image builder."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from scripts import sovereign_release_build
+
+
+def _config(tmp_path: Path) -> Path:
+    path = tmp_path / "release-builder.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "registry_prefix": "registry.internal.example.de/compliancehub",
+                "allowed_registry_hosts": ["registry.internal.example.de"],
+                "base_images": {
+                    "backend": "registry.internal.example.de/mirror/python@sha256:" + "a" * 64,
+                    "frontend": "registry.internal.example.de/mirror/node@sha256:" + "b" * 64,
+                },
+                "package_mirrors": {
+                    "python": "https://packages.internal.example.de/pypi/simple",
+                    "npm": "https://packages.internal.example.de/npm/",
+                },
+                "allowed_package_hosts": ["packages.internal.example.de"],
+                "trivy_cache_dir": str(tmp_path / "trivy-cache"),
+                "trivy_db_max_age_hours": 24,
+                "evidence_root": str(tmp_path / "evidence"),
+                "openbao_address": "https://openbao.internal.example.de:8200",
+                "openbao_transit_key": "compliancehub-release",
+                "openbao_token_file": str(tmp_path / "openbao-token"),
+                "cosign_public_key": str(tmp_path / "cosign.pub"),
+                "required_tools": {
+                    "cosign": "v3.0.6",
+                    "syft": "1.50.0",
+                    "trivy": "0.73.0",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    path.chmod(0o400)
+    return path
+
+
+def test_builder_config_accepts_only_explicit_private_registry(tmp_path: Path) -> None:
+    path = _config(tmp_path)
+    config = sovereign_release_build.load_builder_config(path, allowed_uids={os.geteuid()})
+    assert config["registry_prefix"] == "registry.internal.example.de/compliancehub"
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    path.chmod(0o600)
+    payload["registry_prefix"] = "ghcr.io/luyzz22/compliancehub"
+    payload["allowed_registry_hosts"] = ["ghcr.io"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_release_build.BuildError, match="private registry"):
+        sovereign_release_build.load_builder_config(path, allowed_uids={os.geteuid()})
+
+
+def test_builder_config_requires_internal_package_and_base_image_mirrors(
+    tmp_path: Path,
+) -> None:
+    path = _config(tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    path.chmod(0o600)
+    payload["package_mirrors"]["npm"] = "https://registry.npmjs.org/"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_release_build.BuildError, match="package mirror"):
+        sovereign_release_build.load_builder_config(path, allowed_uids={os.geteuid()})
+
+    path.chmod(0o600)
+    payload["package_mirrors"]["npm"] = "https://packages.internal.example.de/npm/"
+    payload["base_images"]["backend"] = "python:3.11@sha256:" + "a" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_release_build.BuildError, match="base image"):
+        sovereign_release_build.load_builder_config(path, allowed_uids={os.geteuid()})
+
+
+def test_evidence_directory_is_owner_only_and_unique(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir(mode=0o700)
+    result = sovereign_release_build._ensure_evidence_directory(root, "a" * 40, "run-1")
+    assert result.stat().st_uid == os.geteuid()
+    assert result.stat().st_mode & 0o777 == 0o700
+    with pytest.raises(FileExistsError):
+        sovereign_release_build._ensure_evidence_directory(root, "a" * 40, "run-1")
+
+
+def _trivy_cache(tmp_path: Path, *, updated_at: datetime, next_update: datetime) -> Path:
+    cache = tmp_path / "trivy-cache"
+    database_dir = cache / "db"
+    database_dir.mkdir(parents=True, mode=0o700)
+    cache.chmod(0o700)
+    database = database_dir / "trivy.db"
+    database.write_bytes(b"0" * 1024)
+    database.chmod(0o400)
+    metadata = database_dir / "metadata.json"
+    metadata.write_text(
+        json.dumps(
+            {
+                "UpdatedAt": updated_at.isoformat().replace("+00:00", "Z"),
+                "NextUpdate": next_update.isoformat().replace("+00:00", "Z"),
+            }
+        ),
+        encoding="utf-8",
+    )
+    metadata.chmod(0o400)
+    return cache
+
+
+def test_trivy_cache_requires_fresh_preprovisioned_database(tmp_path: Path) -> None:
+    now = datetime(2026, 8, 13, 12, tzinfo=UTC)
+    cache = _trivy_cache(
+        tmp_path,
+        updated_at=now - timedelta(hours=1),
+        next_update=now + timedelta(hours=5),
+    )
+    sovereign_release_build._validate_trivy_cache(
+        cache,
+        maximum_age_hours=24,
+        allowed_uids={os.geteuid()},
+        now=now,
+    )
+
+    metadata = cache / "db" / "metadata.json"
+    metadata.chmod(0o600)
+    metadata.write_text(
+        json.dumps(
+            {
+                "UpdatedAt": (now - timedelta(hours=25)).isoformat(),
+                "NextUpdate": (now - timedelta(hours=19)).isoformat(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    metadata.chmod(0o400)
+    with pytest.raises(sovereign_release_build.BuildError, match="stale"):
+        sovereign_release_build._validate_trivy_cache(
+            cache,
+            maximum_age_hours=24,
+            allowed_uids={os.geteuid()},
+            now=now,
+        )
+
+
+def test_preproduction_workflow_never_uploads_sovereign_artifacts() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (root / ".github/workflows/preproduction-build.yml").read_text(encoding="utf-8")
+    assert "runs-on: [self-hosted, linux, x64, compliancehub-hetzner-release]" in source
+    assert "environment: preproduction" in source
+    assert "github.ref == 'refs/heads/main'" in source
+    assert "actions/upload-artifact" not in source
+    assert "persist-credentials: false" in source
+    assert "COMPLIANCEHUB_RELEASE_BUILDER_CONFIG: /etc/compliancehub/release-builder.json" in source
+
+
+def test_builder_uses_openbao_transit_and_private_infrastructure_verification() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (root / "scripts/sovereign_release_build.py").read_text(encoding="utf-8")
+    assert 'kms_key = f"openbao://{transit_key}"' in source
+    assert source.count('"--tlog-upload=false"') == 2
+    assert source.count('"--use-signing-config=false"') == 2
+    assert '"--skip-db-update"' in source
+    assert '"--offline-scan"' in source
+    assert source.count('"--private-infrastructure"') == 3
+    assert '"slsaprovenance1"' in source
+    assert '"cyclonedx"' in source
+    assert '"BAO_TOKEN": token' in source

--- a/tests/test_sovereign_restore_drill.py
+++ b/tests/test_sovereign_restore_drill.py
@@ -1,0 +1,332 @@
+"""Adversarial contracts for isolated PostgreSQL and S3 restore drills."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from scripts import sovereign_restore_drill
+
+
+def _config(tmp_path: Path) -> Path:
+    payload = {
+        "schema_version": 1,
+        "drill_id": "DR-20260813-CHANGE1234",
+        "evidence_root": str(tmp_path / "evidence"),
+        "postgres_backup_file": str(tmp_path / "approved.dump"),
+        "postgres_backup_sha256": "a" * 64,
+        "postgres_backup_created_at": "2026-08-13T10:00:00Z",
+        "postgres_connection_file": str(tmp_path / "postgres-connection.json"),
+        "postgres_pgpass_file": str(tmp_path / "pgpass"),
+        "allowed_postgres_hosts": ["postgres-restore.internal.example.de"],
+        "postgres_restore_database": "compliancehub_restore_20260813_change1234",
+        "postgres_required_tables": ["tenants", "ai_systems", "audit_logs"],
+        "postgres_minimum_public_tables": 3,
+        "object_rclone_config_file": str(tmp_path / "rclone.conf"),
+        "object_remote": "hetzner_restore",
+        "object_backup_bucket": "compliancehub-backups",
+        "object_restore_bucket": "compliancehub-restore-drills",
+        "object_backup_prefix": "approved/2026-08-13",
+        "object_backup_created_at": "2026-08-13T10:00:00Z",
+        "object_restore_prefix": "restore-drills/DR-20260813-CHANGE1234",
+        "allowed_object_hosts": ["fsn1.your-objectstorage.com"],
+        "rpo_target_minutes": 1440,
+        "rto_target_minutes": 240,
+        "required_tools": {
+            "psql": "17.9",
+            "pg_restore": "17.9",
+            "createdb": "17.9",
+            "dropdb": "17.9",
+            "rclone": "v1.72.1",
+        },
+    }
+    path = tmp_path / "restore-drill.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    return path
+
+
+def test_config_accepts_only_dedicated_restore_targets(tmp_path: Path) -> None:
+    path = _config(tmp_path)
+    config = sovereign_restore_drill.load_drill_config(path, allowed_uids={os.geteuid()})
+    assert config["object_restore_prefix"] == "restore-drills/DR-20260813-CHANGE1234"
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    path.chmod(0o600)
+    payload["postgres_restore_database"] = "compliancehub_production"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="isolated drill prefix"):
+        sovereign_restore_drill.load_drill_config(path, allowed_uids={os.geteuid()})
+
+    path.chmod(0o600)
+    payload["postgres_restore_database"] = "compliancehub_restore_20260813_change1234"
+    payload["object_restore_prefix"] = payload["object_backup_prefix"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="dedicated drill target"):
+        sovereign_restore_drill.load_drill_config(path, allowed_uids={os.geteuid()})
+
+    path.chmod(0o600)
+    payload["object_restore_prefix"] = "restore-drills/DR-20260813-CHANGE1234"
+    payload["object_restore_bucket"] = payload["object_backup_bucket"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="dedicated restore bucket"):
+        sovereign_restore_drill.load_drill_config(path, allowed_uids={os.geteuid()})
+
+
+def test_config_rejects_boolean_schema_version(tmp_path: Path) -> None:
+    path = _config(tmp_path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    path.chmod(0o600)
+    payload["schema_version"] = True
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o400)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="schema must be 1"):
+        sovereign_restore_drill.load_drill_config(path, allowed_uids={os.geteuid()})
+
+
+def test_rclone_contract_requires_allowed_https_s3_endpoint(tmp_path: Path) -> None:
+    path = tmp_path / "rclone.conf"
+    path.write_text(
+        "[hetzner_restore]\n"
+        "type = s3\n"
+        "provider = Other\n"
+        "endpoint = https://fsn1.your-objectstorage.com\n"
+        "access_key_id = restore-access-id\n"
+        "secret_access_key = restore-secret-value-with-32-bytes\n"
+        "acl = private\n",
+        encoding="utf-8",
+    )
+    path.chmod(0o400)
+    assert (
+        sovereign_restore_drill._validate_rclone_config(
+            path,
+            remote="hetzner_restore",
+            allowed_hosts={"fsn1.your-objectstorage.com"},
+            allowed_uids={os.geteuid()},
+        )
+        == "fsn1.your-objectstorage.com"
+    )
+
+    path.chmod(0o600)
+    path.write_text(path.read_text().replace("fsn1.your-objectstorage.com", "s3.amazonaws.com"))
+    path.chmod(0o400)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="allowed HTTPS host"):
+        sovereign_restore_drill._validate_rclone_config(
+            path,
+            remote="hetzner_restore",
+            allowed_hosts={"fsn1.your-objectstorage.com"},
+            allowed_uids={os.geteuid()},
+        )
+
+
+def test_pgpass_is_bound_to_exact_restore_host_port_and_user() -> None:
+    connection = {
+        "host": "postgres-restore.internal.example.de",
+        "port": 5432,
+        "username": "restore_operator",
+    }
+    sovereign_restore_drill._validate_pgpass(
+        b"postgres-restore.internal.example.de:5432:*:restore_operator:long-restore-password\n",
+        connection,
+    )
+    with pytest.raises(sovereign_restore_drill.DrillError, match="does not match"):
+        sovereign_restore_drill._validate_pgpass(
+            b"*:5432:*:restore_operator:long-restore-password\n",
+            connection,
+        )
+
+
+def test_drill_id_reservation_is_atomic_and_persistent(tmp_path: Path) -> None:
+    root = tmp_path / "evidence"
+    root.mkdir(mode=0o700)
+    reservation = sovereign_restore_drill._reserve_drill(root, "DR-20260813-CHANGE1234")
+    assert reservation.stat().st_mode & 0o777 == 0o600
+    with pytest.raises(sovereign_restore_drill.DrillError, match="already reserved"):
+        sovereign_restore_drill._reserve_drill(root, "DR-20260813-CHANGE1234")
+
+
+def test_postgres_restore_verifies_schema_cleans_up_and_never_passes_password(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[tuple[list[str], dict[str, str]]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        environment: dict[str, str],
+        capture: bool = False,
+        timeout: int = 14_400,
+    ) -> str:
+        del cwd, timeout
+        commands.append((command, environment))
+        if command[0] == "psql" and "pg_database" in command[-3]:
+            return "0"
+        if command[0] == "psql":
+            return json.dumps(
+                {
+                    "database": "compliancehub_restore_20260813_change1234",
+                    "table_count": 3,
+                    "tables": ["ai_systems", "audit_logs", "tenants"],
+                }
+            )
+        return "" if capture else ""
+
+    monkeypatch.setattr(sovereign_restore_drill, "_run", fake_run)
+    result = sovereign_restore_drill._run_postgres_restore(
+        repository=tmp_path,
+        connection={
+            "host": "postgres-restore.internal.example.de",
+            "port": 5432,
+            "username": "restore_operator",
+            "maintenance_database": "postgres",
+            "sslmode": "verify-full",
+        },
+        pgpass_file=tmp_path / "pgpass",
+        backup=tmp_path / "approved.dump",
+        restore_database="compliancehub_restore_20260813_change1234",
+        required_tables={"tenants", "ai_systems", "audit_logs"},
+        minimum_tables=3,
+    )
+    assert result["status"] == "passed"
+    assert result["cleanup_status"] == "passed"
+    assert [command[0] for command, _ in commands].count("dropdb") == 1
+    assert all("password" not in " ".join(command).lower() for command, _ in commands)
+    assert all(env["PGPASSFILE"] == str(tmp_path / "pgpass") for _, env in commands)
+    assert all(env["PGSSLMODE"] == "verify-full" for _, env in commands)
+
+
+def test_postgres_create_failure_does_not_delete_ambiguous_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        environment: dict[str, str],
+        capture: bool = False,
+        timeout: int = 14_400,
+    ) -> str:
+        del cwd, environment, capture, timeout
+        commands.append(command)
+        if command[0] == "psql":
+            return "0"
+        if command[0] == "createdb":
+            raise sovereign_restore_drill.DrillError("restore command failed: createdb")
+        return ""
+
+    monkeypatch.setattr(sovereign_restore_drill, "_run", fake_run)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="createdb"):
+        sovereign_restore_drill._run_postgres_restore(
+            repository=tmp_path,
+            connection={
+                "host": "postgres-restore.internal.example.de",
+                "port": 5432,
+                "username": "restore_operator",
+                "maintenance_database": "postgres",
+                "sslmode": "verify-full",
+            },
+            pgpass_file=tmp_path / "pgpass",
+            backup=tmp_path / "approved.dump",
+            restore_database="compliancehub_restore_20260813_change1234",
+            required_tables={"tenants"},
+            minimum_tables=1,
+        )
+    assert all(command[0] != "dropdb" for command in commands)
+
+
+def test_object_restore_byte_checks_and_purges_dedicated_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+    size_results = iter(
+        [
+            '{"count":2,"bytes":42}',
+            '{"count":0,"bytes":0}',
+            '{"count":2,"bytes":42}',
+            '{"count":0,"bytes":0}',
+        ]
+    )
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        environment: dict[str, str],
+        capture: bool = False,
+        timeout: int = 14_400,
+    ) -> str:
+        del cwd, environment, capture, timeout
+        commands.append(command)
+        return next(size_results) if command[:2] == ["rclone", "size"] else ""
+
+    monkeypatch.setattr(sovereign_restore_drill, "_run", fake_run)
+    result = sovereign_restore_drill._run_object_restore(
+        repository=tmp_path,
+        config_file=tmp_path / "rclone.conf",
+        remote="hetzner_restore",
+        backup_bucket="compliancehub-backups",
+        restore_bucket="compliancehub-restore-drills",
+        source_prefix="approved/2026-08-13",
+        target_prefix="restore-drills/DR-20260813-CHANGE1234",
+    )
+    assert result["status"] == "passed"
+    assert result["cleanup_status"] == "passed"
+    assert result["object_count"] == 2
+    assert any(
+        command[:2] == ["rclone", "check"] and "--download" in command for command in commands
+    )
+    assert any(command[:2] == ["rclone", "purge"] for command in commands)
+
+
+def test_object_copy_failure_still_purges_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    commands: list[list[str]] = []
+    size_results = iter(
+        ['{"count":1,"bytes":21}', '{"count":0,"bytes":0}', '{"count":0,"bytes":0}']
+    )
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        environment: dict[str, str],
+        capture: bool = False,
+        timeout: int = 14_400,
+    ) -> str:
+        del cwd, environment, capture, timeout
+        commands.append(command)
+        if command[:2] == ["rclone", "copy"]:
+            raise sovereign_restore_drill.DrillError("restore command failed: rclone")
+        return next(size_results) if command[:2] == ["rclone", "size"] else ""
+
+    monkeypatch.setattr(sovereign_restore_drill, "_run", fake_run)
+    with pytest.raises(sovereign_restore_drill.DrillError, match="command failed"):
+        sovereign_restore_drill._run_object_restore(
+            repository=tmp_path,
+            config_file=tmp_path / "rclone.conf",
+            remote="hetzner_restore",
+            backup_bucket="compliancehub-backups",
+            restore_bucket="compliancehub-restore-drills",
+            source_prefix="approved/2026-08-13",
+            target_prefix="restore-drills/DR-20260813-CHANGE1234",
+        )
+    assert any(command[:2] == ["rclone", "purge"] for command in commands)
+
+
+def test_utc_contract_rejects_naive_timestamps() -> None:
+    assert sovereign_restore_drill._parse_utc("2026-08-13T12:00:00Z", "created") == datetime(
+        2026, 8, 13, 12, tzinfo=UTC
+    )
+    with pytest.raises(sovereign_restore_drill.DrillError, match="must use UTC"):
+        sovereign_restore_drill._parse_utc("2026-08-13T12:00:00", "created")


### PR DESCRIPTION
## Zweck

Pre-Production-Readiness für den souveränen Hetzner/Azure-Betrieb mit nachvollziehbarer Build-, Signatur-, Secret- und Restore-Evidence.

## Änderungen

- GitHub Actions auf offizielle Node-24-Versionen aktualisiert und weiterhin unveränderlich per Commit-SHA fixiert
- OpenBao-Secret-Verträge um Eigentümer, Dateimodus, Mindestlänge, Inhaltstyp, Verbraucher und Rotation erweitert
- souveränen Release-Build auf selbst gehostetem Hetzner-Runner ergänzt
- interne Container-, Python- und npm-Mirrors sowie frische Offline-Trivy-Datenbank verbindlich gemacht
- SBOM, Trivy-Policy, Cosign-Signaturen und SLSA-/CycloneDX-Attestierungen über OpenBao Transit umgesetzt
- PostgreSQL- und S3-Restore-Drill in isolierte Ziele mit RPO/RTO-, Hash-, Berechtigungs- und Cleanup-Nachweisen ergänzt
- Freigabe an eine konkrete, maximal 31 Tage alte Restore-Evidence gebunden

## Sicherheitsgrenzen

- kein Produktions-Deployment durch diesen PR
- Workflow läuft ausschließlich manuell auf einem selbst gehosteten Hetzner-Release-Runner
- Azure bleibt der einzige freigegebene externe KI-Pfad; Vercel wurde als Git-Integration getrennt
- reale Freigaben bleiben bis zu gültigen Hetzner-/Azure-Secrets, Signaturen und Restore-Nachweisen geschlossen

## Prüfung

- vollständige lokale Backend-Suite grün
- Ruff, Ruff Format, Bandit und pip-audit grün
- GitHub CI: Backend, Frontend, Container, CodeQL, Dependency Review, OPA, PostgreSQL RLS und Release-Evidence grün
- Arbeitsbaum sauber und Branch konfliktfrei zu main

## Externe Kontomaßnahme

Die alte Supabase-Preview-Integration ist im PR übersprungen und kein Codebestandteil. Ihre vollständige Entfernung im Supabase-Dashboard erfordert die persönliche Kontoanmeldung des Eigentümers.