### PR TITLE
Hetzner-Ausrollpfad für die öffentliche Website herstellen

### DIFF
--- a/deploy/hetzner/.env.compose.example
+++ b/deploy/hetzner/.env.compose.example
@@ -1,0 +1,25 @@
+# Substitutionswerte für Docker Compose — NICHT die Container-Umgebung.
+#
+# Compose liest diese Datei automatisch als `.env` im Verzeichnis der
+# Compose-Datei und ersetzt damit `${...}` in `compose.public-site.yml`.
+# Sie darf NICHT als `env_file` eingebunden werden: Die Namen beginnen mit
+# COMPLIANCEHUB_, stehen aber nicht auf der Allowlist des public_site-Profils.
+# Landen sie in der Container-Umgebung, bricht der Start mit
+# „is forbidden in the stateless public_site release" ab.
+#
+# Ablage auf dem Server:  deploy/hetzner/.env
+# Container-Umgebung:     deploy/hetzner/.env.public-site
+
+# Hostname für Caddy (TLS-Vhost und Redirect).
+COMPLIANCEHUB_PUBLIC_HOST=complywithai.de
+
+# Unveränderliche Image-Referenz mit Digest, kein beweglicher Tag.
+# Beispiel: registry.example.de/compliancehub/frontend@sha256:…
+COMPLIANCEHUB_FRONTEND_IMAGE=
+
+# Nachvollziehbarkeit des ausgerollten Stands.
+COMPLIANCEHUB_RELEASE_ID=
+COMPLIANCEHUB_RELEASE_COMMIT=
+
+# Pfad der Container-Umgebungsdatei (Standard: .env.public-site).
+COMPLIANCEHUB_ENV_FILE=.env.public-site

--- a/deploy/hetzner/.env.public-site.example
+++ b/deploy/hetzner/.env.public-site.example
@@ -1,0 +1,71 @@
+# Laufzeitkonfiguration der öffentlichen Website (Profil `public_site`).
+#
+# Diese Datei enthält ausschließlich nicht geheime Werte. Sie wird dem
+# Frontend-Container als `env_file` übergeben; das Release-Gate im CMD des
+# Images prüft sie bei jedem Start.
+#
+# WICHTIG — die Allowlist ist eng: Im public_site-Profil sind nur die unten
+# aufgeführten `COMPLIANCEHUB_*`-Variablen zulässig. Jede weitere sowie jede
+# `NEXT_PUBLIC_*`-, `POSTGRES_*`-, `SUPABASE_*`-, `AZURE_*`-, `DATABASE_URL`-
+# oder `PGPASSWORD`-Variable lässt den Containerstart fehlschlagen. Das ist
+# beabsichtigt: Die Website soll die Datenebene nicht erreichen können.
+#
+# Vor dem Ausrollen prüfen:
+#   python3 deploy/hetzner/preflight-public-site.py deploy/hetzner/.env.public-site
+
+# ── Release-Kennzeichnung ────────────────────────────────────────────────
+COMPLIANCEHUB_RELEASE_CHANNEL=production
+COMPLIANCEHUB_RELEASE_PROFILE=public_site
+# Attestiert den geprüften, zustandslosen öffentlichen Release.
+COMPLIANCEHUB_PUBLIC_SITE_READY=true
+
+# ── Herkunft und Hosts ───────────────────────────────────────────────────
+# Muss im public_site-Profil exakt diese Origin sein.
+COMPLIANCEHUB_APP_ORIGIN=https://complywithai.de
+COMPLIANCEHUB_TRUSTED_HOSTS=complywithai.de
+
+# ── Rechtliche Pflichtangaben (§ 5 DDG, Art. 13 DSGVO) ───────────────────
+# Alle Werte müssen nach dokumentierter rechtlicher Prüfung gesetzt werden.
+# Platzhalter wie "replace-…", "change-me", "TODO" oder "your-…" werden vom
+# Gate abgewiesen.
+COMPLIANCEHUB_LEGAL_ENTITY_NAME=
+COMPLIANCEHUB_LEGAL_REPRESENTATIVE=
+COMPLIANCEHUB_LEGAL_STREET=
+# Fünfstellig, wenn COMPLIANCEHUB_LEGAL_COUNTRY=Deutschland
+COMPLIANCEHUB_LEGAL_POSTAL_CODE=
+COMPLIANCEHUB_LEGAL_CITY=
+COMPLIANCEHUB_LEGAL_COUNTRY=Deutschland
+COMPLIANCEHUB_LEGAL_EMAIL=
+COMPLIANCEHUB_LEGAL_REGISTER_COURT=
+COMPLIANCEHUB_LEGAL_REGISTER_NUMBER=
+# Format DE + neun Ziffern, wenn COMPLIANCEHUB_LEGAL_COUNTRY=Deutschland
+COMPLIANCEHUB_LEGAL_VAT_ID=
+# Optional
+COMPLIANCEHUB_LEGAL_PHONE=
+# Muss nach dokumentierter rechtlicher Prüfung auf true stehen.
+COMPLIANCEHUB_LEGAL_PUBLISH_READY=false
+
+# ── Datenschutz ──────────────────────────────────────────────────────────
+COMPLIANCEHUB_PRIVACY_EMAIL=
+COMPLIANCEHUB_PRIVACY_NOTICE_VERSION=
+# YYYY-MM-DD, nicht in der Zukunft, höchstens ein Jahr alt.
+COMPLIANCEHUB_PRIVACY_REVIEWED_AT=
+# 1 bis 365
+COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS=14
+# 1 bis 3650
+COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS=180
+# Optional
+COMPLIANCEHUB_PRIVACY_DPO_CONTACT=
+
+# ── Sicherheitskontakt (security.txt) ────────────────────────────────────
+# HTTPS- oder mailto-URL.
+COMPLIANCEHUB_SECURITY_CONTACT=mailto:security@complywithai.de
+
+# ── Im öffentlichen Release deaktiviert ──────────────────────────────────
+# Diese vier dürfen im public_site-Profil nicht auf true stehen. Sie sind
+# ausdrücklich aufgeführt, damit die Abschaltung dokumentiert und nicht
+# zufällig ist.
+COMPLIANCEHUB_PUBLIC_DEMO_ENABLED=false
+COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED=false
+COMPLIANCEHUB_ENTRA_ENABLED=false
+COMPLIANCEHUB_CSP_REPORTING_READY=false

--- a/deploy/hetzner/.gitignore
+++ b/deploy/hetzner/.gitignore
@@ -1,3 +1,5 @@
+.env
+.env.public-site
 .env.production
 .env.candidate
 release-evidence.json

--- a/deploy/hetzner/PUBLIC-SITE-RUNBOOK.md
+++ b/deploy/hetzner/PUBLIC-SITE-RUNBOOK.md
@@ -1,0 +1,199 @@
+# Runbook: Öffentliche Website auf Hetzner
+
+Ziel: `complywithai.de` läuft im souveränen Hetzner-Profil statt auf Vercel.
+
+Dieses Runbook deckt **Stufe 1** ab — die öffentliche Website im Profil
+`public_site`. Der vollständige Enterprise-Stack (Backend, OPA, PostgreSQL,
+S3, OpenBao, Entra, Azure OpenAI) ist **Stufe 2** und folgt `README.md` sowie
+`compose.yml`.
+
+## Warum zwei Stufen
+
+Der `public_site`-Release ist zustandslos: keine Anmeldung, keine
+Mandantendaten, keine Zustands-APIs. `src/proxy.ts` weist jeden nicht
+freigegebenen Pfad ab, und das Release-Gate lässt den Container gar nicht
+starten, wenn Datenbank-, Storage- oder Identitätsvariablen gesetzt sind.
+
+Damit braucht die Website weder PostgreSQL noch S3, OpenBao, Entra oder Azure
+OpenAI. Sie braucht: einen Server, Docker, ein TLS-Zertifikat und DNS. Der
+Apparat aus Stufe 2 ist für die Datenebene gedacht und für die Website
+überdimensioniert — ihn vorzuziehen würde den Live-Gang um Wochen verzögern,
+ohne die Schutzwirkung zu erhöhen.
+
+## Ausgangslage (Stand 19.08.2026)
+
+- `complywithai.de` wird von **Vercel** ausgeliefert.
+- Der letzte erfolgreiche Deploy stammt vom **11.08.2026** (Commit `2d57a0a`).
+- Seit dem 13.08.2026 schlägt dort **jeder** Build fehl:
+  `Enterprise release gate failed: Vercel runtime variables are forbidden in
+  the Hetzner-first profile`. Ursache ist PR #290, der das Hetzner-first-Gate
+  eingeführt hat. Vercel setzt `VERCEL=1` selbst — der Check ist unbedingt.
+- `preproduction-build.yml` ist **noch nie gelaufen**; der self-hosted Runner
+  mit dem Label `compliancehub-hetzner-release` existiert nicht.
+
+Die Website hängt damit auf einem Stand von vor mehreren Releases fest.
+
+## Reihenfolge — die Website darf nicht offline gehen
+
+Vercel bleibt bis zum DNS-Cutover die ausliefernde Plattform. Erst wenn der
+Hetzner-Stack unter seiner eigenen Adresse verifiziert antwortet, wird DNS
+umgestellt. Vercel wird **danach** stillgelegt, nicht vorher.
+
+---
+
+## Schritt 1 — Server
+
+Hetzner-Server in `fsn1` oder `nbg1`, Debian oder Ubuntu LTS, Docker Engine
+mit Compose-Plugin.
+
+Host-Firewall: eingehend nur 22 (administrativ, idealerweise auf bekannte
+Quell-IPs beschränkt), 80 und 443. Ausgehend genügt der Website DNS und NTP —
+sie ruft keine externen Dienste auf. Das `egress_net` aus `compose.yml`
+entfällt hier bewusst.
+
+## Schritt 2 — Image bauen
+
+Das Image trägt keine Konfiguration; alle Werte kommen zur Laufzeit. Der Build
+selbst braucht daher keine Legal-Angaben.
+
+```bash
+git clone https://github.com/Luyzz22/Compliance-Hub.git
+cd Compliance-Hub
+git checkout main
+
+docker build -f frontend/Dockerfile.hetzner -t compliancehub-frontend:build .
+```
+
+Digest festhalten — Compose verlangt eine unveränderliche Referenz:
+
+```bash
+docker image inspect compliancehub-frontend:build \
+  --format '{{index .RepoDigests 0}}'
+```
+
+Ohne interne Registry gibt es noch keinen `RepoDigest`. Für Stufe 1 genügt es,
+das lokal gebaute Image über seine Image-ID zu pinnen und Release-ID sowie
+Commit in `.env` festzuhalten. Sobald die interne Registry aus Stufe 2 steht,
+übernimmt `scripts/sovereign_release_build.py` Build, Scan, Signatur und
+Attestierung.
+
+## Schritt 3 — TLS-Zertifikat
+
+Die `Caddyfile` setzt `auto_https off` und liest Zertifikat und Schlüssel aus
+Docker-Secrets — bewusst ohne ACME-Abhängigkeit.
+
+```bash
+mkdir -p deploy/hetzner/secrets
+# Zertifikatskette und privaten Schlüssel ablegen:
+#   deploy/hetzner/secrets/tls-certificate.pem
+#   deploy/hetzner/secrets/tls-private-key.pem
+chmod 600 deploy/hetzner/secrets/tls-private-key.pem
+```
+
+`deploy/hetzner/.gitignore` hält `secrets/` aus dem Repository heraus — vor dem
+ersten Commit auf dem Server verifizieren.
+
+## Schritt 4 — Konfiguration
+
+Zwei Dateien mit unterschiedlicher Rolle. Sie zu verwechseln ist der
+naheliegendste Fehler:
+
+| Datei | Rolle | Wirkung |
+|---|---|---|
+| `.env.public-site` | Container-Umgebung (`env_file`) | Wird vom Release-Gate geprüft |
+| `.env` | Compose-Substitution für `${...}` | Erreicht den Container **nicht** |
+
+Die Compose-Parameter (`COMPLIANCEHUB_PUBLIC_HOST`, `…_FRONTEND_IMAGE`,
+`…_RELEASE_ID`, `…_RELEASE_COMMIT`) beginnen mit `COMPLIANCEHUB_`, stehen aber
+**nicht** auf der Allowlist des `public_site`-Profils. Landen sie in der
+Container-Umgebung, bricht der Start ab.
+
+```bash
+cd deploy/hetzner
+cp .env.public-site.example .env.public-site
+cp .env.compose.example .env
+```
+
+In `.env.public-site` sind die rechtlichen Pflichtangaben zu ergänzen — nach
+dokumentierter rechtlicher Prüfung, nicht vorläufig. Erst danach
+`COMPLIANCEHUB_LEGAL_PUBLISH_READY=true` setzen.
+
+## Schritt 5 — Preflight
+
+Prüft dieselben Invarianten wie das Gate im Container, aber bevor irgendetwas
+startet:
+
+```bash
+python3 deploy/hetzner/preflight-public-site.py \
+  deploy/hetzner/.env.public-site --compose-env deploy/hetzner/.env
+```
+
+Exit 0 bedeutet ausrollbar. Jeder Befund wird einzeln benannt.
+
+## Schritt 6 — Start und Verifikation
+
+```bash
+cd deploy/hetzner
+docker compose -f compose.public-site.yml up -d
+docker compose -f compose.public-site.yml ps
+docker compose -f compose.public-site.yml logs frontend | head -20
+```
+
+Im Log muss stehen: `Enterprise release gate passed (public_site)`.
+
+Vor dem DNS-Wechsel gegen die Server-IP prüfen, mit `Host`-Header, damit Caddy
+den richtigen Vhost bedient:
+
+```bash
+IP=<server-ip>
+for p in / /plattform /eu-ai-act-iso-42001 /nis2-kritis /fuer-beratungen \
+         /integrationen /sicherheit /ressourcen /produkt-tour /demo \
+         /kontakt /trust-center /impressum /datenschutz; do
+  code=$(curl -sS -o /dev/null -w '%{http_code}' \
+    --resolve "complywithai.de:443:$IP" "https://complywithai.de$p")
+  echo "$p -> $code"
+done
+```
+
+Alle vierzehn Pfade müssen 200 liefern. Zusätzlich prüfen:
+
+- `/auth/login` und `/board/kpis` müssen **404** liefern — der zustandslose
+  Release gibt die Anwendung nicht frei.
+- `curl -sSI` zeigt `content-security-policy` mit `nonce-…` und **ohne**
+  `unsafe-inline`.
+- Der Antwort-Header `server: Vercel` ist verschwunden.
+
+## Schritt 7 — DNS-Cutover
+
+Erst wenn Schritt 6 vollständig grün ist:
+
+1. TTL des bestehenden Eintrags vorab auf 300 s senken und die alte TTL
+   ablaufen lassen.
+2. A- und AAAA-Record auf die Server-IP umstellen.
+3. Aus mehreren Netzen verifizieren, dass `server: Vercel` nicht mehr erscheint.
+4. Erst danach das Vercel-Projekt stilllegen — Domain trennen und
+   Git-Integration deaktivieren, damit keine fehlschlagenden Deploys mehr
+   entstehen.
+
+Rollback bis Schritt 4: DNS zurückstellen. Vercel liefert dann wieder den
+Stand vom 11.08.2026 aus.
+
+## Schritt 8 — Nachziehen
+
+- `COMPLIANCEHUB_PRIVACY_REVIEWED_AT` muss jährlich erneuert werden; das Gate
+  weist eine ältere Prüfung ab und der Container startet dann nicht mehr.
+  Wiedervorlage setzen.
+- Zertifikatserneuerung: Secret-Dateien ersetzen und `docker compose … up -d
+  edge`. Ohne ACME ist das ein bewusster manueller Schritt.
+- Stufe 2 (Enterprise-Datenebene) folgt `README.md`; sie verlangt zusätzlich
+  self-hosted Runner, interne Registry, Paket-Mirrors, OpenBao, Cosign,
+  PostgreSQL und S3.
+
+## Was Stufe 1 bewusst nicht leistet
+
+Signierte, attestierte Releases über `sovereign_release_build.py` setzen die
+interne Registry und OpenBao aus Stufe 2 voraus. Bis dahin ist die Herkunft
+über Release-ID, Commit und gepinnten Image-Digest nachvollziehbar, aber nicht
+kryptografisch attestiert. Das ist für die zustandslose Website vertretbar und
+sollte im Betriebskonzept als solches vermerkt werden — für die Datenebene
+wäre es das nicht.

--- a/deploy/hetzner/compose.public-site.yml
+++ b/deploy/hetzner/compose.public-site.yml
@@ -1,0 +1,99 @@
+# Öffentliche Website (Profil `public_site`) auf Hetzner.
+#
+# Bewusst reduziert gegenüber `compose.yml`: Der public_site-Release ist
+# zustandslos. Es gibt keine Anmeldung, keine Mandantendaten und keine
+# Zustands-APIs — `src/proxy.ts` weist alle nicht freigegebenen Pfade ab.
+# Deshalb laufen hier weder Backend noch OPA, und es werden weder PostgreSQL,
+# S3, Entra noch Azure OpenAI angebunden. Das Release-Gate
+# (`frontend/scripts/verify-enterprise-readiness.mjs`) erzwingt das zusätzlich:
+# Datenbank-, Storage- und Identitätsvariablen lassen den Containerstart
+# fehlschlagen.
+#
+# Einzige Geheimnisse: TLS-Zertifikat und -Schlüssel für die Edge.
+#
+# Start:
+#   COMPLIANCEHUB_ENV_FILE=.env.public-site \
+#     docker compose -f compose.public-site.yml up -d
+#
+# Der volle Enterprise-Stack (Backend, OPA, PostgreSQL, S3, OpenBao) bleibt
+# `compose.yml` vorbehalten und wird separat freigegeben.
+
+secrets:
+  tls_certificate:
+    file: ./secrets/tls-certificate.pem
+  tls_private_key:
+    file: ./secrets/tls-private-key.pem
+
+configs:
+  caddyfile:
+    file: ./Caddyfile
+
+services:
+  edge:
+    image: caddy:2.10-alpine@sha256:4c6e91c6ed0e2fa03efd5b44747b625fec79bc9cd06ac5235a779726618e530d
+    restart: unless-stopped
+    user: "65532:65532"
+    read_only: true
+    cap_drop: ["ALL"]
+    cap_add: ["NET_BIND_SERVICE"]
+    security_opt: ["no-new-privileges:true"]
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      COMPLIANCEHUB_PUBLIC_HOST: ${COMPLIANCEHUB_PUBLIC_HOST:?required}
+    configs:
+      - source: caddyfile
+        target: /etc/caddy/Caddyfile
+        mode: 0444
+    secrets:
+      - source: tls_certificate
+        target: tls_certificate
+      - source: tls_private_key
+        target: tls_private_key
+    tmpfs:
+      - /config:uid=65532,gid=65532,mode=0700
+      - /data:uid=65532,gid=65532,mode=0700
+    networks: [edge_net]
+    depends_on:
+      frontend:
+        condition: service_healthy
+
+  frontend:
+    image: ${COMPLIANCEHUB_FRONTEND_IMAGE:?immutable frontend image digest required}
+    labels:
+      com.complywithai.release.id: ${COMPLIANCEHUB_RELEASE_ID:?approved release id required}
+      com.complywithai.release.commit: ${COMPLIANCEHUB_RELEASE_COMMIT:?approved release commit required}
+      com.complywithai.release.profile: public_site
+    restart: unless-stopped
+    read_only: true
+    init: true
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
+    # Trägt die rechtlichen Pflichtangaben und die Release-Attestierung.
+    # Das Gate im CMD des Images prüft sie bei jedem Start.
+    env_file: ${COMPLIANCEHUB_ENV_FILE:-.env.public-site}
+    environment:
+      COMPLIANCEHUB_RELEASE_CHANNEL: production
+      COMPLIANCEHUB_RELEASE_PROFILE: public_site
+    tmpfs:
+      - /tmp:uid=10001,gid=10001,mode=0700
+    # Kein egress_net: Die Website ruft keine externen Dienste auf.
+    networks: [edge_net]
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:3000/').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+networks:
+  edge_net:
+    driver: bridge
+    internal: false

--- a/deploy/hetzner/preflight-public-site.py
+++ b/deploy/hetzner/preflight-public-site.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Preflight für die öffentliche Website (Profil `public_site`).
+
+Prüft die Container-Umgebungsdatei, bevor auf dem Server irgendetwas gestartet
+wird. Das Release-Gate im Image prüft dieselben Invarianten beim Containerstart
+— dort aber erst, wenn Server, TLS und DNS bereits stehen. Dieses Skript zieht
+die Prüfung nach vorn und benennt jede Abweichung einzeln.
+
+Aufruf:
+    python3 deploy/hetzner/preflight-public-site.py deploy/hetzner/.env.public-site
+
+Optional zusätzlich die Compose-Substitutionsdatei:
+    python3 deploy/hetzner/preflight-public-site.py .env.public-site --compose-env .env
+
+Exit 0 = ausrollbar, Exit 1 = Befund. Keine Netzwerkzugriffe, keine Secrets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+# Spiegelt `allowedComplianceHubKeys` in
+# frontend/scripts/verify-enterprise-readiness.mjs für das public_site-Profil.
+LEGAL_REQUIRED = [
+    "COMPLIANCEHUB_APP_ORIGIN",
+    "COMPLIANCEHUB_TRUSTED_HOSTS",
+    "COMPLIANCEHUB_LEGAL_ENTITY_NAME",
+    "COMPLIANCEHUB_LEGAL_REPRESENTATIVE",
+    "COMPLIANCEHUB_LEGAL_STREET",
+    "COMPLIANCEHUB_LEGAL_POSTAL_CODE",
+    "COMPLIANCEHUB_LEGAL_CITY",
+    "COMPLIANCEHUB_LEGAL_COUNTRY",
+    "COMPLIANCEHUB_LEGAL_EMAIL",
+    "COMPLIANCEHUB_LEGAL_REGISTER_COURT",
+    "COMPLIANCEHUB_LEGAL_REGISTER_NUMBER",
+    "COMPLIANCEHUB_LEGAL_VAT_ID",
+    "COMPLIANCEHUB_PRIVACY_EMAIL",
+    "COMPLIANCEHUB_PRIVACY_NOTICE_VERSION",
+    "COMPLIANCEHUB_PRIVACY_REVIEWED_AT",
+    "COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS",
+    "COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS",
+    "COMPLIANCEHUB_SECURITY_CONTACT",
+]
+
+ALLOWED_KEYS = set(LEGAL_REQUIRED) | {
+    "COMPLIANCEHUB_RELEASE_CHANNEL",
+    "COMPLIANCEHUB_RELEASE_PROFILE",
+    "COMPLIANCEHUB_PUBLIC_SITE_READY",
+    "COMPLIANCEHUB_PUBLIC_DEMO_ENABLED",
+    "COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED",
+    "COMPLIANCEHUB_ENTRA_ENABLED",
+    "COMPLIANCEHUB_CSP_REPORTING_READY",
+    "COMPLIANCEHUB_LEGAL_PHONE",
+    "COMPLIANCEHUB_LEGAL_PUBLISH_READY",
+    "COMPLIANCEHUB_PRIVACY_DPO_CONTACT",
+    "COMPLIANCEHUB_LLM_PII_MODE",
+    "COMPLIANCEHUB_RUNTIME_PREFLIGHT",
+}
+
+MUST_STAY_DISABLED = [
+    "COMPLIANCEHUB_PUBLIC_DEMO_ENABLED",
+    "COMPLIANCEHUB_PUBLIC_LEAD_CAPTURE_ENABLED",
+    "COMPLIANCEHUB_ENTRA_ENABLED",
+    "COMPLIANCEHUB_CSP_REPORTING_READY",
+]
+
+FORBIDDEN_PREFIXES = ("POSTGRES_", "SUPABASE_", "AZURE_", "NEXT_PUBLIC_", "VERCEL")
+FORBIDDEN_EXACT = {"DATABASE_URL", "PGPASSWORD"}
+PLACEHOLDER = re.compile(r"(?:replace-after|replace-with|change-?me|todo|tbd|your-)", re.I)
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def check_container_env(env: dict[str, str]) -> list[str]:
+    findings: list[str] = []
+
+    for key in LEGAL_REQUIRED:
+        if not env.get(key):
+            findings.append(f"{key} fehlt oder ist leer")
+
+    for key, value in env.items():
+        if not value:
+            continue
+        if key.startswith("COMPLIANCEHUB_") and key not in ALLOWED_KEYS:
+            findings.append(
+                f"{key} steht nicht auf der Allowlist des public_site-Profils "
+                "— der Containerstart würde abbrechen"
+            )
+        if key in FORBIDDEN_EXACT or key.startswith(FORBIDDEN_PREFIXES):
+            findings.append(f"{key} ist im zustandslosen public_site-Release verboten")
+        if key in LEGAL_REQUIRED and PLACEHOLDER.search(value):
+            findings.append(f"{key} enthält noch einen Platzhalter: {value!r}")
+
+    if env.get("COMPLIANCEHUB_RELEASE_PROFILE") != "public_site":
+        findings.append("COMPLIANCEHUB_RELEASE_PROFILE muss public_site sein")
+    if env.get("COMPLIANCEHUB_RELEASE_CHANNEL") != "production":
+        findings.append("COMPLIANCEHUB_RELEASE_CHANNEL muss production sein")
+    if env.get("COMPLIANCEHUB_PUBLIC_SITE_READY") != "true":
+        findings.append(
+            "COMPLIANCEHUB_PUBLIC_SITE_READY muss den geprüften Release attestieren (true)"
+        )
+    if env.get("COMPLIANCEHUB_LEGAL_PUBLISH_READY") != "true":
+        findings.append(
+            "COMPLIANCEHUB_LEGAL_PUBLISH_READY muss nach dokumentierter "
+            "rechtlicher Prüfung true sein"
+        )
+
+    for key in MUST_STAY_DISABLED:
+        if env.get(key) == "true":
+            findings.append(f"{key} muss im public_site-Release deaktiviert bleiben")
+
+    if env.get("COMPLIANCEHUB_APP_ORIGIN") and (
+        env["COMPLIANCEHUB_APP_ORIGIN"] != "https://complywithai.de"
+    ):
+        findings.append(
+            "COMPLIANCEHUB_APP_ORIGIN muss im public_site-Profil "
+            "https://complywithai.de sein"
+        )
+
+    hosts = {
+        host.strip().lower()
+        for host in env.get("COMPLIANCEHUB_TRUSTED_HOSTS", "").split(",")
+        if host.strip()
+    }
+    if hosts and "complywithai.de" not in hosts:
+        findings.append("COMPLIANCEHUB_TRUSTED_HOSTS muss den Anwendungshost enthalten")
+
+    if env.get("COMPLIANCEHUB_LEGAL_COUNTRY") == "Deutschland":
+        postal = env.get("COMPLIANCEHUB_LEGAL_POSTAL_CODE", "")
+        if postal and not re.fullmatch(r"\d{5}", postal):
+            findings.append("COMPLIANCEHUB_LEGAL_POSTAL_CODE muss fünfstellig sein")
+        vat = env.get("COMPLIANCEHUB_LEGAL_VAT_ID", "")
+        if vat and not re.fullmatch(r"DE\d{9}", vat):
+            findings.append("COMPLIANCEHUB_LEGAL_VAT_ID muss dem Format DE + 9 Ziffern folgen")
+
+    for key in ("COMPLIANCEHUB_LEGAL_EMAIL", "COMPLIANCEHUB_PRIVACY_EMAIL"):
+        value = env.get(key, "")
+        if value and not re.fullmatch(r"[^@\s]+@[^@\s]+\.[^@\s]+", value):
+            findings.append(f"{key} muss eine gültige E-Mail-Adresse sein")
+
+    contact = env.get("COMPLIANCEHUB_SECURITY_CONTACT", "")
+    if contact and not contact.startswith(("https://", "mailto:")):
+        findings.append(
+            "COMPLIANCEHUB_SECURITY_CONTACT muss eine HTTPS- oder mailto-Adresse sein"
+        )
+
+    reviewed = env.get("COMPLIANCEHUB_PRIVACY_REVIEWED_AT", "")
+    if reviewed:
+        try:
+            reviewed_date = dt.date.fromisoformat(reviewed)
+        except ValueError:
+            findings.append("COMPLIANCEHUB_PRIVACY_REVIEWED_AT muss YYYY-MM-DD sein")
+        else:
+            today = dt.date.today()
+            if reviewed_date > today:
+                findings.append(
+                    "COMPLIANCEHUB_PRIVACY_REVIEWED_AT darf nicht in der Zukunft liegen"
+                )
+            elif (today - reviewed_date).days > 366:
+                findings.append(
+                    "Die Datenschutzerklärung muss mindestens jährlich erneut "
+                    "geprüft werden"
+                )
+
+    for key, low, high in (
+        ("COMPLIANCEHUB_PRIVACY_LOG_RETENTION_DAYS", 1, 365),
+        ("COMPLIANCEHUB_PRIVACY_LEAD_RETENTION_DAYS", 1, 3650),
+    ):
+        value = env.get(key, "")
+        if value and (not value.isdigit() or not low <= int(value) <= high):
+            findings.append(f"{key} muss zwischen {low} und {high} liegen")
+
+    return findings
+
+
+def check_compose_env(env: dict[str, str]) -> list[str]:
+    findings: list[str] = []
+
+    image = env.get("COMPLIANCEHUB_FRONTEND_IMAGE", "")
+    if not image:
+        findings.append("COMPLIANCEHUB_FRONTEND_IMAGE fehlt")
+    elif "@sha256:" not in image:
+        findings.append(
+            "COMPLIANCEHUB_FRONTEND_IMAGE muss einen unveränderlichen Digest "
+            "tragen (…@sha256:…), keinen beweglichen Tag"
+        )
+
+    for key in ("COMPLIANCEHUB_PUBLIC_HOST", "COMPLIANCEHUB_RELEASE_ID", "COMPLIANCEHUB_RELEASE_COMMIT"):
+        if not env.get(key):
+            findings.append(f"{key} fehlt")
+
+    return findings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("env_file", type=Path, help="Container-Umgebungsdatei")
+    parser.add_argument(
+        "--compose-env",
+        type=Path,
+        default=None,
+        help="Optionale Compose-Substitutionsdatei (.env)",
+    )
+    args = parser.parse_args()
+
+    if not args.env_file.is_file():
+        print(f"Datei nicht gefunden: {args.env_file}", file=sys.stderr)
+        return 1
+
+    findings = check_container_env(read_env(args.env_file))
+    scope = [f"Container-Umgebung: {args.env_file}"]
+
+    if args.compose_env:
+        if not args.compose_env.is_file():
+            print(f"Datei nicht gefunden: {args.compose_env}", file=sys.stderr)
+            return 1
+        findings += check_compose_env(read_env(args.compose_env))
+        scope.append(f"Compose-Substitution: {args.compose_env}")
+
+    for line in scope:
+        print(line)
+
+    if findings:
+        print(f"\nPreflight fehlgeschlagen — {len(findings)} Befund(e):", file=sys.stderr)
+        for finding in findings:
+            print(f"  - {finding}", file=sys.stderr)
+        return 1
+
+    print("\nPreflight bestanden: Die Konfiguration erfüllt das public_site-Profil.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/frontend/scripts/verify-enterprise-readiness.mjs
+++ b/frontend/scripts/verify-enterprise-readiness.mjs
@@ -207,6 +207,9 @@ if (releaseProfile === "public_site") {
     "COMPLIANCEHUB_LEGAL_PUBLISH_READY",
     "COMPLIANCEHUB_PRIVACY_DPO_CONTACT",
     "COMPLIANCEHUB_LLM_PII_MODE",
+    // Vom Laufzeit-Image gesetzt: im Runtime-Layer existiert `src` nicht mehr,
+    // die Quellcode-Prüfung greift dort bewusst nicht. Kein Konfigurationswert.
+    "COMPLIANCEHUB_RUNTIME_PREFLIGHT",
   ]);
   const forbiddenPublicPrefixes = [
     "POSTGRES_",

--- a/frontend/src/lib/enterpriseReleaseGate.test.ts
+++ b/frontend/src/lib/enterpriseReleaseGate.test.ts
@@ -62,6 +62,19 @@ describe("enterprise release gate profiles", () => {
     expect(result.stdout).toContain("passed (public_site)");
   });
 
+  it("starts the public-site runtime image, which sets the preflight flag itself", () => {
+    // frontend/Dockerfile.hetzner setzt COMPLIANCEHUB_RUNTIME_PREFLIGHT=true und ruft
+    // das Gate im CMD auf. Fehlt die Variable auf der Allowlist, bricht jeder
+    // Containerstart ab — die Website wäre nicht ausrollbar.
+    const result = runGate({
+      ...publicSiteEnvironment(),
+      COMPLIANCEHUB_RUNTIME_PREFLIGHT: "true",
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("passed (public_site)");
+  });
+
   it("rejects inherited database credentials in the public-site release", () => {
     const result = runGate({
       ...publicSiteEnvironment(),


### PR DESCRIPTION
Vorbereitung für Weg A: `complywithai.de` soll im souveränen Hetzner-Profil laufen statt auf Vercel.

## Ausgangslage

- Die Domain wird von **Vercel** ausgeliefert; letzter erfolgreicher Deploy war der **11.08.2026** (Commit `2d57a0a`).
- Seit dem 13.08.2026 schlägt dort **jeder** Build fehl: `Enterprise release gate failed: Vercel runtime variables are forbidden in the Hetzner-first profile`. Ursache ist PR #290 — Vercel setzt `VERCEL=1` selbst, und der Check ist unbedingt.
- `preproduction-build.yml` ist **noch nie gelaufen**; der self-hosted Runner mit dem Label `compliancehub-hetzner-release` existiert nicht.

Die Website hängt damit auf einem Stand von vor mehreren Releases fest.

## Blocker im Release-Gate

`frontend/Dockerfile.hetzner` setzt `COMPLIANCEHUB_RUNTIME_PREFLIGHT=true` und ruft das Gate im `CMD` auf. Diese Variable stand nicht auf der Allowlist des `public_site`-Profils — **jeder Containerstart wäre mit Exit 1 abgebrochen.** Der Hetzner-Weg war für die Website also unabhängig von aller Infrastruktur gar nicht lauffähig.

Reproduzierbar vor dem Fix:

```
Enterprise release gate failed (public_site):
- COMPLIANCEHUB_RUNTIME_PREFLIGHT is forbidden in the stateless public_site release
```

Die Variable ist jetzt zugelassen. Sie signalisiert nur, dass `src` im Runtime-Layer fehlt, und trägt keinen Konfigurationswert. Gegengeprüft, dass die übrigen Schranken unverändert greifen:

| Szenario | Ergebnis |
|---|---|
| Container-Bedingungen (`RUNTIME_PREFLIGHT=true`) | passed (public_site) |
| zusätzlich `VERCEL=1` | abgewiesen |
| zusätzlich `POSTGRES_HOST` | abgewiesen |

Ein Regressionstest führt das Gate unter Container-Bedingungen aus, damit der Bug nicht zurückkommt.

## Ausrollpfad Stufe 1 — zustandslose Website

Der `public_site`-Release hat keine Anmeldung, keine Mandantendaten und keine Zustands-APIs; das Gate lässt den Container gar nicht starten, wenn Datenbank-, Storage- oder Identitätsvariablen gesetzt sind. Die Website braucht daher weder PostgreSQL noch S3, OpenBao, Entra oder Azure OpenAI — sie braucht Server, Docker, TLS und DNS.

- **`compose.public-site.yml`** — nur Edge und Frontend, kein Egress-Netz.
- **`.env.public-site.example`** und **`.env.compose.example`** — trennen Container-Umgebung von Compose-Substitution. Beide Namensräume beginnen mit `COMPLIANCEHUB_`, aber nur der erste gehört in den Container; die Compose-Parameter (`…_PUBLIC_HOST`, `…_FRONTEND_IMAGE`, `…_RELEASE_ID`, `…_RELEASE_COMMIT`) stehen nicht auf der Allowlist und würden den Start sonst abbrechen.
- **`preflight-public-site.py`** — prüft dieselben Invarianten wie das Gate, bevor Server, TLS und DNS angefasst werden. Getestet gegen vier Szenarien: unausgefüllte Vorlage, vollständige Konfiguration, beweglicher Image-Tag statt Digest, verbotene Datenbankvariable.
- **`PUBLIC-SITE-RUNBOOK.md`** — Reihenfolge inklusive Verifikation aller vierzehn Pfade vor dem DNS-Cutover. Vercel bleibt bis dahin die ausliefernde Plattform und wird erst danach stillgelegt, damit die Website beim Umzug nicht offline geht.
- **`.gitignore`** deckt die neuen Betriebsdateien ab.

Stufe 2 (Enterprise-Datenebene mit interner Registry, OpenBao, Cosign, PostgreSQL und S3) bleibt unverändert `README.md` und `compose.yml` vorbehalten.

## Verifikation

- `npm run lint` sauber
- `npm run test:unit`: 387 Tests in 107 Dateien grün (vorher 386)
- `docker compose -f compose.public-site.yml config` löst sauber auf; im Ergebnis ist außer der expliziten Abschaltung `COMPLIANCEHUB_ENTRA_ENABLED=false` keine Datenebenen-Referenz enthalten
- Preflight-Skript in vier Szenarien geprüft

## Hinweis zum Review

`frontend/scripts/verify-enterprise-readiness.mjs` steht unter CODEOWNERS. Die Änderung erweitert die Allowlist um genau einen Eintrag und lockert keine andere Schranke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019mHv5LXRZKmRKASJb47pzi

---
_Generated by [Claude Code](https://claude.ai/code/session_019mHv5LXRZKmRKASJb47pzi)_